### PR TITLE
Add thumb.jpg sidecar for finished video captures

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -389,7 +389,7 @@ public class AsgConstants {
     public static final long VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS = 1_000L;
 
     /** Maximum abandoned native decoder workers retained after timeout. */
-    public static final int VIDEO_THUMBNAIL_MAX_RETIRED_DECODERS = 1;
+    public static final int VIDEO_THUMBNAIL_MAX_RETIRED_DECODERS = 2;
 
     /**
      * Max wait for the deferred background photo write ({@code CapturedPhoto.persistence}) when a

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -385,6 +385,9 @@ public class AsgConstants {
     /** Maximum time allowed for platform video-frame extraction. */
     public static final long VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS = 10_000L;
 
+    /** Maximum wait before deleting a video whose thumbnail task is still finishing. */
+    public static final long VIDEO_THUMBNAIL_TASK_TIMEOUT_MS = 12_000L;
+
     /**
      * Max wait for the deferred background photo write ({@code CapturedPhoto.persistence}) when a
      * BLE photo consumer needs the file on disk (gallery save, text-mode canonical crop, cleanup).

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -364,6 +364,27 @@ public class AsgConstants {
      */
     public static final int FILE_TRANSFER_PROGRESS_LOG_INTERVAL = 10;
 
+    // Video capture thumbnails
+    // -------------------------------------------------------------------------
+
+    /** JPEG sidecar written next to a finalized video for direct-filesystem consumers. */
+    public static final String VIDEO_THUMBNAIL_SIDECAR_NAME = "thumb.jpg";
+
+    /** Transient thumbnail filename; the .partial suffix keeps it out of gallery listings. */
+    public static final String VIDEO_THUMBNAIL_PARTIAL_NAME = "thumb.jpg.partial";
+
+    /** Longest edge of generated video thumbnails, in pixels. */
+    public static final int VIDEO_THUMBNAIL_MAX_DIMENSION = 480;
+
+    /** JPEG compression quality for video thumbnail sidecars. */
+    public static final int VIDEO_THUMBNAIL_JPEG_QUALITY = 80;
+
+    /** Frame position sampled for video thumbnails, in microseconds. */
+    public static final long VIDEO_THUMBNAIL_FRAME_TIME_US = 1_000_000L;
+
+    /** Maximum time allowed for platform video-frame extraction. */
+    public static final long VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS = 10_000L;
+
     /**
      * Max wait for the deferred background photo write ({@code CapturedPhoto.persistence}) when a
      * BLE photo consumer needs the file on disk (gallery save, text-mode canonical crop, cleanup).

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -385,8 +385,11 @@ public class AsgConstants {
     /** Maximum time allowed for platform video-frame extraction. */
     public static final long VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS = 10_000L;
 
-    /** Maximum wait for queued thumbnail work during media-service cleanup. */
-    public static final long VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS = 12_000L;
+    /** Final main-thread wait after thumbnail work has drained during other cleanup steps. */
+    public static final long VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS = 1_000L;
+
+    /** Maximum abandoned native decoder workers retained after timeout. */
+    public static final int VIDEO_THUMBNAIL_MAX_RETIRED_DECODERS = 1;
 
     /**
      * Max wait for the deferred background photo write ({@code CapturedPhoto.persistence}) when a

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -385,8 +385,8 @@ public class AsgConstants {
     /** Maximum time allowed for platform video-frame extraction. */
     public static final long VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS = 10_000L;
 
-    /** Maximum wait before deleting a video whose thumbnail task is still finishing. */
-    public static final long VIDEO_THUMBNAIL_TASK_TIMEOUT_MS = 12_000L;
+    /** Maximum wait for queued thumbnail work during media-service cleanup. */
+    public static final long VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS = 12_000L;
 
     /**
      * Max wait for the deferred background photo write ({@code CapturedPhoto.persistence}) when a

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -386,7 +386,7 @@ public class AsgConstants {
     public static final long VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS = 10_000L;
 
     /** Final main-thread wait after thumbnail work has drained during other cleanup steps. */
-    public static final long VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS = 1_000L;
+    public static final long VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS = 250L;
 
     /** Maximum abandoned native decoder workers retained after timeout. */
     public static final int VIDEO_THUMBNAIL_MAX_RETIRED_DECODERS = 2;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
@@ -8,6 +8,7 @@ import com.mentra.asg_client.io.file.managers.DirectoryManager;
 import com.mentra.asg_client.io.file.managers.ThumbnailManager;
 import com.mentra.asg_client.io.file.utils.FileOperationLogger;
 import com.mentra.asg_client.io.file.utils.MimeTypeRegistry;
+import com.mentra.asg_client.io.media.utils.VideoThumbnailWriter;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -322,6 +323,12 @@ public class FileManagerImpl implements FileManager {
                     // for Wi-Fi sync, where unknown leaf names are treated as primary capture files.
                     if (item.getName().endsWith(".partial")) {
                         Log.d(TAG, "⏭️ Skipping .partial file from listing: " + item.getAbsolutePath());
+                        continue;
+                    }
+                    // Skip thumb.jpg capture sidecars (written at video finalize for USB/desktop
+                    // consumers). The Wi-Fi gallery has its own thumbnail cache; listing these
+                    // would advertise them to phone sync as primary capture files.
+                    if (item.getName().equals(VideoThumbnailWriter.SIDECAR_NAME)) {
                         continue;
                     }
                     // Add file to metadata list

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
@@ -331,7 +331,8 @@ public class FileManagerImpl implements FileManager {
                     if (getDefaultPackageName().equals(packageName)
                             && directory.getName().startsWith("VID_")
                             && item.getName()
-                                    .equals(AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME)) {
+                                    .equalsIgnoreCase(
+                                            AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME)) {
                         continue;
                     }
                     // Add file to metadata list

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
@@ -1,5 +1,6 @@
 package com.mentra.asg_client.io.file.core;
 
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.logging.Logger;
 import com.mentra.asg_client.io.file.managers.FileOperationsManager;
 import com.mentra.asg_client.io.file.managers.FileSecurityManager;
@@ -8,7 +9,6 @@ import com.mentra.asg_client.io.file.managers.DirectoryManager;
 import com.mentra.asg_client.io.file.managers.ThumbnailManager;
 import com.mentra.asg_client.io.file.utils.FileOperationLogger;
 import com.mentra.asg_client.io.file.utils.MimeTypeRegistry;
-import com.mentra.asg_client.io.media.utils.VideoThumbnailWriter;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -328,7 +328,10 @@ public class FileManagerImpl implements FileManager {
                     // Skip thumb.jpg capture sidecars (written at video finalize for USB/desktop
                     // consumers). The Wi-Fi gallery has its own thumbnail cache; listing these
                     // would advertise them to phone sync as primary capture files.
-                    if (item.getName().equals(VideoThumbnailWriter.SIDECAR_NAME)) {
+                    if (getDefaultPackageName().equals(packageName)
+                            && directory.getName().startsWith("VID_")
+                            && item.getName()
+                                    .equals(AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME)) {
                         continue;
                     }
                     // Add file to metadata list
@@ -801,8 +804,10 @@ public class FileManagerImpl implements FileManager {
                         lower.endsWith(".mp4") || lower.endsWith(".mov") || lower.endsWith(".avi");
                     // Exclude HDR brackets — they're not standalone media
                     boolean isBracket = lower.matches("ev-?\\d+\\.jpe?g");
+                    boolean isVideoThumbnail =
+                            lower.equals(AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
 
-                    if (isMediaExtension && !isBracket) {
+                    if (isMediaExtension && !isBracket && !isVideoThumbnail) {
                         boolean isVideo = lower.endsWith(".mp4") || lower.endsWith(".mov") || lower.endsWith(".avi");
                         if (isVideo) {
                             // Videos need moov atom validation — a killed process leaves

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -6851,7 +6851,9 @@ public class MediaCaptureService {
         String taskKey = new File(filePath).getAbsolutePath();
         VideoThumbnailTask task = new VideoThumbnailTask(taskKey);
         synchronized (videoThumbnailLifecycleLock) {
-            if (isCleaningUp.get() || videoThumbnailExecutor.isShutdown()) {
+            // Cleanup blocks new integrity checks first, then lets checks already in flight enqueue
+            // their sidecars before closing this executor.
+            if (videoThumbnailExecutor.isShutdown()) {
                 return;
             }
             if (videoThumbnailTasks.putIfAbsent(taskKey, task) != null) {
@@ -6905,12 +6907,9 @@ public class MediaCaptureService {
                 mBatteryMonitorHandler = null;
             }
 
-            // Close submission before waiting for integrity work. Existing thumbnail tasks drain
-            // in parallel with the integrity wait, keeping the final main-thread wait short.
-            synchronized (videoThumbnailLifecycleLock) {
-                videoThumbnailExecutor.shutdown();
-            }
-
+            // isCleaningUp prevents new integrity submissions. Let checks already in flight enqueue
+            // their thumbnails before closing thumbnail submission; existing thumbnail work still
+            // drains in parallel with this wait.
             videoIntegrityExecutor.shutdown();
             try {
                 if (!videoIntegrityExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
@@ -6919,6 +6918,9 @@ public class MediaCaptureService {
             } catch (InterruptedException e) {
                 videoIntegrityExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
+            }
+            synchronized (videoThumbnailLifecycleLock) {
+                videoThumbnailExecutor.shutdown();
             }
             try {
                 if (!videoThumbnailExecutor.awaitTermination(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -149,6 +149,13 @@ public class MediaCaptureService {
         }
     }
 
+    private static boolean shouldWriteVideoThumbnail(UploadTarget uploadTarget, boolean save) {
+        return save
+                || uploadTarget == null
+                || uploadTarget.webhookUrl == null
+                || uploadTarget.webhookUrl.trim().isEmpty();
+    }
+
     // Guards the stop prologue (mCurrentStopReason + pending-upload target) so the
     // check-and-set is atomic across threads. The user stop arrives on the BLE worker
     // thread while auto-stops (max-duration/battery/error) fire on the main looper; without
@@ -613,6 +620,15 @@ public class MediaCaptureService {
             Executors.newSingleThreadExecutor(
                     r -> {
                         Thread t = new Thread(r, "RecordedVideoIntegrity");
+                        t.setPriority(Thread.NORM_PRIORITY - 1);
+                        return t;
+                    });
+
+    /** Keeps best-effort thumbnail decoding from delaying integrity callbacks or uploads. */
+    private final ExecutorService videoThumbnailExecutor =
+            Executors.newSingleThreadExecutor(
+                    r -> {
+                        Thread t = new Thread(r, "VideoThumbnailWriter");
                         t.setPriority(Thread.NORM_PRIORITY - 1);
                         return t;
                     });
@@ -1407,13 +1423,6 @@ public class MediaCaptureService {
                                                 final boolean ok =
                                                         RecordedVideoIntegrityChecker.verify(
                                                                 filePath);
-                                                if (ok) {
-                                                    // Still on the background thread: write the
-                                                    // thumb.jpg sidecar for the verified video so
-                                                    // USB/desktop consumers get a preview.
-                                                    VideoThumbnailWriter.writeSidecar(
-                                                            new File(filePath));
-                                                }
                                                 mainHandler.post(
                                                         () -> {
                                                             videoCaptureIdsPendingIntegrityCheck
@@ -1494,6 +1503,24 @@ public class MediaCaptureService {
                                                                 sendGalleryStatusUpdate();
                                                             }
                                                         });
+                                                if (ok
+                                                        && shouldWriteVideoThumbnail(
+                                                                uploadTarget, save)
+                                                        && !isCleaningUp.get()) {
+                                                    try {
+                                                        videoThumbnailExecutor.execute(
+                                                                () ->
+                                                                        VideoThumbnailWriter
+                                                                                .writeSidecar(
+                                                                                        new File(
+                                                                                                filePath)));
+                                                    } catch (RejectedExecutionException e) {
+                                                        Log.d(
+                                                                TAG,
+                                                                "Skipping video thumbnail during"
+                                                                        + " cleanup");
+                                                    }
+                                                }
                                             } catch (Throwable t) {
                                                 Log.e(
                                                         TAG,
@@ -4374,6 +4401,7 @@ public class MediaCaptureService {
 
                                     if (!save) {
                                         try {
+                                            VideoThumbnailWriter.deleteSidecar(videoFile);
                                             if (videoFile.delete()) {
                                                 Log.d(
                                                         TAG,
@@ -6813,6 +6841,7 @@ public class MediaCaptureService {
                 videoIntegrityExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
+            videoThumbnailExecutor.shutdownNow();
             textModeProcessingExecutor.shutdown();
             try {
                 if (!textModeProcessingExecutor.awaitTermination(3, TimeUnit.SECONDS)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -64,14 +64,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -150,6 +147,54 @@ public class MediaCaptureService {
         UploadTarget(String webhookUrl, String authToken) {
             this.webhookUrl = webhookUrl;
             this.authToken = authToken;
+        }
+    }
+
+    private final class VideoThumbnailTask
+            implements Runnable, VideoThumbnailWriter.SidecarCommitter {
+        private final File videoFile;
+        private final Object commitLock = new Object();
+        private volatile Future<?> execution;
+        private boolean discarded;
+
+        VideoThumbnailTask(String filePath) {
+            videoFile = new File(filePath);
+        }
+
+        void setExecution(Future<?> execution) {
+            this.execution = execution;
+        }
+
+        @Override
+        public void run() {
+            try {
+                VideoThumbnailWriter.writeSidecar(videoFile, this);
+            } finally {
+                videoThumbnailTasks.remove(videoFile.getAbsolutePath(), this);
+            }
+        }
+
+        @Override
+        public boolean commit(File partial, File sidecar) {
+            synchronized (commitLock) {
+                return !discarded && videoFile.isFile() && partial.renameTo(sidecar);
+            }
+        }
+
+        boolean discardAndDeleteVideo() {
+            synchronized (commitLock) {
+                boolean deleted = !videoFile.exists() || videoFile.delete();
+                if (!deleted) {
+                    return false;
+                }
+                discarded = true;
+                Future<?> currentExecution = execution;
+                if (currentExecution != null) {
+                    currentExecution.cancel(true);
+                }
+                VideoThumbnailWriter.deleteSidecar(videoFile);
+                return true;
+            }
         }
     }
 
@@ -629,7 +674,7 @@ public class MediaCaptureService {
                         t.setPriority(Thread.NORM_PRIORITY - 1);
                         return t;
                     });
-    private final ConcurrentHashMap<String, Future<?>> videoThumbnailTasks =
+    private final ConcurrentHashMap<String, VideoThumbnailTask> videoThumbnailTasks =
             new ConcurrentHashMap<>();
 
     /**
@@ -4385,9 +4430,7 @@ public class MediaCaptureService {
 
                                     if (!save) {
                                         try {
-                                            awaitVideoThumbnail(videoFilePath);
-                                            VideoThumbnailWriter.deleteSidecar(videoFile);
-                                            if (videoFile.delete()) {
+                                            if (discardThumbnailAndDeleteVideo(videoFile)) {
                                                 Log.d(
                                                         TAG,
                                                         "🗑️ Deleted video file after successful"
@@ -6793,47 +6836,31 @@ public class MediaCaptureService {
     }
 
     private void scheduleVideoThumbnail(String filePath) {
-        FutureTask<Void> task =
-                new FutureTask<Void>(
-                        () -> {
-                            VideoThumbnailWriter.writeSidecar(new File(filePath));
-                            return null;
-                        }) {
-                    @Override
-                    protected void done() {
-                        videoThumbnailTasks.remove(filePath, this);
-                    }
-                };
-        if (videoThumbnailTasks.putIfAbsent(filePath, task) != null) {
+        String taskKey = new File(filePath).getAbsolutePath();
+        VideoThumbnailTask task = new VideoThumbnailTask(taskKey);
+        if (videoThumbnailTasks.putIfAbsent(taskKey, task) != null) {
             return;
         }
         try {
-            videoThumbnailExecutor.execute(task);
+            task.setExecution(videoThumbnailExecutor.submit(task));
         } catch (RejectedExecutionException e) {
-            videoThumbnailTasks.remove(filePath, task);
-            task.cancel(false);
+            videoThumbnailTasks.remove(taskKey, task);
             Log.d(TAG, "Skipping video thumbnail during cleanup");
         }
     }
 
-    private void awaitVideoThumbnail(String filePath) {
-        Future<?> task = videoThumbnailTasks.get(filePath);
-        if (task == null) {
-            return;
+    private boolean discardThumbnailAndDeleteVideo(File videoFile) {
+        VideoThumbnailTask task = videoThumbnailTasks.get(videoFile.getAbsolutePath());
+        if (task != null) {
+            boolean deleted = task.discardAndDeleteVideo();
+            videoThumbnailTasks.remove(videoFile.getAbsolutePath(), task);
+            return deleted;
         }
-        try {
-            task.get(AsgConstants.VIDEO_THUMBNAIL_TASK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            task.cancel(true);
-            Log.w(TAG, "Timed out waiting for video thumbnail before deleting " + filePath);
-        } catch (InterruptedException e) {
-            task.cancel(true);
-            Thread.currentThread().interrupt();
-        } catch (ExecutionException e) {
-            Log.w(TAG, "Video thumbnail task failed for " + filePath, e.getCause());
-        } finally {
-            videoThumbnailTasks.remove(filePath, task);
+        boolean deleted = !videoFile.exists() || videoFile.delete();
+        if (deleted) {
+            VideoThumbnailWriter.deleteSidecar(videoFile);
         }
+        return deleted;
     }
 
     /**
@@ -6871,6 +6898,20 @@ public class MediaCaptureService {
                 Thread.currentThread().interrupt();
             }
             videoThumbnailExecutor.shutdown();
+            try {
+                if (!videoThumbnailExecutor.awaitTermination(
+                        AsgConstants.VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS,
+                        TimeUnit.MILLISECONDS)) {
+                    videoThumbnailExecutor.shutdownNow();
+                    if (!videoThumbnailExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+                        Log.w(TAG, "Video thumbnail executor did not terminate during cleanup");
+                    }
+                }
+            } catch (InterruptedException e) {
+                videoThumbnailExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+            videoThumbnailTasks.clear();
             textModeProcessingExecutor.shutdown();
             try {
                 if (!textModeProcessingExecutor.awaitTermination(3, TimeUnit.SECONDS)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -27,6 +27,7 @@ import com.mentra.asg_client.io.media.core.textdetect.MlKitTextRoiDetector;
 import com.mentra.asg_client.io.media.interfaces.ServiceCallbackInterface;
 import com.mentra.asg_client.io.media.managers.MediaUploadQueueManager;
 import com.mentra.asg_client.io.media.upload.MediaUploadService;
+import com.mentra.asg_client.io.media.utils.VideoThumbnailWriter;
 import com.mentra.asg_client.io.storage.StorageManager;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
 import com.mentra.asg_client.io.streaming.services.SrtStreamingService;
@@ -1406,6 +1407,13 @@ public class MediaCaptureService {
                                                 final boolean ok =
                                                         RecordedVideoIntegrityChecker.verify(
                                                                 filePath);
+                                                if (ok) {
+                                                    // Still on the background thread: write the
+                                                    // thumb.jpg sidecar for the verified video so
+                                                    // USB/desktop consumers get a preview.
+                                                    VideoThumbnailWriter.writeSidecar(
+                                                            new File(filePath));
+                                                }
                                                 mainHandler.post(
                                                         () -> {
                                                             videoCaptureIdsPendingIntegrityCheck

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -64,10 +64,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -147,13 +151,6 @@ public class MediaCaptureService {
             this.webhookUrl = webhookUrl;
             this.authToken = authToken;
         }
-    }
-
-    private static boolean shouldWriteVideoThumbnail(UploadTarget uploadTarget, boolean save) {
-        return save
-                || uploadTarget == null
-                || uploadTarget.webhookUrl == null
-                || uploadTarget.webhookUrl.trim().isEmpty();
     }
 
     // Guards the stop prologue (mCurrentStopReason + pending-upload target) so the
@@ -632,6 +629,8 @@ public class MediaCaptureService {
                         t.setPriority(Thread.NORM_PRIORITY - 1);
                         return t;
                     });
+    private final ConcurrentHashMap<String, Future<?>> videoThumbnailTasks =
+            new ConcurrentHashMap<>();
 
     /**
      * Keeps ML Kit and final-crop persistence off CameraNeo's shared callback executor. A single
@@ -1423,6 +1422,9 @@ public class MediaCaptureService {
                                                 final boolean ok =
                                                         RecordedVideoIntegrityChecker.verify(
                                                                 filePath);
+                                                if (ok) {
+                                                    scheduleVideoThumbnail(filePath);
+                                                }
                                                 mainHandler.post(
                                                         () -> {
                                                             videoCaptureIdsPendingIntegrityCheck
@@ -1503,24 +1505,6 @@ public class MediaCaptureService {
                                                                 sendGalleryStatusUpdate();
                                                             }
                                                         });
-                                                if (ok
-                                                        && shouldWriteVideoThumbnail(
-                                                                uploadTarget, save)
-                                                        && !isCleaningUp.get()) {
-                                                    try {
-                                                        videoThumbnailExecutor.execute(
-                                                                () ->
-                                                                        VideoThumbnailWriter
-                                                                                .writeSidecar(
-                                                                                        new File(
-                                                                                                filePath)));
-                                                    } catch (RejectedExecutionException e) {
-                                                        Log.d(
-                                                                TAG,
-                                                                "Skipping video thumbnail during"
-                                                                        + " cleanup");
-                                                    }
-                                                }
                                             } catch (Throwable t) {
                                                 Log.e(
                                                         TAG,
@@ -4401,6 +4385,7 @@ public class MediaCaptureService {
 
                                     if (!save) {
                                         try {
+                                            awaitVideoThumbnail(videoFilePath);
                                             VideoThumbnailWriter.deleteSidecar(videoFile);
                                             if (videoFile.delete()) {
                                                 Log.d(
@@ -6807,6 +6792,50 @@ public class MediaCaptureService {
         }
     }
 
+    private void scheduleVideoThumbnail(String filePath) {
+        FutureTask<Void> task =
+                new FutureTask<Void>(
+                        () -> {
+                            VideoThumbnailWriter.writeSidecar(new File(filePath));
+                            return null;
+                        }) {
+                    @Override
+                    protected void done() {
+                        videoThumbnailTasks.remove(filePath, this);
+                    }
+                };
+        if (videoThumbnailTasks.putIfAbsent(filePath, task) != null) {
+            return;
+        }
+        try {
+            videoThumbnailExecutor.execute(task);
+        } catch (RejectedExecutionException e) {
+            videoThumbnailTasks.remove(filePath, task);
+            task.cancel(false);
+            Log.d(TAG, "Skipping video thumbnail during cleanup");
+        }
+    }
+
+    private void awaitVideoThumbnail(String filePath) {
+        Future<?> task = videoThumbnailTasks.get(filePath);
+        if (task == null) {
+            return;
+        }
+        try {
+            task.get(AsgConstants.VIDEO_THUMBNAIL_TASK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            task.cancel(true);
+            Log.w(TAG, "Timed out waiting for video thumbnail before deleting " + filePath);
+        } catch (InterruptedException e) {
+            task.cancel(true);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            Log.w(TAG, "Video thumbnail task failed for " + filePath, e.getCause());
+        } finally {
+            videoThumbnailTasks.remove(filePath, task);
+        }
+    }
+
     /**
      * Cleanup resources and stop all monitoring. MUST be called before service is destroyed to
      * prevent leaks.
@@ -6841,7 +6870,7 @@ public class MediaCaptureService {
                 videoIntegrityExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
-            videoThumbnailExecutor.shutdownNow();
+            videoThumbnailExecutor.shutdown();
             textModeProcessingExecutor.shutdown();
             try {
                 if (!textModeProcessingExecutor.awaitTermination(3, TimeUnit.SECONDS)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -6930,14 +6930,13 @@ public class MediaCaptureService {
                             .values()
                             .forEach(VideoThumbnailTask::cancelThumbnailWrite);
                     videoThumbnailExecutor.shutdownNow();
-                    if (!videoThumbnailExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
-                        Log.w(TAG, "Video thumbnail executor did not terminate during cleanup");
-                    }
                 }
             } catch (InterruptedException e) {
                 videoThumbnailTasks.values().forEach(VideoThumbnailTask::cancelThumbnailWrite);
                 videoThumbnailExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
+            } finally {
+                VideoThumbnailWriter.shutdownFrameExtraction();
             }
             videoThumbnailTasks.clear();
             textModeProcessingExecutor.shutdown();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -188,12 +188,12 @@ public class MediaCaptureService {
                 if (currentExecution != null) {
                     currentExecution.cancel(true);
                 }
-                try {
-                    return !videoFile.exists() || videoFile.delete();
-                } finally {
-                    // A failed video deletion must not let this task commit a late sidecar.
+                boolean deleted = !videoFile.exists() || videoFile.delete();
+                if (deleted) {
                     VideoThumbnailWriter.deleteSidecar(videoFile);
                 }
+                // Even if deletion fails, discarded prevents this task from committing late.
+                return deleted;
             }
         }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -183,17 +183,17 @@ public class MediaCaptureService {
 
         boolean discardAndDeleteVideo() {
             synchronized (commitLock) {
-                boolean deleted = !videoFile.exists() || videoFile.delete();
-                if (!deleted) {
-                    return false;
-                }
                 discarded = true;
                 Future<?> currentExecution = execution;
                 if (currentExecution != null) {
                     currentExecution.cancel(true);
                 }
-                VideoThumbnailWriter.deleteSidecar(videoFile);
-                return true;
+                try {
+                    return !videoFile.exists() || videoFile.delete();
+                } finally {
+                    // A failed video deletion must not let this task commit a late sidecar.
+                    VideoThumbnailWriter.deleteSidecar(videoFile);
+                }
             }
         }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -196,6 +196,16 @@ public class MediaCaptureService {
                 return true;
             }
         }
+
+        void cancelThumbnailWrite() {
+            synchronized (commitLock) {
+                discarded = true;
+                Future<?> currentExecution = execution;
+                if (currentExecution != null) {
+                    currentExecution.cancel(true);
+                }
+            }
+        }
     }
 
     // Guards the stop prologue (mCurrentStopReason + pending-upload target) so the
@@ -672,10 +682,12 @@ public class MediaCaptureService {
                     r -> {
                         Thread t = new Thread(r, "VideoThumbnailWriter");
                         t.setPriority(Thread.NORM_PRIORITY - 1);
+                        t.setDaemon(true);
                         return t;
                     });
     private final ConcurrentHashMap<String, VideoThumbnailTask> videoThumbnailTasks =
             new ConcurrentHashMap<>();
+    private final Object videoThumbnailLifecycleLock = new Object();
 
     /**
      * Keeps ML Kit and final-crop persistence off CameraNeo's shared callback executor. A single
@@ -6838,14 +6850,19 @@ public class MediaCaptureService {
     private void scheduleVideoThumbnail(String filePath) {
         String taskKey = new File(filePath).getAbsolutePath();
         VideoThumbnailTask task = new VideoThumbnailTask(taskKey);
-        if (videoThumbnailTasks.putIfAbsent(taskKey, task) != null) {
-            return;
-        }
-        try {
-            task.setExecution(videoThumbnailExecutor.submit(task));
-        } catch (RejectedExecutionException e) {
-            videoThumbnailTasks.remove(taskKey, task);
-            Log.d(TAG, "Skipping video thumbnail during cleanup");
+        synchronized (videoThumbnailLifecycleLock) {
+            if (isCleaningUp.get() || videoThumbnailExecutor.isShutdown()) {
+                return;
+            }
+            if (videoThumbnailTasks.putIfAbsent(taskKey, task) != null) {
+                return;
+            }
+            try {
+                task.setExecution(videoThumbnailExecutor.submit(task));
+            } catch (RejectedExecutionException e) {
+                videoThumbnailTasks.remove(taskKey, task);
+                Log.d(TAG, "Skipping video thumbnail during cleanup");
+            }
         }
     }
 
@@ -6888,6 +6905,12 @@ public class MediaCaptureService {
                 mBatteryMonitorHandler = null;
             }
 
+            // Close submission before waiting for integrity work. Existing thumbnail tasks drain
+            // in parallel with the integrity wait, keeping the final main-thread wait short.
+            synchronized (videoThumbnailLifecycleLock) {
+                videoThumbnailExecutor.shutdown();
+            }
+
             videoIntegrityExecutor.shutdown();
             try {
                 if (!videoIntegrityExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
@@ -6897,17 +6920,20 @@ public class MediaCaptureService {
                 videoIntegrityExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
-            videoThumbnailExecutor.shutdown();
             try {
                 if (!videoThumbnailExecutor.awaitTermination(
                         AsgConstants.VIDEO_THUMBNAIL_SHUTDOWN_TIMEOUT_MS,
                         TimeUnit.MILLISECONDS)) {
+                    videoThumbnailTasks
+                            .values()
+                            .forEach(VideoThumbnailTask::cancelThumbnailWrite);
                     videoThumbnailExecutor.shutdownNow();
                     if (!videoThumbnailExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
                         Log.w(TAG, "Video thumbnail executor did not terminate during cleanup");
                     }
                 }
             } catch (InterruptedException e) {
+                videoThumbnailTasks.values().forEach(VideoThumbnailTask::cancelThumbnailWrite);
                 videoThumbnailExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -265,7 +265,7 @@ public final class VideoThumbnailWriter {
 
     private static Bitmap frameAt(MediaMetadataRetriever retriever, long timeUs, int[] targetSize) {
         if (targetSize == null) {
-            return null;
+            targetSize = scaledTargetSize(0, 0);
         }
         return retriever.getScaledFrameAtTime(
                 timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetSize[0], targetSize[1]);
@@ -277,7 +277,7 @@ public final class VideoThumbnailWriter {
             dimensions = mediaTrackDimensions(videoFile);
         }
         if (dimensions == null) {
-            return null;
+            return scaledTargetSize(0, 0);
         }
         return scaledTargetSize(dimensions[0], dimensions[1]);
     }
@@ -324,7 +324,11 @@ public final class VideoThumbnailWriter {
 
     static int[] scaledTargetSize(int width, int height) {
         if (width <= 0 || height <= 0) {
-            return null;
+            // The platform preserves source aspect ratio while fitting inside this box.
+            return new int[] {
+                AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION,
+                AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION
+            };
         }
         int longestEdge = Math.max(width, height);
         float scale =

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -1,6 +1,8 @@
 package com.mentra.asg_client.io.media.utils;
 
 import android.graphics.Bitmap;
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
 import android.media.MediaMetadataRetriever;
 import android.util.Log;
 import com.mentra.asg_client.AsgConstants;
@@ -196,6 +198,7 @@ public final class VideoThumbnailWriter {
             future.cancel(true);
             extractor.cancel();
             recycleUnclaimed(unclaimedResult);
+            retireFrameExtractionExecutor(submission.executor);
             Thread.currentThread().interrupt();
             return null;
         } catch (ExecutionException e) {
@@ -214,7 +217,7 @@ public final class VideoThumbnailWriter {
             activeRetriever.set(retriever);
             try {
                 retriever.setDataSource(videoFile.getAbsolutePath());
-                int[] targetSize = scaledTargetSize(retriever);
+                int[] targetSize = scaledTargetSize(retriever, videoFile);
                 Bitmap frame =
                         frameAt(retriever, AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US, targetSize);
                 if (frame == null) {
@@ -255,13 +258,24 @@ public final class VideoThumbnailWriter {
 
     private static Bitmap frameAt(MediaMetadataRetriever retriever, long timeUs, int[] targetSize) {
         if (targetSize == null) {
-            return retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
+            return null;
         }
         return retriever.getScaledFrameAtTime(
                 timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetSize[0], targetSize[1]);
     }
 
-    private static int[] scaledTargetSize(MediaMetadataRetriever retriever) {
+    private static int[] scaledTargetSize(MediaMetadataRetriever retriever, File videoFile) {
+        int[] dimensions = retrieverDimensions(retriever);
+        if (dimensions == null) {
+            dimensions = mediaTrackDimensions(videoFile);
+        }
+        if (dimensions == null) {
+            return null;
+        }
+        return scaledTargetSize(dimensions[0], dimensions[1]);
+    }
+
+    private static int[] retrieverDimensions(MediaMetadataRetriever retriever) {
         try {
             int width =
                     Integer.parseInt(
@@ -271,18 +285,46 @@ public final class VideoThumbnailWriter {
                     Integer.parseInt(
                             retriever.extractMetadata(
                                     MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT));
-            int longestEdge = Math.max(width, height);
-            if (width <= 0 || height <= 0) {
-                return null;
-            }
-            float scale =
-                    Math.min(1f, (float) AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION / longestEdge);
-            return new int[] {
-                Math.max(1, Math.round(width * scale)), Math.max(1, Math.round(height * scale))
-            };
+            return width > 0 && height > 0 ? new int[] {width, height} : null;
         } catch (Exception ignored) {
             return null;
         }
+    }
+
+    private static int[] mediaTrackDimensions(File videoFile) {
+        MediaExtractor extractor = new MediaExtractor();
+        try {
+            extractor.setDataSource(videoFile.getAbsolutePath());
+            for (int index = 0; index < extractor.getTrackCount(); index++) {
+                MediaFormat format = extractor.getTrackFormat(index);
+                String mime = format.getString(MediaFormat.KEY_MIME);
+                if (mime != null
+                        && mime.startsWith("video/")
+                        && format.containsKey(MediaFormat.KEY_WIDTH)
+                        && format.containsKey(MediaFormat.KEY_HEIGHT)) {
+                    int width = format.getInteger(MediaFormat.KEY_WIDTH);
+                    int height = format.getInteger(MediaFormat.KEY_HEIGHT);
+                    return width > 0 && height > 0 ? new int[] {width, height} : null;
+                }
+            }
+            return null;
+        } catch (Exception ignored) {
+            return null;
+        } finally {
+            extractor.release();
+        }
+    }
+
+    static int[] scaledTargetSize(int width, int height) {
+        if (width <= 0 || height <= 0) {
+            return null;
+        }
+        int longestEdge = Math.max(width, height);
+        float scale =
+                Math.min(1f, (float) AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION / longestEdge);
+        return new int[] {
+            Math.max(1, Math.round(width * scale)), Math.max(1, Math.round(height * scale))
+        };
     }
 
     private static void recycleUnclaimed(AtomicReference<Bitmap> unclaimedResult) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -234,12 +234,7 @@ public final class VideoThumbnailWriter {
                 if (cancelled.get()) {
                     return null;
                 }
-                Bitmap frame =
-                        frameAt(retriever, AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US, targetSize);
-                if (frame == null) {
-                    frame = frameAt(retriever, 0L, targetSize);
-                }
-                return frame;
+                return frameWithFallback(timeUs -> frameAt(retriever, timeUs, targetSize));
             } catch (Exception e) {
                 Log.w(TAG, "Frame extraction failed for " + videoFile.getAbsolutePath(), e);
                 return null;
@@ -269,6 +264,18 @@ public final class VideoThumbnailWriter {
         }
         return retriever.getScaledFrameAtTime(
                 timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetSize[0], targetSize[1]);
+    }
+
+    static Bitmap frameWithFallback(FrameAtTime extractor) {
+        try {
+            Bitmap frame = extractor.extract(AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US);
+            if (frame != null) {
+                return frame;
+            }
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Could not extract preferred thumbnail frame; trying first frame", e);
+        }
+        return extractor.extract(0L);
     }
 
     private static int[] scaledTargetSize(MediaMetadataRetriever retriever, File videoFile) {
@@ -439,6 +446,11 @@ public final class VideoThumbnailWriter {
     interface BitmapEncoder {
         boolean compress(
                 Bitmap bitmap, Bitmap.CompressFormat format, int quality, FileOutputStream output);
+    }
+
+    @FunctionalInterface
+    interface FrameAtTime {
+        Bitmap extract(long timeUs);
     }
 
     private static final class ExtractionSubmission {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -12,6 +12,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Writes a {@code thumb.jpg} sidecar next to a finished video capture (e.g. {@code
@@ -28,6 +30,14 @@ import java.util.concurrent.TimeoutException;
  */
 public final class VideoThumbnailWriter {
     private static final String TAG = "VideoThumbnailWriter";
+    private static final ExecutorService FRAME_EXTRACTION_EXECUTOR =
+            Executors.newSingleThreadExecutor(
+                    runnable -> {
+                        Thread thread = new Thread(runnable, "VideoThumbnailDecode");
+                        thread.setPriority(Thread.NORM_PRIORITY - 1);
+                        thread.setDaemon(true);
+                        return thread;
+                    });
 
     private VideoThumbnailWriter() {}
 
@@ -122,24 +132,34 @@ public final class VideoThumbnailWriter {
     private static Bitmap extractFrame(File videoFile) {
         return extractFrameWithTimeout(
                 videoFile,
-                VideoThumbnailWriter::extractFrameDirect,
+                new MediaMetadataFrameExtractor(),
                 AsgConstants.VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS);
     }
 
     static Bitmap extractFrameWithTimeout(
             File videoFile, FrameExtractor extractor, long timeoutMs) {
-        ExecutorService executor =
-                Executors.newSingleThreadExecutor(
-                        runnable -> {
-                            Thread thread = new Thread(runnable, "VideoThumbnailDecode");
-                            thread.setPriority(Thread.NORM_PRIORITY - 1);
-                            return thread;
+        AtomicBoolean acceptResult = new AtomicBoolean(true);
+        AtomicReference<Bitmap> unclaimedResult = new AtomicReference<>();
+        Future<Bitmap> future =
+                FRAME_EXTRACTION_EXECUTOR.submit(
+                        () -> {
+                            Bitmap frame = extractor.extract(videoFile);
+                            unclaimedResult.set(frame);
+                            if (!acceptResult.get()) {
+                                recycleUnclaimed(unclaimedResult);
+                                return null;
+                            }
+                            return frame;
                         });
-        Future<Bitmap> future = executor.submit(() -> extractor.extract(videoFile));
         try {
-            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+            Bitmap frame = future.get(timeoutMs, TimeUnit.MILLISECONDS);
+            unclaimedResult.compareAndSet(frame, null);
+            return frame;
         } catch (TimeoutException e) {
+            acceptResult.set(false);
             future.cancel(true);
+            extractor.cancel();
+            recycleUnclaimed(unclaimedResult);
             Log.w(
                     TAG,
                     "Frame extraction timed out after "
@@ -148,35 +168,103 @@ public final class VideoThumbnailWriter {
                             + videoFile.getAbsolutePath());
             return null;
         } catch (InterruptedException e) {
+            acceptResult.set(false);
             future.cancel(true);
+            extractor.cancel();
+            recycleUnclaimed(unclaimedResult);
             Thread.currentThread().interrupt();
             return null;
         } catch (ExecutionException e) {
             Log.w(TAG, "Frame extraction failed for " + videoFile.getAbsolutePath(), e.getCause());
             return null;
-        } finally {
-            executor.shutdownNow();
         }
     }
 
-    private static Bitmap extractFrameDirect(File videoFile) {
-        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
-        try {
-            retriever.setDataSource(videoFile.getAbsolutePath());
-            Bitmap frame = retriever.getFrameAtTime(AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US);
-            if (frame == null) {
-                frame = retriever.getFrameAtTime();
+    private static final class MediaMetadataFrameExtractor implements FrameExtractor {
+        private final AtomicReference<MediaMetadataRetriever> activeRetriever =
+                new AtomicReference<>();
+
+        @Override
+        public Bitmap extract(File videoFile) {
+            MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+            activeRetriever.set(retriever);
+            try {
+                retriever.setDataSource(videoFile.getAbsolutePath());
+                int[] targetSize = scaledTargetSize(retriever);
+                Bitmap frame =
+                        frameAt(retriever, AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US, targetSize);
+                if (frame == null) {
+                    frame = frameAt(retriever, -1L, targetSize);
+                }
+                return frame;
+            } catch (Exception e) {
+                Log.w(TAG, "Frame extraction failed for " + videoFile.getAbsolutePath(), e);
+                return null;
+            } finally {
+                release(retriever);
             }
-            return frame;
-        } catch (Exception e) {
-            Log.w(TAG, "Frame extraction failed for " + videoFile.getAbsolutePath(), e);
-            return null;
-        } finally {
+        }
+
+        @Override
+        public void cancel() {
+            MediaMetadataRetriever retriever = activeRetriever.getAndSet(null);
+            releaseDirect(retriever);
+        }
+
+        private void release(MediaMetadataRetriever retriever) {
+            if (activeRetriever.compareAndSet(retriever, null)) {
+                releaseDirect(retriever);
+            }
+        }
+
+        private static void releaseDirect(MediaMetadataRetriever retriever) {
+            if (retriever == null) {
+                return;
+            }
             try {
                 retriever.release();
             } catch (Exception ignored) {
                 // best effort
             }
+        }
+    }
+
+    private static Bitmap frameAt(MediaMetadataRetriever retriever, long timeUs, int[] targetSize) {
+        if (targetSize == null) {
+            return null;
+        }
+        return retriever.getScaledFrameAtTime(
+                timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetSize[0], targetSize[1]);
+    }
+
+    private static int[] scaledTargetSize(MediaMetadataRetriever retriever) {
+        try {
+            int width =
+                    Integer.parseInt(
+                            retriever.extractMetadata(
+                                    MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH));
+            int height =
+                    Integer.parseInt(
+                            retriever.extractMetadata(
+                                    MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT));
+            int longestEdge = Math.max(width, height);
+            if (width <= 0 || height <= 0) {
+                return null;
+            }
+            float scale =
+                    Math.min(1f, (float) AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION / longestEdge);
+            return new int[] {
+                Math.max(1, Math.round(width * scale)), Math.max(1, Math.round(height * scale))
+            };
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static void recycleUnclaimed(AtomicReference<Bitmap> unclaimedResult) {
+        Bitmap frame = unclaimedResult.getAndSet(null);
+        if (frame != null) {
+            frame.recycle();
         }
     }
 
@@ -193,5 +281,7 @@ public final class VideoThumbnailWriter {
     @FunctionalInterface
     interface FrameExtractor {
         Bitmap extract(File videoFile);
+
+        default void cancel() {}
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -292,7 +292,11 @@ public final class VideoThumbnailWriter {
                     Integer.parseInt(
                             retriever.extractMetadata(
                                     MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT));
-            return width > 0 && height > 0 ? new int[] {width, height} : null;
+            int rotation =
+                    parseRotation(
+                            retriever.extractMetadata(
+                                    MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION));
+            return orientedDimensions(width, height, rotation);
         } catch (Exception ignored) {
             return null;
         }
@@ -311,7 +315,11 @@ public final class VideoThumbnailWriter {
                         && format.containsKey(MediaFormat.KEY_HEIGHT)) {
                     int width = format.getInteger(MediaFormat.KEY_WIDTH);
                     int height = format.getInteger(MediaFormat.KEY_HEIGHT);
-                    return width > 0 && height > 0 ? new int[] {width, height} : null;
+                    int rotation =
+                            format.containsKey(MediaFormat.KEY_ROTATION)
+                                    ? format.getInteger(MediaFormat.KEY_ROTATION)
+                                    : 0;
+                    return orientedDimensions(width, height, rotation);
                 }
             }
             return null;
@@ -320,6 +328,24 @@ public final class VideoThumbnailWriter {
         } finally {
             extractor.release();
         }
+    }
+
+    private static int parseRotation(String value) {
+        try {
+            return value == null ? 0 : Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+
+    static int[] orientedDimensions(int width, int height, int rotation) {
+        if (width <= 0 || height <= 0) {
+            return null;
+        }
+        int normalizedRotation = ((rotation % 360) + 360) % 360;
+        return normalizedRotation == 90 || normalizedRotation == 270
+                ? new int[] {height, width}
+                : new int[] {width, height};
     }
 
     static int[] scaledTargetSize(int width, int height) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class VideoThumbnailWriter {
     private static final String TAG = "VideoThumbnailWriter";
+    private static final BitmapEncoder JPEG_ENCODER =
+            (bitmap, format, quality, output) -> bitmap.compress(format, quality, output);
     private static final ExecutorService FRAME_EXTRACTION_EXECUTOR =
             Executors.newSingleThreadExecutor(
                     runnable -> {
@@ -69,6 +71,23 @@ public final class VideoThumbnailWriter {
      * @return the sidecar file on success, or null if extraction or writing failed
      */
     public static File writeSidecar(File videoFile) {
+        return writeSidecar(videoFile, File::renameTo);
+    }
+
+    /** Write a sidecar whose final rename is coordinated by {@code committer}. */
+    public static File writeSidecar(File videoFile, SidecarCommitter committer) {
+        return writeSidecar(videoFile, new MediaMetadataFrameExtractor(), committer);
+    }
+
+    static File writeSidecar(File videoFile, FrameExtractor extractor, SidecarCommitter committer) {
+        return writeSidecar(videoFile, extractor, committer, JPEG_ENCODER);
+    }
+
+    static File writeSidecar(
+            File videoFile,
+            FrameExtractor extractor,
+            SidecarCommitter committer,
+            BitmapEncoder encoder) {
         if (videoFile == null) {
             return null;
         }
@@ -82,7 +101,11 @@ public final class VideoThumbnailWriter {
             }
             sidecar = sidecarFor(videoFile);
             partial = partialFor(videoFile);
-            frame = extractFrame(videoFile);
+            frame =
+                    extractFrameWithTimeout(
+                            videoFile,
+                            extractor,
+                            AsgConstants.VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS);
             if (frame == null) {
                 Log.w(TAG, "No frame extracted for thumbnail: " + videoFile.getAbsolutePath());
                 return null;
@@ -101,14 +124,15 @@ public final class VideoThumbnailWriter {
                                     true)
                             : frame;
             try (FileOutputStream fos = new FileOutputStream(partial)) {
-                if (!scaled.compress(
+                if (!encoder.compress(
+                        scaled,
                         Bitmap.CompressFormat.JPEG,
                         AsgConstants.VIDEO_THUMBNAIL_JPEG_QUALITY,
                         fos)) {
                     return null;
                 }
             }
-            if (!partial.renameTo(sidecar)) {
+            if (!committer.commit(partial, sidecar)) {
                 Log.w(TAG, "Could not move thumbnail into place: " + sidecar.getAbsolutePath());
                 return null;
             }
@@ -127,13 +151,6 @@ public final class VideoThumbnailWriter {
                 Log.w(TAG, "Could not delete partial thumbnail: " + partial.getAbsolutePath());
             }
         }
-    }
-
-    private static Bitmap extractFrame(File videoFile) {
-        return extractFrameWithTimeout(
-                videoFile,
-                new MediaMetadataFrameExtractor(),
-                AsgConstants.VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS);
     }
 
     static Bitmap extractFrameWithTimeout(
@@ -231,7 +248,7 @@ public final class VideoThumbnailWriter {
 
     private static Bitmap frameAt(MediaMetadataRetriever retriever, long timeUs, int[] targetSize) {
         if (targetSize == null) {
-            return null;
+            return retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
         }
         return retriever.getScaledFrameAtTime(
                 timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetSize[0], targetSize[1]);
@@ -283,5 +300,17 @@ public final class VideoThumbnailWriter {
         Bitmap extract(File videoFile);
 
         default void cancel() {}
+    }
+
+    @FunctionalInterface
+    interface BitmapEncoder {
+        boolean compress(
+                Bitmap bitmap, Bitmap.CompressFormat format, int quality, FileOutputStream output);
+    }
+
+    /** Coordinates the atomic partial-to-final sidecar commit with capture lifecycle changes. */
+    @FunctionalInterface
+    public interface SidecarCommitter {
+        boolean commit(File partial, File sidecar);
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -3,9 +3,15 @@ package com.mentra.asg_client.io.media.utils;
 import android.graphics.Bitmap;
 import android.media.MediaMetadataRetriever;
 import android.util.Log;
-
+import com.mentra.asg_client.AsgConstants;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Writes a {@code thumb.jpg} sidecar next to a finished video capture (e.g. {@code
@@ -23,22 +29,26 @@ import java.io.FileOutputStream;
 public final class VideoThumbnailWriter {
     private static final String TAG = "VideoThumbnailWriter";
 
-    /** Sidecar filename inside a capture folder. */
-    public static final String SIDECAR_NAME = "thumb.jpg";
-
-    /** Longest edge of the generated thumbnail, in pixels. Aspect ratio is preserved. */
-    static final int MAX_DIMENSION = 480;
-
-    static final int JPEG_QUALITY = 80;
-
-    /** Frame to sample, in microseconds (1 second in, falling back to the first frame). */
-    private static final long FRAME_TIME_US = 1_000_000L;
-
     private VideoThumbnailWriter() {}
 
     /** The sidecar file a given video would get, whether or not it exists yet. */
     public static File sidecarFor(File videoFile) {
-        return new File(videoFile.getParentFile(), SIDECAR_NAME);
+        return new File(videoFile.getParentFile(), AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
+    }
+
+    private static File partialFor(File videoFile) {
+        return new File(videoFile.getParentFile(), AsgConstants.VIDEO_THUMBNAIL_PARTIAL_NAME);
+    }
+
+    /**
+     * Remove thumbnail artifacts when the owning video is intentionally discarded. Never throws.
+     */
+    public static void deleteSidecar(File videoFile) {
+        if (videoFile == null) {
+            return;
+        }
+        deleteBestEffort(sidecarFor(videoFile));
+        deleteBestEffort(partialFor(videoFile));
     }
 
     /**
@@ -49,14 +59,19 @@ public final class VideoThumbnailWriter {
      * @return the sidecar file on success, or null if extraction or writing failed
      */
     public static File writeSidecar(File videoFile) {
-        if (videoFile == null || !videoFile.isFile()) {
+        if (videoFile == null) {
             return null;
         }
-        File sidecar = sidecarFor(videoFile);
-        File tmp = new File(sidecar.getParentFile(), SIDECAR_NAME + ".tmp");
+        File sidecar = null;
+        File partial = null;
         Bitmap frame = null;
         Bitmap scaled = null;
         try {
+            if (!videoFile.isFile()) {
+                return null;
+            }
+            sidecar = sidecarFor(videoFile);
+            partial = partialFor(videoFile);
             frame = extractFrame(videoFile);
             if (frame == null) {
                 Log.w(TAG, "No frame extracted for thumbnail: " + videoFile.getAbsolutePath());
@@ -65,7 +80,8 @@ public final class VideoThumbnailWriter {
             float scale =
                     Math.min(
                             1f,
-                            (float) MAX_DIMENSION / Math.max(frame.getWidth(), frame.getHeight()));
+                            (float) AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION
+                                    / Math.max(frame.getWidth(), frame.getHeight()));
             scaled =
                     scale < 1f
                             ? Bitmap.createScaledBitmap(
@@ -74,12 +90,15 @@ public final class VideoThumbnailWriter {
                                     Math.round(frame.getHeight() * scale),
                                     true)
                             : frame;
-            try (FileOutputStream fos = new FileOutputStream(tmp)) {
-                if (!scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, fos)) {
+            try (FileOutputStream fos = new FileOutputStream(partial)) {
+                if (!scaled.compress(
+                        Bitmap.CompressFormat.JPEG,
+                        AsgConstants.VIDEO_THUMBNAIL_JPEG_QUALITY,
+                        fos)) {
                     return null;
                 }
             }
-            if (!tmp.renameTo(sidecar)) {
+            if (!partial.renameTo(sidecar)) {
                 Log.w(TAG, "Could not move thumbnail into place: " + sidecar.getAbsolutePath());
                 return null;
             }
@@ -94,17 +113,57 @@ public final class VideoThumbnailWriter {
             if (frame != null) {
                 frame.recycle();
             }
-            if (tmp.exists() && !tmp.delete()) {
-                Log.w(TAG, "Could not delete temp thumbnail: " + tmp.getAbsolutePath());
+            if (partial != null && partial.exists() && !partial.delete()) {
+                Log.w(TAG, "Could not delete partial thumbnail: " + partial.getAbsolutePath());
             }
         }
     }
 
     private static Bitmap extractFrame(File videoFile) {
+        return extractFrameWithTimeout(
+                videoFile,
+                VideoThumbnailWriter::extractFrameDirect,
+                AsgConstants.VIDEO_THUMBNAIL_EXTRACTION_TIMEOUT_MS);
+    }
+
+    static Bitmap extractFrameWithTimeout(
+            File videoFile, FrameExtractor extractor, long timeoutMs) {
+        ExecutorService executor =
+                Executors.newSingleThreadExecutor(
+                        runnable -> {
+                            Thread thread = new Thread(runnable, "VideoThumbnailDecode");
+                            thread.setPriority(Thread.NORM_PRIORITY - 1);
+                            return thread;
+                        });
+        Future<Bitmap> future = executor.submit(() -> extractor.extract(videoFile));
+        try {
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            Log.w(
+                    TAG,
+                    "Frame extraction timed out after "
+                            + timeoutMs
+                            + "ms for "
+                            + videoFile.getAbsolutePath());
+            return null;
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (ExecutionException e) {
+            Log.w(TAG, "Frame extraction failed for " + videoFile.getAbsolutePath(), e.getCause());
+            return null;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Bitmap extractFrameDirect(File videoFile) {
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();
         try {
             retriever.setDataSource(videoFile.getAbsolutePath());
-            Bitmap frame = retriever.getFrameAtTime(FRAME_TIME_US);
+            Bitmap frame = retriever.getFrameAtTime(AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US);
             if (frame == null) {
                 frame = retriever.getFrameAtTime();
             }
@@ -119,5 +178,20 @@ public final class VideoThumbnailWriter {
                 // best effort
             }
         }
+    }
+
+    private static void deleteBestEffort(File file) {
+        try {
+            if (file.exists() && !file.delete()) {
+                Log.w(TAG, "Could not delete thumbnail artifact: " + file.getAbsolutePath());
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Could not delete thumbnail artifact: " + file.getAbsolutePath(), e);
+        }
+    }
+
+    @FunctionalInterface
+    interface FrameExtractor {
+        Bitmap extract(File videoFile);
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -208,16 +208,23 @@ public final class VideoThumbnailWriter {
     }
 
     private static final class MediaMetadataFrameExtractor implements FrameExtractor {
-        private final AtomicReference<MediaMetadataRetriever> activeRetriever =
-                new AtomicReference<>();
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
         @Override
         public Bitmap extract(File videoFile) {
+            if (cancelled.get()) {
+                return null;
+            }
             MediaMetadataRetriever retriever = new MediaMetadataRetriever();
-            activeRetriever.set(retriever);
             try {
+                if (cancelled.get()) {
+                    return null;
+                }
                 retriever.setDataSource(videoFile.getAbsolutePath());
                 int[] targetSize = scaledTargetSize(retriever, videoFile);
+                if (cancelled.get()) {
+                    return null;
+                }
                 Bitmap frame =
                         frameAt(retriever, AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US, targetSize);
                 if (frame == null) {
@@ -234,20 +241,11 @@ public final class VideoThumbnailWriter {
 
         @Override
         public void cancel() {
-            MediaMetadataRetriever retriever = activeRetriever.getAndSet(null);
-            releaseDirect(retriever);
+            // MediaMetadataRetriever is not thread-safe; its decode thread releases it in finally.
+            cancelled.set(true);
         }
 
-        private void release(MediaMetadataRetriever retriever) {
-            if (activeRetriever.compareAndSet(retriever, null)) {
-                releaseDirect(retriever);
-            }
-        }
-
-        private static void releaseDirect(MediaMetadataRetriever retriever) {
-            if (retriever == null) {
-                return;
-            }
+        private static void release(MediaMetadataRetriever retriever) {
             try {
                 retriever.release();
             } catch (Exception ignored) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -6,10 +6,14 @@ import android.util.Log;
 import com.mentra.asg_client.AsgConstants;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,14 +36,9 @@ public final class VideoThumbnailWriter {
     private static final String TAG = "VideoThumbnailWriter";
     private static final BitmapEncoder JPEG_ENCODER =
             (bitmap, format, quality, output) -> bitmap.compress(format, quality, output);
-    private static final ExecutorService FRAME_EXTRACTION_EXECUTOR =
-            Executors.newSingleThreadExecutor(
-                    runnable -> {
-                        Thread thread = new Thread(runnable, "VideoThumbnailDecode");
-                        thread.setPriority(Thread.NORM_PRIORITY - 1);
-                        thread.setDaemon(true);
-                        return thread;
-                    });
+    private static final Object FRAME_EXECUTOR_LOCK = new Object();
+    private static final Set<ExecutorService> RETIRED_FRAME_EXECUTORS = new HashSet<>();
+    private static ExecutorService frameExtractionExecutor = newFrameExtractionExecutor();
 
     private VideoThumbnailWriter() {}
 
@@ -157,17 +156,24 @@ public final class VideoThumbnailWriter {
             File videoFile, FrameExtractor extractor, long timeoutMs) {
         AtomicBoolean acceptResult = new AtomicBoolean(true);
         AtomicReference<Bitmap> unclaimedResult = new AtomicReference<>();
-        Future<Bitmap> future =
-                FRAME_EXTRACTION_EXECUTOR.submit(
-                        () -> {
-                            Bitmap frame = extractor.extract(videoFile);
-                            unclaimedResult.set(frame);
-                            if (!acceptResult.get()) {
-                                recycleUnclaimed(unclaimedResult);
-                                return null;
-                            }
-                            return frame;
-                        });
+        ExtractionSubmission submission;
+        try {
+            submission =
+                    submitFrameExtraction(
+                            () -> {
+                                Bitmap frame = extractor.extract(videoFile);
+                                unclaimedResult.set(frame);
+                                if (!acceptResult.get()) {
+                                    recycleUnclaimed(unclaimedResult);
+                                    return null;
+                                }
+                                return frame;
+                            });
+        } catch (RejectedExecutionException e) {
+            Log.w(TAG, "No bounded frame decoder is available for " + videoFile.getAbsolutePath());
+            return null;
+        }
+        Future<Bitmap> future = submission.future;
         try {
             Bitmap frame = future.get(timeoutMs, TimeUnit.MILLISECONDS);
             unclaimedResult.compareAndSet(frame, null);
@@ -177,6 +183,7 @@ public final class VideoThumbnailWriter {
             future.cancel(true);
             extractor.cancel();
             recycleUnclaimed(unclaimedResult);
+            retireFrameExtractionExecutor(submission.executor);
             Log.w(
                     TAG,
                     "Frame extraction timed out after "
@@ -211,7 +218,7 @@ public final class VideoThumbnailWriter {
                 Bitmap frame =
                         frameAt(retriever, AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US, targetSize);
                 if (frame == null) {
-                    frame = frameAt(retriever, -1L, targetSize);
+                    frame = frameAt(retriever, 0L, targetSize);
                 }
                 return frame;
             } catch (Exception e) {
@@ -285,6 +292,53 @@ public final class VideoThumbnailWriter {
         }
     }
 
+    private static ExecutorService newFrameExtractionExecutor() {
+        return Executors.newSingleThreadExecutor(
+                runnable -> {
+                    Thread thread = new Thread(runnable, "VideoThumbnailDecode");
+                    thread.setPriority(Thread.NORM_PRIORITY - 1);
+                    thread.setDaemon(true);
+                    return thread;
+                });
+    }
+
+    private static ExtractionSubmission submitFrameExtraction(Callable<Bitmap> extraction) {
+        synchronized (FRAME_EXECUTOR_LOCK) {
+            RETIRED_FRAME_EXECUTORS.removeIf(ExecutorService::isTerminated);
+            if (frameExtractionExecutor.isShutdown()) {
+                if (!frameExtractionExecutor.isTerminated()) {
+                    if (RETIRED_FRAME_EXECUTORS.size()
+                            >= AsgConstants.VIDEO_THUMBNAIL_MAX_RETIRED_DECODERS) {
+                        throw new RejectedExecutionException(
+                                "Bounded video decoder workers are still hung");
+                    }
+                    RETIRED_FRAME_EXECUTORS.add(frameExtractionExecutor);
+                }
+                frameExtractionExecutor = newFrameExtractionExecutor();
+            }
+            return new ExtractionSubmission(
+                    frameExtractionExecutor, frameExtractionExecutor.submit(extraction));
+        }
+    }
+
+    private static void retireFrameExtractionExecutor(ExecutorService timedOutExecutor) {
+        synchronized (FRAME_EXECUTOR_LOCK) {
+            timedOutExecutor.shutdownNow();
+            RETIRED_FRAME_EXECUTORS.removeIf(ExecutorService::isTerminated);
+            if (timedOutExecutor != frameExtractionExecutor) {
+                return;
+            }
+            if (!timedOutExecutor.isTerminated()) {
+                if (RETIRED_FRAME_EXECUTORS.size()
+                        >= AsgConstants.VIDEO_THUMBNAIL_MAX_RETIRED_DECODERS) {
+                    return;
+                }
+                RETIRED_FRAME_EXECUTORS.add(timedOutExecutor);
+            }
+            frameExtractionExecutor = newFrameExtractionExecutor();
+        }
+    }
+
     private static void deleteBestEffort(File file) {
         try {
             if (file.exists() && !file.delete()) {
@@ -306,6 +360,16 @@ public final class VideoThumbnailWriter {
     interface BitmapEncoder {
         boolean compress(
                 Bitmap bitmap, Bitmap.CompressFormat format, int quality, FileOutputStream output);
+    }
+
+    private static final class ExtractionSubmission {
+        final ExecutorService executor;
+        final Future<Bitmap> future;
+
+        ExtractionSubmission(ExecutorService executor, Future<Bitmap> future) {
+            this.executor = executor;
+            this.future = future;
+        }
     }
 
     /** Coordinates the atomic partial-to-final sidecar commit with capture lifecycle changes. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -64,6 +64,15 @@ public final class VideoThumbnailWriter {
         deleteBestEffort(partialFor(videoFile));
     }
 
+    /** Release the idle decoder worker during service teardown; later use restarts it lazily. */
+    public static void shutdownFrameExtraction() {
+        ExecutorService executor;
+        synchronized (FRAME_EXECUTOR_LOCK) {
+            executor = frameExtractionExecutor;
+        }
+        retireFrameExtractionExecutor(executor);
+    }
+
     /**
      * Extract a frame from {@code videoFile} and write it as {@code thumb.jpg} in the same folder.
      * The write is atomic (temp file + rename) so readers never observe a half-written thumbnail.

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriter.java
@@ -1,0 +1,123 @@
+package com.mentra.asg_client.io.media.utils;
+
+import android.graphics.Bitmap;
+import android.media.MediaMetadataRetriever;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * Writes a {@code thumb.jpg} sidecar next to a finished video capture (e.g. {@code
+ * VID_xxx/base.mp4} → {@code VID_xxx/thumb.jpg}) so consumers that read capture folders directly
+ * (USB/WebUSB transfer, desktop tools) get a preview without decoding the full video.
+ *
+ * <p>This is distinct from {@link com.mentra.asg_client.io.file.managers.ThumbnailManager}, which
+ * maintains an on-demand, content-hashed thumbnail cache for the Wi-Fi camera server. The sidecar
+ * is written eagerly, once, at capture-finalize time, and lives (and dies) with its capture folder.
+ *
+ * <p>Static and side-effect free beyond the sidecar file itself, following the {@code
+ * VideoRecordingSession.deleteCorruptCapture} pattern so the path/guard logic is unit-testable
+ * without camera plumbing.
+ */
+public final class VideoThumbnailWriter {
+    private static final String TAG = "VideoThumbnailWriter";
+
+    /** Sidecar filename inside a capture folder. */
+    public static final String SIDECAR_NAME = "thumb.jpg";
+
+    /** Longest edge of the generated thumbnail, in pixels. Aspect ratio is preserved. */
+    static final int MAX_DIMENSION = 480;
+
+    static final int JPEG_QUALITY = 80;
+
+    /** Frame to sample, in microseconds (1 second in, falling back to the first frame). */
+    private static final long FRAME_TIME_US = 1_000_000L;
+
+    private VideoThumbnailWriter() {}
+
+    /** The sidecar file a given video would get, whether or not it exists yet. */
+    public static File sidecarFor(File videoFile) {
+        return new File(videoFile.getParentFile(), SIDECAR_NAME);
+    }
+
+    /**
+     * Extract a frame from {@code videoFile} and write it as {@code thumb.jpg} in the same folder.
+     * The write is atomic (temp file + rename) so readers never observe a half-written thumbnail.
+     * Never throws.
+     *
+     * @return the sidecar file on success, or null if extraction or writing failed
+     */
+    public static File writeSidecar(File videoFile) {
+        if (videoFile == null || !videoFile.isFile()) {
+            return null;
+        }
+        File sidecar = sidecarFor(videoFile);
+        File tmp = new File(sidecar.getParentFile(), SIDECAR_NAME + ".tmp");
+        Bitmap frame = null;
+        Bitmap scaled = null;
+        try {
+            frame = extractFrame(videoFile);
+            if (frame == null) {
+                Log.w(TAG, "No frame extracted for thumbnail: " + videoFile.getAbsolutePath());
+                return null;
+            }
+            float scale =
+                    Math.min(
+                            1f,
+                            (float) MAX_DIMENSION / Math.max(frame.getWidth(), frame.getHeight()));
+            scaled =
+                    scale < 1f
+                            ? Bitmap.createScaledBitmap(
+                                    frame,
+                                    Math.round(frame.getWidth() * scale),
+                                    Math.round(frame.getHeight() * scale),
+                                    true)
+                            : frame;
+            try (FileOutputStream fos = new FileOutputStream(tmp)) {
+                if (!scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, fos)) {
+                    return null;
+                }
+            }
+            if (!tmp.renameTo(sidecar)) {
+                Log.w(TAG, "Could not move thumbnail into place: " + sidecar.getAbsolutePath());
+                return null;
+            }
+            return sidecar;
+        } catch (Exception | OutOfMemoryError e) {
+            Log.w(TAG, "Thumbnail generation failed for " + videoFile.getAbsolutePath(), e);
+            return null;
+        } finally {
+            if (scaled != null && scaled != frame) {
+                scaled.recycle();
+            }
+            if (frame != null) {
+                frame.recycle();
+            }
+            if (tmp.exists() && !tmp.delete()) {
+                Log.w(TAG, "Could not delete temp thumbnail: " + tmp.getAbsolutePath());
+            }
+        }
+    }
+
+    private static Bitmap extractFrame(File videoFile) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        try {
+            retriever.setDataSource(videoFile.getAbsolutePath());
+            Bitmap frame = retriever.getFrameAtTime(FRAME_TIME_US);
+            if (frame == null) {
+                frame = retriever.getFrameAtTime();
+            }
+            return frame;
+        } catch (Exception e) {
+            Log.w(TAG, "Frame extraction failed for " + videoFile.getAbsolutePath(), e);
+            return null;
+        } finally {
+            try {
+                retriever.release();
+            } catch (Exception ignored) {
+                // best effort
+            }
+        }
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
@@ -74,7 +74,8 @@ public class FileManagerCleanupTest {
     @Test
     public void listingHidesOnlyVideoCaptureThumbnailSidecars() throws Exception {
         File video = write("VID_video/base.mp4");
-        write("VID_video/" + AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
+        File sidecar = write("VID_video/" + AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
+        File mixedCaseSidecar = write("VID_video/THUMB.JPG");
         File regularThumb = write("documents/" + AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
 
         List<FileMetadata> files = fileManager.listFiles(fileManager.getDefaultPackageName());
@@ -88,13 +89,13 @@ public class FileManagerCleanupTest {
                                 file -> file.getFilePath().equals(regularThumb.getAbsolutePath())));
         assertFalse(
                 files.stream()
+                        .anyMatch(file -> file.getFilePath().equals(sidecar.getAbsolutePath())));
+        assertFalse(
+                files.stream()
                         .anyMatch(
                                 file ->
-                                        file.getFileName()
-                                                .equals(
-                                                        "VID_video/"
-                                                                + AsgConstants
-                                                                        .VIDEO_THUMBNAIL_SIDECAR_NAME)));
+                                        file.getFilePath()
+                                                .equals(mixedCaseSidecar.getAbsolutePath())));
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
@@ -105,7 +105,6 @@ public class FileManagerCleanupTest {
             File capture =
                     new File(orphanBase, "com.mentra.asg_client.camera/VID_orphaned_thumbnail");
             assertTrue(capture.mkdirs());
-            write(new File(capture, "base.mp4"));
             write(new File(capture, AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME));
 
             new FileManagerImpl(orphanBase, mock(Logger.class));

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
@@ -5,11 +5,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.io.file.core.FileManager.FileMetadata;
 import com.mentra.asg_client.logging.Logger;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,9 +71,57 @@ public class FileManagerCleanupTest {
         assertTrue(metadata.isFile());
     }
 
+    @Test
+    public void listingHidesOnlyVideoCaptureThumbnailSidecars() throws Exception {
+        File video = write("VID_video/base.mp4");
+        write("VID_video/" + AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
+        File regularThumb = write("documents/" + AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME);
+
+        List<FileMetadata> files = fileManager.listFiles(fileManager.getDefaultPackageName());
+
+        assertTrue(
+                files.stream()
+                        .anyMatch(file -> file.getFilePath().equals(video.getAbsolutePath())));
+        assertTrue(
+                files.stream()
+                        .anyMatch(
+                                file -> file.getFilePath().equals(regularThumb.getAbsolutePath())));
+        assertFalse(
+                files.stream()
+                        .anyMatch(
+                                file ->
+                                        file.getFileName()
+                                                .equals(
+                                                        "VID_video/"
+                                                                + AsgConstants
+                                                                        .VIDEO_THUMBNAIL_SIDECAR_NAME)));
+    }
+
+    @Test
+    public void startupCleanupDoesNotTreatVideoThumbnailAsPrimaryMedia() throws Exception {
+        File orphanBase = Files.createTempDirectory("file-manager-orphan-test").toFile();
+        try {
+            File capture =
+                    new File(orphanBase, "com.mentra.asg_client.camera/VID_orphaned_thumbnail");
+            assertTrue(capture.mkdirs());
+            write(new File(capture, "base.mp4"));
+            write(new File(capture, AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME));
+
+            new FileManagerImpl(orphanBase, mock(Logger.class));
+
+            assertFalse(capture.exists());
+        } finally {
+            deleteRecursively(orphanBase);
+        }
+    }
+
     private File write(String relativePath) throws Exception {
         File file = new File(packageDirectory, relativePath);
         assertTrue(file.getParentFile().mkdirs() || file.getParentFile().isDirectory());
+        return write(file);
+    }
+
+    private static File write(File file) throws Exception {
         try (FileOutputStream output = new FileOutputStream(file)) {
             output.write("data".getBytes(StandardCharsets.UTF_8));
         }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -2,16 +2,16 @@ package com.mentra.asg_client.io.media.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.mentra.asg_client.AsgConstants;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
@@ -44,7 +44,7 @@ public class VideoThumbnailWriterTest {
     @Test
     public void writeSidecar_undecodableVideo_returnsNullAndLeavesNoTempFile() throws IOException {
         // Robolectric's MediaMetadataRetriever shadow returns no frames, which also models a
-        // corrupt/undecodable mp4: generation must fail cleanly with no thumb.jpg and no .tmp.
+        // corrupt/undecodable mp4: generation must fail cleanly with no sidecar or .partial file.
         File captureDir = temporaryFolder.newFolder("VID_20260731_120000_123_456");
         File video = new File(captureDir, "base.mp4");
         try (FileOutputStream fos = new FileOutputStream(video)) {
@@ -60,5 +60,49 @@ public class VideoThumbnailWriterTest {
     @Test
     public void writeSidecar_nullVideo_returnsNull() {
         assertThat(VideoThumbnailWriter.writeSidecar(null)).isNull();
+    }
+
+    @Test
+    public void deleteSidecar_removesFinalAndPartialArtifactsButKeepsVideo() throws IOException {
+        File captureDir = temporaryFolder.newFolder("VID_20260731_120000_123_456");
+        File video = write(new File(captureDir, "base.mp4"));
+        File sidecar = write(new File(captureDir, AsgConstants.VIDEO_THUMBNAIL_SIDECAR_NAME));
+        File partial = write(new File(captureDir, AsgConstants.VIDEO_THUMBNAIL_PARTIAL_NAME));
+
+        VideoThumbnailWriter.deleteSidecar(video);
+
+        assertThat(video).exists();
+        assertThat(sidecar).doesNotExist();
+        assertThat(partial).doesNotExist();
+    }
+
+    @Test
+    public void extractFrameWithTimeout_stalledDecoderReturnsPromptly() throws IOException {
+        File video = new File(temporaryFolder.newFolder("VID_timeout"), "base.mp4");
+        long startedAt = System.nanoTime();
+
+        assertThat(
+                        VideoThumbnailWriter.extractFrameWithTimeout(
+                                video,
+                                ignored -> {
+                                    try {
+                                        Thread.sleep(5_000);
+                                    } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                    }
+                                    return null;
+                                },
+                                10))
+                .isNull();
+
+        long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
+        assertThat(elapsedMs).isLessThan(1_000L);
+    }
+
+    private static File write(File file) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(new byte[] {0, 1, 2, 3});
+        }
+        return file;
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -26,6 +27,11 @@ import org.robolectric.annotation.Config;
 public class VideoThumbnailWriterTest {
 
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @After
+    public void releaseDecoderWorker() {
+        VideoThumbnailWriter.shutdownFrameExtraction();
+    }
 
     @Test
     public void sidecarFor_isThumbJpgInCaptureFolder() throws IOException {
@@ -254,6 +260,19 @@ public class VideoThumbnailWriterTest {
             releaseDecoder.countDown();
             timeoutCaller.join(1_000);
         }
+    }
+
+    @Test
+    public void shutdownFrameExtraction_nextUseRestartsDecoderLazily() throws IOException {
+        File video = new File(temporaryFolder.newFolder("VID_restart"), "base.mp4");
+        VideoThumbnailWriter.shutdownFrameExtraction();
+        Bitmap frame = Bitmap.createBitmap(8, 8, Bitmap.Config.ARGB_8888);
+
+        Bitmap extracted =
+                VideoThumbnailWriter.extractFrameWithTimeout(video, ignored -> frame, 1_000);
+
+        assertThat(extracted).isSameAs(frame);
+        extracted.recycle();
     }
 
     private static File write(File file) throws IOException {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -2,10 +2,12 @@ package com.mentra.asg_client.io.media.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import android.graphics.Bitmap;
 import com.mentra.asg_client.AsgConstants;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -79,24 +81,34 @@ public class VideoThumbnailWriterTest {
     @Test
     public void extractFrameWithTimeout_stalledDecoderReturnsPromptly() throws IOException {
         File video = new File(temporaryFolder.newFolder("VID_timeout"), "base.mp4");
+        AtomicBoolean cancelCalled = new AtomicBoolean(false);
         long startedAt = System.nanoTime();
 
         assertThat(
                         VideoThumbnailWriter.extractFrameWithTimeout(
                                 video,
-                                ignored -> {
-                                    try {
-                                        Thread.sleep(5_000);
-                                    } catch (InterruptedException e) {
-                                        Thread.currentThread().interrupt();
+                                new VideoThumbnailWriter.FrameExtractor() {
+                                    @Override
+                                    public Bitmap extract(File ignored) {
+                                        try {
+                                            Thread.sleep(5_000);
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                        return null;
                                     }
-                                    return null;
+
+                                    @Override
+                                    public void cancel() {
+                                        cancelCalled.set(true);
+                                    }
                                 },
                                 10))
                 .isNull();
 
         long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
         assertThat(elapsedMs).isLessThan(1_000L);
+        assertThat(cancelCalled).isTrue();
     }
 
     private static File write(File file) throws IOException {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -118,6 +118,27 @@ public class VideoThumbnailWriterTest {
     }
 
     @Test
+    public void frameWithFallback_preferredSeekThrows_triesFirstFrame() {
+        AtomicInteger calls = new AtomicInteger();
+        Bitmap firstFrame = Bitmap.createBitmap(8, 8, Bitmap.Config.ARGB_8888);
+
+        Bitmap extracted =
+                VideoThumbnailWriter.frameWithFallback(
+                        timeUs -> {
+                            calls.incrementAndGet();
+                            if (timeUs == AsgConstants.VIDEO_THUMBNAIL_FRAME_TIME_US) {
+                                throw new IllegalArgumentException("preferred seek unavailable");
+                            }
+                            assertThat(timeUs).isZero();
+                            return firstFrame;
+                        });
+
+        assertThat(extracted).isSameAs(firstFrame);
+        assertThat(calls).hasValue(2);
+        extracted.recycle();
+    }
+
+    @Test
     public void writeSidecar_validFrame_scalesCompressesAndCommitsAtomically() throws IOException {
         File captureDir = temporaryFolder.newFolder("VID_success");
         File video = write(new File(captureDir, "base.mp4"));

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -9,6 +9,8 @@ import com.mentra.asg_client.AsgConstants;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -187,6 +189,54 @@ public class VideoThumbnailWriterTest {
         long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
         assertThat(elapsedMs).isLessThan(1_000L);
         assertThat(cancelCalled).isTrue();
+    }
+
+    @Test
+    public void extractFrameWithTimeout_hungDecoderDoesNotBlockNextVideo() throws Exception {
+        File hungVideo = new File(temporaryFolder.newFolder("VID_hung"), "base.mp4");
+        File nextVideo = new File(temporaryFolder.newFolder("VID_next"), "base.mp4");
+        CountDownLatch decoderStarted = new CountDownLatch(1);
+        CountDownLatch releaseDecoder = new CountDownLatch(1);
+        AtomicReference<Bitmap> firstResult = new AtomicReference<>();
+        Thread timeoutCaller =
+                new Thread(
+                        () ->
+                                firstResult.set(
+                                        VideoThumbnailWriter.extractFrameWithTimeout(
+                                                hungVideo,
+                                                ignored -> {
+                                                    decoderStarted.countDown();
+                                                    while (releaseDecoder.getCount() > 0) {
+                                                        try {
+                                                            releaseDecoder.await();
+                                                        } catch (InterruptedException ignored2) {
+                                                            // Model a native decode that ignores
+                                                            // interruption.
+                                                        }
+                                                    }
+                                                    return null;
+                                                },
+                                                50)),
+                        "ThumbnailTimeoutTest");
+
+        try {
+            timeoutCaller.start();
+            assertThat(decoderStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            timeoutCaller.join(1_000);
+            assertThat(timeoutCaller.isAlive()).isFalse();
+            assertThat(firstResult.get()).isNull();
+
+            Bitmap nextFrame = Bitmap.createBitmap(16, 16, Bitmap.Config.ARGB_8888);
+            Bitmap extracted =
+                    VideoThumbnailWriter.extractFrameWithTimeout(
+                            nextVideo, ignored -> nextFrame, 1_000);
+
+            assertThat(extracted).isSameAs(nextFrame);
+            extracted.recycle();
+        } finally {
+            releaseDecoder.countDown();
+            timeoutCaller.join(1_000);
+        }
     }
 
     private static File write(File file) throws IOException {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -3,11 +3,15 @@ package com.mentra.asg_client.io.media.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import com.mentra.asg_client.AsgConstants;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -62,6 +66,80 @@ public class VideoThumbnailWriterTest {
     @Test
     public void writeSidecar_nullVideo_returnsNull() {
         assertThat(VideoThumbnailWriter.writeSidecar(null)).isNull();
+    }
+
+    @Test
+    public void writeSidecar_validFrame_scalesCompressesAndCommitsAtomically() throws IOException {
+        File captureDir = temporaryFolder.newFolder("VID_success");
+        File video = write(new File(captureDir, "base.mp4"));
+        Bitmap source = Bitmap.createBitmap(960, 480, Bitmap.Config.ARGB_8888);
+        source.eraseColor(Color.BLUE);
+        AtomicReference<Bitmap.CompressFormat> format = new AtomicReference<>();
+        AtomicInteger quality = new AtomicInteger();
+
+        File result =
+                VideoThumbnailWriter.writeSidecar(
+                        video,
+                        ignored -> source,
+                        File::renameTo,
+                        (bitmap, requestedFormat, requestedQuality, output) -> {
+                            format.set(requestedFormat);
+                            quality.set(requestedQuality);
+                            return bitmap.compress(requestedFormat, requestedQuality, output);
+                        });
+
+        assertThat(result).isEqualTo(VideoThumbnailWriter.sidecarFor(video)).exists();
+        assertThat(new File(captureDir, AsgConstants.VIDEO_THUMBNAIL_PARTIAL_NAME)).doesNotExist();
+        assertThat(format.get()).isEqualTo(Bitmap.CompressFormat.JPEG);
+        assertThat(quality.get()).isEqualTo(AsgConstants.VIDEO_THUMBNAIL_JPEG_QUALITY);
+        Bitmap decoded = BitmapFactory.decodeFile(result.getAbsolutePath());
+        assertThat(decoded.getWidth()).isEqualTo(AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION);
+        assertThat(decoded.getHeight()).isEqualTo(240);
+        decoded.recycle();
+        assertThat(source.isRecycled()).isTrue();
+    }
+
+    @Test
+    public void writeSidecar_compressionFailure_removesPartialAndDoesNotCommit()
+            throws IOException {
+        File captureDir = temporaryFolder.newFolder("VID_compress_failure");
+        File video = write(new File(captureDir, "base.mp4"));
+        Bitmap source = Bitmap.createBitmap(100, 50, Bitmap.Config.ARGB_8888);
+        AtomicBoolean commitCalled = new AtomicBoolean(false);
+
+        File result =
+                VideoThumbnailWriter.writeSidecar(
+                        video,
+                        ignored -> source,
+                        (partial, sidecar) -> {
+                            commitCalled.set(true);
+                            return partial.renameTo(sidecar);
+                        },
+                        (bitmap, format, quality, output) -> false);
+
+        assertThat(result).isNull();
+        assertThat(commitCalled).isFalse();
+        assertThat(captureDir.listFiles()).containsExactly(video);
+        assertThat(source.isRecycled()).isTrue();
+    }
+
+    @Test
+    public void writeSidecar_commitFailure_removesPartialAndReturnsNull() throws IOException {
+        File captureDir = temporaryFolder.newFolder("VID_commit_failure");
+        File video = write(new File(captureDir, "base.mp4"));
+        Bitmap source = Bitmap.createBitmap(100, 50, Bitmap.Config.ARGB_8888);
+
+        File result =
+                VideoThumbnailWriter.writeSidecar(
+                        video,
+                        ignored -> source,
+                        (partial, sidecar) -> false,
+                        (bitmap, format, quality, output) ->
+                                bitmap.compress(format, quality, output));
+
+        assertThat(result).isNull();
+        assertThat(captureDir.listFiles()).containsExactly(video);
+        assertThat(source.isRecycled()).isTrue();
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -1,0 +1,64 @@
+package com.mentra.asg_client.io.media.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class VideoThumbnailWriterTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void sidecarFor_isThumbJpgInCaptureFolder() throws IOException {
+        File captureDir = temporaryFolder.newFolder("VID_20260731_120000_123_456");
+        File video = new File(captureDir, "base.mp4");
+
+        File sidecar = VideoThumbnailWriter.sidecarFor(video);
+
+        assertThat(sidecar.getParentFile()).isEqualTo(captureDir);
+        assertThat(sidecar.getName()).isEqualTo("thumb.jpg");
+    }
+
+    @Test
+    public void writeSidecar_missingVideo_returnsNullAndWritesNothing() throws IOException {
+        File captureDir = temporaryFolder.newFolder("VID_20260731_120000_123_456");
+        File video = new File(captureDir, "base.mp4");
+
+        File result = VideoThumbnailWriter.writeSidecar(video);
+
+        assertThat(result).isNull();
+        assertThat(captureDir.listFiles()).isEmpty();
+    }
+
+    @Test
+    public void writeSidecar_undecodableVideo_returnsNullAndLeavesNoTempFile() throws IOException {
+        // Robolectric's MediaMetadataRetriever shadow returns no frames, which also models a
+        // corrupt/undecodable mp4: generation must fail cleanly with no thumb.jpg and no .tmp.
+        File captureDir = temporaryFolder.newFolder("VID_20260731_120000_123_456");
+        File video = new File(captureDir, "base.mp4");
+        try (FileOutputStream fos = new FileOutputStream(video)) {
+            fos.write(new byte[] {0, 1, 2, 3});
+        }
+
+        File result = VideoThumbnailWriter.writeSidecar(video);
+
+        assertThat(result).isNull();
+        assertThat(captureDir.listFiles()).containsExactly(video);
+    }
+
+    @Test
+    public void writeSidecar_nullVideo_returnsNull() {
+        assertThat(VideoThumbnailWriter.writeSidecar(null)).isNull();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -100,6 +100,24 @@ public class VideoThumbnailWriterTest {
     }
 
     @Test
+    public void orientedDimensions_quarterTurnsSwapCodedDimensions() {
+        assertThat(VideoThumbnailWriter.orientedDimensions(1920, 1080, 90))
+                .containsExactly(1080, 1920);
+        assertThat(VideoThumbnailWriter.orientedDimensions(1920, 1080, 270))
+                .containsExactly(1080, 1920);
+        assertThat(VideoThumbnailWriter.orientedDimensions(1920, 1080, -90))
+                .containsExactly(1080, 1920);
+    }
+
+    @Test
+    public void orientedDimensions_halfTurnsKeepCodedDimensions() {
+        assertThat(VideoThumbnailWriter.orientedDimensions(1920, 1080, 0))
+                .containsExactly(1920, 1080);
+        assertThat(VideoThumbnailWriter.orientedDimensions(1920, 1080, 180))
+                .containsExactly(1920, 1080);
+    }
+
+    @Test
     public void writeSidecar_validFrame_scalesCompressesAndCommitsAtomically() throws IOException {
         File captureDir = temporaryFolder.newFolder("VID_success");
         File video = write(new File(captureDir, "base.mp4"));

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -88,9 +88,15 @@ public class VideoThumbnailWriterTest {
     }
 
     @Test
-    public void scaledTargetSize_invalidDimensionsReturnsNull() {
-        assertThat(VideoThumbnailWriter.scaledTargetSize(0, 240)).isNull();
-        assertThat(VideoThumbnailWriter.scaledTargetSize(320, -1)).isNull();
+    public void scaledTargetSize_invalidDimensionsUsesBoundedFallback() {
+        assertThat(VideoThumbnailWriter.scaledTargetSize(0, 240))
+                .containsExactly(
+                        AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION,
+                        AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION);
+        assertThat(VideoThumbnailWriter.scaledTargetSize(320, -1))
+                .containsExactly(
+                        AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION,
+                        AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION);
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/utils/VideoThumbnailWriterTest.java
@@ -71,6 +71,23 @@ public class VideoThumbnailWriterTest {
     }
 
     @Test
+    public void scaledTargetSize_largeFrameBoundsLongestEdgeAndPreservesAspectRatio() {
+        assertThat(VideoThumbnailWriter.scaledTargetSize(3840, 2160))
+                .containsExactly(AsgConstants.VIDEO_THUMBNAIL_MAX_DIMENSION, 270);
+    }
+
+    @Test
+    public void scaledTargetSize_smallFrameKeepsOriginalDimensions() {
+        assertThat(VideoThumbnailWriter.scaledTargetSize(320, 240)).containsExactly(320, 240);
+    }
+
+    @Test
+    public void scaledTargetSize_invalidDimensionsReturnsNull() {
+        assertThat(VideoThumbnailWriter.scaledTargetSize(0, 240)).isNull();
+        assertThat(VideoThumbnailWriter.scaledTargetSize(320, -1)).isNull();
+    }
+
+    @Test
     public void writeSidecar_validFrame_scalesCompressesAndCommitsAtomically() throws IOException {
         File captureDir = temporaryFolder.newFolder("VID_success");
         File video = write(new File(captureDir, "base.mp4"));


### PR DESCRIPTION
## Scope

Mentra Live video captures get an eagerly-written `thumb.jpg` sidecar inside the capture folder (next to `base.mp4`) once the recording passes the post-stop integrity check. This gives consumers that read capture folders directly — the upcoming USB/WebUSB media-transfer website (OS-1874) and desktop tools — instant video previews without pulling or decoding the full mp4. Glasses on older firmware simply won't have sidecars; the web tool falls back to a video icon.

- **`VideoThumbnailWriter`** (new, `io/media/utils`): static helper following the `VideoRecordingSession.deleteCorruptCapture` testable-helper pattern. Extracts a frame via `MediaMetadataRetriever` (1s in, falling back to first frame), scales to max 480px preserving aspect ratio, writes JPEG q80 atomically (tmp + rename), never throws.
- **`MediaCaptureService`**: writes the sidecar on the existing `videoIntegrityExecutor` background thread, only when `RecordedVideoIntegrityChecker.verify()` succeeds — corrupt/failed recordings never get one.
- **`FileManagerImpl.collectFilesRecursively`**: excludes `thumb.jpg` from listings (same treatment as `.partial`), so the Wi-Fi gallery server, phone sync, and gallery counts are completely unaffected. The Wi-Fi gallery keeps using its existing hashed `ThumbnailManager` cache. Capture-level trash/delete already removes the whole folder, sidecar included.

## Test evidence

- `:app:testDebugUnitTest --tests "*VideoThumbnailWriterTest*"` — passes (sidecar path, missing video, undecodable video leaves no temp file, null input).
- `:app:testDebugUnitTest --tests "*FileManager*" --tests "*GalleryTrash*" --tests "*GallerySync*"` — passes (no regressions from the listing exclusion).
- Debug variant compiles as part of the test runs.
- Not yet run on hardware; thumbnail rendering path (`MediaMetadataRetriever` frame decode) needs a device pass since Robolectric can't decode frames.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-capture video lifecycle, background decoders, and file listing/cleanup; failures are mostly best-effort but races around delete-vs-commit need careful review on device.
> 
> **Overview**
> Adds **`thumb.jpg`** sidecars next to finalized videos so USB/WebUSB and desktop tools can show previews without decoding **`base.mp4`**.
> 
> **`VideoThumbnailWriter`** (new) extracts a frame (~1s, fallback to first), scales to ≤480px, writes JPEG atomically via **`thumb.jpg.partial`**, with bounded decode timeouts and hung-worker retirement. **`AsgConstants`** centralizes thumbnail tuning.
> 
> **`MediaCaptureService`** schedules thumbnail work on a dedicated executor only after **`RecordedVideoIntegrityChecker`** passes; webhook uploads with **`save=false`** cancel in-flight work and remove video + sidecar so late commits cannot land. Service **`cleanup()`** drains thumbnail work and shuts down frame extraction.
> 
> **`FileManagerImpl`** omits **`thumb.jpg`** from **`VID_*`** listings and startup orphan cleanup so Wi‑Fi gallery/sync still treat **`base.mp4`** as the primary file. Unit tests cover the writer and file-manager behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77eef6814089ac97e82907b28ce0b2c0748ea05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `thumb.jpg` sidecar to verified video captures for instant previews in USB/WebUSB and desktop tools without decoding `base.mp4`. Extraction is bounded (10s), rotation‑aware with metadata and seek fallbacks; cleanup safely cancels thumbnail tasks and releases the decoder; Wi‑Fi gallery/sync unchanged; supports OS‑1874.

- **New Features**
  - `VideoThumbnailWriter`: extracts a frame at ~1s (fallback to first), honors rotation, scales to ≤480px, writes JPEG q80 atomically (tmp + rename), 10s timeout with cancellation; retires hung decoder workers (max 2) with thread‑confined teardown; uses metadata or `MediaExtractor` track dimensions when needed; `sidecarFor()` / `deleteSidecar()` / `shutdownFrameExtraction()`; never throws.
  - `MediaCaptureService`: after `RecordedVideoIntegrityChecker.verify()` passes, schedules work on a dedicated `videoThumbnailExecutor`; tracks tasks; webhook‑only uploads with `save=false` cancel in‑flight work, attempt video deletion, and remove the sidecar only if the deletion succeeds; if deletion fails the thumbnail is preserved and late sidecar commits are blocked.
  - `FileManagerImpl`: hides `thumb.jpg` only inside `VID_*` capture folders (case‑insensitive) in the default package; startup cleanup does not treat it as primary media so thumbnail‑only folders aren’t kept.

<sup>Written for commit b77eef6814089ac97e82907b28ce0b2c0748ea05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

