### PR TITLE
Add DX automation toolkit for miniapps and glasses

### DIFF
--- a/.agents/skills/ci-triage/SKILL.md
+++ b/.agents/skills/ci-triage/SKILL.md
@@ -2,9 +2,8 @@
 name: ci-triage
 description: >-
   Triage failing GitHub PR checks: list failures with gh, fetch capped Actions
-  logs, skip non-Actions checks, and summarize root cause via the
-  ci-investigator subagent. Use when the user pastes CI failures, asks why a PR
-  is red, mentions failing checks, or says /ci.
+  logs, skip non-Actions checks, and summarize root cause. Use when the user
+  pastes CI failures, asks why a PR is red, mentions failing checks, or says /ci.
 ---
 
 # CI failure triage
@@ -57,9 +56,9 @@ gh run view <runId> --log-failed | tail -c 20000
 
 Always pipe through `tail -c 20000` (~20KB). Never feed the unbounded stream into context.
 
-### 6. Root-cause via `ci-investigator` subagent
+### 6. Root-cause analysis
 
-`ci-investigator` is a **built-in Task subagent type** (not a file under `~/.cursor/agents`). Invoke:
+Prefer the built-in Task subagent when available:
 
 ```
 Task(
@@ -69,13 +68,13 @@ Task(
 )
 ```
 
-Do **not** search the filesystem for a `ci-investigator` agent definition.
+If `ci-investigator` is not available in this agent runtime, analyze the capped log excerpt yourself (or use any local agent definition under `~/.cursor/agents/` / `.cursor/agents/` if present). Do not stall the triage on a missing subagent type.
 
 ### 7. Reply format
 
 One aggregated report:
 
-1. **Actions root causes** — short summaries from ci-investigator (per run/check).
+1. **Actions root causes** — short summaries (per run/check).
 2. **Non-Actions failures** — name, state, link only (open in browser).
 3. No raw log pastes.
 

--- a/.agents/skills/ci-triage/SKILL.md
+++ b/.agents/skills/ci-triage/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ci-triage
+description: >-
+  Triage failing GitHub PR checks: list failures with gh, fetch capped Actions
+  logs, skip non-Actions checks, and summarize root cause via the
+  ci-investigator subagent. Use when the user pastes CI failures, asks why a PR
+  is red, mentions failing checks, or says /ci.
+---
+
+# CI failure triage
+
+## Never paste multi-thousand-line logs into chat
+
+Summarize root causes. Cap every log fetch.
+
+## Protocol
+
+### 1. Resolve PR number
+
+- Explicit arg from the user (e.g. `/ci 523` or "PR 3502"), **or**
+- `gh pr view --json number -q .number` on the current branch.
+
+### 2. List failing checks
+
+```bash
+gh pr checks <n> --json name,link,workflow,bucket,state
+```
+
+Filter to entries where `bucket == "fail"`.
+
+**Field name is `workflow`, not `workflowName`.**
+
+### 3. Classify each failure
+
+For each failing check, test `link` against:
+
+```
+/\/actions\/runs\/(\d+)/
+```
+
+| Match | Meaning | Next step |
+|---|---|---|
+| Yes | GitHub Actions run | Extract `runId`, go to step 4 |
+| No | External check (Cloudflare Pages, Vercel, Bugbot, etc.) | **Do not** call `gh run view`. Carry forward as name + link + state only |
+
+### 4. Dedupe Actions runs
+
+Multiple failing jobs can share one `runId`. Deduplicate by `runId` before fetching logs.
+
+### 5. Fetch bounded logs (max 3 runs)
+
+For each unique `runId`, **stop after the first 3 distinct runs**. Extra runs: list by check name only, with a note that more failures exist.
+
+```bash
+gh run view <runId> --log-failed | tail -c 20000
+```
+
+Always pipe through `tail -c 20000` (~20KB). Never feed the unbounded stream into context.
+
+### 6. Root-cause via `ci-investigator` subagent
+
+`ci-investigator` is a **built-in Task subagent type** (not a file under `~/.cursor/agents`). Invoke:
+
+```
+Task(
+  subagent_type: "ci-investigator",
+  description: "Investigate PR <n> check <name>",
+  prompt: "<PR number, repo, run id, failing check name, and the capped log excerpt>"
+)
+```
+
+Do **not** search the filesystem for a `ci-investigator` agent definition.
+
+### 7. Reply format
+
+One aggregated report:
+
+1. **Actions root causes** — short summaries from ci-investigator (per run/check).
+2. **Non-Actions failures** — name, state, link only (open in browser).
+3. No raw log pastes.
+
+If nothing failed, say so and stop.

--- a/.agents/skills/sync-miniapp/SKILL.md
+++ b/.agents/skills/sync-miniapp/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sync-miniapp
+description: >-
+  Prepare an external Mentra miniapp for bundling into mobile/assets/miniapps
+  (version bump, pack, zip install, regenerate bundledMiniapps). Use when the
+  user asks to sync a miniapp, bundle livestreamer/notes/etc into the Mentra
+  App, or update mobile/assets/miniapps from an external miniapp repo. Never
+  commits or pushes.
+---
+
+# Sync miniapp (prepare only — no git commits)
+
+## Command
+
+From the MentraOS repo root:
+
+```bash
+bun scripts/sync-miniapp.mjs <name> [--bump patch|minor|major] [--no-bump] [--dry-run]
+# or
+bun scripts/sync-miniapp.mjs --repo /path/to/external-miniapp [--bump patch] [--dry-run]
+```
+
+Named repos live in [scripts/miniapp-repos.json](../../../scripts/miniapp-repos.json).
+
+## What it does
+
+1. Reads `miniapp.json` (packageName + version are canonical).
+2. Bumps strict `MAJOR.MINOR.PATCH` (rejects prerelease/build unless `--no-bump`).
+3. Runs the external repo's `bun run pack` (or vendored `mentra-miniapp pack`).
+4. Verifies the zip's embedded `miniapp.json`.
+5. Copies into `mobile/assets/miniapps/`, prunes older same-package zips.
+6. Regenerates `mobile/src/generated/bundledMiniapps.ts`.
+
+## Critical: no commits
+
+This skill **must not** run `git add`, `git commit`, or `git push` in either the external miniapp repo or MentraOS.
+
+After a successful run, tell the user:
+
+> No commits made. Remaining manual steps: commit+push in `<repoPath>`, then commit the MentraOS changes.
+
+## Agent workflow
+
+1. Prefer `--dry-run` first if the user wants a preview.
+2. Run the script; do not reimplement pack/copy by hand.
+3. Report old → new version and destination zip path.
+4. Never commit unless the user explicitly asks in a separate request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Consult module-specific AGENTS.md when working within that module.
 
 ## Project Structure & Module Organization
 
-Core client app lives in `mobile/` (Expo React Native). Backend services and the TypeScript SDK sit in `cloud/packages/`, while the Developer Console and Store front ends live in `cloud/websites/`; cloud integration tests are in `cloud/tests/`. Platform SDKs are in `android_core/`, `android_library/`, `sdk_ios/`; hardware tooling lives in `mcu_client/`. Public Mintlify docs live in `mintlify-docs/`; notes and plans live in `agents/` and `notes/`.
+Core client app lives in `mobile/` (Expo React Native). Backend services and the TypeScript SDK sit in `cloud/packages/`, while the Developer Console and Store front ends live in `cloud/websites/`; cloud integration tests are in `cloud/tests/`. Platform SDKs are in `android_core/`, `android_library/`, `sdk_ios/`; hardware tooling lives in `mcu_client/`. Public Mintlify docs live in `mintlify-docs/`; notes and plans live in `agents/` and `notes/` — see [`notes/README.md`](notes/README.md) for the specs/plans convention.
 
 ## Build Commands
 
@@ -214,5 +214,5 @@ Note: the **mentra-console** MCP server (`cloud/packages/console-mcp`, tools `in
 ## Additional Documentation
 
 - Mintlify docs: `/mintlify-docs/`
-- Architecture specs, design docs, and working notes: `/notes/`
+- Architecture specs, design docs, and working notes: `/notes/` (convention: [`notes/README.md`](notes/README.md))
 - Module-specific implementation details: See module-specific `AGENTS.md` files

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -103,6 +103,9 @@ pnpm-lock.yaml
 .model-cache/
 scripts/stress-test/runs/
 
+# Device photos from pull-glasses-photos.sh (default OUTPUT_DIR)
+Camera_comparison/
+
 # Local secret backups — never commit
 *.mapbox-bak
 .env.*-bak

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -39,6 +39,8 @@
     "release-android": "zx ./scripts/release-android.mjs",
     "release-ios": "zx ./scripts/release-ios.mjs",
     "generate-bundled-miniapps": "zx ./scripts/generate-bundled-miniapps.mjs",
+    "pull:glasses-photos": "bash ./scripts/pull-glasses-photos.sh",
+    "wipe:glasses-photos": "bash ./scripts/wipe-glasses-photos.sh",
     "compile": "tsc --noEmit -p . --pretty",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/mobile/scripts/pull-glasses-photos.sh
+++ b/mobile/scripts/pull-glasses-photos.sh
@@ -28,8 +28,9 @@ resolve_media_roots
 
 mkdir -p "$OUTPUT_DIR"
 if [[ "$CLEAN" -eq 1 ]]; then
-  find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.jpg' -delete 2>/dev/null || true
-  echo "Cleaned existing JPGs in $OUTPUT_DIR"
+  # Match the same extensions/case variants the pull search can write.
+  find "$OUTPUT_DIR" -maxdepth 1 -type f \( -iname '*.jpg' -o -iname '*.jpeg' \) -delete 2>/dev/null || true
+  echo "Cleaned existing JPG/JPEG files in $OUTPUT_DIR"
 fi
 
 # Prefer earlier roots (asg_media) over later legacy roots on name collision.
@@ -41,8 +42,8 @@ copy_photo() {
     echo "Skip (already present): $(basename "$dest")"
     return 1
   fi
+  # Propagate cp status — callers use `if copy_photo`, so set -e won't abort here.
   cp "$src" "$dest"
-  return 0
 }
 
 TOTAL=0

--- a/mobile/scripts/pull-glasses-photos.sh
+++ b/mobile/scripts/pull-glasses-photos.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pull photos from Mentra Live glasses (current asg_media + legacy app-files paths).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../scripts/lib/glasses-device.sh
+source "${SCRIPT_DIR}/../../scripts/lib/glasses-device.sh"
+
+CLEAN=0
+for arg in "$@"; do
+  case "$arg" in
+    --clean) CLEAN=1 ;;
+    -h|--help)
+      echo "Usage: $0 [--clean]"
+      echo "  ADB_SERIAL=…  device serial (default ${DEFAULT_GLASSES_SERIAL})"
+      echo "  OUTPUT_DIR=… host folder (default mobile/Camera_comparison/new_focus)"
+      exit 0
+      ;;
+  esac
+done
+
+MOBILE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-${MOBILE_ROOT}/Camera_comparison/new_focus}"
+
+resolve_serial
+resolve_package
+resolve_media_roots
+
+mkdir -p "$OUTPUT_DIR"
+if [[ "$CLEAN" -eq 1 ]]; then
+  find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.jpg' -delete 2>/dev/null || true
+  echo "Cleaned existing JPGs in $OUTPUT_DIR"
+fi
+
+TOTAL=0
+for ROOT in "${MEDIA_ROOTS[@]}"; do
+  ROOT_COUNT=0
+  # Exists on device?
+  if ! adb -s "$SERIAL" shell "test -d '$ROOT'" 2>/dev/null; then
+    echo "Skip (missing on device): $ROOT"
+    continue
+  fi
+
+  TMP="$(mktemp -d)"
+  # Pull IMG_* dirs and flat files; tolerate empty
+  adb -s "$SERIAL" pull "$ROOT" "$TMP/root" 2>/dev/null || true
+
+  # Flatten: any **/IMG_*/base.jpg → {capture_id}.jpg
+  while IFS= read -r -d '' base; do
+    capture_id="$(basename "$(dirname "$base")")"
+    dest="${OUTPUT_DIR}/${capture_id}.jpg"
+    cp "$base" "$dest"
+    ROOT_COUNT=$((ROOT_COUNT + 1))
+    TOTAL=$((TOTAL + 1))
+  done < <(find "$TMP/root" -type f -path '*/IMG_*/base.jpg' -print0 2>/dev/null || true)
+
+  # Also flatten loose base.jpg under camera package dirs without exact path
+  while IFS= read -r -d '' base; do
+    # skip if already counted under IMG_*
+    if [[ "$base" == *"/IMG_"*"/base.jpg" ]]; then
+      continue
+    fi
+  done < <(true)
+
+  rm -rf "$TMP"
+  echo "Pulled $ROOT_COUNT photo(s) from $ROOT"
+done
+
+echo "Total: $TOTAL photo(s) → $OUTPUT_DIR"

--- a/mobile/scripts/pull-glasses-photos.sh
+++ b/mobile/scripts/pull-glasses-photos.sh
@@ -12,7 +12,7 @@ for arg in "$@"; do
     --clean) CLEAN=1 ;;
     -h|--help)
       echo "Usage: $0 [--clean]"
-      echo "  ADB_SERIAL=…  device serial (default ${DEFAULT_GLASSES_SERIAL})"
+      echo "  ADB_SERIAL=…  optional; if unset, requires exactly one connected device"
       echo "  OUTPUT_DIR=… host folder (default mobile/Camera_comparison/new_focus)"
       exit 0
       ;;
@@ -35,26 +35,24 @@ fi
 TOTAL=0
 for ROOT in "${MEDIA_ROOTS[@]}"; do
   ROOT_COUNT=0
-  # Exists on device?
-  if ! adb -s "$SERIAL" shell "test -d '$ROOT'" 2>/dev/null; then
+  if ! adb -s "$SERIAL" shell "test -d '$ROOT'"; then
     echo "Skip (missing on device): $ROOT"
     continue
   fi
 
   TMP="$(mktemp -d)"
-  # Pull IMG_* dirs and flat files; tolerate empty
-  adb -s "$SERIAL" pull "$ROOT" "$TMP/root" 2>/dev/null || true
+  # Fail on transport errors; empty directories still pull successfully.
+  if ! adb -s "$SERIAL" pull "$ROOT" "$TMP/root"; then
+    rm -rf "$TMP"
+    echo "Error: adb pull failed for $ROOT" >&2
+    exit 1
+  fi
 
   # Flatten capture packages: **/IMG_*/base.jpg → {capture_id}.jpg
-  # Also pick up any other base.jpg not already under IMG_* (legacy layouts).
+  # Also pick up any other base.jpg (legacy layouts).
   while IFS= read -r -d '' base; do
     parent="$(basename "$(dirname "$base")")"
-    if [[ "$parent" == IMG_* ]]; then
-      capture_id="$parent"
-    else
-      # Non-package path: derive a stable name from the parent dir.
-      capture_id="${parent}"
-    fi
+    capture_id="$parent"
     dest="${OUTPUT_DIR}/${capture_id}.jpg"
     cp "$base" "$dest"
     ROOT_COUNT=$((ROOT_COUNT + 1))

--- a/mobile/scripts/pull-glasses-photos.sh
+++ b/mobile/scripts/pull-glasses-photos.sh
@@ -45,22 +45,21 @@ for ROOT in "${MEDIA_ROOTS[@]}"; do
   # Pull IMG_* dirs and flat files; tolerate empty
   adb -s "$SERIAL" pull "$ROOT" "$TMP/root" 2>/dev/null || true
 
-  # Flatten: any **/IMG_*/base.jpg → {capture_id}.jpg
+  # Flatten capture packages: **/IMG_*/base.jpg → {capture_id}.jpg
+  # Also pick up any other base.jpg not already under IMG_* (legacy layouts).
   while IFS= read -r -d '' base; do
-    capture_id="$(basename "$(dirname "$base")")"
+    parent="$(basename "$(dirname "$base")")"
+    if [[ "$parent" == IMG_* ]]; then
+      capture_id="$parent"
+    else
+      # Non-package path: derive a stable name from the parent dir.
+      capture_id="${parent}"
+    fi
     dest="${OUTPUT_DIR}/${capture_id}.jpg"
     cp "$base" "$dest"
     ROOT_COUNT=$((ROOT_COUNT + 1))
     TOTAL=$((TOTAL + 1))
-  done < <(find "$TMP/root" -type f -path '*/IMG_*/base.jpg' -print0 2>/dev/null || true)
-
-  # Also flatten loose base.jpg under camera package dirs without exact path
-  while IFS= read -r -d '' base; do
-    # skip if already counted under IMG_*
-    if [[ "$base" == *"/IMG_"*"/base.jpg" ]]; then
-      continue
-    fi
-  done < <(true)
+  done < <(find "$TMP/root" -type f -name 'base.jpg' -print0 2>/dev/null || true)
 
   rm -rf "$TMP"
   echo "Pulled $ROOT_COUNT photo(s) from $ROOT"

--- a/mobile/scripts/pull-glasses-photos.sh
+++ b/mobile/scripts/pull-glasses-photos.sh
@@ -32,6 +32,19 @@ if [[ "$CLEAN" -eq 1 ]]; then
   echo "Cleaned existing JPGs in $OUTPUT_DIR"
 fi
 
+# Prefer earlier roots (asg_media) over later legacy roots on name collision.
+# Also avoids clobbering when two trees share the same parent basename.
+copy_photo() {
+  local src="$1"
+  local dest="$2"
+  if [[ -e "$dest" ]]; then
+    echo "Skip (already present): $(basename "$dest")"
+    return 1
+  fi
+  cp "$src" "$dest"
+  return 0
+}
+
 TOTAL=0
 for ROOT in "${MEDIA_ROOTS[@]}"; do
   ROOT_COUNT=0
@@ -51,13 +64,24 @@ for ROOT in "${MEDIA_ROOTS[@]}"; do
   # Flatten capture packages: **/IMG_*/base.jpg → {capture_id}.jpg
   # Also pick up any other base.jpg (legacy layouts).
   while IFS= read -r -d '' base; do
-    parent="$(basename "$(dirname "$base")")"
-    capture_id="$parent"
+    capture_id="$(basename "$(dirname "$base")")"
     dest="${OUTPUT_DIR}/${capture_id}.jpg"
-    cp "$base" "$dest"
-    ROOT_COUNT=$((ROOT_COUNT + 1))
-    TOTAL=$((TOTAL + 1))
+    if copy_photo "$base" "$dest"; then
+      ROOT_COUNT=$((ROOT_COUNT + 1))
+      TOTAL=$((TOTAL + 1))
+    fi
   done < <(find "$TMP/root" -type f -name 'base.jpg' -print0 2>/dev/null || true)
+
+  # Loose flat captures (IMG_*.jpg) that are not package base.jpg files.
+  while IFS= read -r -d '' jpg; do
+    dest="${OUTPUT_DIR}/$(basename "$jpg")"
+    if copy_photo "$jpg" "$dest"; then
+      ROOT_COUNT=$((ROOT_COUNT + 1))
+      TOTAL=$((TOTAL + 1))
+    fi
+  done < <(
+    find "$TMP/root" -type f \( -iname 'IMG_*.jpg' -o -iname 'IMG_*.jpeg' \) -print0 2>/dev/null || true
+  )
 
   rm -rf "$TMP"
   echo "Pulled $ROOT_COUNT photo(s) from $ROOT"

--- a/mobile/scripts/wipe-glasses-photos.sh
+++ b/mobile/scripts/wipe-glasses-photos.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Wipe Mentra Live media (asg_media + legacy). Default is dry-run; pass --yes to delete.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../scripts/lib/glasses-device.sh
+source "${SCRIPT_DIR}/../../scripts/lib/glasses-device.sh"
+
+DO_YES=0
+DO_DRY=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes) DO_YES=1 ;;
+    --dry-run) DO_DRY=1 ;;
+    -h|--help)
+      echo "Usage: $0 [--dry-run] [--yes]"
+      echo "  Default mode is dry-run (list only). Pass --yes to actually delete."
+      echo "  ADB_SERIAL=…  device serial (default ${DEFAULT_GLASSES_SERIAL})"
+      exit 0
+      ;;
+  esac
+done
+
+# Default is dry-run unless --yes
+DRY_RUN=1
+if [[ "$DO_YES" -eq 1 ]]; then
+  DRY_RUN=0
+fi
+# Explicit --dry-run always wins over accidental --yes together
+if [[ "$DO_DRY" -eq 1 ]]; then
+  DRY_RUN=1
+fi
+
+resolve_serial
+resolve_package
+resolve_media_roots
+
+count_matches() {
+  local root="$1"
+  adb -s "$SERIAL" shell "
+    root='$root'
+    pkg='$PACKAGE'
+    n=0
+    if [ ! -d \"\$root\" ]; then echo 0; exit 0; fi
+    # capture folders
+    for d in \"\$root\"/\${pkg}.camera/IMG_* \"\$root\"/\${pkg}.camera/VID_* \"\$root\"/\${pkg}.camera/BUFFER_* \\
+             \"\$root\"/IMG_* \"\$root\"/VID_*; do
+      [ -e \"\$d\" ] || continue
+      n=\$((n+1))
+    done
+    for d in photos videos audio temp thumbnails photo_queue; do
+      if [ -d \"\$root/\$d\" ]; then
+        n=\$((n + \$(find \"\$root/\$d\" -type f 2>/dev/null | wc -l)))
+      fi
+    done
+    if [ -f \"\$root/media_queue/queue_manifest.json\" ]; then n=\$((n+1)); fi
+    echo \$n
+  " 2>/dev/null | tr -d '\r' | tail -n 1
+}
+
+wipe_root() {
+  local root="$1"
+  local dry="$2"
+  adb -s "$SERIAL" shell "
+    root='$root'
+    pkg='$PACKAGE'
+    dry='$dry'
+    log() { echo \"\$@\"; }
+    if [ ! -d \"\$root\" ]; then
+      log \"missing: \$root\"
+      exit 0
+    fi
+    remove_path() {
+      p=\"\$1\"
+      [ -e \"\$p\" ] || return 0
+      if [ \"\$dry\" = \"1\" ]; then
+        log \"would delete: \$p\"
+      else
+        rm -rf \"\$p\"
+        log \"deleted: \$p\"
+      fi
+    }
+    cam=\"\$root/\${pkg}.camera\"
+    if [ -d \"\$cam\" ]; then
+      for d in \"\$cam\"/IMG_* \"\$cam\"/VID_* \"\$cam\"/BUFFER_*; do
+        remove_path \"\$d\"
+      done
+      # loose media in camera dir
+      for f in \"\$cam\"/*; do
+        [ -e \"\$f\" ] || continue
+        base=\$(basename \"\$f\")
+        case \"\$base\" in
+          IMG_*|VID_*|*.jpg|*.jpeg|*.mp4|*.png) remove_path \"\$f\" ;;
+        esac
+      done
+    fi
+    for d in \"\$root\"/IMG_* \"\$root\"/VID_*; do
+      remove_path \"\$d\"
+    done
+    for d in photos videos audio temp thumbnails photo_queue; do
+      remove_path \"\$root/\$d\"
+    done
+    # Reset media_queue manifest to valid empty schema (do not leave broken JSON)
+    mq=\"\$root/media_queue\"
+    mf=\"\$mq/queue_manifest.json\"
+    if [ \"\$dry\" = \"1\" ]; then
+      if [ -e \"\$mf\" ]; then log \"would reset: \$mf\"; fi
+    else
+      mkdir -p \"\$mq\"
+      # epoch millis
+      ts=\$(date +%s000)
+      printf '%s' \"{\\\"mediaItems\\\":[],\\\"lastUpdated\\\":\${ts}}\" > \"\$mf\"
+      log \"reset manifest: \$mf\"
+    fi
+  " 2>/dev/null | tr -d '\r'
+}
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "DRY RUN — would delete (pass --yes to apply):"
+else
+  echo "Deleting media (ASG will be force-stopped first)…"
+  stop_asg
+fi
+
+GRAND=0
+for ROOT in "${MEDIA_ROOTS[@]}"; do
+  c="$(count_matches "$ROOT" || echo 0)"
+  c="$(echo "$c" | tr -d '[:space:]')"
+  [[ -z "$c" ]] && c=0
+  GRAND=$((GRAND + c))
+  echo "--- $ROOT (approx entries: $c) ---"
+  wipe_root "$ROOT" "$DRY_RUN"
+done
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "DRY RUN complete. Approx entries that would be touched: $GRAND"
+else
+  echo "Wipe complete. Approx entries considered: $GRAND"
+fi

--- a/mobile/scripts/wipe-glasses-photos.sh
+++ b/mobile/scripts/wipe-glasses-photos.sh
@@ -15,7 +15,7 @@ for arg in "$@"; do
     -h|--help)
       echo "Usage: $0 [--dry-run] [--yes]"
       echo "  Default mode is dry-run (list only). Pass --yes to actually delete."
-      echo "  ADB_SERIAL=…  device serial (default ${DEFAULT_GLASSES_SERIAL})"
+      echo "  ADB_SERIAL=…  optional; if unset, requires exactly one connected device"
       exit 0
       ;;
   esac

--- a/mobile/scripts/wipe-glasses-photos.sh
+++ b/mobile/scripts/wipe-glasses-photos.sh
@@ -48,7 +48,10 @@ count_matches() {
     n=0
     if [ ! -d \"\$root\" ]; then echo 0; exit 0; fi
     # Prefer the fixed asg_media camera dir; also cover legacy \${pkg}.camera when distinct.
+    prev_cam=\"\"
     for cam_name in \"\$cam_current\" \"\${pkg}.camera\"; do
+      [ \"\$cam_name\" = \"\$prev_cam\" ] && continue
+      prev_cam=\"\$cam_name\"
       cam=\"\$root/\$cam_name\"
       [ -d \"\$cam\" ] || continue
       for d in \"\$cam\"/IMG_* \"\$cam\"/VID_* \"\$cam\"/BUFFER_*; do

--- a/mobile/scripts/wipe-glasses-photos.sh
+++ b/mobile/scripts/wipe-glasses-photos.sh
@@ -6,6 +6,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../../scripts/lib/glasses-device.sh
 source "${SCRIPT_DIR}/../../scripts/lib/glasses-device.sh"
 
+# Capture package dir on asg_media is always this name (FileManagerImpl.getDefaultPackageName),
+# even when the installed APK is the .thirdparty variant.
+CAMERA_DIR_CURRENT="com.mentra.asg_client.camera"
+
 DO_YES=0
 DO_DRY=0
 for arg in "$@"; do
@@ -40,11 +44,19 @@ count_matches() {
   adb -s "$SERIAL" shell "
     root='$root'
     pkg='$PACKAGE'
+    cam_current='$CAMERA_DIR_CURRENT'
     n=0
     if [ ! -d \"\$root\" ]; then echo 0; exit 0; fi
-    # capture folders
-    for d in \"\$root\"/\${pkg}.camera/IMG_* \"\$root\"/\${pkg}.camera/VID_* \"\$root\"/\${pkg}.camera/BUFFER_* \\
-             \"\$root\"/IMG_* \"\$root\"/VID_*; do
+    # Prefer the fixed asg_media camera dir; also cover legacy \${pkg}.camera when distinct.
+    for cam_name in \"\$cam_current\" \"\${pkg}.camera\"; do
+      cam=\"\$root/\$cam_name\"
+      [ -d \"\$cam\" ] || continue
+      for d in \"\$cam\"/IMG_* \"\$cam\"/VID_* \"\$cam\"/BUFFER_*; do
+        [ -e \"\$d\" ] || continue
+        n=\$((n+1))
+      done
+    done
+    for d in \"\$root\"/IMG_* \"\$root\"/VID_*; do
       [ -e \"\$d\" ] || continue
       n=\$((n+1))
     done
@@ -53,7 +65,9 @@ count_matches() {
         n=\$((n + \$(find \"\$root/\$d\" -type f 2>/dev/null | wc -l)))
       fi
     done
-    if [ -f \"\$root/media_queue/queue_manifest.json\" ]; then n=\$((n+1)); fi
+    if [ -d \"\$root/media_queue\" ]; then
+      n=\$((n + \$(find \"\$root/media_queue\" -type f 2>/dev/null | wc -l)))
+    fi
     echo \$n
   " 2>/dev/null | tr -d '\r' | tail -n 1
 }
@@ -64,6 +78,7 @@ wipe_root() {
   adb -s "$SERIAL" shell "
     root='$root'
     pkg='$PACKAGE'
+    cam_current='$CAMERA_DIR_CURRENT'
     dry='$dry'
     log() { echo \"\$@\"; }
     if [ ! -d \"\$root\" ]; then
@@ -80,12 +95,12 @@ wipe_root() {
         log \"deleted: \$p\"
       fi
     }
-    cam=\"\$root/\${pkg}.camera\"
-    if [ -d \"\$cam\" ]; then
+    wipe_camera_dir() {
+      cam=\"\$1\"
+      [ -d \"\$cam\" ] || return 0
       for d in \"\$cam\"/IMG_* \"\$cam\"/VID_* \"\$cam\"/BUFFER_*; do
         remove_path \"\$d\"
       done
-      # loose media in camera dir
       for f in \"\$cam\"/*; do
         [ -e \"\$f\" ] || continue
         base=\$(basename \"\$f\")
@@ -93,6 +108,10 @@ wipe_root() {
           IMG_*|VID_*|*.jpg|*.jpeg|*.mp4|*.png) remove_path \"\$f\" ;;
         esac
       done
+    }
+    wipe_camera_dir \"\$root/\$cam_current\"
+    if [ \"\${pkg}.camera\" != \"\$cam_current\" ]; then
+      wipe_camera_dir \"\$root/\${pkg}.camera\"
     fi
     for d in \"\$root\"/IMG_* \"\$root\"/VID_*; do
       remove_path \"\$d\"
@@ -100,17 +119,22 @@ wipe_root() {
     for d in photos videos audio temp thumbnails photo_queue; do
       remove_path \"\$root/\$d\"
     done
-    # Reset media_queue manifest to valid empty schema (do not leave broken JSON)
+    # Clear queued media files, then reset manifest to a valid empty schema.
     mq=\"\$root/media_queue\"
     mf=\"\$mq/queue_manifest.json\"
-    if [ \"\$dry\" = \"1\" ]; then
-      if [ -e \"\$mf\" ]; then log \"would reset: \$mf\"; fi
-    else
-      mkdir -p \"\$mq\"
-      # epoch millis
-      ts=\$(date +%s000)
-      printf '%s' \"{\\\"mediaItems\\\":[],\\\"lastUpdated\\\":\${ts}}\" > \"\$mf\"
-      log \"reset manifest: \$mf\"
+    if [ -d \"\$mq\" ]; then
+      if [ \"\$dry\" = \"1\" ]; then
+        find \"\$mq\" -type f ! -name 'queue_manifest.json' 2>/dev/null | while IFS= read -r f; do
+          log \"would delete: \$f\"
+        done
+        if [ -e \"\$mf\" ]; then log \"would reset: \$mf\"; fi
+      else
+        find \"\$mq\" -type f ! -name 'queue_manifest.json' -exec rm -f {} + 2>/dev/null || true
+        mkdir -p \"\$mq\"
+        ts=\$(date +%s000)
+        printf '%s' \"{\\\"mediaItems\\\":[],\\\"lastUpdated\\\":\${ts}}\" > \"\$mf\"
+        log \"reset manifest: \$mf\"
+      fi
     fi
   " 2>/dev/null | tr -d '\r'
 }

--- a/notes/README.md
+++ b/notes/README.md
@@ -1,0 +1,44 @@
+# Notes
+
+Design specs, implementation plans, and working notes for MentraOS live here. This is intentionally a working tree for humans and agents — not the public product docs (those live in `mintlify-docs/`).
+
+## Specs vs plans
+
+This seed convention is based on a small set of examples under `notes/superpowers/` (originally one plan + a few specs). It is a convention to adopt going forward, not a long historical archive of every past plan.
+
+| Kind | Path | Purpose |
+|---|---|---|
+| **Spec** | `notes/superpowers/specs/YYYY-MM-DD-kebab-topic.md` | Design / requirements source of truth: **what** should be built and **why** |
+| **Plan** | `notes/superpowers/plans/YYYY-MM-DD-kebab-topic.md` | Execution checklist that **references a spec** and tracks **how** implementation progresses |
+
+## Frontmatter
+
+Start specs and plans with:
+
+```yaml
+---
+status: draft | active | completed | archived
+owner: <name or handle>
+---
+```
+
+## Lifecycle
+
+1. Write a **spec** when the design is non-trivial.
+2. Write a **plan** that points at that spec and lists concrete tasks.
+3. When a plan’s `status` becomes `completed`, **move** the file into `notes/superpowers/plans/archive/` (do not delete it). That keeps the active plans directory short while preserving history.
+
+## Multi-session work
+
+Any plan that will span multiple chat sessions should be saved as a file under `notes/superpowers/plans/` and updated in place. Prefer that over pasting the same plan YAML into every new conversation.
+
+- **Cursor:** reference with `@notes/superpowers/plans/<file>.md`
+- **Other tools:** open or attach the file by path
+
+## Templates
+
+- Plan skeleton: [superpowers/plans/TEMPLATE.md](superpowers/plans/TEMPLATE.md)
+
+## Other content under `notes/`
+
+Architecture notes, bluetooth-sdk subsystem docs, OTA specs, and related material also live under `notes/` (and under `agents/` for agent scratchpads). Use the superpowers layout above for **new** multi-session implementation plans.

--- a/notes/superpowers/plans/TEMPLATE.md
+++ b/notes/superpowers/plans/TEMPLATE.md
@@ -1,0 +1,55 @@
+---
+status: draft
+owner: <name>
+---
+
+# <Feature> implementation plan
+
+> Execution checklist. Update checkboxes as work lands. Prefer editing this file over re-pasting plans into chat.
+
+**Goal:** <one paragraph: what done looks like>
+
+**Architecture:** <short description of main components and data flow>
+
+**Tech Stack:** <languages, frameworks, key libs>
+
+**Spec source of truth:** `notes/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `path/to/file` | Create / Modify / Delete | <what changes> |
+
+---
+
+## Conventions
+
+- <team / code conventions for this work stream>
+
+---
+
+## Phase 1: <name>
+
+### Task 1: <name>
+
+**Files:** `path/a`, `path/b`
+
+- [ ] Step 1: …
+- [ ] Step 2: …
+
+### Task 2: <name>
+
+**Files:** …
+
+- [ ] Step 1: …
+
+---
+
+## Phase 2: <name>
+
+### Task 1: <name>
+
+- [ ] Step 1: …

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prepare": "husky",
     "generate-licenses": "bun mintlify-docs/generate-licenses.ts",
     "build:miniapp": "cd mobile/modules/miniapp && bun run build",
+    "sync-miniapp": "bun scripts/sync-miniapp.mjs",
     "postinstall": "bun run build:miniapp || echo '\\n[postinstall] WARNING: failed to build @mentra/miniapp. Miniapps will not run until you build it manually:\\n  cd mobile/modules/miniapp && bun run build\\n'"
   }
 }

--- a/scripts/glasses.sh
+++ b/scripts/glasses.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Unified Mentra Live / glasses adb helper.
+# Usage: scripts/glasses.sh <devices|logs|install|restart|pull-photos|wipe-photos> …
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/glasses-device.sh
+source "${SCRIPT_DIR}/lib/glasses-device.sh"
+MOBILE_SCRIPTS="$(cd "${SCRIPT_DIR}/../mobile/scripts" && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: $0 <command> [args]
+
+Commands:
+  devices                 List adb devices (-l)
+  logs [tag] [--clear]    logcat dump (last 500 lines); optional single tag filter
+  install <apk>           adb install -r -g
+  restart                 force-stop ASG then start MainActivity
+  pull-photos [flags]     proxy to mobile/scripts/pull-glasses-photos.sh
+  wipe-photos [flags]     proxy to mobile/scripts/wipe-glasses-photos.sh (default dry-run)
+
+Env:
+  ADB_SERIAL   device serial (default ${DEFAULT_GLASSES_SERIAL})
+EOF
+}
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  devices)
+    adb devices -l
+    ;;
+  logs)
+    resolve_serial
+    CLEAR=0
+    TAG=""
+    for a in "$@"; do
+      case "$a" in
+        --clear) CLEAR=1 ;;
+        *) TAG="$a" ;;
+      esac
+    done
+    if [[ "$CLEAR" -eq 1 ]]; then
+      adb -s "$SERIAL" logcat -c
+      echo "logcat cleared"
+    fi
+    if [[ -n "$TAG" ]]; then
+      adb -s "$SERIAL" logcat -d -t 500 -s "$TAG"
+    else
+      adb -s "$SERIAL" logcat -d -t 500
+    fi
+    ;;
+  install)
+    resolve_serial
+    apk="${1:-}"
+    if [[ -z "$apk" || ! -f "$apk" ]]; then
+      echo "Usage: $0 install <apk>" >&2
+      exit 1
+    fi
+    adb -s "$SERIAL" install -r -g "$apk"
+    ;;
+  restart)
+    resolve_serial
+    resolve_package
+    stop_asg
+    adb -s "$SERIAL" shell am start -n "${PACKAGE}/.MainActivity"
+    ;;
+  pull-photos)
+    exec bash "${MOBILE_SCRIPTS}/pull-glasses-photos.sh" "$@"
+    ;;
+  wipe-photos)
+    exec bash "${MOBILE_SCRIPTS}/wipe-glasses-photos.sh" "$@"
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: $cmd" >&2
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/glasses.sh
+++ b/scripts/glasses.sh
@@ -21,7 +21,7 @@ Commands:
   wipe-photos [flags]     proxy to mobile/scripts/wipe-glasses-photos.sh (default dry-run)
 
 Env:
-  ADB_SERIAL   device serial (default ${DEFAULT_GLASSES_SERIAL})
+  ADB_SERIAL   optional; if unset, exactly one connected device is required
 EOF
 }
 

--- a/scripts/glasses.sh
+++ b/scripts/glasses.sh
@@ -65,7 +65,10 @@ case "$cmd" in
     resolve_serial
     resolve_package
     stop_asg
-    adb -s "$SERIAL" shell am start -n "${PACKAGE}/.MainActivity"
+    # Activity class lives under the Java package (com.mentra.asg_client), not the
+    # applicationId. thirdparty builds use applicationIdSuffix ".thirdparty", so
+    # "${PACKAGE}/.MainActivity" would look for com.mentra.asg_client.thirdparty.MainActivity.
+    adb -s "$SERIAL" shell am start -n "${PACKAGE}/com.mentra.asg_client.MainActivity"
     ;;
   pull-photos)
     exec bash "${MOBILE_SCRIPTS}/pull-glasses-photos.sh" "$@"

--- a/scripts/lib/glasses-device.sh
+++ b/scripts/lib/glasses-device.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Shared Mentra Live / ASG device helpers for adb scripts.
+# Source this file:  source "$(dirname "$0")/../lib/glasses-device.sh"
+# or from mobile/scripts: source "$(dirname "$0")/../../scripts/lib/glasses-device.sh"
+
+DEFAULT_GLASSES_SERIAL="0123456789ABCDEF"
+PKG_PROD="com.mentra.asg_client"
+PKG_THIRDPARTY="com.mentra.asg_client.thirdparty"
+MEDIA_ROOT_CURRENT="/storage/emulated/0/asg_media"
+
+resolve_serial() {
+  SERIAL="${ADB_SERIAL:-$DEFAULT_GLASSES_SERIAL}"
+  if ! adb devices -l | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "$SERIAL"; then
+    echo "Error: device serial '$SERIAL' is not connected (or not in 'device' state)." >&2
+    echo "Connected devices:" >&2
+    adb devices -l >&2 || true
+    echo "Override with ADB_SERIAL=<serial> if needed." >&2
+    return 1
+  fi
+  export SERIAL
+  echo "Using serial: $SERIAL"
+}
+
+resolve_package() {
+  if [[ -z "${SERIAL:-}" ]]; then
+    resolve_serial || return 1
+  fi
+  local pkgs
+  pkgs="$(adb -s "$SERIAL" shell pm list packages 2>/dev/null | tr -d '\r' || true)"
+  local has_prod=0 has_tp=0
+  echo "$pkgs" | grep -qx "package:${PKG_PROD}" && has_prod=1
+  echo "$pkgs" | grep -qx "package:${PKG_THIRDPARTY}" && has_tp=1
+
+  if [[ "$has_prod" -eq 1 ]]; then
+    PACKAGE="$PKG_PROD"
+  elif [[ "$has_tp" -eq 1 ]]; then
+    PACKAGE="$PKG_THIRDPARTY"
+  else
+    echo "Error: neither ${PKG_PROD} nor ${PKG_THIRDPARTY} is installed on $SERIAL." >&2
+    return 1
+  fi
+  export PACKAGE
+  echo "Using package: $PACKAGE"
+}
+
+resolve_media_roots() {
+  if [[ -z "${PACKAGE:-}" ]]; then
+    resolve_package || return 1
+  fi
+  MEDIA_ROOTS=("$MEDIA_ROOT_CURRENT" "/storage/emulated/0/Android/data/${PACKAGE}/files")
+  export MEDIA_ROOTS
+  echo "Media roots:"
+  for r in "${MEDIA_ROOTS[@]}"; do
+    echo "  - $r"
+  done
+}
+
+stop_asg() {
+  if [[ -z "${PACKAGE:-}" ]]; then
+    resolve_package || return 1
+  fi
+  echo "Force-stopping $PACKAGE …"
+  adb -s "$SERIAL" shell am force-stop "$PACKAGE"
+}

--- a/scripts/lib/glasses-device.sh
+++ b/scripts/lib/glasses-device.sh
@@ -47,20 +47,38 @@ resolve_serial() {
   echo "Using serial: $SERIAL"
 }
 
+# True if package appears in `pm list packages` output (any state).
+_package_listed() {
+  local list="$1" pkg="$2"
+  printf '%s\n' "$list" | grep -Fqx "package:${pkg}"
+}
+
 resolve_package() {
   if [[ -z "${SERIAL:-}" ]]; then
     resolve_serial || return 1
   fi
-  local pkgs
-  pkgs="$(adb -s "$SERIAL" shell pm list packages 2>/dev/null | tr -d '\r' || true)"
-  local has_prod=0 has_tp=0
-  printf '%s\n' "$pkgs" | grep -Fqx "package:${PKG_PROD}" && has_prod=1
-  printf '%s\n' "$pkgs" | grep -Fqx "package:${PKG_THIRDPARTY}" && has_tp=1
 
-  if [[ "$has_prod" -eq 1 ]]; then
+  # After ./asg_client/scripts/dev-setup.sh, stock stays installed but disabled
+  # while .thirdparty is the live launcher. Prefer enabled packages so wipe /
+  # restart hit the process that actually holds media files.
+  local enabled all
+  enabled="$(adb -s "$SERIAL" shell pm list packages -e 2>/dev/null | tr -d '\r' || true)"
+  all="$(adb -s "$SERIAL" shell pm list packages 2>/dev/null | tr -d '\r' || true)"
+
+  local en_tp=0 en_prod=0 has_tp=0 has_prod=0
+  _package_listed "$enabled" "$PKG_THIRDPARTY" && en_tp=1
+  _package_listed "$enabled" "$PKG_PROD" && en_prod=1
+  _package_listed "$all" "$PKG_THIRDPARTY" && has_tp=1
+  _package_listed "$all" "$PKG_PROD" && has_prod=1
+
+  if [[ "$en_tp" -eq 1 ]]; then
+    PACKAGE="$PKG_THIRDPARTY"
+  elif [[ "$en_prod" -eq 1 ]]; then
     PACKAGE="$PKG_PROD"
   elif [[ "$has_tp" -eq 1 ]]; then
     PACKAGE="$PKG_THIRDPARTY"
+  elif [[ "$has_prod" -eq 1 ]]; then
+    PACKAGE="$PKG_PROD"
   else
     echo "Error: neither ${PKG_PROD} nor ${PKG_THIRDPARTY} is installed on $SERIAL." >&2
     return 1

--- a/scripts/lib/glasses-device.sh
+++ b/scripts/lib/glasses-device.sh
@@ -3,20 +3,46 @@
 # Source this file:  source "$(dirname "$0")/../lib/glasses-device.sh"
 # or from mobile/scripts: source "$(dirname "$0")/../../scripts/lib/glasses-device.sh"
 
-DEFAULT_GLASSES_SERIAL="0123456789ABCDEF"
 PKG_PROD="com.mentra.asg_client"
 PKG_THIRDPARTY="com.mentra.asg_client.thirdparty"
 MEDIA_ROOT_CURRENT="/storage/emulated/0/asg_media"
 
+# List serials that are in "device" state (one per line).
+list_ready_serials() {
+  adb devices -l | awk 'NR>1 && $2=="device" {print $1}'
+}
+
 resolve_serial() {
-  SERIAL="${ADB_SERIAL:-$DEFAULT_GLASSES_SERIAL}"
-  if ! adb devices -l | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "$SERIAL"; then
-    echo "Error: device serial '$SERIAL' is not connected (or not in 'device' state)." >&2
-    echo "Connected devices:" >&2
-    adb devices -l >&2 || true
-    echo "Override with ADB_SERIAL=<serial> if needed." >&2
-    return 1
+  local serials
+  serials="$(list_ready_serials || true)"
+
+  if [[ -n "${ADB_SERIAL:-}" ]]; then
+    # Fixed-string match — serials can contain regex metacharacters over TCP.
+    if ! printf '%s\n' "$serials" | grep -Fqx -- "$ADB_SERIAL"; then
+      echo "Error: device serial '$ADB_SERIAL' is not connected (or not in 'device' state)." >&2
+      echo "Connected devices:" >&2
+      adb devices -l >&2 || true
+      return 1
+    fi
+    SERIAL="$ADB_SERIAL"
+  else
+    local count
+    count="$(printf '%s\n' "$serials" | sed '/^$/d' | wc -l | tr -d ' ')"
+    if [[ "$count" -eq 0 ]]; then
+      echo "Error: no adb devices in 'device' state." >&2
+      adb devices -l >&2 || true
+      echo "Connect Mentra Live (or set ADB_SERIAL=<serial>)." >&2
+      return 1
+    fi
+    if [[ "$count" -gt 1 ]]; then
+      echo "Error: multiple adb devices connected; set ADB_SERIAL to pick one:" >&2
+      printf '%s\n' "$serials" >&2
+      adb devices -l >&2 || true
+      return 1
+    fi
+    SERIAL="$(printf '%s\n' "$serials" | sed '/^$/d' | head -n 1)"
   fi
+
   export SERIAL
   echo "Using serial: $SERIAL"
 }
@@ -28,8 +54,8 @@ resolve_package() {
   local pkgs
   pkgs="$(adb -s "$SERIAL" shell pm list packages 2>/dev/null | tr -d '\r' || true)"
   local has_prod=0 has_tp=0
-  echo "$pkgs" | grep -qx "package:${PKG_PROD}" && has_prod=1
-  echo "$pkgs" | grep -qx "package:${PKG_THIRDPARTY}" && has_tp=1
+  printf '%s\n' "$pkgs" | grep -Fqx "package:${PKG_PROD}" && has_prod=1
+  printf '%s\n' "$pkgs" | grep -Fqx "package:${PKG_THIRDPARTY}" && has_tp=1
 
   if [[ "$has_prod" -eq 1 ]]; then
     PACKAGE="$PKG_PROD"

--- a/scripts/miniapp-repos.json
+++ b/scripts/miniapp-repos.json
@@ -1,0 +1,6 @@
+{
+  "livestreamer": {
+    "repo": "../Livestreamer-Miniapp",
+    "miniappDir": "miniapp"
+  }
+}

--- a/scripts/miniapp-repos.json
+++ b/scripts/miniapp-repos.json
@@ -1,6 +1,5 @@
 {
   "livestreamer": {
-    "repo": "../Livestreamer-Miniapp",
-    "miniappDir": "miniapp"
+    "repo": "../Livestreamer-Miniapp"
   }
 }

--- a/scripts/sync-miniapp.mjs
+++ b/scripts/sync-miniapp.mjs
@@ -86,6 +86,19 @@ export function bumpStrictSemver(version, part = "patch") {
   return `${major}.${minor}.${patch}`
 }
 
+/** Filename-safe reverse-domain package ids only (no path separators). */
+export function assertSafePackageName(packageName) {
+  if (typeof packageName !== "string" || !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(packageName)) {
+    throw new Error(
+      `packageName "${packageName}" is not a safe filename identifier ` +
+        `(expected letters/digits/._- only, no path separators)`,
+    )
+  }
+  if (packageName.includes("..") || packageName.includes("/") || packageName.includes("\\")) {
+    throw new Error(`packageName "${packageName}" must not contain path components`)
+  }
+}
+
 export function parseArgs(argv) {
   const args = {
     name: null,
@@ -263,6 +276,10 @@ function generateBundled(mobileRoot) {
   }
 }
 
+function restoreManifestVersion(manifestPath, manifest, originalVersion) {
+  writeManifestVersion(manifestPath, {...manifest, version: originalVersion}, originalVersion)
+}
+
 /**
  * Main entry used by CLI and tests.
  * @returns {{ code: number, summary?: object, error?: string }}
@@ -321,10 +338,20 @@ Never commits or pushes. Prepares local changes only.`)
 
   const miniappDir = resolveMiniappDir(repoPath)
   const manifestPath = join(miniappDir, "miniapp.json")
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  let manifest
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  } catch (err) {
+    die(`could not parse ${manifestPath}: ${err.message}`)
+  }
   const packageName = manifest.packageName
   if (typeof packageName !== "string" || !packageName) {
     die("miniapp.json is missing packageName")
+  }
+  try {
+    assertSafePackageName(packageName)
+  } catch (err) {
+    die(err.message)
   }
   if (configEntry?.packageName && configEntry.packageName !== packageName) {
     die(
@@ -415,7 +442,7 @@ Never commits or pushes. Prepares local changes only.`)
   if (packResult.status !== 0) {
     // 7. Rollback version on failure
     if (newVersion !== originalVersion) {
-      writeManifestVersion(manifestPath, {...manifest, version: originalVersion}, originalVersion)
+      restoreManifestVersion(manifestPath, manifest, originalVersion)
       console.error(`Pack failed — restored miniapp.json version to ${originalVersion}`)
     } else {
       console.error("Pack failed")
@@ -429,10 +456,13 @@ Never commits or pushes. Prepares local changes only.`)
     if (existsSync(alt)) {
       producedZip = alt
     } else {
+      if (newVersion !== originalVersion) {
+        restoreManifestVersion(manifestPath, manifest, originalVersion)
+      }
       die(
         `expected zip not found at ${zipPath}. Pack exited 0 but did not produce ${zipName}. ` +
           (newVersion !== originalVersion
-            ? `miniapp.json version was left at ${newVersion} (pack reported success).`
+            ? `Restored miniapp.json version to ${originalVersion}.`
             : ""),
       )
     }
@@ -447,13 +477,18 @@ Never commits or pushes. Prepares local changes only.`)
     } catch {
       // ignore
     }
+    if (newVersion !== originalVersion) {
+      restoreManifestVersion(manifestPath, manifest, originalVersion)
+    }
     die(
-      `${err.message}. Deleted the bad zip. miniapp.json version remains at ${newVersion} ` +
-        `(pack itself succeeded; only the artifact was wrong).`,
+      `${err.message}. Deleted the bad zip` +
+        (newVersion !== originalVersion
+          ? ` and restored miniapp.json version to ${originalVersion}.`
+          : "."),
     )
   }
 
-  // 9. Atomic copy into assets
+  // 9. Atomic copy into assets (keep old zips until codegen succeeds)
   mkdirSync(ctx.assetsDir, {recursive: true})
   const tempName = `.${zipName}.tmp-${process.pid}`
   const tempPath = join(ctx.assetsDir, tempName)
@@ -466,7 +501,32 @@ Never commits or pushes. Prepares local changes only.`)
     } catch {
       // ignore
     }
-    die(`failed to install zip into assets: ${err.message}. Previous zip left intact.`)
+    if (newVersion !== originalVersion) {
+      restoreManifestVersion(manifestPath, manifest, originalVersion)
+    }
+    die(
+      `failed to install zip into assets: ${err.message}. Previous zip left intact` +
+        (newVersion !== originalVersion
+          ? `; restored miniapp.json version to ${originalVersion}.`
+          : "."),
+    )
+  }
+
+  // 10. Regenerate bundled list while old same-package zips are still present,
+  // then prune. If codegen fails, leave assets as-is (new + old zips) and
+  // restore the external version so a retry can re-bump cleanly.
+  try {
+    generateBundled(ctx.mobileRoot)
+  } catch (err) {
+    if (newVersion !== originalVersion) {
+      restoreManifestVersion(manifestPath, manifest, originalVersion)
+    }
+    die(
+      `${err.message}. New zip is at ${destZip} alongside previous versions` +
+        (newVersion !== originalVersion
+          ? `; restored miniapp.json version to ${originalVersion}. Re-run after fixing codegen.`
+          : "."),
+    )
   }
 
   const removed = pruneOtherZips(ctx.assetsDir, packageName, zipName)
@@ -474,8 +534,15 @@ Never commits or pushes. Prepares local changes only.`)
     console.log(`Pruned:      ${removed.join(", ")}`)
   }
 
-  // 10. Regenerate bundled list
-  generateBundled(ctx.mobileRoot)
+  // Regenerate again so the committed list matches the pruned directory.
+  try {
+    generateBundled(ctx.mobileRoot)
+  } catch (err) {
+    die(
+      `${err.message} after prune. Zip ${destZip} is installed; re-run ` +
+        `bun run generate-bundled-miniapps in mobile/ to refresh the list.`,
+    )
+  }
 
   console.log("\nSummary:")
   console.log(`  ${packageName} ${originalVersion} → ${newVersion}`)

--- a/scripts/sync-miniapp.mjs
+++ b/scripts/sync-miniapp.mjs
@@ -1,0 +1,504 @@
+#!/usr/bin/env bun
+/**
+ * Prepare an external miniapp for bundling into mobile/assets/miniapps/.
+ *
+ * Never runs git. Stages version bump + zip + codegen only.
+ *
+ *   bun scripts/sync-miniapp.mjs <name|--repo path> [--bump patch|minor|major] [--no-bump] [--dry-run]
+ */
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs"
+import {dirname, join, resolve} from "path"
+import {fileURLToPath} from "url"
+import {spawnSync} from "child_process"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, "..")
+const MOBILE_ROOT = join(REPO_ROOT, "mobile")
+const ASSETS_DIR = join(MOBILE_ROOT, "assets", "miniapps")
+const REPOS_CONFIG_PATH = join(__dirname, "miniapp-repos.json")
+
+/** Optional override for tests — point assets + generator at a fixture. */
+export function createSyncContext(overrides = {}) {
+  return {
+    repoRoot: overrides.repoRoot ?? REPO_ROOT,
+    mobileRoot: overrides.mobileRoot ?? MOBILE_ROOT,
+    assetsDir: overrides.assetsDir ?? ASSETS_DIR,
+    reposConfigPath: overrides.reposConfigPath ?? REPOS_CONFIG_PATH,
+  }
+}
+
+function die(msg) {
+  const err = new Error(msg)
+  err.name = "SyncMiniappError"
+  throw err
+}
+
+function loadReposConfig(path) {
+  if (!existsSync(path)) return {}
+  try {
+    return JSON.parse(readFileSync(path, "utf8"))
+  } catch (err) {
+    die(`could not parse ${path}: ${err.message}`)
+  }
+}
+
+/**
+ * Parse strict MAJOR.MINOR.PATCH only. Rejects prerelease/build suffixes.
+ * @returns {[number, number, number] | null}
+ */
+export function parseStrictSemver(version) {
+  if (typeof version !== "string") return null
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)$/)
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
+}
+
+/**
+ * @param {"patch"|"minor"|"major"} part
+ */
+export function bumpStrictSemver(version, part = "patch") {
+  const parsed = parseStrictSemver(version)
+  if (!parsed) {
+    throw new Error(
+      `version "${version}" is not strict MAJOR.MINOR.PATCH (no prerelease/build suffixes). Edit miniapp.json manually.`,
+    )
+  }
+  let [major, minor, patch] = parsed
+  if (part === "major") {
+    major += 1
+    minor = 0
+    patch = 0
+  } else if (part === "minor") {
+    minor += 1
+    patch = 0
+  } else {
+    patch += 1
+  }
+  return `${major}.${minor}.${patch}`
+}
+
+export function parseArgs(argv) {
+  const args = {
+    name: null,
+    repo: null,
+    bump: "patch",
+    noBump: false,
+    dryRun: false,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === "--repo") {
+      args.repo = argv[++i]
+    } else if (a === "--bump") {
+      args.bump = argv[++i]
+    } else if (a === "--no-bump") {
+      args.noBump = true
+    } else if (a === "--dry-run") {
+      args.dryRun = true
+    } else if (a === "--help" || a === "-h") {
+      args.help = true
+    } else if (!a.startsWith("-") && !args.name && !args.repo) {
+      args.name = a
+    } else {
+      die(`unknown argument: ${a}`)
+    }
+  }
+  if (args.bump && !["patch", "minor", "major"].includes(args.bump)) {
+    die(`--bump must be patch, minor, or major (got ${args.bump})`)
+  }
+  return args
+}
+
+function resolveMiniappDir(repoPath) {
+  const nested = join(repoPath, "miniapp", "miniapp.json")
+  const root = join(repoPath, "miniapp.json")
+  if (existsSync(nested)) return join(repoPath, "miniapp")
+  if (existsSync(root)) return repoPath
+  die(
+    `miniapp.json not found at ${nested} or ${root}. ` +
+      `Pass --repo to the external miniapp checkout root.`,
+  )
+}
+
+/**
+ * Find nearest package.json between miniappDir and repoPath (inclusive) that defines scripts.pack.
+ * @returns {{ cwd: string, packageJsonPath: string } | null}
+ */
+function findPackScript(miniappDir, repoPath) {
+  let cur = miniappDir
+  const stop = resolve(repoPath)
+  while (true) {
+    const pkgPath = join(cur, "package.json")
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"))
+        if (pkg.scripts && typeof pkg.scripts.pack === "string") {
+          return {cwd: cur, packageJsonPath: pkgPath}
+        }
+      } catch {
+        // keep walking
+      }
+    }
+    if (resolve(cur) === stop) break
+    const parent = dirname(cur)
+    if (parent === cur) break
+    cur = parent
+  }
+  // Also check stop once more if we walked past via resolve equality edge cases
+  const rootPkg = join(repoPath, "package.json")
+  if (existsSync(rootPkg)) {
+    try {
+      const pkg = JSON.parse(readFileSync(rootPkg, "utf8"))
+      if (pkg.scripts && typeof pkg.scripts.pack === "string") {
+        return {cwd: repoPath, packageJsonPath: rootPkg}
+      }
+    } catch {
+      // fallthrough
+    }
+  }
+  return null
+}
+
+function findMentraMiniappBin(repoPath) {
+  const candidates = [
+    join(repoPath, "node_modules", ".bin", "mentra-miniapp"),
+    join(repoPath, "miniapp", "node_modules", ".bin", "mentra-miniapp"),
+  ]
+  for (const c of candidates) {
+    if (existsSync(c)) return c
+  }
+  return null
+}
+
+function writeManifestVersion(manifestPath, manifest, version) {
+  const next = {...manifest, version}
+  writeFileSync(manifestPath, `${JSON.stringify(next, null, 2)}\n`)
+}
+
+function verifyZip(zipPath, expectedPackageName, expectedVersion) {
+  // Write extracted JSON to a temp file rather than relying on spawn stdout.
+  // Bun's test runner can return empty stdout for nested spawnSync while status is 0.
+  const outPath = `${zipPath}.verify-${process.pid}.json`
+  const py = `
+import json, sys, zipfile
+path, out = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(path) as z:
+    names = z.namelist()
+    match = next((n for n in names if n == "miniapp.json" or n.endswith("/miniapp.json")), None)
+    if match is None:
+        raise SystemExit("no miniapp.json in zip; names=" + ",".join(names))
+    data = json.loads(z.read(match).decode("utf-8"))
+with open(out, "w", encoding="utf-8") as f:
+    json.dump(data, f)
+`
+  const result = spawnSync("python3", ["-c", py, zipPath, outPath], {
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+  })
+  if (result.status !== 0) {
+    try {
+      unlinkSync(outPath)
+    } catch {
+      // ignore
+    }
+    throw new Error(`could not verify zip: ${(result.stderr || result.stdout || "").trim()}`)
+  }
+  let embedded
+  try {
+    embedded = JSON.parse(readFileSync(outPath, "utf8"))
+  } catch (err) {
+    throw new Error(`embedded miniapp.json is not valid JSON: ${err.message}`)
+  } finally {
+    try {
+      unlinkSync(outPath)
+    } catch {
+      // ignore
+    }
+  }
+  if (embedded.packageName !== expectedPackageName) {
+    throw new Error(
+      `zip packageName mismatch: expected ${expectedPackageName}, got ${embedded.packageName}`,
+    )
+  }
+  if (embedded.version !== expectedVersion) {
+    throw new Error(`zip version mismatch: expected ${expectedVersion}, got ${embedded.version}`)
+  }
+}
+
+function pruneOtherZips(assetsDir, packageName, keepFileName) {
+  if (!existsSync(assetsDir)) return []
+  const removed = []
+  for (const name of readdirSync(assetsDir)) {
+    if (!name.toLowerCase().endsWith(".zip")) continue
+    if (name === keepFileName) continue
+    if (name.startsWith(`${packageName}-`)) {
+      unlinkSync(join(assetsDir, name))
+      removed.push(name)
+    }
+  }
+  return removed
+}
+
+function generateBundled(mobileRoot) {
+  const script = join(mobileRoot, "scripts", "generate-bundled-miniapps.mjs")
+  if (!existsSync(script)) {
+    // Test fixtures may skip full mobile layout.
+    return
+  }
+  const result = spawnSync("bun", ["run", script], {
+    cwd: mobileRoot,
+    stdio: "inherit",
+  })
+  if (result.status !== 0) {
+    die("generate-bundled-miniapps failed")
+  }
+}
+
+/**
+ * Main entry used by CLI and tests.
+ * @returns {{ code: number, summary?: object, error?: string }}
+ */
+export function syncMiniapp(rawArgs, ctx = createSyncContext()) {
+  try {
+    return syncMiniappInner(rawArgs, ctx)
+  } catch (err) {
+    if (err?.name === "SyncMiniappError") {
+      console.error(`Error: ${err.message}`)
+      return {code: 1, error: err.message}
+    }
+    throw err
+  }
+}
+
+function syncMiniappInner(rawArgs, ctx) {
+  const args = parseArgs(rawArgs)
+  if (args.help) {
+    console.log(`Usage: bun scripts/sync-miniapp.mjs <name|--repo path> [options]
+
+Options:
+  --bump patch|minor|major   Semver part to bump (default: patch)
+  --no-bump                  Keep the current miniapp.json version
+  --dry-run                  Print plan only; write nothing
+  --repo <path>              External miniapp repo root (skips name map)
+
+Named repos live in scripts/miniapp-repos.json (paths relative to MentraOS root).
+
+Never commits or pushes. Prepares local changes only.`)
+    return {code: 0}
+  }
+
+  if (!args.name && !args.repo) {
+    die("pass a miniapp name from miniapp-repos.json or --repo <path>")
+  }
+
+  const config = loadReposConfig(ctx.reposConfigPath)
+  let repoPath
+  let configEntry = null
+  if (args.repo) {
+    repoPath = resolve(args.repo)
+  } else {
+    configEntry = config[args.name]
+    if (!configEntry) {
+      die(
+        `unknown miniapp name "${args.name}". Known: ${Object.keys(config).join(", ") || "(none)"}. Or use --repo.`,
+      )
+    }
+    repoPath = resolve(ctx.repoRoot, configEntry.repo)
+  }
+
+  if (!existsSync(repoPath)) {
+    die(`repo path does not exist: ${repoPath}`)
+  }
+
+  const miniappDir = resolveMiniappDir(repoPath)
+  const manifestPath = join(miniappDir, "miniapp.json")
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  const packageName = manifest.packageName
+  if (typeof packageName !== "string" || !packageName) {
+    die("miniapp.json is missing packageName")
+  }
+  if (configEntry?.packageName && configEntry.packageName !== packageName) {
+    die(
+      `config packageName "${configEntry.packageName}" does not match manifest "${packageName}"`,
+    )
+  }
+
+  const originalVersion = manifest.version
+  if (typeof originalVersion !== "string" || !originalVersion) {
+    die("miniapp.json is missing version")
+  }
+
+  let newVersion = originalVersion
+  if (!args.noBump) {
+    try {
+      newVersion = bumpStrictSemver(originalVersion, args.bump)
+    } catch (err) {
+      die(err.message)
+    }
+  }
+
+  const packInfo = findPackScript(miniappDir, repoPath)
+  const mentraBin = findMentraMiniappBin(repoPath)
+  let packCommand
+  let packCwd
+  if (packInfo) {
+    packCommand = "bun run pack"
+    packCwd = packInfo.cwd
+  } else if (mentraBin) {
+    packCommand = `"${mentraBin}" pack`
+    packCwd = miniappDir
+  } else {
+    die(
+      `no pack script found under ${repoPath} and no node_modules/.bin/mentra-miniapp. ` +
+        `Run bun install in the target repo or add a "pack" script.`,
+    )
+  }
+
+  const zipName = `${packageName}-${newVersion}.zip`
+  const zipPath = join(miniappDir, "build", zipName)
+  const destZip = join(ctx.assetsDir, zipName)
+
+  console.log(`Miniapp:     ${packageName}`)
+  console.log(`Repo:        ${repoPath}`)
+  console.log(`Miniapp dir: ${miniappDir}`)
+  console.log(`Version:     ${originalVersion} → ${newVersion}${args.noBump ? " (no bump)" : ""}`)
+  console.log(`Pack:        ${packCommand} (cwd ${packCwd})`)
+  console.log(`Destination: ${destZip}`)
+
+  if (args.dryRun) {
+    console.log("\n[dry-run] No files written.")
+    return {
+      code: 0,
+      summary: {
+        dryRun: true,
+        packageName,
+        originalVersion,
+        newVersion,
+        zipPath,
+        destZip,
+        packCommand,
+        packCwd,
+      },
+    }
+  }
+
+  // 5. Bump version in place
+  if (newVersion !== originalVersion) {
+    writeManifestVersion(manifestPath, manifest, newVersion)
+  }
+
+  // 6. Build+pack
+  let packResult
+  if (packInfo) {
+    packResult = spawnSync("bun", ["run", "pack"], {
+      cwd: packCwd,
+      stdio: "inherit",
+      env: process.env,
+    })
+  } else {
+    packResult = spawnSync(mentraBin, ["pack"], {
+      cwd: packCwd,
+      stdio: "inherit",
+      env: process.env,
+    })
+  }
+
+  if (packResult.status !== 0) {
+    // 7. Rollback version on failure
+    if (newVersion !== originalVersion) {
+      writeManifestVersion(manifestPath, {...manifest, version: originalVersion}, originalVersion)
+      console.error(`Pack failed — restored miniapp.json version to ${originalVersion}`)
+    } else {
+      console.error("Pack failed")
+    }
+    return {code: 1}
+  }
+
+  let producedZip = zipPath
+  if (!existsSync(producedZip)) {
+    const alt = join(packCwd, "build", zipName)
+    if (existsSync(alt)) {
+      producedZip = alt
+    } else {
+      die(
+        `expected zip not found at ${zipPath}. Pack exited 0 but did not produce ${zipName}. ` +
+          (newVersion !== originalVersion
+            ? `miniapp.json version was left at ${newVersion} (pack reported success).`
+            : ""),
+      )
+    }
+  }
+
+  // 8. Verify zip
+  try {
+    verifyZip(producedZip, packageName, newVersion)
+  } catch (err) {
+    try {
+      unlinkSync(producedZip)
+    } catch {
+      // ignore
+    }
+    die(
+      `${err.message}. Deleted the bad zip. miniapp.json version remains at ${newVersion} ` +
+        `(pack itself succeeded; only the artifact was wrong).`,
+    )
+  }
+
+  // 9. Atomic copy into assets
+  mkdirSync(ctx.assetsDir, {recursive: true})
+  const tempName = `.${zipName}.tmp-${process.pid}`
+  const tempPath = join(ctx.assetsDir, tempName)
+  try {
+    copyFileSync(producedZip, tempPath)
+    renameSync(tempPath, destZip)
+  } catch (err) {
+    try {
+      unlinkSync(tempPath)
+    } catch {
+      // ignore
+    }
+    die(`failed to install zip into assets: ${err.message}. Previous zip left intact.`)
+  }
+
+  const removed = pruneOtherZips(ctx.assetsDir, packageName, zipName)
+  if (removed.length) {
+    console.log(`Pruned:      ${removed.join(", ")}`)
+  }
+
+  // 10. Regenerate bundled list
+  generateBundled(ctx.mobileRoot)
+
+  console.log("\nSummary:")
+  console.log(`  ${packageName} ${originalVersion} → ${newVersion}`)
+  console.log(`  Zip: ${destZip}`)
+  console.log(
+    `\nNo commits made. Remaining manual steps: commit+push in ${repoPath}, then commit the MentraOS changes.`,
+  )
+
+  return {
+    code: 0,
+    summary: {
+      dryRun: false,
+      packageName,
+      originalVersion,
+      newVersion,
+      destZip,
+      removed,
+    },
+  }
+}
+
+// CLI entry
+if (import.meta.main) {
+  const result = syncMiniapp(process.argv.slice(2))
+  process.exit(result.code ?? 0)
+}

--- a/scripts/sync-miniapp.mjs
+++ b/scripts/sync-miniapp.mjs
@@ -247,16 +247,28 @@ with open(out, "w", encoding="utf-8") as f:
   }
 }
 
-function pruneOtherZips(assetsDir, packageName, keepFileName) {
+/**
+ * True when `name` is exactly `${packageName}-${strictSemver}.zip`.
+ * Avoids prefix collisions like pruning `com.mentra.foo` deleting
+ * `com.mentra.foo-bar-1.0.0.zip`.
+ */
+export function isSamePackageZip(name, packageName) {
+  if (typeof name !== "string" || typeof packageName !== "string") return false
+  if (!name.toLowerCase().endsWith(".zip")) return false
+  const prefix = `${packageName}-`
+  if (!name.startsWith(prefix)) return false
+  const versionPart = name.slice(prefix.length, -".zip".length)
+  return parseStrictSemver(versionPart) !== null
+}
+
+export function pruneOtherZips(assetsDir, packageName, keepFileName) {
   if (!existsSync(assetsDir)) return []
   const removed = []
   for (const name of readdirSync(assetsDir)) {
-    if (!name.toLowerCase().endsWith(".zip")) continue
     if (name === keepFileName) continue
-    if (name.startsWith(`${packageName}-`)) {
-      unlinkSync(join(assetsDir, name))
-      removed.push(name)
-    }
+    if (!isSamePackageZip(name, packageName)) continue
+    unlinkSync(join(assetsDir, name))
+    removed.push(name)
   }
   return removed
 }

--- a/scripts/sync-miniapp.test.mjs
+++ b/scripts/sync-miniapp.test.mjs
@@ -1,0 +1,221 @@
+import {afterAll, describe, expect, test} from "bun:test"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "fs"
+import {tmpdir} from "os"
+import {join} from "path"
+import {syncMiniapp, bumpStrictSemver, parseStrictSemver} from "./sync-miniapp.mjs"
+
+const fixtureRoots = []
+
+function makeFixtureRoot() {
+  const dir = mkdtempSync(join(tmpdir(), "sync-miniapp-test-"))
+  fixtureRoots.push(dir)
+  return dir
+}
+
+afterAll(() => {
+  for (const dir of fixtureRoots) {
+    try {
+      rmSync(dir, {recursive: true, force: true})
+    } catch {
+      // ignore
+    }
+  }
+})
+
+function writeFixtureRepo(base, {version = "1.0.0", packageName = "com.mentra.test", packFails = false} = {}) {
+  const repo = join(base, "TestMiniapp")
+  const miniappDir = join(repo, "miniapp")
+  const distDir = join(miniappDir, "dist")
+  mkdirSync(distDir, {recursive: true})
+  writeFileSync(
+    join(miniappDir, "miniapp.json"),
+    JSON.stringify(
+      {
+        packageName,
+        version,
+        name: "Test",
+        hardwareRequirements: [],
+      },
+      null,
+      2,
+    ) + "\n",
+  )
+  writeFileSync(join(distDir, "index.js"), "console.log('ok')\n")
+  // Embed miniapp.json into dist so the pack script's zip contains it.
+  writeFileSync(
+    join(distDir, "miniapp.json"),
+    JSON.stringify({packageName, version, name: "Test", hardwareRequirements: []}, null, 2) + "\n",
+  )
+
+  if (packFails) {
+    writeFileSync(join(repo, "pack.sh"), "#!/bin/sh\nexit 1\n", {mode: 0o755})
+  } else {
+    // Build zip with bun/node so fixtures don't depend on shell zip variable quirks.
+    writeFileSync(
+      join(repo, "pack.mjs"),
+      `import {readFileSync, mkdirSync, copyFileSync} from "fs"
+import {join} from "path"
+import {spawnSync} from "child_process"
+const miniappDir = join(import.meta.dir, "miniapp")
+const manifest = JSON.parse(readFileSync(join(miniappDir, "miniapp.json"), "utf8"))
+const dist = join(miniappDir, "dist")
+copyFileSync(join(miniappDir, "miniapp.json"), join(dist, "miniapp.json"))
+const buildDir = join(miniappDir, "build")
+mkdirSync(buildDir, {recursive: true})
+const zipPath = join(buildDir, \`\${manifest.packageName}-\${manifest.version}.zip\`)
+// Zip via python so the fixture does not depend on system zip/stdout quirks.
+const py = \`
+import pathlib, sys, zipfile
+dist, zip_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+    for path in sorted(dist.rglob("*")):
+        if path.is_file():
+            zf.write(path, path.relative_to(dist).as_posix())
+\`
+const result = spawnSync("python3", ["-c", py, dist, zipPath], {stdio: "inherit"})
+if (result.status !== 0) process.exit(result.status ?? 1)
+`,
+    )
+    writeFileSync(
+      join(repo, "pack.sh"),
+      "#!/bin/sh\nset -e\nbun ./pack.mjs\n",
+      {mode: 0o755},
+    )
+  }
+
+  writeFileSync(
+    join(repo, "package.json"),
+    JSON.stringify(
+      {
+        name: "test-miniapp",
+        private: true,
+        scripts: {pack: "sh ./pack.sh"},
+      },
+      null,
+      2,
+    ) + "\n",
+  )
+
+  return {repo, miniappDir}
+}
+
+function writeMentraLayout(base) {
+  const assetsDir = join(base, "mobile", "assets", "miniapps")
+  const scriptsDir = join(base, "mobile", "scripts")
+  const genDir = join(base, "mobile", "src", "generated")
+  mkdirSync(assetsDir, {recursive: true})
+  mkdirSync(scriptsDir, {recursive: true})
+  mkdirSync(genDir, {recursive: true})
+  // Minimal generator that writes whatever zips exist
+  writeFileSync(
+    join(scriptsDir, "generate-bundled-miniapps.mjs"),
+    `import {readdir, writeFile, mkdir} from "fs/promises"
+import path from "path"
+import {fileURLToPath} from "url"
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const dir = path.join(root, "assets", "miniapps")
+const zips = (await readdir(dir)).filter(f => f.endsWith(".zip")).sort()
+const out = path.join(root, "src", "generated", "bundledMiniapps.ts")
+await mkdir(path.dirname(out), {recursive: true})
+await writeFile(out, "export const BUNDLED_MINIAPPS = [\\n" + zips.map(z => "  '" + z + "',\\n").join("") + "]\\n")
+console.log("generated", zips.length)
+`,
+  )
+  writeFileSync(join(genDir, "bundledMiniapps.ts"), "export const BUNDLED_MINIAPPS = []\n")
+  return {assetsDir, mobileRoot: join(base, "mobile")}
+}
+
+describe("parseStrictSemver / bumpStrictSemver", () => {
+  test("accepts strict versions and bumps", () => {
+    expect(parseStrictSemver("1.2.3")).toEqual([1, 2, 3])
+    expect(bumpStrictSemver("1.2.3", "patch")).toBe("1.2.4")
+    expect(bumpStrictSemver("1.2.3", "minor")).toBe("1.3.0")
+    expect(bumpStrictSemver("1.2.3", "major")).toBe("2.0.0")
+  })
+
+  test("rejects prerelease", () => {
+    expect(parseStrictSemver("1.0.0-dev.1")).toBeNull()
+    expect(() => bumpStrictSemver("1.0.0-dev.1", "patch")).toThrow(/strict MAJOR.MINOR.PATCH/)
+  })
+})
+
+describe("syncMiniapp", () => {
+  test("dry-run mutates nothing", () => {
+    const base = makeFixtureRoot()
+    const {repo, miniappDir} = writeFixtureRepo(base, {version: "1.0.0"})
+    const {assetsDir, mobileRoot} = writeMentraLayout(base)
+    // Stale zip already present
+    writeFileSync(join(assetsDir, "com.mentra.test-1.0.0.zip"), "old")
+
+    const beforeManifest = readFileSync(join(miniappDir, "miniapp.json"), "utf8")
+    const beforeAssets = readdirSync(assetsDir).sort().join(",")
+
+    const result = syncMiniapp(["--repo", repo, "--dry-run"], {
+      repoRoot: base,
+      mobileRoot,
+      assetsDir,
+      reposConfigPath: join(base, "missing.json"),
+    })
+
+    expect(result.code).toBe(0)
+    expect(result.summary.dryRun).toBe(true)
+    expect(result.summary.newVersion).toBe("1.0.1")
+    expect(readFileSync(join(miniappDir, "miniapp.json"), "utf8")).toBe(beforeManifest)
+    expect(readdirSync(assetsDir).sort().join(",")).toBe(beforeAssets)
+  })
+
+  test("normal run bumps version, installs zip, prunes old, regenerates list", () => {
+    const base = makeFixtureRoot()
+    const {repo} = writeFixtureRepo(base, {version: "1.0.0", packageName: "com.mentra.test"})
+    const {assetsDir, mobileRoot} = writeMentraLayout(base)
+    writeFileSync(join(assetsDir, "com.mentra.test-1.0.0.zip"), "old-zip-bytes")
+    writeFileSync(join(assetsDir, "com.mentra.other-2.0.0.zip"), "keep-me")
+
+    const result = syncMiniapp(["--repo", repo], {
+      repoRoot: base,
+      mobileRoot,
+      assetsDir,
+      reposConfigPath: join(base, "missing.json"),
+    })
+
+    expect(result.code).toBe(0)
+    expect(result.summary.newVersion).toBe("1.0.1")
+    expect(existsSync(join(assetsDir, "com.mentra.test-1.0.1.zip"))).toBe(true)
+    expect(existsSync(join(assetsDir, "com.mentra.test-1.0.0.zip"))).toBe(false)
+    expect(existsSync(join(assetsDir, "com.mentra.other-2.0.0.zip"))).toBe(true)
+
+    const gen = readFileSync(join(mobileRoot, "src", "generated", "bundledMiniapps.ts"), "utf8")
+    expect(gen).toContain("com.mentra.test-1.0.1.zip")
+    expect(gen).toContain("com.mentra.other-2.0.0.zip")
+
+    const manifest = JSON.parse(readFileSync(join(repo, "miniapp", "miniapp.json"), "utf8"))
+    expect(manifest.version).toBe("1.0.1")
+  })
+
+  test("failed pack restores miniapp.json version and leaves assets untouched", () => {
+    const base = makeFixtureRoot()
+    const {repo, miniappDir} = writeFixtureRepo(base, {version: "2.0.0", packFails: true})
+    const {assetsDir, mobileRoot} = writeMentraLayout(base)
+    writeFileSync(join(assetsDir, "com.mentra.test-2.0.0.zip"), "existing")
+
+    const result = syncMiniapp(["--repo", repo], {
+      repoRoot: base,
+      mobileRoot,
+      assetsDir,
+      reposConfigPath: join(base, "missing.json"),
+    })
+
+    expect(result.code).toBe(1)
+    const manifest = JSON.parse(readFileSync(join(miniappDir, "miniapp.json"), "utf8"))
+    expect(manifest.version).toBe("2.0.0")
+    expect(readdirSync(assetsDir)).toEqual(["com.mentra.test-2.0.0.zip"])
+  })
+})

--- a/scripts/sync-miniapp.test.mjs
+++ b/scripts/sync-miniapp.test.mjs
@@ -15,6 +15,8 @@ import {
   bumpStrictSemver,
   parseStrictSemver,
   assertSafePackageName,
+  isSamePackageZip,
+  pruneOtherZips,
 } from "./sync-miniapp.mjs"
 
 const fixtureRoots = []
@@ -160,6 +162,28 @@ describe("assertSafePackageName", () => {
   test("rejects path traversal", () => {
     expect(() => assertSafePackageName("../evil")).toThrow(/safe filename/)
     expect(() => assertSafePackageName("com/mentra")).toThrow(/safe filename/)
+  })
+})
+
+describe("isSamePackageZip / pruneOtherZips", () => {
+  test("matches only exact packageName-version.zip", () => {
+    expect(isSamePackageZip("com.mentra.foo-1.0.0.zip", "com.mentra.foo")).toBe(true)
+    expect(isSamePackageZip("com.mentra.foo-bar-1.0.0.zip", "com.mentra.foo")).toBe(false)
+    expect(isSamePackageZip("com.mentra.foo-bar-1.0.0.zip", "com.mentra.foo-bar")).toBe(true)
+  })
+
+  test("prune does not delete hyphenated sibling packages", () => {
+    const base = makeFixtureRoot()
+    const assetsDir = join(base, "assets")
+    mkdirSync(assetsDir, {recursive: true})
+    writeFileSync(join(assetsDir, "com.mentra.foo-1.0.0.zip"), "old")
+    writeFileSync(join(assetsDir, "com.mentra.foo-bar-2.0.0.zip"), "sibling")
+    writeFileSync(join(assetsDir, "com.mentra.foo-1.0.1.zip"), "keep")
+
+    const removed = pruneOtherZips(assetsDir, "com.mentra.foo", "com.mentra.foo-1.0.1.zip")
+    expect(removed).toEqual(["com.mentra.foo-1.0.0.zip"])
+    expect(existsSync(join(assetsDir, "com.mentra.foo-bar-2.0.0.zip"))).toBe(true)
+    expect(existsSync(join(assetsDir, "com.mentra.foo-1.0.1.zip"))).toBe(true)
   })
 })
 

--- a/scripts/sync-miniapp.test.mjs
+++ b/scripts/sync-miniapp.test.mjs
@@ -162,6 +162,8 @@ describe("assertSafePackageName", () => {
   test("rejects path traversal", () => {
     expect(() => assertSafePackageName("../evil")).toThrow(/safe filename/)
     expect(() => assertSafePackageName("com/mentra")).toThrow(/safe filename/)
+    // Passes the char-class regex; must still be caught by the `..` guard.
+    expect(() => assertSafePackageName("evil..name")).toThrow(/path components/)
   })
 })
 

--- a/scripts/sync-miniapp.test.mjs
+++ b/scripts/sync-miniapp.test.mjs
@@ -10,7 +10,12 @@ import {
 } from "fs"
 import {tmpdir} from "os"
 import {join} from "path"
-import {syncMiniapp, bumpStrictSemver, parseStrictSemver} from "./sync-miniapp.mjs"
+import {
+  syncMiniapp,
+  bumpStrictSemver,
+  parseStrictSemver,
+  assertSafePackageName,
+} from "./sync-miniapp.mjs"
 
 const fixtureRoots = []
 
@@ -144,6 +149,17 @@ describe("parseStrictSemver / bumpStrictSemver", () => {
   test("rejects prerelease", () => {
     expect(parseStrictSemver("1.0.0-dev.1")).toBeNull()
     expect(() => bumpStrictSemver("1.0.0-dev.1", "patch")).toThrow(/strict MAJOR.MINOR.PATCH/)
+  })
+})
+
+describe("assertSafePackageName", () => {
+  test("accepts reverse-domain ids", () => {
+    expect(() => assertSafePackageName("com.mentra.livestreamer")).not.toThrow()
+  })
+
+  test("rejects path traversal", () => {
+    expect(() => assertSafePackageName("../evil")).toThrow(/safe filename/)
+    expect(() => assertSafePackageName("com/mentra")).toThrow(/safe filename/)
   })
 })
 

--- a/sdk/miniapp-cli/src/dev.ts
+++ b/sdk/miniapp-cli/src/dev.ts
@@ -1,7 +1,7 @@
 import os from 'os';
-import { readFileSync, existsSync, statSync } from 'fs';
+import { readFileSync, existsSync, statSync, unlinkSync } from 'fs';
 import { join, resolve } from 'path';
-import { printQR } from './qr.js';
+import { printQR, writeQRPng } from './qr.js';
 import { validateManifest } from './manifest.js';
 import { startDevSidecar } from './dev-server.js';
 
@@ -15,6 +15,7 @@ export interface DevAttestationInput {
 
 export interface DevOptions {
   cwd?: string;
+  qrOutput?: string;
   signDevAttestation?: (input: DevAttestationInput) => string | Promise<string | null | undefined> | null | undefined;
 }
 
@@ -264,10 +265,19 @@ export async function dev(options: DevOptions = {}): Promise<void> {
     console.log('╚══════════════════════════════════════════════════════════════╝\n');
   };
 
+  const defaultQrPath = join(os.tmpdir(), `mentra-dev-qr-${packageName}-${port}.png`);
+  const qrOutputPath = resolve(options.qrOutput ?? defaultQrPath);
+
+  const emitQR = async (url: string): Promise<void> => {
+    await printQR(url);
+    await writeQRPng(url, qrOutputPath);
+    console.log(`\n${url}`);
+    console.log(`PNG QR: ${qrOutputPath}\n`);
+  };
+
   printBanner();
   const devUrl = await buildDevUrl(lanIp);
-  await printQR(devUrl);
-  console.log(`\n${devUrl}\n`);
+  await emitQR(devUrl);
 
   // Monitor for LAN IP changes (e.g., WiFi switch).
   const ipCheckInterval = setInterval(async () => {
@@ -277,13 +287,17 @@ export async function dev(options: DevOptions = {}): Promise<void> {
       console.log(`\nLAN IP changed to ${newIp}. New QR:`);
       printBanner();
       const newDevUrl = await buildDevUrl(newIp);
-      await printQR(newDevUrl);
-      console.log(`\n${newDevUrl}\n`);
+      await emitQR(newDevUrl);
     }
   }, 10_000);
 
   const shutdown = () => {
     clearInterval(ipCheckInterval);
+    try {
+      unlinkSync(qrOutputPath);
+    } catch {
+      // best-effort cleanup of temp PNG
+    }
     sidecar?.stop();
     userServer.stop(true);
     process.exit(0);

--- a/sdk/miniapp-cli/src/dev.ts
+++ b/sdk/miniapp-cli/src/dev.ts
@@ -267,12 +267,17 @@ export async function dev(options: DevOptions = {}): Promise<void> {
 
   const defaultQrPath = join(os.tmpdir(), `mentra-dev-qr-${packageName}-${port}.png`);
   const qrOutputPath = resolve(options.qrOutput ?? defaultQrPath);
+  const cleanupQrOnExit = !options.qrOutput;
 
   const emitQR = async (url: string): Promise<void> => {
     await printQR(url);
-    await writeQRPng(url, qrOutputPath);
+    const wrote = await writeQRPng(url, qrOutputPath);
     console.log(`\n${url}`);
-    console.log(`PNG QR: ${qrOutputPath}\n`);
+    if (wrote) {
+      console.log(`PNG QR: ${qrOutputPath}\n`);
+    } else {
+      console.log(`PNG QR: (not written — see warning above)\n`);
+    }
   };
 
   printBanner();
@@ -293,10 +298,13 @@ export async function dev(options: DevOptions = {}): Promise<void> {
 
   const shutdown = () => {
     clearInterval(ipCheckInterval);
-    try {
-      unlinkSync(qrOutputPath);
-    } catch {
-      // best-effort cleanup of temp PNG
+    // Only remove the auto temp path — keep an explicit --qr-output artifact.
+    if (cleanupQrOnExit) {
+      try {
+        unlinkSync(qrOutputPath);
+      } catch {
+        // best-effort cleanup of temp PNG
+      }
     }
     sidecar?.stop();
     userServer.stop(true);

--- a/sdk/miniapp-cli/src/index.ts
+++ b/sdk/miniapp-cli/src/index.ts
@@ -33,7 +33,12 @@ function printUsage(): void {
 function flagValue(flag: string): string | undefined {
   const idx = process.argv.indexOf(flag);
   if (idx === -1) return undefined;
-  return process.argv[idx + 1];
+  const value = process.argv[idx + 1];
+  if (!value || value.startsWith('-')) {
+    console.error(`Error: ${flag} requires a path argument`);
+    process.exit(1);
+  }
+  return value;
 }
 
 switch (subcommand) {

--- a/sdk/miniapp-cli/src/index.ts
+++ b/sdk/miniapp-cli/src/index.ts
@@ -15,7 +15,9 @@ function printUsage(): void {
   console.log('Usage: mentra-miniapp <command>\n');
   console.log('Commands:');
   console.log('  dev                              Start dev server with hot reload and QR code');
+  console.log('                                   Options: --qr-output <path>  write PNG QR to path');
   console.log('  release                          Build, pack, and serve a QR to install on a phone');
+  console.log('                                   Options: --no-cache  --qr-output <path>');
   console.log('  pack                             Production-build and package miniapp into build/<pkg>-<version>.zip (--no-build to skip build)');
   console.log('  manifest                         Edit miniapp.json interactively');
   console.log('  permission list                  List declared permissions');
@@ -28,12 +30,21 @@ function printUsage(): void {
   console.log('  schema regenerate                Regenerate the published schema file (CLI internal)');
 }
 
+function flagValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
 switch (subcommand) {
   case 'dev':
-    await dev();
+    await dev({qrOutput: flagValue('--qr-output')});
     break;
   case 'release':
-    await release({noCache: process.argv.includes('--no-cache')});
+    await release({
+      noCache: process.argv.includes('--no-cache'),
+      qrOutput: flagValue('--qr-output'),
+    });
     break;
   case 'pack':
     // Build with NODE_ENV=production before zipping, so `pack` never ships

--- a/sdk/miniapp-cli/src/qr.test.ts
+++ b/sdk/miniapp-cli/src/qr.test.ts
@@ -1,0 +1,64 @@
+import {afterEach, describe, expect, test} from 'bun:test';
+import {chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync} from 'fs';
+import {tmpdir} from 'os';
+import {join} from 'path';
+import {writeQRPng} from './qr.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mentra-qr-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      chmodSync(dir, 0o700);
+      rmSync(dir, {recursive: true, force: true});
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe('writeQRPng', () => {
+  test('creates a file with mode 0o600 and non-empty PNG content', async () => {
+    const dir = makeTempDir();
+    const outPath = join(dir, 'qr.png');
+    await writeQRPng('miniapp://dev?url=http%3A%2F%2F192.168.1.1%3A3000', outPath);
+
+    const st = statSync(outPath);
+    expect(st.size).toBeGreaterThan(0);
+    // Mask off higher mode bits so comparison is portable across platforms.
+    expect(st.mode & 0o777).toBe(0o600);
+
+    const header = readFileSync(outPath).subarray(0, 8);
+    // PNG magic number
+    expect([...header]).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  });
+
+  test('overwrites the same path in place on a second call', async () => {
+    const dir = makeTempDir();
+    const outPath = join(dir, 'qr.png');
+    await writeQRPng('miniapp://dev?url=http%3A%2F%2F192.168.1.1%3A3000', outPath);
+    const first = readFileSync(outPath);
+
+    await writeQRPng('miniapp://dev?url=http%3A%2F%2F10.0.0.1%3A3000', outPath);
+    const second = readFileSync(outPath);
+
+    expect(Buffer.compare(first, second)).not.toBe(0);
+    expect(statSync(outPath).isFile()).toBe(true);
+  });
+
+  test('does not throw when the output directory is unwritable', async () => {
+    const dir = makeTempDir();
+    const readonlyDir = join(dir, 'readonly');
+    // Create a directory entry that exists as a file, so writing qr.png under it fails.
+    writeFileSync(readonlyDir, 'not-a-directory');
+    const outPath = join(readonlyDir, 'qr.png');
+
+    await expect(writeQRPng('miniapp://dev?test=1', outPath)).resolves.toBeUndefined();
+  });
+});

--- a/sdk/miniapp-cli/src/qr.test.ts
+++ b/sdk/miniapp-cli/src/qr.test.ts
@@ -63,13 +63,19 @@ describe('writeQRPng', () => {
     expect(statSync(outPath).mode & 0o777).toBe(0o600);
   });
 
-  test('does not throw when the output directory is unwritable', async () => {
+  test('returns false when the output directory is unwritable', async () => {
     const dir = makeTempDir();
     const readonlyDir = join(dir, 'readonly');
     // Create a directory entry that exists as a file, so writing qr.png under it fails.
     writeFileSync(readonlyDir, 'not-a-directory');
     const outPath = join(readonlyDir, 'qr.png');
 
-    await expect(writeQRPng('miniapp://dev?test=1', outPath)).resolves.toBeUndefined();
+    await expect(writeQRPng('miniapp://dev?test=1', outPath)).resolves.toBe(false);
+  });
+
+  test('returns true on success', async () => {
+    const dir = makeTempDir();
+    const outPath = join(dir, 'ok.png');
+    await expect(writeQRPng('miniapp://dev?test=1', outPath)).resolves.toBe(true);
   });
 });

--- a/sdk/miniapp-cli/src/qr.test.ts
+++ b/sdk/miniapp-cli/src/qr.test.ts
@@ -52,6 +52,17 @@ describe('writeQRPng', () => {
     expect(statSync(outPath).isFile()).toBe(true);
   });
 
+  test('forces mode 0o600 even when overwriting a looser-mode file', async () => {
+    const dir = makeTempDir();
+    const outPath = join(dir, 'qr.png');
+    writeFileSync(outPath, 'placeholder', {mode: 0o644});
+    chmodSync(outPath, 0o644);
+    expect(statSync(outPath).mode & 0o777).toBe(0o644);
+
+    await writeQRPng('miniapp://dev?url=http%3A%2F%2F192.168.1.1%3A3000', outPath);
+    expect(statSync(outPath).mode & 0o777).toBe(0o600);
+  });
+
   test('does not throw when the output directory is unwritable', async () => {
     const dir = makeTempDir();
     const readonlyDir = join(dir, 'readonly');

--- a/sdk/miniapp-cli/src/qr.ts
+++ b/sdk/miniapp-cli/src/qr.ts
@@ -1,3 +1,4 @@
+import {writeFileSync} from 'fs';
 import QRCode from 'qrcode';
 
 /**
@@ -21,5 +22,26 @@ export async function printQR(url: string): Promise<void> {
     process.stdout.write('\n' + str);
   } catch (error) {
     console.error(`Could not render terminal QR code: ${(error as Error).message}`);
+  }
+}
+
+/**
+ * Write a PNG QR to disk with mode 0o600.
+ *
+ * Dev/release URLs can carry a signed attestation query param; writing with
+ * restrictive permissions avoids a world-readable window on multi-user machines.
+ * Failures only warn — a broken PNG write must not take down the server.
+ */
+export async function writeQRPng(url: string, outPath: string): Promise<void> {
+  try {
+    const buffer = await QRCode.toBuffer(url, {
+      type: 'png',
+      errorCorrectionLevel: 'M',
+      margin: 2,
+      scale: 8,
+    });
+    writeFileSync(outPath, buffer, {mode: 0o600});
+  } catch (error) {
+    console.warn(`Could not write QR PNG to ${outPath}: ${(error as Error).message}`);
   }
 }

--- a/sdk/miniapp-cli/src/qr.ts
+++ b/sdk/miniapp-cli/src/qr.ts
@@ -1,4 +1,4 @@
-import {writeFileSync} from 'fs';
+import {chmodSync, writeFileSync} from 'fs';
 import QRCode from 'qrcode';
 
 /**
@@ -40,7 +40,10 @@ export async function writeQRPng(url: string, outPath: string): Promise<void> {
       margin: 2,
       scale: 8,
     });
+    // mode on writeFileSync only applies to newly created files — always chmod
+    // after write so overwrites of a looser-mode temp path stay private.
     writeFileSync(outPath, buffer, {mode: 0o600});
+    chmodSync(outPath, 0o600);
   } catch (error) {
     console.warn(`Could not write QR PNG to ${outPath}: ${(error as Error).message}`);
   }

--- a/sdk/miniapp-cli/src/qr.ts
+++ b/sdk/miniapp-cli/src/qr.ts
@@ -31,8 +31,10 @@ export async function printQR(url: string): Promise<void> {
  * Dev/release URLs can carry a signed attestation query param; writing with
  * restrictive permissions avoids a world-readable window on multi-user machines.
  * Failures only warn — a broken PNG write must not take down the server.
+ *
+ * @returns true if the file was written successfully
  */
-export async function writeQRPng(url: string, outPath: string): Promise<void> {
+export async function writeQRPng(url: string, outPath: string): Promise<boolean> {
   try {
     const buffer = await QRCode.toBuffer(url, {
       type: 'png',
@@ -44,7 +46,9 @@ export async function writeQRPng(url: string, outPath: string): Promise<void> {
     // after write so overwrites of a looser-mode temp path stay private.
     writeFileSync(outPath, buffer, {mode: 0o600});
     chmodSync(outPath, 0o600);
+    return true;
   } catch (error) {
     console.warn(`Could not write QR PNG to ${outPath}: ${(error as Error).message}`);
+    return false;
   }
 }

--- a/sdk/miniapp-cli/src/release.ts
+++ b/sdk/miniapp-cli/src/release.ts
@@ -171,9 +171,9 @@ export async function release(opts: ReleaseOptions = {}): Promise<void> {
   }
   console.log(`Serving on ${baseUrl}`)
 
-  // ---- 6. Wait for SIGINT ---------------------------------------------
+  // ---- 6. Wait for SIGINT / SIGTERM -----------------------------------
   await new Promise<void>((resolvePromise) => {
-    process.on('SIGINT', () => {
+    const shutdown = () => {
       console.log('\nShutting down...')
       // Only remove the auto temp path — keep an explicit --qr-output artifact.
       if (cleanupQrOnExit) {
@@ -185,7 +185,9 @@ export async function release(opts: ReleaseOptions = {}): Promise<void> {
       }
       server.stop()
       resolvePromise()
-    })
+    }
+    process.on('SIGINT', shutdown)
+    process.on('SIGTERM', shutdown)
   })
 }
 

--- a/sdk/miniapp-cli/src/release.ts
+++ b/sdk/miniapp-cli/src/release.ts
@@ -22,12 +22,12 @@
  * collision and matches Android's `installRelease` mental model.
  */
 
-import {readFileSync, existsSync, statSync, readdirSync} from 'fs'
+import {readFileSync, existsSync, statSync, readdirSync, unlinkSync} from 'fs'
 import os from 'os'
 import {resolve, join} from 'path'
 import {buildProduction} from './build.js'
 import {pack} from './pack.js'
-import {printQR} from './qr.js'
+import {printQR, writeQRPng} from './qr.js'
 import {validateManifest} from './manifest.js'
 
 const DEFAULT_PORT_START = 6789
@@ -39,6 +39,7 @@ const BUNDLE_PATH = '/bundle.zip'
 
 interface ReleaseOptions {
   noCache?: boolean
+  qrOutput?: string
 }
 
 export async function release(opts: ReleaseOptions = {}): Promise<void> {
@@ -156,16 +157,26 @@ export async function release(opts: ReleaseOptions = {}): Promise<void> {
   console.log('║  Ctrl+C to stop.                                             ║')
   console.log('╚══════════════════════════════════════════════════════════════╝\n')
 
+  const defaultQrPath = join(os.tmpdir(), `mentra-release-qr-${packageName}.png`)
+  const qrOutputPath = resolve(opts.qrOutput ?? defaultQrPath)
+
   await printQR(qrUrl)
-  console.log(`\n${qrUrl}\n`)
+  await writeQRPng(qrUrl, qrOutputPath)
+  console.log(`\n${qrUrl}`)
+  console.log(`PNG QR: ${qrOutputPath}\n`)
   console.log(`Serving on ${baseUrl}`)
 
   // ---- 6. Wait for SIGINT ---------------------------------------------
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolvePromise) => {
     process.on('SIGINT', () => {
       console.log('\nShutting down...')
+      try {
+        unlinkSync(qrOutputPath)
+      } catch {
+        // best-effort cleanup of temp PNG
+      }
       server.stop()
-      resolve()
+      resolvePromise()
     })
   })
 }

--- a/sdk/miniapp-cli/src/release.ts
+++ b/sdk/miniapp-cli/src/release.ts
@@ -159,21 +159,29 @@ export async function release(opts: ReleaseOptions = {}): Promise<void> {
 
   const defaultQrPath = join(os.tmpdir(), `mentra-release-qr-${packageName}.png`)
   const qrOutputPath = resolve(opts.qrOutput ?? defaultQrPath)
+  const cleanupQrOnExit = !opts.qrOutput
 
   await printQR(qrUrl)
-  await writeQRPng(qrUrl, qrOutputPath)
+  const wrotePng = await writeQRPng(qrUrl, qrOutputPath)
   console.log(`\n${qrUrl}`)
-  console.log(`PNG QR: ${qrOutputPath}\n`)
+  if (wrotePng) {
+    console.log(`PNG QR: ${qrOutputPath}\n`)
+  } else {
+    console.log(`PNG QR: (not written — see warning above)\n`)
+  }
   console.log(`Serving on ${baseUrl}`)
 
   // ---- 6. Wait for SIGINT ---------------------------------------------
   await new Promise<void>((resolvePromise) => {
     process.on('SIGINT', () => {
       console.log('\nShutting down...')
-      try {
-        unlinkSync(qrOutputPath)
-      } catch {
-        // best-effort cleanup of temp PNG
+      // Only remove the auto temp path — keep an explicit --qr-output artifact.
+      if (cleanupQrOnExit) {
+        try {
+          unlinkSync(qrOutputPath)
+        } catch {
+          // best-effort cleanup of temp PNG
+        }
       }
       server.stop()
       resolvePromise()


### PR DESCRIPTION
## Summary
- Add secure miniapp dev/release PNG QR export (`writeQRPng`, `--qr-output`, cleanup on exit)
- Add transactional `scripts/sync-miniapp.mjs` (no git commit/push) with tests and agent skill
- Add CI triage skill, notes/plans convention, glasses ADB helpers against `asg_media` + legacy paths

## Test plan
- [ ] `bun test sdk/miniapp-cli/src/qr.test.ts scripts/sync-miniapp.test.mjs`
- [ ] `bun scripts/sync-miniapp.mjs livestreamer --dry-run`
- [ ] `mentra-miniapp dev` prints a PNG QR path that overwrites after LAN IP change
- [ ] With glasses connected: `./scripts/glasses.sh devices` and `mobile/scripts/wipe-glasses-photos.sh --dry-run`

Note: left other agents' local-stream / nitro-bg-timer / example-miniapp work unstaged on this machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `wipe-glasses-photos.sh --yes` deletes on-device media (mitigated by default dry-run); `sync-miniapp` mutates external repos and mobile assets but is tested and rolls back on failure.
> 
> **Overview**
> Adds a **DX automation layer** for miniapp bundling, glasses debugging, agent workflows, and miniapp CLI QR output—without changing mobile runtime behavior.
> 
> **Miniapp bundling:** New `scripts/sync-miniapp.mjs` (and root `sync-miniapp` npm script) bumps strict semver in an external repo, runs `pack`, verifies the zip, copies into `mobile/assets/miniapps/`, prunes older same-package zips, and regenerates `bundledMiniapps.ts`, with rollback on failure and **no git commit/push**. Includes `miniapp-repos.json`, Bun tests, and a `sync-miniapp` agent skill.
> 
> **Miniapp CLI:** `mentra-miniapp dev` and `release` gain `writeQRPng` (mode `0o600`), optional `--qr-output`, and temp PNG cleanup on exit; `release` also handles `SIGTERM`.
> 
> **Glasses / ADB:** Shared `scripts/lib/glasses-device.sh` (serial, prod vs `.thirdparty` package, `asg_media` + legacy roots). `scripts/glasses.sh` unifies devices, logs, install, restart, pull/wipe photos; mobile scripts and `pull:glasses-photos` / `wipe:glasses-photos` npm scripts; wipe defaults to dry-run (`--yes` to delete). `mobile/.gitignore` ignores `Camera_comparison/`.
> 
> **Docs & agents:** `notes/README.md` + plan template for specs/plans under `notes/superpowers/`; `AGENTS.md` links the convention. New **ci-triage** agent skill (`gh pr checks`, capped Actions logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40c07e6cfa5ef124cc24b4f71c76a566aa59432d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->