### PR TITLE
Mark the Miniapp SDK docs as beta (OS-1880)

### DIFF
--- a/mintlify-docs/app-devs/getting-started/distribution.mdx
+++ b/mintlify-docs/app-devs/getting-started/distribution.mdx
@@ -5,11 +5,14 @@ icon: "upload"
 ---
 
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'
+import BetaNote from '/snippets/beta-note.mdx'
 
 A miniapp is a **bundle that runs on the user's phone**: there's no server to
 host, no domain, no uptime to manage. Distribution means producing that bundle
 and getting it installed. There are three ways to get a miniapp onto a device,
 from quickest to widest reach.
+
+<BetaNote />
 
 <LegacyCloudNote />
 

--- a/mintlify-docs/app-devs/getting-started/overview.mdx
+++ b/mintlify-docs/app-devs/getting-started/overview.mdx
@@ -4,6 +4,7 @@ description: "Build on-device apps for smart glasses with the Mentra Miniapp SDK
 ---
 
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'
+import BetaNote from '/snippets/beta-note.mdx'
 
 MentraOS is the operating system for smart glasses. A **miniapp** is an app that
 runs on the user's phone, inside the Mentra App, and drives the glasses through the
@@ -14,6 +15,8 @@ from the Mentra Miniapp Store, and it runs on their device.
 Building a mobile app that connects directly to glasses over Bluetooth? Use the
 [Bluetooth SDK docs](/mentra-live/overview) instead.
 </Info>
+
+<BetaNote />
 
 <LegacyCloudNote />
 

--- a/mintlify-docs/app-devs/getting-started/quickstart.mdx
+++ b/mintlify-docs/app-devs/getting-started/quickstart.mdx
@@ -56,8 +56,11 @@ save and forwards the miniapp's console logs back to your terminal.
 
 ### Step 4: Load it on your phone
 
-In the Mentra App, go to **Settings → Developer settings → Mini App Development
-→ Scan Mini App QR Code** and scan the QR from your terminal.
+In the Mentra App, go to **Settings → Miniapp Developer Settings → Scan Miniapp
+QR Code** and scan the QR from your terminal. If Miniapp Developer Settings is
+hidden, open **Settings → Debug Settings**, enable **Miniapp Developer
+Settings**, then return to Settings. If Debug Settings is hidden, tap the
+version number at the bottom of Settings ten times to reveal it.
 
 <Info>
 Your phone and your laptop must be on the **same Wi-Fi network**. `bun dev`

--- a/mintlify-docs/app-devs/getting-started/quickstart.mdx
+++ b/mintlify-docs/app-devs/getting-started/quickstart.mdx
@@ -4,6 +4,7 @@ description: Scaffold a Mentra miniapp and run it on your phone in a few minutes
 ---
 
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'
+import BetaNote from '/snippets/beta-note.mdx'
 
 This Quickstart goes from zero to a miniapp running on your glasses. You need a
 phone, [Bun](https://bun.sh/docs/installation), and basic TypeScript. You can do
@@ -13,6 +14,8 @@ the whole thing **without glasses**: the display just won't have anywhere to dra
 Building a mobile app that connects directly to glasses over Bluetooth? Use the
 [Bluetooth SDK Quickstart](/mentra-live/quickstart) instead.
 </Info>
+
+<BetaNote />
 
 <LegacyCloudNote />
 

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -2,6 +2,10 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
   "name": "MentraOS",
+  "banner": {
+    "content": "**Beta.** The Mentra Miniapp SDK and these docs are in beta and subject to change. The SDK is available under debug settings in the Mentra App. [Send feedback](https://discord.gg/5ukNvkEAqT).",
+    "dismissible": false
+  },
   "colors": {
     "primary": "#00b869",
     "light": "#00b869",

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -3,7 +3,7 @@
   "theme": "aspen",
   "name": "MentraOS",
   "banner": {
-    "content": "**Beta.** The Mentra Miniapp SDK and these docs are in beta and subject to change. The SDK is available under debug settings in the Mentra App. [Send feedback](https://discord.gg/5ukNvkEAqT).",
+    "content": "**Beta.** The Mentra Miniapp SDK and these docs are subject to change. Enable it at **Settings → Debug Settings → Miniapp Developer Settings** in the Mentra App. Send feedback with an in-app bug report, on [Discord](https://discord.gg/5ukNvkEAqT), or by [email](mailto:help@mentra.glass).",
     "dismissible": false
   },
   "colors": {

--- a/mintlify-docs/snippets/beta-note.mdx
+++ b/mintlify-docs/snippets/beta-note.mdx
@@ -1,8 +1,10 @@
 <Warning>
   **The Mentra Miniapp SDK is in beta.** It has not been thoroughly tested yet,
-  so it ships behind debug settings in the Mentra App rather than on by default.
-  Open the Mentra App, go to Settings, enable debug settings, and the miniapp
-  surface appears there.
+  so it ships behind a developer toggle in the Mentra App rather than on by
+  default. Open **Settings → Debug Settings**, enable **Miniapp Developer
+  Settings**, then return to Settings and open **Miniapp Developer Settings**.
+  If Debug Settings is hidden, tap the version number at the bottom of Settings
+  ten times to reveal it.
 
   These docs describe the SDK as it stands today. Both the SDK and the docs are
   subject to change, and some of it will change based on what beta testers run

--- a/mintlify-docs/snippets/beta-note.mdx
+++ b/mintlify-docs/snippets/beta-note.mdx
@@ -1,0 +1,14 @@
+<Warning>
+  **The Mentra Miniapp SDK is in beta.** It has not been thoroughly tested yet,
+  so it ships behind debug settings in the Mentra App rather than on by default.
+  Open the Mentra App, go to Settings, enable debug settings, and the miniapp
+  surface appears there.
+
+  These docs describe the SDK as it stands today. Both the SDK and the docs are
+  subject to change, and some of it will change based on what beta testers run
+  into.
+
+  Please tell us what you hit. File a bug report from inside the Mentra App,
+  post on [Discord](https://discord.gg/5ukNvkEAqT), or email
+  [help@mentra.glass](mailto:help@mentra.glass).
+</Warning>


### PR DESCRIPTION
Marks the Miniapp SDK docs as beta ahead of 3.0, per OS-1880.

The SDK is not launching publicly. It ships behind debug settings in the Mentra App for a small group of beta testers, but the docs go public so those testers have something to read. Nothing on the site currently says any of that, so a reader has no way to know the SDK is gated, untested, or still moving.

## What changed

**A site-wide banner** in `docs.json`, so the beta status shows on every page including deep links that skip the getting-started flow.

**A fuller note** (`snippets/beta-note.mdx`) explaining what beta means here: how to turn the SDK on, that both the SDK and the docs will change, and the three feedback routes (bug report in the Mentra App, Discord, help@mentra.glass). It follows the existing snippet convention and lands on the same three getting-started pages that already carry the legacy cloud note, which is where someone starting out actually arrives.

Two levels rather than one because a one-line banner cannot carry the enablement steps, and a page-level callout alone misses anyone arriving by deep link.

## Notes

The banner is **non-dismissible**. It sets expectations rather than announcing something, so it should not vanish on first click and never return. Easy to flip if you disagree.

`docs.json` is edited surgically rather than reserialised. Writing it back with a JSON formatter expanded every compact array and produced a 259-line diff for a 4-line change.

## Verification

Built locally with `mint export`: 56 pages, banner present on every page sampled (index, an app-devs page, a mentra-live page), fuller note present only on the three pages it is wired into.

Not yet visible on docs-dev.mentraglass.com: `deploy-dev-docs.yml` only fires on push to `dev`, so this publishes when it merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only messaging in Mintlify config and MDX; no runtime, auth, or product code changes.
> 
> **Overview**
> Public Miniapp SDK docs now clearly state **beta** status: the SDK is gated behind Mentra App debug settings, is still moving, and feedback is welcome.
> 
> A **non-dismissible site-wide banner** in `docs.json` surfaces that message on every page (including deep links). A new **`snippets/beta-note.mdx`** Warning adds enablement steps and feedback channels (in-app bug report, Discord, help@mentra.glass). That snippet is imported on **Overview**, **Quickstart**, and **Distribution**, alongside the existing legacy cloud note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f4e8724dc6ea356191ee9bbfddd0a9cc486e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the Miniapp SDK docs as beta and aligns with OS-1880. Adds clear beta messaging and fixes the enable instructions to match the Mentra App UI.

- **New Features**
  - Site-wide, non-dismissible beta banner in `docs.json` with enable path and feedback links (Discord, email).
  - New `snippets/beta-note.mdx` with enable steps and feedback routes. Inserted on `overview.mdx`, `quickstart.mdx`, and `distribution.mdx`.

- **Bug Fixes**
  - Corrected Miniapp enable instructions and menu names in Quickstart and the note: use Settings → Miniapp Developer Settings → Scan Miniapp QR Code; if hidden, enable via Settings → Debug Settings, and reveal Debug Settings by tapping the version number ten times.

<sup>Written for commit 3e3e170f585804b96270bf83fb7c5f57bcd70170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

