### PR TITLE
Fix text-mode ML Kit initialization order

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetector.java
@@ -79,7 +79,7 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
             Bitmap blank = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888);
             blank.eraseColor(Color.WHITE);
             long startMs = SystemClock.elapsedRealtime();
-            Task<Text> task = tryStartRecognizerProcess(InputImage.fromBitmap(blank, 0));
+            Task<Text> task = tryStartRecognizerProcess(blank);
             if (task == null) {
                 blank.recycle();
                 return;
@@ -105,7 +105,7 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
      *     #lastStartFailureReason} for the caller-facing full-frame reason.
      */
     @Nullable
-    private Task<Text> tryStartRecognizerProcess(InputImage image) {
+    private Task<Text> tryStartRecognizerProcess(Bitmap bitmap) {
         TextRecognizer availableRecognizer = getOrCreateRecognizer();
         if (availableRecognizer == null) {
             if (lastStartFailureReason == null) {
@@ -123,6 +123,10 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
                 activeRecognizerTask.compareAndSet(activeTask, null);
             }
             try {
+                // InputImage.fromBitmap() also reads MlKitContext. Build it only after
+                // getOrCreateRecognizer() has repaired provider initialization for a process that
+                // started during direct boot.
+                InputImage image = InputImage.fromBitmap(bitmap, 0);
                 Task<Text> newTask = availableRecognizer.process(image);
                 activeRecognizerTask.set(newTask);
                 newTask.addOnCompleteListener(
@@ -281,7 +285,7 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
             }
 
             analysis = scaleLongEdge(decoded, analysisLongEdge);
-            detectionTask = tryStartRecognizerProcess(InputImage.fromBitmap(analysis, 0));
+            detectionTask = tryStartRecognizerProcess(analysis);
             if (detectionTask == null) {
                 String reason =
                         lastStartFailureReason != null ? lastStartFailureReason : "mlkit_busy";

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
@@ -1,7 +1,10 @@
 package com.mentra.asg_client.io.media.core.textdetect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.graphics.Bitmap;
@@ -11,6 +14,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.mlkit.vision.common.InputImage;
 import com.google.mlkit.vision.text.Text;
 import com.google.mlkit.vision.text.TextRecognizer;
 
@@ -58,6 +62,20 @@ public class MlKitTextRoiDetectorTest {
         Field recognizerField = MlKitTextRoiDetector.class.getDeclaredField("recognizer");
         recognizerField.setAccessible(true);
         assertThat(recognizerField.get(detector)).isSameAs(created);
+        detector.close();
+    }
+
+    @Test
+    public void warmupFallsBackWhenInputImageCannotReadMlKitContext() {
+        TextRecognizer recognizer = mock(TextRecognizer.class);
+        MlKitTextRoiDetector detector = new MlKitTextRoiDetector(1280, recognizer);
+
+        // The injected-recognizer constructor deliberately has no Context, so Robolectric's
+        // InputImage cannot read MlKitContext. This reproduces the incident's synchronous failure
+        // and verifies that warm-up degrades to a full-frame transfer instead of aborting capture.
+        assertThatCode(detector::warmUp).doesNotThrowAnyException();
+
+        verify(recognizer, never()).process(org.mockito.ArgumentMatchers.any(InputImage.class));
         detector.close();
     }
 


### PR DESCRIPTION
## What changed

- initialize or recover ML Kit before constructing `InputImage` during text-mode warm-up and detection
- keep synchronous ML Kit input failures inside the existing full-frame fallback instead of failing the photo request
- add a regression test for the direct-boot `MlKitContext` failure seen in `rep_01KZ58D9571NHYGPJJ6YZYA9SW`

## Root cause

Mentra Live can start `asg_client` during direct boot, before ML Kit's manifest provider initializes `MlKitContext`. The lazy recognizer repair ran inside `tryStartRecognizerProcess`, but callers constructed `InputImage` first. `InputImage.fromBitmap()` also reads `MlKitContext`, so it threw before the repair or fallback could run.

## Impact

Text-mode photos no longer fail with `PHOTO_COMMAND_FAILED: MlKitContext has not been initialized`. ML Kit is repaired before input construction when possible; if it remains unavailable, the text-mode pipeline preserves and transfers the full frame.

## Validation

- `./scripts/check-android-compile.sh asg` — passed
- focused regression test `warmupFallsBackWhenInputImageCannotReadMlKitContext` — passed
- full `MlKitTextRoiDetectorTest` class — changed-path test passed; two unrelated existing Robolectric native-runtime tests failed with `NoClassDefFoundError` during runtime teardown
- `git diff --check` — passed
- Spotless could not complete because of a pre-existing non-contiguous import error in `MediaUploadQueueManager.java`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text‑mode photo failures during direct boot by initializing/repairing ML Kit before building `InputImage`. If ML Kit is still unavailable, we now fall back to full‑frame transfer instead of failing the capture.

- **Bug Fixes**
  - Initialize or recover ML Kit before `InputImage` construction in warm‑up and detection.
  - Contain synchronous ML Kit input errors within the existing full‑frame fallback.
  - Add a regression test that reproduces direct‑boot `MlKitContext` failure and verifies graceful warm‑up.

<sup>Written for commit 920ed1fa73a1df26e3feaf9ee907d54afd0dd437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the text-mode capture/ML Kit startup path on device boot; behavior change is localized but user-visible when ML Kit is unavailable.
> 
> **Overview**
> Fixes text-mode photo failures when `asg_client` starts during **direct boot** and `MlKitContext` is not ready yet. Callers used to build `InputImage.fromBitmap()` before `tryStartRecognizerProcess` ran `getOrCreateRecognizer()`, but `InputImage` also touches `MlKitContext`, so recognition could throw with `MlKitContext has not been initialized` instead of using the existing full-frame fallback.
> 
> **`tryStartRecognizerProcess`** now accepts a `Bitmap` and creates `InputImage` only after recognizer creation/repair. Warm-up and detection both pass bitmaps through that path. A regression test asserts warm-up does not throw and skips `process()` when `InputImage` cannot be built (no-context test constructor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920ed1fa73a1df26e3feaf9ee907d54afd0dd437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->