### PR TITLE
Prefer Wi-Fi LAN + mDNS for miniapp dev QRs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -168,7 +168,6 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.14.1",
-        "release": "^6.3.1",
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "^4.0.8",
       },
@@ -420,8 +419,6 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
-
-    "@octokit/rest": ["@octokit/rest@15.2.6", "", { "dependencies": { "before-after-hook": "^1.1.0", "btoa-lite": "^1.0.0", "debug": "^3.1.0", "http-proxy-agent": "^2.1.0", "https-proxy-agent": "^2.2.0", "lodash": "^4.17.4", "node-fetch": "^2.1.1", "url-template": "^2.0.8" } }, "sha512-KcqG0zjnjzUqn7wczz/fKiueNpTLiAI7erhUG6bXWAsYKJJlqnwYonFSXrMW/nmes5y+qOk4uSyHBh1mdRXdVQ=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
 
@@ -873,13 +870,9 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, ""],
 
-    "after-all-results": ["after-all-results@2.0.0", "", {}, "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg=="],
-
-    "agent-base": ["agent-base@4.3.0", "", { "dependencies": { "es6-promisify": "^5.0.0" } }, "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg=="],
-
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, ""],
 
-    "ansi-escapes": ["ansi-escapes@3.2.0", "", {}, "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="],
+    "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -888,8 +881,6 @@
     "arc": ["arc@0.2.0", "", {}, "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, ""],
-
-    "args": ["args@4.0.0", "", { "dependencies": { "camelcase": "5.0.0", "chalk": "2.3.2", "leven": "2.1.0", "mri": "1.1.0" } }, "sha512-4b7lVF58nlo7sNtq8s2OueroOY/UHn0Nt/NVjsx9zn28u6yDVb9bQ/uy/5jKtHCbUDil4MlMyDLF5+OHEgnTug=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -913,8 +904,6 @@
 
     "async-function": ["async-function@1.0.0", "", {}, ""],
 
-    "async-retry": ["async-retry@1.2.1", "", { "dependencies": { "retry": "0.10.1" } }, "sha512-FadV8UDcyZDjzb6eV7MCJj0bfrNjwKw7/X0QHPFCbYP6T20FXgZCYXpJKlQC8RxEQP1E6Xs8pNHdh3bcrZAuAw=="],
-
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, ""],
@@ -923,8 +912,6 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "before-after-hook": ["before-after-hook@1.4.0", "", {}, "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="],
-
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, ""],
@@ -932,8 +919,6 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, ""],
 
     "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
-
-    "btoa-lite": ["btoa-lite@1.0.0", "", {}, "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -951,9 +936,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, ""],
 
-    "camelcase": ["camelcase@5.0.0", "", {}, "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="],
-
-    "capitalize": ["capitalize@1.0.0", "", {}, "sha512-ZvPF27zRh4ZiRbWYfSktO+t7xi4RPfqL9w6gfPAWGT5pT9TjB0rlP8cKHmKWHYYCR8QHKDDebX3HVHcfw6K3GQ=="],
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, ""],
 
@@ -961,23 +944,13 @@
 
     "character-entities": ["character-entities@2.0.2", "", {}, ""],
 
-    "chardet": ["chardet@0.4.2", "", {}, "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg=="],
-
-    "child-process-promise": ["child-process-promise@2.2.1", "", { "dependencies": { "cross-spawn": "^4.0.2", "node-version": "^1.0.0", "promise-polyfill": "^6.0.1" } }, "sha512-Fi4aNdqBsr0mv+jgWxcZ/7rAIC2mgihrptyVI4foh/rrjY/3BNjfP9+oaiFx/fzim+1ZyCNBae0DlyfQhSugog=="],
-
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
-    "cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
-
-    "cli-spinners": ["cli-spinners@1.3.1", "", {}, "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="],
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
 
-    "cli-width": ["cli-width@2.2.1", "", {}, "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="],
-
     "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -997,19 +970,13 @@
 
     "concaveman": ["concaveman@1.2.1", "", { "dependencies": { "point-in-polygon": "^1.1.0", "rbush": "^3.0.1", "robust-predicates": "^2.0.4", "tinyqueue": "^2.0.3" } }, "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw=="],
 
-    "configstore": ["configstore@3.1.2", "", { "dependencies": { "dot-prop": "^4.1.0", "graceful-fs": "^4.1.2", "make-dir": "^1.0.0", "unique-string": "^1.0.0", "write-file-atomic": "^2.0.0", "xdg-basedir": "^3.0.0" } }, "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw=="],
-
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, ""],
 
-    "crypto-random-string": ["crypto-random-string@1.0.0", "", {}, "sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg=="],
-
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "cwd": ["cwd@0.9.1", "", { "dependencies": { "find-pkg": "^0.1.0" } }, "sha512-4+0D+ojEasdLndYX4Cqff057I/Jp6ysXpwKkdLQLnZxV8f6IYZmZtTP5uqD91a/kWqejoc0sSqK4u8wpTKCh8A=="],
 
     "d3-array": ["d3-array@1.2.4", "", {}, "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="],
 
@@ -1031,19 +998,11 @@
 
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, ""],
 
-    "decompress-response": ["decompress-response@3.3.0", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
     "deep-is": ["deep-is@0.1.4", "", {}, ""],
-
-    "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, ""],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, ""],
-
-    "delay": ["delay@4.3.0", "", {}, "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
@@ -1059,11 +1018,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "dot-prop": ["dot-prop@4.2.1", "", { "dependencies": { "is-obj": "^1.0.0" } }, "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ=="],
-
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, ""],
-
-    "duplexer3": ["duplexer3@0.1.5", "", {}, "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="],
 
     "earcut": ["earcut@2.2.4", "", {}, "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="],
 
@@ -1088,12 +1043,6 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, ""],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, ""],
-
-    "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
-
-    "es6-promisify": ["es6-promisify@5.0.0", "", { "dependencies": { "es6-promise": "^4.0.3" } }, "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ=="],
-
-    "escape-goat": ["escape-goat@1.3.0", "", {}, "sha512-E2nU1Y39N5UgfLU8qwMlK0vZrZprIwWLeVmDYN8wd/e37hMtGzu2w1DBiREts0XHfgyZEQlj/hYr0H0izF0HDQ=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, ""],
 
@@ -1149,12 +1098,6 @@
 
     "example-miniapp": ["example-miniapp@workspace:miniapps/example-miniapp"],
 
-    "expand-tilde": ["expand-tilde@1.2.2", "", { "dependencies": { "os-homedir": "^1.0.1" } }, "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q=="],
-
-    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
-
-    "external-editor": ["external-editor@2.2.0", "", { "dependencies": { "chardet": "^0.4.0", "iconv-lite": "^0.4.17", "tmp": "^0.0.33" } }, "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A=="],
-
     "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, ""],
@@ -1177,17 +1120,9 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "figures": ["figures@2.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA=="],
-
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, ""],
 
-    "file-name": ["file-name@0.1.0", "", {}, "sha512-Q8SskhjF4eUk/xoQkmubwLkoHwOTv6Jj/WGtOVLKkZ0vvM+LipkSXugkn1F/+mjWXU32AXLZB3qaz0arUzgtRw=="],
-
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, ""],
-
-    "find-file-up": ["find-file-up@0.1.3", "", { "dependencies": { "fs-exists-sync": "^0.1.0", "resolve-dir": "^0.1.0" } }, "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A=="],
-
-    "find-pkg": ["find-pkg@0.1.2", "", { "dependencies": { "find-file-up": "^0.1.2" } }, "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, ""],
 
@@ -1200,10 +1135,6 @@
     "format": ["format@0.2.2", "", {}, ""],
 
     "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
-
-    "fs-exists-sync": ["fs-exists-sync@0.1.0", "", {}, "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="],
-
-    "fs-extra": ["fs-extra@5.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, ""],
 
@@ -1225,43 +1156,19 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, ""],
 
-    "get-stream": ["get-stream@3.0.0", "", {}, "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ=="],
-
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, ""],
 
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
-    "gh-got": ["gh-got@6.0.0", "", { "dependencies": { "got": "^7.0.0", "is-plain-obj": "^1.1.0" } }, "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw=="],
-
-    "git-config-path": ["git-config-path@1.0.1", "", { "dependencies": { "extend-shallow": "^2.0.1", "fs-exists-sync": "^0.1.0", "homedir-polyfill": "^1.0.0" } }, "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg=="],
-
-    "git-repo-name": ["git-repo-name@0.6.0", "", { "dependencies": { "cwd": "^0.9.1", "file-name": "^0.1.0", "lazy-cache": "^1.0.4", "remote-origin-url": "^0.5.1" } }, "sha512-DF4XxB6H+Te79JA08/QF/IjIv+j+0gF990WlgAX3SXXU2irfqvBc/xxlAIh6eJWYaKz45MrrGVBFS0Qc4bBz5g=="],
-
-    "git-spawned-stream": ["git-spawned-stream@1.0.0", "", { "dependencies": { "debug": "~0.8.1", "spawn-to-readstream": "~0.1.3" } }, "sha512-CdUpBulxMBlEkUGh9hpvqmmmCKS2X7q/Ct3ml+wmkpnXwEJfkXr2v7APLPyeZ33DKbpehxSiF6Skl2P1itJjRA=="],
-
-    "git-state": ["git-state@4.0.0", "", { "dependencies": { "after-all-results": "^2.0.0" } }, "sha512-7rW22+ryQP6az93gU2jr+4SVAAoEPLELTwQiZd1ldq+77N+KLinP1FyZ61bkWrbXiZcEc9F9mpam2r30yG68Tw=="],
-
-    "git-username": ["git-username@1.0.0", "", { "dependencies": { "parse-github-url": "^1.0.2", "remote-origin-url": "^1.0.0" } }, "sha512-xm45KwBR6Eu1jO4umx/o2M84v9TC7tdOBuzLx8ayhdR9H1FBiiG9azz31uC0esDvaWVBTDINpJ5USomk+ja8OQ=="],
-
     "github-slugger": ["github-slugger@2.0.0", "", {}, ""],
 
-    "github-username": ["github-username@4.1.0", "", { "dependencies": { "gh-got": "^6.0.0" } }, "sha512-ABDfD5sjQOE8XDatHhN/WORUIAN1AGpgW4vegrKtby8x+jC/ALqCEuUDhCPlk9EXtjTHJWpuK25QdaehSUlCQg=="],
-
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, ""],
-
-    "global-modules": ["global-modules@0.2.3", "", { "dependencies": { "global-prefix": "^0.1.4", "is-windows": "^0.2.0" } }, "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA=="],
-
-    "global-prefix": ["global-prefix@0.1.5", "", { "dependencies": { "homedir-polyfill": "^1.0.0", "ini": "^1.3.4", "is-windows": "^0.2.0", "which": "^1.2.12" } }, "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw=="],
 
     "globals": ["globals@16.3.0", "", {}, ""],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, ""],
 
     "gopd": ["gopd@1.2.0", "", {}, ""],
-
-    "got": ["got@7.1.0", "", { "dependencies": { "decompress-response": "^3.2.0", "duplexer3": "^0.1.4", "get-stream": "^3.0.0", "is-plain-obj": "^1.1.0", "is-retry-allowed": "^1.0.0", "is-stream": "^1.0.0", "isurl": "^1.0.0-alpha5", "lowercase-keys": "^1.0.0", "p-cancelable": "^0.3.0", "p-timeout": "^1.1.1", "safe-buffer": "^5.0.1", "timed-out": "^4.0.0", "url-parse-lax": "^1.0.0", "url-to-options": "^1.0.1" } }, "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "happy-dom": ["happy-dom@17.6.3", "", { "dependencies": { "webidl-conversions": "^7.0.0", "whatwg-mimetype": "^3.0.0" } }, "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug=="],
 
@@ -1273,11 +1180,7 @@
 
     "has-proto": ["has-proto@1.2.0", "", { "dependencies": { "dunder-proto": "^1.0.0" } }, ""],
 
-    "has-symbol-support-x": ["has-symbol-support-x@1.4.2", "", {}, "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="],
-
     "has-symbols": ["has-symbols@1.1.0", "", {}, ""],
-
-    "has-to-string-tag-x": ["has-to-string-tag-x@1.4.1", "", { "dependencies": { "has-symbol-support-x": "^1.4.1" } }, "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw=="],
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, ""],
 
@@ -1285,17 +1188,9 @@
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
-    "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
-
     "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
-    "http-proxy-agent": ["http-proxy-agent@2.1.0", "", { "dependencies": { "agent-base": "4", "debug": "3.1.0" } }, "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg=="],
-
-    "https-proxy-agent": ["https-proxy-agent@2.2.4", "", { "dependencies": { "agent-base": "^4.3.0", "debug": "^3.1.0" } }, "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg=="],
-
     "husky": ["husky@9.1.7", "", { "bin": "bin.js" }, ""],
-
-    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -1308,10 +1203,6 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, ""],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
-    "inquirer": ["inquirer@5.2.0", "", { "dependencies": { "ansi-escapes": "^3.0.0", "chalk": "^2.0.0", "cli-cursor": "^2.1.0", "cli-width": "^2.0.0", "external-editor": "^2.1.0", "figures": "^2.0.0", "lodash": "^4.3.0", "mute-stream": "0.0.7", "run-async": "^2.2.0", "rxjs": "^5.5.2", "string-width": "^2.1.0", "strip-ansi": "^4.0.0", "through": "^2.3.6" } }, "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, ""],
 
@@ -1335,8 +1226,6 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, ""],
 
-    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
-
     "is-extglob": ["is-extglob@2.1.1", "", {}, ""],
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, ""],
@@ -1355,21 +1244,11 @@
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, ""],
 
-    "is-obj": ["is-obj@1.0.1", "", {}, "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="],
-
-    "is-object": ["is-object@1.0.2", "", {}, "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA=="],
-
-    "is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
-
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, ""],
-
-    "is-retry-allowed": ["is-retry-allowed@1.2.0", "", {}, "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="],
 
     "is-set": ["is-set@2.0.3", "", {}, ""],
 
     "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, ""],
-
-    "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
 
     "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, ""],
 
@@ -1383,15 +1262,9 @@
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, ""],
 
-    "is-windows": ["is-windows@0.2.0", "", {}, "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q=="],
-
-    "is-wsl": ["is-wsl@1.1.0", "", {}, "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw=="],
-
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, ""],
-
-    "isurl": ["isurl@1.0.0", "", { "dependencies": { "has-to-string-tag-x": "^1.2.0", "is-object": "^1.0.1" } }, "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w=="],
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, ""],
 
@@ -1411,8 +1284,6 @@
 
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": "lib/cli.js" }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
-    "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
     "jsts": ["jsts@2.7.1", "", {}, "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, ""],
@@ -1425,15 +1296,9 @@
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, ""],
 
-    "lazy-cache": ["lazy-cache@1.0.4", "", {}, "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="],
-
-    "leven": ["leven@2.1.0", "", {}, "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="],
-
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, ""],
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
-
-    "limit-spawn": ["limit-spawn@0.0.3", "", {}, "sha512-2vJ6FDCit0ohq77qdbIdk5JqGs/98W1fGEgozoAMq/oybKPdgLuB8bHH/wWgvCdQzEJpm6Sxh0abG/PtxFr7XA=="],
 
     "lint-staged": ["lint-staged@16.2.7", "", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": "bin/lint-staged.js" }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
 
@@ -1449,11 +1314,7 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, ""],
 
-    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
-
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, ""],
-
-    "log-symbols": ["log-symbols@2.2.0", "", { "dependencies": { "chalk": "^2.0.1" } }, "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg=="],
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
@@ -1461,15 +1322,9 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, ""],
 
-    "lowercase-keys": ["lowercase-keys@1.0.1", "", {}, "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="],
-
-    "lru-cache": ["lru-cache@4.1.5", "", { "dependencies": { "pseudomap": "^1.0.2", "yallist": "^2.1.2" } }, "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g=="],
-
     "lucide-react": ["lucide-react@0.511.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
-
-    "make-dir": ["make-dir@1.3.0", "", { "dependencies": { "pify": "^3.0.0" } }, "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ=="],
 
     "mapbox-gl": ["mapbox-gl@3.25.0", "", {}, "sha512-I+9oSkJVFu51xIAAQcjKophFe6zVAGWROHsszeRhX9E1OXEizgPH+8BkF7GaxmmLd9FbADdEfvULF8NxEFcB5w=="],
 
@@ -1565,11 +1420,7 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, ""],
 
-    "mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
-
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
-    "mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, ""],
 
@@ -1591,11 +1442,7 @@
 
     "mquery": ["mquery@5.0.0", "", { "dependencies": { "debug": "4.x" } }, "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg=="],
 
-    "mri": ["mri@1.1.0", "", {}, "sha512-NbJtWIE2QEVbr9xQHXBY92fxX0Tu8EsS9NBwz7Qn3zoeuvcbP3LzBJw3EUJDpfb9IY8qnZvFSWIepeEFQga28w=="],
-
     "ms": ["ms@2.1.3", "", {}, ""],
-
-    "mute-stream": ["mute-stream@0.0.7", "", {}, "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ=="],
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
@@ -1604,10 +1451,6 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, ""],
 
     "navigation-miniapp": ["navigation-miniapp@workspace:miniapps/navigation"],
-
-    "node-fetch": ["node-fetch@2.6.1", "", {}, "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="],
-
-    "node-version": ["node-version@1.1.3", "", {}, "sha512-rEwE51JWn0yN3Wl5BXeGn5d52OGbSXzWiiXRjAQeuyvcGKyvuSILW2rb3G7Xh+nexzLwhTpek6Ehxd6IjvHePg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, ""],
 
@@ -1629,41 +1472,21 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
-
-    "opn": ["opn@5.4.0", "", { "dependencies": { "is-wsl": "^1.1.0" } }, "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw=="],
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, ""],
 
-    "ora": ["ora@2.0.0", "", { "dependencies": { "chalk": "^2.3.1", "cli-cursor": "^2.1.0", "cli-spinners": "^1.1.0", "log-symbols": "^2.2.0", "strip-ansi": "^4.0.0", "wcwidth": "^1.0.1" } }, "sha512-g+IR0nMUXq1k4nE3gkENbN4wkF0XsVZFyxznTF6CdmwQ9qeTGONGpSR9LM5//1l0TVvJoJF3MkMtJp6slUsWFg=="],
-
-    "os-homedir": ["os-homedir@1.0.2", "", {}, "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="],
-
-    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
-
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, ""],
-
-    "p-cancelable": ["p-cancelable@0.3.0", "", {}, "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="],
-
-    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, ""],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, ""],
-
-    "p-timeout": ["p-timeout@1.2.1", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-gb0ryzr+K2qFqFv6qi3khoeqMZF/+ajxQipEF6NteZVnvz9tzdsfAVj3lYtn1gAXvH5lfLwfxEII799gt/mRIA=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, ""],
-
-    "parse-git-config": ["parse-git-config@1.1.1", "", { "dependencies": { "extend-shallow": "^2.0.1", "fs-exists-sync": "^0.1.0", "git-config-path": "^1.0.1", "ini": "^1.3.4" } }, "sha512-S3LGXJZVSy/hswvbSkfdbKBRVsnqKrVu6j8fcvdtJ4TxosSELyQDsJPuGPXuZ+EyuYuJd3O4uAF8gcISR0OFrQ=="],
-
-    "parse-github-url": ["parse-github-url@1.0.4", "", { "bin": { "parse-github-url": "cli.js" } }, "sha512-CEtCOt55fHmd6DpBc/N7H5NC4vJpcquhzzs9Iw2mRj8bVxo1O5TQI5MXKOMO7+yBOqD+5dKCCRK4Kj1KskZc6Q=="],
-
-    "parse-passwd": ["parse-passwd@1.0.0", "", {}, "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, ""],
 
@@ -1676,8 +1499,6 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": "bin/pidtree.js" }, ""],
-
-    "pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
 
     "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
@@ -1699,8 +1520,6 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, ""],
 
-    "prepend-http": ["prepend-http@1.0.4", "", {}, "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg=="],
-
     "prettier": ["prettier@3.6.2", "", { "bin": "bin/prettier.cjs" }, ""],
 
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
@@ -1713,11 +1532,7 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
-    "promise-polyfill": ["promise-polyfill@6.1.0", "", {}, "sha512-g0LWaH0gFsxovsU7R5LrrhHhWAWiHRnh1GPrhXnPgYsDkIqjRYUYSZEsej/wtleDrz5xVSIDbeKfidztp2XHFQ=="],
-
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, ""],
-
-    "pseudomap": ["pseudomap@1.0.2", "", {}, "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
@@ -1729,11 +1544,7 @@
 
     "quickselect": ["quickselect@2.0.0", "", {}, "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="],
 
-    "random-string": ["random-string@0.2.0", "", {}, "sha512-isA91IquV3ZrFbvwkAtExP8aGL+csx3KGEsEJrvCidzOHioPl5B5g7WyJlk0lMkEz5/i1PqrWTvcdtJHPtrp1g=="],
-
     "rbush": ["rbush@3.0.1", "", { "dependencies": { "quickselect": "^2.0.0" } }, "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w=="],
-
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -1765,37 +1576,21 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, ""],
 
-    "registry-auth-token": ["registry-auth-token@3.3.2", "", { "dependencies": { "rc": "^1.1.6", "safe-buffer": "^5.0.1" } }, "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ=="],
-
-    "registry-url": ["registry-url@3.1.0", "", { "dependencies": { "rc": "^1.0.1" } }, "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA=="],
-
-    "release": ["release@6.3.1", "", { "dependencies": { "@octokit/rest": "15.2.6", "args": "4.0.0", "async-retry": "1.2.1", "capitalize": "1.0.0", "chalk": "2.4.0", "configstore": "3.1.2", "delay": "4.3.0", "escape-goat": "1.3.0", "fs-extra": "5.0.0", "git-repo-name": "0.6.0", "git-spawned-stream": "1.0.0", "git-state": "4.0.0", "git-username": "1.0.0", "github-username": "4.1.0", "inquirer": "5.2.0", "node-fetch": "2.6.1", "node-version": "1.1.3", "opn": "5.4.0", "ora": "2.0.0", "random-string": "0.2.0", "semver": "5.5.0", "tagged-versions": "1.3.0", "update-check": "1.3.2" }, "bin": { "release": "bin/release.js" } }, "sha512-CbbxhelI6eFc9lrhQh9SH2NAl7kROKkJW0LFfzk8qrAowXxBcA08YLXpzNSmuFv9rFnbcMyAUDE7aCLNO6v2GQ=="],
-
-    "remote-origin-url": ["remote-origin-url@0.5.3", "", { "dependencies": { "parse-git-config": "^1.1.1" } }, "sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg=="],
-
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, ""],
 
-    "resolve-dir": ["resolve-dir@0.1.1", "", { "dependencies": { "expand-tilde": "^1.2.2", "global-modules": "^0.2.3" } }, "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA=="],
-
     "resolve-from": ["resolve-from@4.0.0", "", {}, ""],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "restore-cursor": ["restore-cursor@2.0.0", "", { "dependencies": { "onetime": "^2.0.0", "signal-exit": "^3.0.2" } }, "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q=="],
-
-    "retry": ["retry@0.10.1", "", {}, "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ=="],
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
-
-    "run-async": ["run-async@2.4.1", "", {}, "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="],
-
-    "rxjs": ["rxjs@5.5.12", "", { "dependencies": { "symbol-observable": "1.0.1" } }, "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, ""],
 
@@ -1806,8 +1601,6 @@
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, ""],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1841,7 +1634,7 @@
 
     "sift": ["sift@17.1.3", "", {}, "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -1854,8 +1647,6 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, ""],
 
     "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
-
-    "spawn-to-readstream": ["spawn-to-readstream@0.1.3", "", { "dependencies": { "limit-spawn": "0.0.3", "through2": "~0.4.1" } }, "sha512-Xxiqu2wU4nkLv8G+fiv9jT6HRTrz9D8Fajli9HQtqWlrgTwQ3DSs4ZztQbhN/HsVxJX5S7ynzmJ2lQiYDQSYmg=="],
 
     "splaytree-ts": ["splaytree-ts@1.0.2", "", {}, "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA=="],
 
@@ -1885,7 +1676,7 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@4.0.0", "", { "dependencies": { "ansi-regex": "^3.0.0" } }, "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -1897,11 +1688,7 @@
 
     "sweepline-intersections": ["sweepline-intersections@1.5.0", "", { "dependencies": { "tinyqueue": "^2.0.0" } }, "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ=="],
 
-    "symbol-observable": ["symbol-observable@1.0.1", "", {}, "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw=="],
-
     "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
-
-    "tagged-versions": ["tagged-versions@1.3.0", "", { "dependencies": { "child-process-promise": "^2.1.3", "semver": "^5.3.0" } }, "sha512-3tkBqKKQzHkBhQyNvEHTWgbvvNVS9a9omiR9nfbWlWzpOpWfgEPUu9pHwBiDHt5mXnJXKVnRKdCSeJiuZYW9oQ=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
@@ -1911,17 +1698,9 @@
 
     "thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
 
-    "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
-
-    "through2": ["through2@0.4.2", "", { "dependencies": { "readable-stream": "~1.0.17", "xtend": "~2.1.1" } }, "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ=="],
-
-    "timed-out": ["timed-out@4.0.1", "", {}, "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="],
-
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tinyqueue": ["tinyqueue@2.0.3", "", {}, "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="],
-
-    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, ""],
 
@@ -1961,8 +1740,6 @@
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
-    "unique-string": ["unique-string@1.0.0", "", { "dependencies": { "crypto-random-string": "^1.0.0" } }, "sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg=="],
-
     "unist-util-is": ["unist-util-is@6.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, ""],
 
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, ""],
@@ -1971,27 +1748,15 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, ""],
 
-    "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
-    "update-check": ["update-check@1.3.2", "", { "dependencies": { "registry-auth-token": "3.3.2", "registry-url": "3.1.0" } }, "sha512-0iGt63gXrsU4VTw4tIGVVk14H6KLHI7ExNPuSmdDdwUrUAQTBnh1hQcRpnoBWetb3/Ab4YyXK1iDWXP7D0VHTQ=="],
-
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, ""],
-
-    "url-parse-lax": ["url-parse-lax@1.0.0", "", { "dependencies": { "prepend-http": "^1.0.1" } }, "sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA=="],
-
-    "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
-
-    "url-to-options": ["url-to-options@1.0.1", "", {}, "sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -2017,17 +1782,9 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "write-file-atomic": ["write-file-atomic@2.4.3", "", { "dependencies": { "graceful-fs": "^4.1.11", "imurmurhash": "^0.1.4", "signal-exit": "^3.0.2" } }, "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ=="],
-
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "xdg-basedir": ["xdg-basedir@3.0.0", "", {}, "sha512-1Dly4xqlulvPD3fZUQJLY+FUIeqN3N2MM3uqe4rCJftAvOjFa3jFGfctOgluGx4ahPbUCsZkmJILiP0Vi4T6lQ=="],
-
-    "xtend": ["xtend@2.1.2", "", { "dependencies": { "object-keys": "~0.4.0" } }, "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ=="],
-
     "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
-
-    "yallist": ["yallist@2.1.2", "", {}, "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": "bin.mjs" }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -2067,15 +1824,9 @@
 
     "@mentra/miniapp-cli/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@octokit/rest/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
-
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "args/chalk": ["chalk@2.3.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ=="],
-
-    "child-process-promise/cross-spawn": ["cross-spawn@4.0.2", "", { "dependencies": { "lru-cache": "^4.0.1", "which": "^1.2.9" } }, "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA=="],
 
     "cli-truncate/string-width": ["string-width@8.1.1", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw=="],
 
@@ -2101,37 +1852,11 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
-    "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
     "geojson-polygon-self-intersections/rbush": ["rbush@2.0.2", "", { "dependencies": { "quickselect": "^1.0.1" } }, "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA=="],
-
-    "git-spawned-stream/debug": ["debug@0.8.1", "", {}, "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA=="],
-
-    "git-username/remote-origin-url": ["remote-origin-url@1.0.0", "", { "dependencies": { "parse-git-config": "^1.1.1" } }, "sha512-xHDM6IBqivpiQ1e4WOuFpM/T6rbzA/WBsu+3WLtgPOhHyjA0nYlijV3NprlTb4FcXlQ5+Q+z174sQ1NnUF5FwA=="],
-
-    "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
-
-    "got/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "http-proxy-agent/debug": ["debug@3.1.0", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="],
-
-    "https-proxy-agent/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
-
-    "inquirer/chalk": ["chalk@2.4.0", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw=="],
-
-    "inquirer/string-width": ["string-width@2.1.1", "", { "dependencies": { "is-fullwidth-code-point": "^2.0.0", "strip-ansi": "^4.0.0" } }, "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
-    "log-symbols/chalk": ["chalk@2.4.0", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw=="],
-
-    "log-update/ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
-
-    "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
-    "log-update/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, ""],
 
@@ -2139,19 +1864,9 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, ""],
 
-    "ora/chalk": ["chalk@2.4.0", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
-
-    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "registry-auth-token/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "release/chalk": ["chalk@2.4.0", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw=="],
-
-    "release/semver": ["semver@5.5.0", "", { "bin": { "semver": "./bin/semver" } }, "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="],
 
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, ""],
 
@@ -2165,11 +1880,7 @@
 
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "strip-ansi/ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
-
-    "tagged-versions/semver": ["semver@5.5.0", "", { "bin": { "semver": "./bin/semver" } }, "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="],
-
-    "through2/readable-stream": ["readable-stream@1.0.34", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.1", "isarray": "0.0.1", "string_decoder": "~0.10.x" } }, "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg=="],
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "topojson-client/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -2181,109 +1892,19 @@
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "xtend/object-keys": ["object-keys@0.4.0", "", {}, "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="],
-
     "yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "args/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "args/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "args/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
-    "child-process-promise/cross-spawn/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
-
-    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "geojson-polygon-self-intersections/rbush/quickselect": ["quickselect@1.1.1", "", {}, "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="],
-
-    "http-proxy-agent/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "inquirer/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "inquirer/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "inquirer/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
-    "inquirer/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
-    "log-symbols/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "log-symbols/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "log-symbols/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
-    "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
-    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "ora/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "ora/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
-    "release/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "release/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "release/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
-    "through2/readable-stream/isarray": ["isarray@0.0.1", "", {}, "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="],
-
-    "through2/readable-stream/string_decoder": ["string_decoder@0.10.31", "", {}, "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="],
-
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "args/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "args/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "inquirer/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "inquirer/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "log-symbols/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "log-symbols/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "log-update/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
-    "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "ora/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "release/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "release/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
     "yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "args/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "inquirer/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "release/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }

--- a/miniapps/example-miniapp/build.ts
+++ b/miniapps/example-miniapp/build.ts
@@ -15,7 +15,7 @@
  * the developer's own backend, not in MENTRA_PUBLIC_*.
  */
 
-import {networkInterfaces} from "os"
+import {getLanIp} from "@mentra/miniapp-cli/lan"
 import {existsSync} from "fs"
 import {rm} from "fs/promises"
 import {reactSingletonPlugin} from "@mentra/miniapp-cli/build-helpers"
@@ -55,18 +55,6 @@ await rm(distDir, {recursive: true, force: true})
 const DEFAULT_ELEVENLABS_AGENT_ID = "agent_0301ks3wg64pf9evgxqa6dw34t1f"
 
 /** Prefer LAN IP so a MentraOS phone can reach the Mac signing server. */
-function getLanIp(): string | null {
-  const interfaces = networkInterfaces()
-  for (const name of Object.keys(interfaces)) {
-    for (const iface of interfaces[name] ?? []) {
-      if (iface.family === "IPv4" && !iface.internal) {
-        return iface.address
-      }
-    }
-  }
-  return null
-}
-
 const lanIp = getLanIp()
 const signerPort = Number(process.env.ELEVENLABS_SIGNING_SERVER_PORT || 8788)
 const DEFAULT_ELEVENLABS_SIGNED_URL_ENDPOINT = lanIp

--- a/miniapps/example-miniapp/scripts/dev.mjs
+++ b/miniapps/example-miniapp/scripts/dev.mjs
@@ -65,7 +65,9 @@ if (!(await signerHealthy())) {
   console.log(`[dev] ElevenLabs signer already healthy on :${port}`)
 }
 
-const miniapp = spawn("bunx", ["mentra-miniapp", "dev"], {
+// Use the workspace CLI bin (not bunx → npm), so LAN IP / QR updates match
+// the local @mentra/miniapp-cli sources in this monorepo.
+const miniapp = spawn("bun", [join(root, "node_modules/@mentra/miniapp-cli/src/index.ts"), "dev"], {
   cwd: root,
   env: process.env,
   stdio: "inherit",

--- a/mobile/modules/engine/src/facades/dev.ts
+++ b/mobile/modules/engine/src/facades/dev.ts
@@ -143,25 +143,29 @@ export const dev = {
       return {ok: false, error: "dev server unreachable, or no miniapp.json served there"}
     }
     const manifest = result.manifest
+    const appName = name ?? manifest.name ?? "Dev Miniapp"
+    const packageName = (manifest.packageName as string | undefined) ?? DEV_APP_PACKAGE_NAME
+    // Persist the host that answered — not the stale input IP — so home-tile
+    // relaunches skip a dead LAN address after mDNS/Metro failover.
+    const resolvedUrl = result.resolvedUrl || devUrl
     // The `mentra-miniapp dev` server puts the hot-reload/log sidecar on the
     // user port PLUS ONE — same convention as the first-party developer-URL
     // screen's deriveDevPort.
     let devPort: number | undefined
     try {
-      const parsed = Number(new URL(devUrl).port)
+      const parsed = Number(new URL(resolvedUrl).port)
       devPort = Number.isFinite(parsed) && parsed > 0 ? parsed + 1 : undefined
     } catch {
       devPort = undefined
     }
-    const appName = name ?? manifest.name ?? "Dev Miniapp"
-    const packageName = (manifest.packageName as string | undefined) ?? DEV_APP_PACKAGE_NAME
     const existing = useAppStatusStore.getState().apps.find((app) => app.packageName === packageName)
     if (existing?.running) await useAppStatusStore.getState().stop(packageName)
     await registerDevApp({
       packageName,
       name: appName,
-      iconUrl: manifest.icon ? new URL(manifest.icon, `${devUrl}/`).toString() : `${devUrl}/icon.png`,
-      devUrl,
+      iconUrl: manifest.icon ? new URL(manifest.icon, `${resolvedUrl}/`).toString() : `${resolvedUrl}/icon.png`,
+      // Persist the host that answered — not the stale input IP.
+      devUrl: resolvedUrl,
       devPort,
       type: manifest.type as DevAppRecord["type"],
       permissions: manifest.permissions as DevAppRecord["permissions"],

--- a/mobile/modules/engine/src/index.ts
+++ b/mobile/modules/engine/src/index.ts
@@ -152,7 +152,12 @@ export {
 } from "./stores/apps"
 
 // Pure dev-miniapp launch-route decision (registration itself is internal).
-export {decideDevLaunchRoute, type DevLaunchResult, type DevManifest} from "./utils/devMiniappLaunch"
+export {
+  decideDevLaunchRoute,
+  type DecideDevLaunchOptions,
+  type DevLaunchResult,
+  type DevManifest,
+} from "./utils/devMiniappLaunch"
 export {HardwareCompatibility, type CompatibilityResult} from "./utils/hardware"
 export {BgTimer, throttle, debounce} from "./utils/timers"
 

--- a/mobile/modules/engine/src/services/AppRegistry.ts
+++ b/mobile/modules/engine/src/services/AppRegistry.ts
@@ -551,6 +551,7 @@ class AppRegistry {
     }
     storage.remove(`${packageName}_dev_url`)
     storage.remove(`${packageName}_dev_port`)
+    storage.remove(`${packageName}_dev_mdns`)
     storage.remove(`${packageName}_dev_last_reachable`)
     // HTTP-direct dev miniapps are indexed by their real package name. A
     // release install/uninstall of that same package should remove only its
@@ -939,6 +940,12 @@ export interface DevAppRecord {
   iconUrl: string
   devUrl: string
   devPort?: number
+  /**
+   * Bonjour / mDNS hostname from the QR (`ComputerName.local`). Used as a
+   * failover host when the raw LAN IP in `devUrl` goes stale after a Wi-Fi
+   * change — phones that resolve `.local` can relaunch without re-scanning.
+   */
+  mdnsHost?: string
   type?: AppletType
   permissions?: Array<string | {type: string; required?: boolean; description?: string}>
   hardwareRequirements?: Array<{type: string; level: string; description?: string}>
@@ -1063,6 +1070,7 @@ function removeDevRecordKeys(packageName: string): void {
   storage.remove(`${packageName}_dev_meta`)
   storage.remove(`${packageName}_dev_url`)
   storage.remove(`${packageName}_dev_port`)
+  storage.remove(`${packageName}_dev_mdns`)
   storage.remove(`${packageName}_dev_last_reachable`)
 }
 
@@ -1105,6 +1113,7 @@ function migrateLegacyDevSlot(): void {
   storage.remove(`${DEV_APP_PACKAGE_NAME}_dev_meta`)
   storage.remove(`${DEV_APP_PACKAGE_NAME}_dev_url`)
   storage.remove(`${DEV_APP_PACKAGE_NAME}_dev_port`)
+  storage.remove(`${DEV_APP_PACKAGE_NAME}_dev_mdns`)
   storage.remove(`${DEV_APP_PACKAGE_NAME}_dev_last_reachable`)
 
   const index = Array.from(new Set(getDevAppIndex().map((pkg) => (pkg === DEV_APP_PACKAGE_NAME ? targetPackage : pkg))))
@@ -1134,6 +1143,12 @@ export async function registerDevApp(record: DevAppRecord): Promise<void> {
     storage.save(`${packageName}_dev_port`, record.devPort)
   } else {
     storage.remove(`${packageName}_dev_port`)
+  }
+  const mdns = record.mdnsHost?.trim()
+  if (mdns) {
+    storage.save(`${packageName}_dev_mdns`, mdns)
+  } else {
+    storage.remove(`${packageName}_dev_mdns`)
   }
   const idx = getDevAppIndex()
   if (!idx.includes(packageName)) {

--- a/mobile/modules/engine/src/services/AppRegistry.ts
+++ b/mobile/modules/engine/src/services/AppRegistry.ts
@@ -24,7 +24,7 @@ import {AsyncResult, Result, result as Res} from "typesafe-ts"
 
 import type {AppletPermission, AppPermissionType, AppletType, ClientApp} from "../types/applet"
 import {HardwareRequirement, HardwareRequirementLevel, HardwareType} from "../types"
-import {getConfigValues} from "../runtime/bootstrap"
+import {configuredDevHost} from "../utils/configuredDevHost"
 import {storage} from "../utils/storage/storage"
 import {printDirectory} from "../utils/storage/zip"
 import {checkManifestVersions} from "./manifestVersionGate"
@@ -964,22 +964,6 @@ export interface DevAppRecord {
 const DEV_APPS_INDEX_KEY = "dev_apps_index"
 const DEV_APP_ICONS_DIR = "dev-miniapp-icons"
 
-function configuredDevHost(): string | undefined {
-  // Explicit escape hatch first; otherwise the host-injected Metro host (the
-  // address this dev bundle was served from — always current for the network
-  // the phone is on). Deliberately NOT the EXPO_PUBLIC_CLOUD_* URLs: those are
-  // cloud endpoints, a different machine entirely from the laptop running the
-  // miniapp dev server, and rewriting a dev URL to a cloud host would break it.
-  const explicit = process.env.EXPO_PUBLIC_LOCAL_MINIAPP_HOST
-  if (explicit) {
-    try {
-      return new URL(explicit).hostname
-    } catch {
-      if (/^[\w.-]+$/.test(explicit)) return explicit
-    }
-  }
-  return getConfigValues().devServerHost?.()
-}
 
 function isPrivateLanHost(hostname: string): boolean {
   return (
@@ -1108,6 +1092,11 @@ function migrateLegacyDevSlot(): void {
   if (!targetPort.is_ok()) {
     const port = migrated.devPort ?? (legacyPort.is_ok() ? legacyPort.value : undefined)
     if (typeof port === "number" && Number.isFinite(port)) storage.save(`${targetPackage}_dev_port`, port)
+  }
+  const legacyMdns = storage.load<string>(`${DEV_APP_PACKAGE_NAME}_dev_mdns`)
+  const targetMdns = storage.load<string>(`${targetPackage}_dev_mdns`)
+  if (!targetMdns.is_ok() && legacyMdns.is_ok() && legacyMdns.value.trim()) {
+    storage.save(`${targetPackage}_dev_mdns`, legacyMdns.value.trim())
   }
 
   storage.remove(`${DEV_APP_PACKAGE_NAME}_dev_meta`)

--- a/mobile/modules/engine/src/services/AppRegistry.ts
+++ b/mobile/modules/engine/src/services/AppRegistry.ts
@@ -1120,6 +1120,12 @@ function migrateLegacyDevSlot(): void {
   storage.save(DEV_APPS_INDEX_KEY, JSON.stringify(index))
 }
 
+function readStoredMdnsHost(packageName: string): string | undefined {
+  const res = storage.load<string>(`${packageName}_dev_mdns`)
+  if (!res.is_ok()) return undefined
+  return res.value.trim() || undefined
+}
+
 /**
  * Register or update one dev miniapp under its real manifest package. Different
  * package names coexist; rescanning the same package updates that package only.
@@ -1130,12 +1136,18 @@ export async function registerDevApp(record: DevAppRecord): Promise<void> {
   if (!packageName) throw new Error("Dev miniapp manifest is missing packageName")
 
   const iconUrl = await cacheDevAppIcon(packageName, record.iconUrl)
+  // Relaunch paths (developer-URL screen, loadDevMiniapp) omit mdnsHost, so an
+  // omitted field keeps whatever the QR scan stored instead of wiping the
+  // `.local` failover host.
+  const mdnsHost =
+    record.mdnsHost !== undefined ? record.mdnsHost.trim() || undefined : readStoredMdnsHost(packageName)
   const devRecord: DevAppRecord = {
     ...record,
     packageName,
     sourcePackageName: packageName,
     name: record.name || DEV_APP_NAME,
     iconUrl,
+    mdnsHost,
   }
   storage.save(`${packageName}_dev_meta`, JSON.stringify(devRecord))
   storage.save(`${packageName}_dev_url`, record.devUrl)
@@ -1144,9 +1156,8 @@ export async function registerDevApp(record: DevAppRecord): Promise<void> {
   } else {
     storage.remove(`${packageName}_dev_port`)
   }
-  const mdns = record.mdnsHost?.trim()
-  if (mdns) {
-    storage.save(`${packageName}_dev_mdns`, mdns)
+  if (mdnsHost) {
+    storage.save(`${packageName}_dev_mdns`, mdnsHost)
   } else {
     storage.remove(`${packageName}_dev_mdns`)
   }

--- a/mobile/modules/engine/src/services/MiniappLauncher.ts
+++ b/mobile/modules/engine/src/services/MiniappLauncher.ts
@@ -109,7 +109,9 @@ class MiniappLauncher {
       const entry = manifest.entry as {background?: string; ui?: string} | undefined
       if (!entry?.background) return null
 
-      const base = devUrl.replace(/\/$/, "")
+      // Use the host that actually answered — may differ from the stored IP
+      // after a laptop Wi-Fi change (mDNS / Metro failover inside decideDevLaunchRoute).
+      const base = route.resolvedUrl.replace(/\/$/, "")
       // entry.* are bundle-root paths (dist/ stripped); the dev server serves
       // files relative to cwd, so prepend dist/.
       const bgUrl = `${base}/dist/${entry.background.replace(/^\.?\/+/, "")}`
@@ -147,7 +149,7 @@ class MiniappLauncher {
         uiBaseDir: uiUri ? uiUri.replace(/\/[^/]+$/, "/") : null,
         declaredPermissions,
         installedManifest,
-        devUrl,
+        devUrl: route.resolvedUrl,
         devPort: this.resolveDevPort(hints?.devPort, packageName),
       }
     }

--- a/mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts
+++ b/mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts
@@ -108,6 +108,32 @@ describe("decideDevLaunchRoute", () => {
     expect(savedKeys.some((s) => s.key === "com.dev.example_dev_url" && s.value === result.resolvedUrl)).toBe(true)
   })
 
+  test("failover leaves a cached file:// icon alone and rehosts a served icon", async () => {
+    fetchImpl = async (url) => {
+      if (url.includes("192.168.1.50")) throw new TypeError("timed out")
+      return new Response(JSON.stringify({packageName: "com.dev.example"}), {status: 200})
+    }
+    const readMeta = () => {
+      const saved = savedKeys.filter((s) => s.key === "com.dev.example_dev_meta").pop()
+      return JSON.parse(String(saved?.value)) as {devUrl?: string; iconUrl?: string}
+    }
+
+    stored.set(
+      "com.dev.example_dev_meta",
+      JSON.stringify({devUrl: DEV_URL, iconUrl: "file:///var/mobile/dev-icons/com.dev.example.png"}),
+    )
+    await decideDevLaunchRoute("com.dev.example", DEV_URL, {alternateHosts: ["Mentas-MacBook-Pro.local"]})
+    expect(readMeta().iconUrl).toBe("file:///var/mobile/dev-icons/com.dev.example.png")
+
+    savedKeys.length = 0
+    stored.set(
+      "com.dev.example_dev_meta",
+      JSON.stringify({devUrl: DEV_URL, iconUrl: "http://192.168.1.50:3000/icon.png"}),
+    )
+    await decideDevLaunchRoute("com.dev.example", DEV_URL, {alternateHosts: ["Mentas-MacBook-Pro.local"]})
+    expect(readMeta().iconUrl).toBe("http://mentas-macbook-pro.local:3000/icon.png")
+  })
+
   test("reads stored mDNS host as an alternate", async () => {
     stored.set("com.dev.example_dev_mdns", "Mentas-MacBook-Pro.local")
     fetchImpl = async (url) => {

--- a/mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts
+++ b/mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts
@@ -132,6 +132,15 @@ describe("decideDevLaunchRoute", () => {
     )
     await decideDevLaunchRoute("com.dev.example", DEV_URL, {alternateHosts: ["Mentas-MacBook-Pro.local"]})
     expect(readMeta().iconUrl).toBe("http://mentas-macbook-pro.local:3000/icon.png")
+
+    savedKeys.length = 0
+    stored.set(
+      "com.dev.example_dev_meta",
+      JSON.stringify({devUrl: DEV_URL, iconUrl: "http://192.168.1.50:9999/other-service/icon.png"}),
+    )
+    await decideDevLaunchRoute("com.dev.example", DEV_URL, {alternateHosts: ["Mentas-MacBook-Pro.local"]})
+    // Same hostname, different port — leave the unrelated service icon alone.
+    expect(readMeta().iconUrl).toBe("http://192.168.1.50:9999/other-service/icon.png")
   })
 
   test("reads stored mDNS host as an alternate", async () => {

--- a/mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts
+++ b/mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts
@@ -6,12 +6,22 @@ import {beforeEach, describe, expect, mock, test} from "bun:test"
 // unavailable outside the RN runtime. Stub it before importing the module under
 // test; decideDevLaunchRoute only touches storage.save() on a "live" resolution.
 const savedKeys: Array<{key: string; value: unknown}> = []
+const stored = new Map<string, unknown>()
 mock.module("../storage/storage", () => ({
   storage: {
     save: (key: string, value: unknown) => {
       savedKeys.push({key, value})
+      stored.set(key, value)
+    },
+    load: <T>(key: string) => {
+      if (!stored.has(key)) return {is_ok: () => false as const}
+      return {is_ok: () => true as const, value: stored.get(key) as T}
     },
   },
+}))
+
+mock.module("../../runtime/bootstrap", () => ({
+  getConfigValues: () => ({}),
 }))
 
 const {decideDevLaunchRoute} = await import("../devMiniappLaunch")
@@ -19,14 +29,16 @@ const {decideDevLaunchRoute} = await import("../devMiniappLaunch")
 const DEV_URL = "http://192.168.1.50:3000"
 
 let fetchCalls = 0
-let fetchImpl: () => Promise<Response>
+let fetchImpl: (url: string) => Promise<Response>
 
 beforeEach(() => {
   fetchCalls = 0
   savedKeys.length = 0
-  ;(globalThis as {fetch: typeof fetch}).fetch = (async (..._args: unknown[]) => {
+  stored.clear()
+  ;(globalThis as {fetch: typeof fetch}).fetch = (async (input: RequestInfo | URL, ..._args: unknown[]) => {
     fetchCalls++
-    return fetchImpl()
+    const url = typeof input === "string" ? input : input.toString()
+    return fetchImpl(url)
   }) as typeof fetch
 })
 
@@ -38,8 +50,9 @@ describe("decideDevLaunchRoute", () => {
     const result = await decideDevLaunchRoute("com.dev.example", DEV_URL)
 
     expect(result.decision).toBe("live")
+    expect(result.resolvedUrl).toBe(DEV_URL)
     expect(fetchCalls).toBe(1)
-    expect(savedKeys).toHaveLength(1)
+    expect(savedKeys.some((s) => s.key === "com.dev.example_dev_last_reachable")).toBe(true)
   })
 
   test("retries once after a network-layer failure, then succeeds", async () => {
@@ -62,15 +75,49 @@ describe("decideDevLaunchRoute", () => {
     const result = await decideDevLaunchRoute("com.dev.example", DEV_URL)
 
     expect(result.decision).toBe("offline")
+    // Two attempts on the primary URL; no alternates configured.
     expect(fetchCalls).toBe(2)
   })
 
-  test("does not retry a definitive non-OK HTTP response", async () => {
+  test("does not retry a definitive non-OK HTTP response on the same URL", async () => {
     fetchImpl = async () => new Response("not found", {status: 404})
 
     const result = await decideDevLaunchRoute("com.dev.example", DEV_URL)
 
     expect(result.decision).toBe("offline")
     expect(fetchCalls).toBe(1)
+  })
+
+  test("failovers to an alternate host and persists the working URL", async () => {
+    fetchImpl = async (url) => {
+      const lower = url.toLowerCase()
+      if (lower.includes("192.168.1.50")) throw new TypeError("timed out")
+      if (lower.includes("mentas-macbook-pro.local")) {
+        return new Response(JSON.stringify({packageName: "com.dev.example", name: "Example"}), {status: 200})
+      }
+      throw new TypeError(`unexpected host: ${url}`)
+    }
+
+    const result = await decideDevLaunchRoute("com.dev.example", DEV_URL, {
+      alternateHosts: ["Mentas-MacBook-Pro.local"],
+    })
+
+    expect(result.decision).toBe("live")
+    // URL() canonicalizes hostnames to lowercase.
+    expect(result.resolvedUrl).toBe("http://mentas-macbook-pro.local:3000")
+    expect(savedKeys.some((s) => s.key === "com.dev.example_dev_url" && s.value === result.resolvedUrl)).toBe(true)
+  })
+
+  test("reads stored mDNS host as an alternate", async () => {
+    stored.set("com.dev.example_dev_mdns", "Mentas-MacBook-Pro.local")
+    fetchImpl = async (url) => {
+      if (url.includes("192.168.1.50")) throw new TypeError("timed out")
+      return new Response(JSON.stringify({packageName: "com.dev.example"}), {status: 200})
+    }
+
+    const result = await decideDevLaunchRoute("com.dev.example", DEV_URL)
+
+    expect(result.decision).toBe("live")
+    expect(result.resolvedUrl).toBe("http://mentas-macbook-pro.local:3000")
   })
 })

--- a/mobile/modules/engine/src/utils/configuredDevHost.ts
+++ b/mobile/modules/engine/src/utils/configuredDevHost.ts
@@ -1,0 +1,17 @@
+import {getConfigValues} from "../runtime/bootstrap"
+
+/**
+ * Explicit Metro / laptop host override used by stale-URL rewrite and launch
+ * failover. One source of truth so AppRegistry and decideDevLaunchRoute stay aligned.
+ */
+export function configuredDevHost(): string | undefined {
+  const explicit = process.env.EXPO_PUBLIC_LOCAL_MINIAPP_HOST
+  if (explicit) {
+    try {
+      return new URL(explicit).hostname
+    } catch {
+      if (/^[\w.-]+$/.test(explicit)) return explicit
+    }
+  }
+  return getConfigValues().devServerHost?.()
+}

--- a/mobile/modules/engine/src/utils/devMiniappLaunch.ts
+++ b/mobile/modules/engine/src/utils/devMiniappLaunch.ts
@@ -94,8 +94,12 @@ function rewriteIconHost(iconUrl: string, staleDevUrl: string, resolvedDevUrl: s
   try {
     const icon = new URL(iconUrl)
     if (icon.protocol !== "http:" && icon.protocol !== "https:") return null
-    if (icon.hostname !== new URL(staleDevUrl).hostname) return null
-    icon.hostname = new URL(resolvedDevUrl).hostname
+    const stale = new URL(staleDevUrl)
+    const resolved = new URL(resolvedDevUrl)
+    // Compare host (hostname+port) so an icon on the same hostname but a
+    // different service port is left alone.
+    if (icon.host !== stale.host) return null
+    icon.host = resolved.host
     return icon.toString()
   } catch {
     return null

--- a/mobile/modules/engine/src/utils/devMiniappLaunch.ts
+++ b/mobile/modules/engine/src/utils/devMiniappLaunch.ts
@@ -12,8 +12,14 @@
  *      get it in the same round trip — no second fetch.
  *
  * Pre-flighting at the call site keeps /applet/local a pure mount route.
+ *
+ * When the laptop's Wi-Fi IP changes, the URL stored from the last QR scan
+ * goes stale. We then retry alternate hosts (Metro / EXPO_PUBLIC_LOCAL_MINIAPP_HOST,
+ * plus an mDNS name captured at scan time) and persist the working URL so
+ * the next launch doesn't need a re-scan.
  */
 
+import {getConfigValues} from "../runtime/bootstrap"
 import {storage} from "./storage/storage"
 
 const REACHABILITY_TIMEOUT_MS = 1500
@@ -37,7 +43,14 @@ export type DevManifest = {
   [key: string]: unknown
 }
 
-export type DevLaunchResult = {decision: "live"; manifest: DevManifest} | {decision: "offline"; manifest: null}
+export type DevLaunchResult =
+  | {decision: "live"; manifest: DevManifest; resolvedUrl: string}
+  | {decision: "offline"; manifest: null; resolvedUrl?: undefined}
+
+export type DecideDevLaunchOptions = {
+  /** Extra hostnames / IPs to try if `devUrl` is unreachable (no scheme/port). */
+  alternateHosts?: string[]
+}
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -59,35 +72,120 @@ async function fetchManifestOnce(devUrl: string): Promise<DevManifest | null> {
   }
 }
 
-/**
- * GET <devUrl>/miniapp.json with a hard timeout, retrying once on a
- * network-layer failure (DNS/connection/abort) before declaring the dev
- * server offline. Returns the parsed manifest on success ("live") or
- * null ("offline").
- *
- * Side effect: on success, writes <packageName>_dev_last_reachable so
- * the dev-offline screen can show "Last reached: N min ago" the next
- * time the user lands there.
- *
- * The fetch doubles as the reachability probe AND the manifest source —
- * one request per attempt instead of two.
- */
-export async function decideDevLaunchRoute(packageName: string, devUrl: string): Promise<DevLaunchResult> {
+function rewriteHost(devUrl: string, host: string): string | null {
+  const trimmed = host.trim()
+  if (!trimmed) return null
+  try {
+    const url = new URL(devUrl)
+    if (url.hostname === trimmed) return null
+    url.hostname = trimmed
+    return url.toString().replace(/\/$/, "")
+  } catch {
+    return null
+  }
+}
+
+function collectAlternateHosts(packageName: string, extra?: string[]): string[] {
+  const hosts: string[] = []
+  const push = (h: string | undefined | null) => {
+    const v = h?.trim()
+    if (v && !hosts.includes(v)) hosts.push(v)
+  }
+
+  // Explicit escape hatch (same contract as AppRegistry.configuredDevHost).
+  const explicit = process.env.EXPO_PUBLIC_LOCAL_MINIAPP_HOST
+  if (explicit) {
+    try {
+      push(new URL(explicit).hostname)
+    } catch {
+      if (/^[\w.-]+$/.test(explicit)) push(explicit)
+    }
+  }
+
+  push(getConfigValues().devServerHost?.())
+
+  if (packageName) {
+    const mdns = storage.load<string>(`${packageName}_dev_mdns`)
+    if (mdns.is_ok()) push(mdns.value)
+  }
+
+  for (const h of extra ?? []) push(h)
+  return hosts
+}
+
+async function probeUrl(devUrl: string): Promise<DevManifest | null | "network-error"> {
   for (let attempt = 1; attempt <= REACHABILITY_MAX_ATTEMPTS; attempt++) {
     try {
       const manifest = await fetchManifestOnce(devUrl)
-      if (!manifest) return {decision: "offline", manifest: null}
-      if (packageName) {
-        storage.save(`${packageName}_dev_last_reachable`, Date.now())
-      }
-      return {decision: "live", manifest}
+      // Definitive HTTP failure — do not retry this URL further.
+      if (!manifest) return null
+      return manifest
     } catch {
       if (attempt < REACHABILITY_MAX_ATTEMPTS) {
         await delay(REACHABILITY_RETRY_DELAY_MS)
         continue
       }
-      return {decision: "offline", manifest: null}
+      return "network-error"
     }
   }
+  return "network-error"
+}
+
+/**
+ * GET <devUrl>/miniapp.json with a hard timeout, retrying once on a
+ * network-layer failure (DNS/connection/abort) before trying alternate
+ * hosts (Metro laptop IP, mDNS name from the QR). Returns the parsed
+ * manifest on success ("live") or null ("offline").
+ *
+ * Side effects on success:
+ *   - writes <packageName>_dev_last_reachable
+ *   - if an alternate host worked, rewrites <packageName>_dev_url so the
+ *     next launch skips the stale IP
+ */
+export async function decideDevLaunchRoute(
+  packageName: string,
+  devUrl: string,
+  options?: DecideDevLaunchOptions,
+): Promise<DevLaunchResult> {
+  const candidates: string[] = [devUrl]
+  for (const host of collectAlternateHosts(packageName, options?.alternateHosts)) {
+    const rewritten = rewriteHost(devUrl, host)
+    if (rewritten && !candidates.includes(rewritten)) candidates.push(rewritten)
+  }
+
+  for (const candidate of candidates) {
+    const result = await probeUrl(candidate)
+    if (result === "network-error" || result === null) continue
+
+    if (packageName) {
+      storage.save(`${packageName}_dev_last_reachable`, Date.now())
+      if (candidate !== devUrl) {
+        storage.save(`${packageName}_dev_url`, candidate)
+        // Keep _dev_meta.devUrl in sync when present so home-tile reads match.
+        const metaRes = storage.load<string>(`${packageName}_dev_meta`)
+        if (metaRes.is_ok()) {
+          try {
+            const meta = JSON.parse(metaRes.value) as {devUrl?: string; iconUrl?: string}
+            meta.devUrl = candidate
+            if (typeof meta.iconUrl === "string") {
+              try {
+                const icon = new URL(meta.iconUrl)
+                const resolved = new URL(candidate)
+                icon.hostname = resolved.hostname
+                meta.iconUrl = icon.toString()
+              } catch {
+                /* keep prior iconUrl */
+              }
+            }
+            storage.save(`${packageName}_dev_meta`, JSON.stringify(meta))
+          } catch {
+            /* ignore malformed meta */
+          }
+        }
+      }
+    }
+    return {decision: "live", manifest: result, resolvedUrl: candidate}
+  }
+
   return {decision: "offline", manifest: null}
 }

--- a/mobile/modules/engine/src/utils/devMiniappLaunch.ts
+++ b/mobile/modules/engine/src/utils/devMiniappLaunch.ts
@@ -85,6 +85,23 @@ function rewriteHost(devUrl: string, host: string): string | null {
   }
 }
 
+/**
+ * Point an http(s) icon at the host that actually answered. Cached dev icons are
+ * local `file://` paths and third-party icons live on unrelated hosts, so only
+ * icons still served by the stale dev host are rewritten.
+ */
+function rewriteIconHost(iconUrl: string, staleDevUrl: string, resolvedDevUrl: string): string | null {
+  try {
+    const icon = new URL(iconUrl)
+    if (icon.protocol !== "http:" && icon.protocol !== "https:") return null
+    if (icon.hostname !== new URL(staleDevUrl).hostname) return null
+    icon.hostname = new URL(resolvedDevUrl).hostname
+    return icon.toString()
+  } catch {
+    return null
+  }
+}
+
 function collectAlternateHosts(packageName: string, extra?: string[]): string[] {
   const hosts: string[] = []
   const push = (h: string | undefined | null) => {
@@ -168,14 +185,8 @@ export async function decideDevLaunchRoute(
             const meta = JSON.parse(metaRes.value) as {devUrl?: string; iconUrl?: string}
             meta.devUrl = candidate
             if (typeof meta.iconUrl === "string") {
-              try {
-                const icon = new URL(meta.iconUrl)
-                const resolved = new URL(candidate)
-                icon.hostname = resolved.hostname
-                meta.iconUrl = icon.toString()
-              } catch {
-                /* keep prior iconUrl */
-              }
+              const rewritten = rewriteIconHost(meta.iconUrl, devUrl, candidate)
+              if (rewritten) meta.iconUrl = rewritten
             }
             storage.save(`${packageName}_dev_meta`, JSON.stringify(meta))
           } catch {

--- a/mobile/modules/engine/src/utils/devMiniappLaunch.ts
+++ b/mobile/modules/engine/src/utils/devMiniappLaunch.ts
@@ -19,7 +19,7 @@
  * the next launch doesn't need a re-scan.
  */
 
-import {getConfigValues} from "../runtime/bootstrap"
+import {configuredDevHost} from "./configuredDevHost"
 import {storage} from "./storage/storage"
 
 const REACHABILITY_TIMEOUT_MS = 1500
@@ -109,17 +109,7 @@ function collectAlternateHosts(packageName: string, extra?: string[]): string[] 
     if (v && !hosts.includes(v)) hosts.push(v)
   }
 
-  // Explicit escape hatch (same contract as AppRegistry.configuredDevHost).
-  const explicit = process.env.EXPO_PUBLIC_LOCAL_MINIAPP_HOST
-  if (explicit) {
-    try {
-      push(new URL(explicit).hostname)
-    } catch {
-      if (/^[\w.-]+$/.test(explicit)) push(explicit)
-    }
-  }
-
-  push(getConfigValues().devServerHost?.())
+  push(configuredDevHost())
 
   if (packageName) {
     const mdns = storage.load<string>(`${packageName}_dev_mdns`)

--- a/mobile/src/app/applet/dev-offline.tsx
+++ b/mobile/src/app/applet/dev-offline.tsx
@@ -6,6 +6,7 @@ import {View} from "react-native"
 import {Button, Screen, Text} from "@/components/ignite"
 import {useNavigationStore} from "@/stores/navigation"
 import {decideDevLaunchRoute, engine, useApps} from "@mentra/engine"
+import {registerDevApp, type DevAppRecord} from "@mentra/engine/internal"
 import {storage} from "@/utils/storage/storage"
 import {useRegisterCapsule} from "@/stores/capsule"
 import {useRef} from "react"
@@ -61,6 +62,28 @@ export default function DevMiniappOfflineScreen() {
     // re-scan. If up, replace into /applet/local.
     const launchResult = await decideDevLaunchRoute(packageName, devUrlRes.value)
     if (launchResult.decision === "live") {
+      // A scan whose very first probe failed only stashed routing keys, so the
+      // package may not be registered yet. Register from the manifest we just
+      // fetched — otherwise setForeground has no app to bring up.
+      const manifest = launchResult.manifest
+      if (manifest && !apps.some(app => app.packageName === packageName)) {
+        const base = (launchResult.resolvedUrl || devUrlRes.value).replace(/\/$/, "")
+        const icon = typeof manifest.icon === "string" ? manifest.icon : undefined
+        const port = storage.load<number>(`${packageName}_dev_port`)
+        await registerDevApp({
+          packageName,
+          name: manifest.name || resolvedName || packageName,
+          iconUrl:
+            icon && /^https?:\/\//.test(icon) ? icon : `${base}/${(icon ?? "icon.png").replace(/^\//, "")}`,
+          devUrl: launchResult.resolvedUrl || devUrlRes.value,
+          devPort: port.is_ok() ? port.value : undefined,
+          type: manifest.type as DevAppRecord["type"],
+          permissions: manifest.permissions as DevAppRecord["permissions"],
+          hardwareRequirements: manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],
+          actions: manifest.actions as DevAppRecord["actions"],
+        })
+        await engine.miniapps.refresh()
+      }
       await engine.miniapps.setForeground(packageName)
     }
     // else: stay put — the "Last reached" line stays accurate, user can

--- a/mobile/src/app/applet/dev-offline.tsx
+++ b/mobile/src/app/applet/dev-offline.tsx
@@ -66,25 +66,43 @@ export default function DevMiniappOfflineScreen() {
       // package may not be registered yet. Register from the manifest we just
       // fetched — otherwise setForeground has no app to bring up.
       const manifest = launchResult.manifest
-      if (manifest && !apps.some(app => app.packageName === packageName)) {
+      const manifestPackage = manifest?.packageName?.trim()
+      if (!manifestPackage) {
+        // Offline stash used unverified QR identity; without a live manifest
+        // package we refuse to mint a home-tile under the QR key.
+        return
+      }
+      // If the QR package disagreed with the server, move stashed routing keys
+      // onto the manifest package before registering/foregrounding.
+      if (manifestPackage !== packageName) {
+        for (const suffix of ["_dev_url", "_dev_mdns", "_dev_port", "_dev_attestation"] as const) {
+          const from = storage.load<string | number>(`${packageName}${suffix}`)
+          if (from.is_ok()) storage.save(`${manifestPackage}${suffix}`, from.value)
+          storage.remove(`${packageName}${suffix}`)
+        }
+      }
+      if (manifest && !apps.some(app => app.packageName === manifestPackage)) {
         const base = (launchResult.resolvedUrl || devUrlRes.value).replace(/\/$/, "")
         const icon = typeof manifest.icon === "string" ? manifest.icon : undefined
-        const port = storage.load<number>(`${packageName}_dev_port`)
+        const port = storage.load<number>(`${manifestPackage}_dev_port`)
+        const attestation = storage.load<string>(`${manifestPackage}_dev_attestation`)
         await registerDevApp({
-          packageName,
-          name: manifest.name || resolvedName || packageName,
+          packageName: manifestPackage,
+          name: manifest.name || resolvedName || manifestPackage,
           iconUrl:
             icon && /^https?:\/\//.test(icon) ? icon : `${base}/${(icon ?? "icon.png").replace(/^\//, "")}`,
           devUrl: launchResult.resolvedUrl || devUrlRes.value,
           devPort: port.is_ok() ? port.value : undefined,
+          devAttestation: attestation.is_ok() ? attestation.value : undefined,
           type: manifest.type as DevAppRecord["type"],
           permissions: manifest.permissions as DevAppRecord["permissions"],
           hardwareRequirements: manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],
           actions: manifest.actions as DevAppRecord["actions"],
         })
+        storage.remove(`${manifestPackage}_dev_attestation`)
         await engine.miniapps.refresh()
       }
-      await engine.miniapps.setForeground(packageName)
+      await engine.miniapps.setForeground(manifestPackage)
     }
     // else: stay put — the "Last reached" line stays accurate, user can
     // tap again or re-scan.

--- a/mobile/src/app/miniapps/miniappdev/developer-url.tsx
+++ b/mobile/src/app/miniapps/miniappdev/developer-url.tsx
@@ -121,12 +121,14 @@ export default function MiniappDeveloperUrlScreen() {
     // dev packages remain registered and independently launchable.
     const existing = engine.miniapps.list().find((app) => app.packageName === packageName)
     if (existing?.running) await engine.miniapps.stop(packageName)
+    const resolvedUrl = launchResult.resolvedUrl || entry.url
     await registerDevApp({
       packageName,
       name: appName,
-      iconUrl: resolveIconUrl(entry.url, launchResult.manifest.icon) ?? entry.iconUrl ?? `${entry.url}/icon.png`,
-      devUrl: entry.url,
-      devPort: deriveDevPort(entry.url),
+      iconUrl: resolveIconUrl(resolvedUrl, launchResult.manifest.icon) ?? entry.iconUrl ?? `${resolvedUrl}/icon.png`,
+      // Persist the host that answered — not the stale QR/recent-list IP.
+      devUrl: resolvedUrl,
+      devPort: deriveDevPort(resolvedUrl),
       type: launchResult.manifest.type as DevAppRecord["type"],
       permissions: launchResult.manifest.permissions as DevAppRecord["permissions"],
       hardwareRequirements: launchResult.manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],

--- a/mobile/src/app/miniapps/miniappdev/scanner.tsx
+++ b/mobile/src/app/miniapps/miniappdev/scanner.tsx
@@ -102,7 +102,10 @@ export default function MiniappDeveloperScannerScreen() {
       })
 
       const manifest = launchResult.manifest
-      packageName = manifest?.packageName || packageName || "com.dev.unknown"
+      // Keep an explicit identity separate from the offline-screen display
+      // fallback — never persist routing keys under the shared `com.dev.unknown`.
+      const knownPackageName = (manifest?.packageName || packageName)?.trim() || undefined
+      packageName = knownPackageName || "com.dev.unknown"
       name = manifest?.name || name || "Dev Miniapp"
       const iconPath = manifest?.icon as string | undefined
       const manifestPermissions: AppletPermission[] = Array.isArray(manifest?.permissions)
@@ -122,35 +125,45 @@ export default function MiniappDeveloperScannerScreen() {
       // Persist a package-keyed home tile and routing record so this dev
       // miniapp remains independently launchable without rescanning. Its icon
       // is copied locally while the server is reachable.
-      if (manifest) {
+      if (manifest && knownPackageName) {
         // A fetched manifest means a real dev app loaded — latch the per-account
         // "this user is a developer" signal (idempotent). Gated on the manifest
         // so a failed/unreachable scan (decision "offline", no manifest) can't
         // flip the flag, matching the URL loader's behavior.
         markMiniappDevMode()
 
-        const existing = engine.miniapps.list().find((app) => app.packageName === packageName)
-        if (existing?.running) await engine.miniapps.stop(packageName)
+        const existing = engine.miniapps.list().find((app) => app.packageName === knownPackageName)
+        if (existing?.running) await engine.miniapps.stop(knownPackageName)
         await registerDevApp({
-          packageName,
-          name: name ?? packageName,
+          packageName: knownPackageName,
+          name: name ?? knownPackageName,
           iconUrl: iconUrl ?? `${resolvedBase}/icon.png`,
           // Prefer the host that actually answered (may be mDNS / Metro failover).
           devUrl: launchResult.resolvedUrl || devUrl,
+          // Explicit empty clears a prior QR's sidecar port / mDNS for this package.
           devPort: Number.isFinite(portNum) ? portNum : undefined,
-          mdnsHost,
+          mdnsHost: mdnsHost ?? "",
           devAttestation,
           type: manifest.type as DevAppRecord["type"],
           permissions: manifest.permissions as DevAppRecord["permissions"],
           hardwareRequirements: manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],
           actions: manifest.actions as DevAppRecord["actions"],
         })
-      } else if (packageName) {
+      } else if (knownPackageName) {
         // Reachability failed — still stash URL + mDNS so "Try again" can recover
-        // after a laptop Wi-Fi IP change without forcing a re-scan.
-        storage.save(`${packageName}_dev_url`, devUrl)
-        if (mdnsHost) storage.save(`${packageName}_dev_mdns`, mdnsHost)
-        if (Number.isFinite(portNum)) storage.save(`${packageName}_dev_port`, portNum)
+        // after a laptop Wi-Fi IP change without forcing a re-scan. Only when the
+        // QR (or a prior identity) named a real package — never `com.dev.unknown`.
+        storage.save(`${knownPackageName}_dev_url`, devUrl)
+        if (mdnsHost) {
+          storage.save(`${knownPackageName}_dev_mdns`, mdnsHost)
+        } else {
+          storage.remove(`${knownPackageName}_dev_mdns`)
+        }
+        if (Number.isFinite(portNum)) {
+          storage.save(`${knownPackageName}_dev_port`, portNum)
+        } else {
+          storage.remove(`${knownPackageName}_dev_port`)
+        }
       }
 
       if (launchResult.decision === "offline") {

--- a/mobile/src/app/miniapps/miniappdev/scanner.tsx
+++ b/mobile/src/app/miniapps/miniappdev/scanner.tsx
@@ -12,6 +12,7 @@ import {decideDevLaunchRoute, engine} from "@mentra/engine"
 import {appRegistry, registerDevApp, type DevAppRecord} from "@mentra/engine/internal"
 import {askPermissionsUI, checkPermissionsUI, PERMISSION_CONFIG} from "@/utils/PermissionsUtils"
 import {markMiniappDevMode} from "@/utils/miniappDevMode"
+import {storage} from "@/utils/storage/storage"
 import type {AppletInterface, AppletPermission} from "@/../../cloud/packages/types/src"
 
 export default function MiniappDeveloperScannerScreen() {
@@ -63,6 +64,7 @@ export default function MiniappDeveloperScannerScreen() {
       let packageName: string | undefined
       let name: string | undefined
       let devPort: string | undefined
+      let mdnsHost: string | undefined
       let devAttestation: string | undefined
 
       if (data.startsWith("miniapp://dev")) {
@@ -71,6 +73,7 @@ export default function MiniappDeveloperScannerScreen() {
         name = url.searchParams.get("name") || undefined
         packageName = url.searchParams.get("package") || undefined
         devPort = url.searchParams.get("dev") || undefined
+        mdnsHost = url.searchParams.get("mdns") || undefined
         devAttestation = url.searchParams.get("attestation") || undefined
       } else if (data.startsWith("http://") || data.startsWith("https://")) {
         devUrl = data
@@ -92,7 +95,11 @@ export default function MiniappDeveloperScannerScreen() {
         return
       }
 
-      const launchResult = await decideDevLaunchRoute(packageName ?? "", devUrl)
+      // Pass mDNS up front — storage hasn't been written yet on first scan, so
+      // decideDevLaunchRoute can't read `_dev_mdns` until we persist below.
+      const launchResult = await decideDevLaunchRoute(packageName ?? "", devUrl, {
+        alternateHosts: mdnsHost ? [mdnsHost] : undefined,
+      })
 
       const manifest = launchResult.manifest
       packageName = manifest?.packageName || packageName || "com.dev.unknown"
@@ -102,12 +109,15 @@ export default function MiniappDeveloperScannerScreen() {
         ? (manifest!.permissions as AppletPermission[])
         : []
 
+      const resolvedBase = (launchResult.resolvedUrl || devUrl).replace(/\/$/, "")
       let iconUrl: string | undefined
       if (iconPath) {
         iconUrl = /^https?:\/\//.test(iconPath)
           ? iconPath
-          : `${devUrl.replace(/\/$/, "")}/${iconPath.replace(/^\//, "")}`
+          : `${resolvedBase}/${iconPath.replace(/^\//, "")}`
       }
+
+      const portNum = devPort ? parseInt(devPort, 10) : NaN
 
       // Persist a package-keyed home tile and routing record so this dev
       // miniapp remains independently launchable without rescanning. Its icon
@@ -119,21 +129,28 @@ export default function MiniappDeveloperScannerScreen() {
         // flip the flag, matching the URL loader's behavior.
         markMiniappDevMode()
 
-        const portNum = devPort ? parseInt(devPort, 10) : NaN
         const existing = engine.miniapps.list().find((app) => app.packageName === packageName)
         if (existing?.running) await engine.miniapps.stop(packageName)
         await registerDevApp({
           packageName,
           name: name ?? packageName,
-          iconUrl: iconUrl ?? `${devUrl.replace(/\/$/, "")}/icon.png`,
-          devUrl: devUrl,
+          iconUrl: iconUrl ?? `${resolvedBase}/icon.png`,
+          // Prefer the host that actually answered (may be mDNS / Metro failover).
+          devUrl: launchResult.resolvedUrl || devUrl,
           devPort: Number.isFinite(portNum) ? portNum : undefined,
+          mdnsHost,
           devAttestation,
           type: manifest.type as DevAppRecord["type"],
           permissions: manifest.permissions as DevAppRecord["permissions"],
           hardwareRequirements: manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],
           actions: manifest.actions as DevAppRecord["actions"],
         })
+      } else if (packageName) {
+        // Reachability failed — still stash URL + mDNS so "Try again" can recover
+        // after a laptop Wi-Fi IP change without forcing a re-scan.
+        storage.save(`${packageName}_dev_url`, devUrl)
+        if (mdnsHost) storage.save(`${packageName}_dev_mdns`, mdnsHost)
+        if (Number.isFinite(portNum)) storage.save(`${packageName}_dev_port`, portNum)
       }
 
       if (launchResult.decision === "offline") {

--- a/mobile/src/app/miniapps/miniappdev/scanner.tsx
+++ b/mobile/src/app/miniapps/miniappdev/scanner.tsx
@@ -164,6 +164,13 @@ export default function MiniappDeveloperScannerScreen() {
         } else {
           storage.remove(`${knownPackageName}_dev_port`)
         }
+        // Keep the QR attestation so offline "Try again" can register with the
+        // same auto-auth proof the live scanner path would have used.
+        if (devAttestation) {
+          storage.save(`${knownPackageName}_dev_attestation`, devAttestation)
+        } else {
+          storage.remove(`${knownPackageName}_dev_attestation`)
+        }
       }
 
       if (launchResult.decision === "offline") {

--- a/sdk/miniapp-cli/package.json
+++ b/sdk/miniapp-cli/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./src/api.ts",
     "./build-helpers": "./src/build-helpers.ts",
+    "./lan": "./src/lan.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/sdk/miniapp-cli/src/api.ts
+++ b/sdk/miniapp-cli/src/api.ts
@@ -1,3 +1,4 @@
 export { buildProduction } from './build.js';
 export { dev, type DevAttestationInput, type DevOptions } from './dev.js';
 export { pack, type PackOptions } from './pack.js';
+export { getLanIp, getMdnsHostname, pickLanIp, scoreLanIface } from './lan.js';

--- a/sdk/miniapp-cli/src/dev.ts
+++ b/sdk/miniapp-cli/src/dev.ts
@@ -296,15 +296,19 @@ export async function dev(options: DevOptions = {}): Promise<void> {
     ipCheckInFlight = true;
     void (async () => {
       try {
-        const previous = lanIp;
-        lanIp = newIp;
-        console.log(`\n📶 LAN IP changed: ${previous} → ${newIp}`);
+        console.log(`\n📶 LAN IP changed: ${lanIp} → ${newIp}`);
         console.log('Rebuilding so baked-in LAN URLs (e.g. signing endpoints) stay current…');
         try {
           await runBuild(cwd);
         } catch (err) {
+          // Leave lanIp on the previous value so the next poll retries this IP.
+          // Committing early would leave dist/ stale while skipping further rebuilds.
           console.error('Rebuild after LAN IP change failed:', (err as Error).message);
+          return;
         }
+        const previous = lanIp;
+        lanIp = newIp;
+        console.log(`LAN IP committed: ${previous} → ${newIp}`);
         console.log('New QR (re-scan if the Mentra App still has the old IP):');
         printBanner();
         if (mdnsHost) {

--- a/sdk/miniapp-cli/src/dev.ts
+++ b/sdk/miniapp-cli/src/dev.ts
@@ -4,9 +4,12 @@ import { join, resolve } from 'path';
 import { printQR, writeQRPng } from './qr.js';
 import { validateManifest } from './manifest.js';
 import { startDevSidecar } from './dev-server.js';
+import { getLanIp, getMdnsHostname } from './lan.js';
 
 const DEFAULT_DEV_PORT = 3000;
 const DEV_PORT_SCAN_LIMIT = 50;
+/** How often to re-check Wi-Fi / LAN IP while `mentra-miniapp dev` is running. */
+const LAN_IP_POLL_MS = 2_000;
 
 export interface DevAttestationInput {
   packageName: string;
@@ -16,19 +19,9 @@ export interface DevAttestationInput {
 export interface DevOptions {
   cwd?: string;
   qrOutput?: string;
-  signDevAttestation?: (input: DevAttestationInput) => string | Promise<string | null | undefined> | null | undefined;
-}
-
-function getLanIp(): string | null {
-  const interfaces = os.networkInterfaces();
-  for (const name of Object.keys(interfaces)) {
-    for (const iface of interfaces[name] ?? []) {
-      if (iface.family === 'IPv4' && !iface.internal) {
-        return iface.address;
-      }
-    }
-  }
-  return null;
+  signDevAttestation?: (
+    input: DevAttestationInput,
+  ) => string | Promise<string | null | undefined> | null | undefined;
 }
 
 function contentTypeFor(path: string): string {
@@ -228,19 +221,24 @@ export async function dev(options: DevOptions = {}): Promise<void> {
     );
   }
 
+  const mdnsHost = getMdnsHostname();
+
   const buildDevUrl = async (ip: string): Promise<string> => {
     const devServerUrl = `http://${ip}:${port}`;
     const base = `miniapp://dev?url=${encodeURIComponent(devServerUrl)}&name=${encodeURIComponent(name)}&package=${encodeURIComponent(packageName)}`;
     const withDevPort = sidecarPort ? `${base}&dev=${sidecarPort}` : base;
-    if (!options.signDevAttestation) return withDevPort;
+    // mDNS hint lets the phone retry via ComputerName.local when the raw IP
+    // goes stale after a Wi-Fi/DHCP change — same QR, new address under the hood.
+    const withMdns = mdnsHost ? `${withDevPort}&mdns=${encodeURIComponent(mdnsHost)}` : withDevPort;
+    if (!options.signDevAttestation) return withMdns;
 
     try {
       const attestation = await options.signDevAttestation({ packageName, devServerUrl });
-      if (!attestation) return withDevPort;
-      return `${withDevPort}&attestation=${encodeURIComponent(attestation)}`;
+      if (!attestation) return withMdns;
+      return `${withMdns}&attestation=${encodeURIComponent(attestation)}`;
     } catch (error) {
       console.warn(`Warning: could not sign dev URL (${(error as Error).message}). Miniapp auto-auth will be unavailable.`);
-      return withDevPort;
+      return withMdns;
     }
   };
 
@@ -281,20 +279,44 @@ export async function dev(options: DevOptions = {}): Promise<void> {
   };
 
   printBanner();
+  if (mdnsHost) {
+    console.log(`mDNS: ${mdnsHost} (phone can keep using this name across Wi-Fi IP changes)\n`);
+  }
   const devUrl = await buildDevUrl(lanIp);
   await emitQR(devUrl);
 
-  // Monitor for LAN IP changes (e.g., WiFi switch).
-  const ipCheckInterval = setInterval(async () => {
+  // Monitor for LAN IP changes (e.g., Wi-Fi switch / DHCP renew).
+  // Re-score interfaces — a VPN coming up must not steal the QR off Wi-Fi,
+  // and a Wi-Fi roam must mint a new QR within a couple seconds.
+  let ipCheckInFlight = false;
+  const ipCheckInterval = setInterval(() => {
+    if (ipCheckInFlight) return;
     const newIp = getLanIp();
-    if (newIp && newIp !== lanIp) {
-      lanIp = newIp;
-      console.log(`\nLAN IP changed to ${newIp}. New QR:`);
-      printBanner();
-      const newDevUrl = await buildDevUrl(newIp);
-      await emitQR(newDevUrl);
-    }
-  }, 10_000);
+    if (!newIp || newIp === lanIp) return;
+    ipCheckInFlight = true;
+    void (async () => {
+      try {
+        const previous = lanIp;
+        lanIp = newIp;
+        console.log(`\n📶 LAN IP changed: ${previous} → ${newIp}`);
+        console.log('Rebuilding so baked-in LAN URLs (e.g. signing endpoints) stay current…');
+        try {
+          await runBuild(cwd);
+        } catch (err) {
+          console.error('Rebuild after LAN IP change failed:', (err as Error).message);
+        }
+        console.log('New QR (re-scan if the Mentra App still has the old IP):');
+        printBanner();
+        if (mdnsHost) {
+          console.log(`mDNS: ${mdnsHost}\n`);
+        }
+        const newDevUrl = await buildDevUrl(newIp);
+        await emitQR(newDevUrl);
+      } finally {
+        ipCheckInFlight = false;
+      }
+    })();
+  }, LAN_IP_POLL_MS);
 
   const shutdown = () => {
     clearInterval(ipCheckInterval);

--- a/sdk/miniapp-cli/src/lan.test.ts
+++ b/sdk/miniapp-cli/src/lan.test.ts
@@ -1,7 +1,8 @@
 /// <reference types="bun-types" />
 
 import {describe, expect, test} from "bun:test"
-import {pickLanIp, scoreLanIface, type LanIface} from "./lan.js"
+import {getMdnsHostname, pickLanIp, scoreLanIface, type LanIface} from "./lan.js"
+import os from "os"
 
 function iface(partial: Partial<LanIface> & Pick<LanIface, "name" | "address">): LanIface {
   return {
@@ -58,5 +59,26 @@ describe("pickLanIp", () => {
         lo0: [iface({name: "lo0", address: "127.0.0.1", internal: true})],
       }),
     ).toBeNull()
+  })
+})
+
+describe("getMdnsHostname first label", () => {
+  test("strips DNS suffixes before appending .local", () => {
+    const original = os.hostname
+    ;(os as {hostname: () => string}).hostname = () => "mba.corp.example.com"
+    try {
+      expect(getMdnsHostname()).toBe("mba.local")
+    } finally {
+      ;(os as {hostname: typeof original}).hostname = original
+    }
+  })
+})
+
+describe("scoreLanIface Linux predictable names", () => {
+  test("ranks wlp*/enp* as real adapters", () => {
+    const wifi = scoreLanIface(iface({name: "wlp3s0", address: "192.168.1.40"}))
+    const eth = scoreLanIface(iface({name: "enp0s3", address: "192.168.1.41"}))
+    expect(wifi).toBeGreaterThan(50)
+    expect(eth).toBeGreaterThan(50)
   })
 })

--- a/sdk/miniapp-cli/src/lan.test.ts
+++ b/sdk/miniapp-cli/src/lan.test.ts
@@ -1,0 +1,62 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, test} from "bun:test"
+import {pickLanIp, scoreLanIface, type LanIface} from "./lan.js"
+
+function iface(partial: Partial<LanIface> & Pick<LanIface, "name" | "address">): LanIface {
+  return {
+    family: "IPv4",
+    internal: false,
+    netmask: "255.255.255.0",
+    mac: "aa:bb:cc:dd:ee:ff",
+    ...partial,
+  }
+}
+
+describe("scoreLanIface", () => {
+  test("rejects internal, link-local, and tunnel names", () => {
+    expect(scoreLanIface(iface({name: "lo0", address: "127.0.0.1", internal: true}))).toBeLessThan(0)
+    expect(scoreLanIface(iface({name: "en0", address: "169.254.1.2"}))).toBeLessThan(0)
+    expect(scoreLanIface(iface({name: "utun0", address: "10.137.68.90", netmask: "255.0.0.0", mac: "00:00:00:00:00:00"}))).toBeLessThan(
+      0,
+    )
+    expect(scoreLanIface(iface({name: "tailscale0", address: "100.64.1.2"}))).toBeLessThan(0)
+  })
+
+  test("prefers en0 Wi-Fi over a leftover /8 tunnel-shaped address", () => {
+    const wifi = scoreLanIface(iface({name: "en0", address: "192.168.50.252"}))
+    const tunnel = scoreLanIface(
+      iface({name: "en5", address: "10.0.0.2", netmask: "255.0.0.0", mac: "00:00:00:00:00:00"}),
+    )
+    expect(wifi).toBeGreaterThan(0)
+    expect(wifi).toBeGreaterThan(tunnel)
+  })
+})
+
+describe("pickLanIp", () => {
+  test("picks Wi-Fi when a VPN utun is also present", () => {
+    const ip = pickLanIp({
+      lo0: [iface({name: "lo0", address: "127.0.0.1", internal: true})],
+      en0: [iface({name: "en0", address: "192.168.50.252"})],
+      utun0: [iface({name: "utun0", address: "10.137.68.90", netmask: "255.0.0.0", mac: "00:00:00:00:00:00"})],
+    })
+    expect(ip).toBe("192.168.50.252")
+  })
+
+  test("prefers 192.168 Wi-Fi over a first-listed 10.x tunnel-like iface", () => {
+    // Object key order would have returned 10.x first with the old naive picker.
+    const ip = pickLanIp({
+      utun2: [iface({name: "utun2", address: "10.1.2.3", netmask: "255.0.0.0", mac: "00:00:00:00:00:00"})],
+      en0: [iface({name: "en0", address: "192.168.3.162"})],
+    })
+    expect(ip).toBe("192.168.3.162")
+  })
+
+  test("returns null when only loopback exists", () => {
+    expect(
+      pickLanIp({
+        lo0: [iface({name: "lo0", address: "127.0.0.1", internal: true})],
+      }),
+    ).toBeNull()
+  })
+})

--- a/sdk/miniapp-cli/src/lan.ts
+++ b/sdk/miniapp-cli/src/lan.ts
@@ -1,0 +1,151 @@
+/**
+ * LAN address selection for miniapp QR codes / release install URLs.
+ *
+ * Naive "first non-internal IPv4" picks VPN/tunnel interfaces (utun, tun,
+ * Tailscale, etc.) on many developer machines, which phones on Wi-Fi cannot
+ * reach. Score candidates and prefer real Wi-Fi / Ethernet instead.
+ */
+
+import os from "os"
+
+export interface LanIface {
+  name: string
+  address: string
+  internal: boolean
+  family: string | number
+  /** Present on normal broadcast LANs; often missing on point-to-point tunnels. */
+  netmask?: string
+  cidr?: string | null
+  mac?: string
+}
+
+/** Interface-name prefixes that are almost never the Wi-Fi the phone shares. */
+const SKIP_NAME_PREFIXES = [
+  "utun",
+  "awdl",
+  "llw",
+  "bridge",
+  "docker",
+  "veth",
+  "vmnet",
+  "tun",
+  "tap",
+  "zt",
+  "tailscale",
+  "ipsec",
+  "ppp",
+  "ap",
+  "phy",
+]
+
+/** Prefer these when present (macOS Wi-Fi is usually en0). */
+const PREFERRED_NAMES = new Set(["en0", "en1", "eth0", "eth1", "wlan0", "wlan1", "wlp0s20f3"])
+
+function isIpv4(family: string | number): boolean {
+  return family === "IPv4" || family === 4
+}
+
+function isLinkLocal(address: string): boolean {
+  return address.startsWith("169.254.")
+}
+
+function isPrivateLan(address: string): boolean {
+  if (address.startsWith("192.168.")) return true
+  if (address.startsWith("10.")) return true
+  return /^172\.(1[6-9]|2\d|3[0-1])\./.test(address)
+}
+
+function shouldSkipName(name: string): boolean {
+  const lower = name.toLowerCase()
+  return SKIP_NAME_PREFIXES.some((prefix) => lower === prefix || lower.startsWith(`${prefix}`))
+}
+
+/**
+ * Rough "how /8-like is this mask?" — tunnel VPNs often advertise 255.0.0.0
+ * while home/office Wi-Fi is /24. Smaller host-count (tighter mask) scores higher.
+ */
+function netmaskSpecificity(netmask: string | undefined): number {
+  if (!netmask) return 0
+  const parts = netmask.split(".").map((p) => Number(p))
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n) || n < 0 || n > 255)) return 0
+  // Count set bits.
+  let bits = 0
+  for (const octet of parts) {
+    let v = octet
+    while (v) {
+      bits += v & 1
+      v >>= 1
+    }
+  }
+  return bits
+}
+
+/** Score a candidate; higher wins. Negative = reject. */
+export function scoreLanIface(iface: LanIface): number {
+  if (!isIpv4(iface.family) || iface.internal) return -1
+  if (isLinkLocal(iface.address)) return -1
+  if (shouldSkipName(iface.name)) return -1
+  // Zero MAC is typical of virtual/tunnel adapters on macOS.
+  if (iface.mac === "00:00:00:00:00:00" && !PREFERRED_NAMES.has(iface.name)) return -1
+
+  let score = 0
+  if (isPrivateLan(iface.address)) score += 50
+  else score += 5 // public / unusual — last resort
+
+  if (PREFERRED_NAMES.has(iface.name)) score += 40
+  else if (/^en\d+$/i.test(iface.name) || /^eth\d+$/i.test(iface.name) || /^wlan\d+$/i.test(iface.name)) {
+    score += 25
+  }
+
+  const specificity = netmaskSpecificity(iface.netmask)
+  // Prefer /16–/24 style LANs over /8 tunnels that slipped past the name filter.
+  if (specificity >= 16 && specificity <= 24) score += 20
+  else if (specificity > 24) score += 10
+  else if (specificity > 0 && specificity < 16) score -= 20
+
+  // 192.168/16 is the common home/office Wi-Fi shape.
+  if (iface.address.startsWith("192.168.")) score += 10
+
+  return score
+}
+
+/**
+ * Pick the best LAN IPv4 for phone reachability from a NetworkInterfaces-like map.
+ * Exposed for unit tests; production code uses {@link getLanIp}.
+ */
+export function pickLanIp(interfaces: NodeJS.Dict<LanIface[] | undefined>): string | null {
+  let best: {address: string; score: number} | null = null
+  for (const [name, list] of Object.entries(interfaces)) {
+    for (const raw of list ?? []) {
+      const iface: LanIface = {...raw, name}
+      const score = scoreLanIface(iface)
+      if (score < 0) continue
+      if (!best || score > best.score) {
+        best = {address: iface.address, score}
+      }
+    }
+  }
+  return best?.address ?? null
+}
+
+/** Current machine's best phone-reachable LAN IPv4, or null if none. */
+export function getLanIp(): string | null {
+  return pickLanIp(os.networkInterfaces() as NodeJS.Dict<LanIface[] | undefined>)
+}
+
+/**
+ * Bonjour / mDNS host for this machine (`ComputerName.local`), when usable.
+ * Survives Wi-Fi IP changes better than a raw IPv4 — phones that resolve
+ * `.local` can keep the same QR/dev URL across DHCP renewals.
+ */
+export function getMdnsHostname(): string | null {
+  const host = String(os.hostname() || "").trim()
+  if (!host) return null
+  const base = host.replace(/\.local$/i, "")
+  if (!base || base.toLowerCase() === "localhost") return null
+  // Reject names that would make a broken URL host.
+  if (!/^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/.test(base)) {
+    return null
+  }
+  return `${base}.local`
+}

--- a/sdk/miniapp-cli/src/lan.ts
+++ b/sdk/miniapp-cli/src/lan.ts
@@ -93,7 +93,14 @@ export function scoreLanIface(iface: LanIface): number {
   else score += 5 // public / unusual — last resort
 
   if (PREFERRED_NAMES.has(iface.name)) score += 40
-  else if (/^en\d+$/i.test(iface.name) || /^eth\d+$/i.test(iface.name) || /^wlan\d+$/i.test(iface.name)) {
+  else if (
+    /^en\d+$/i.test(iface.name) ||
+    /^eth\d+$/i.test(iface.name) ||
+    /^wlan\d+$/i.test(iface.name) ||
+    // Predictable NetworkManager names on modern Linux (wlp3s0, enp0s3, …).
+    /^wlp\w+/i.test(iface.name) ||
+    /^enp\w+/i.test(iface.name)
+  ) {
     score += 25
   }
 
@@ -141,10 +148,13 @@ export function getLanIp(): string | null {
 export function getMdnsHostname(): string | null {
   const host = String(os.hostname() || "").trim()
   if (!host) return null
-  const base = host.replace(/\.local$/i, "")
+  // Bonjour advertises the first DNS label as `Label.local`. Machines whose
+  // hostname includes a corporate DNS suffix (e.g. `mba.corp.example.com`)
+  // must not become `mba.corp.example.com.local`.
+  const base = host.replace(/\.local$/i, "").split(".")[0] ?? ""
   if (!base || base.toLowerCase() === "localhost") return null
   // Reject names that would make a broken URL host.
-  if (!/^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/.test(base)) {
+  if (!/^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(base)) {
     return null
   }
   return `${base}.local`

--- a/sdk/miniapp-cli/src/release.ts
+++ b/sdk/miniapp-cli/src/release.ts
@@ -28,6 +28,7 @@ import {resolve, join} from 'path'
 import {buildProduction} from './build.js'
 import {pack} from './pack.js'
 import {printQR, writeQRPng} from './qr.js'
+import {getLanIp} from './lan.js'
 import {validateManifest} from './manifest.js'
 
 const DEFAULT_PORT_START = 6789
@@ -194,18 +195,6 @@ export async function release(opts: ReleaseOptions = {}): Promise<void> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function getLanIp(): string | null {
-  const interfaces = os.networkInterfaces()
-  for (const name of Object.keys(interfaces)) {
-    for (const iface of interfaces[name] ?? []) {
-      if (iface.family === 'IPv4' && !iface.internal) {
-        return iface.address
-      }
-    }
-  }
-  return null
-}
 
 async function pickPort(start: number, limit: number): Promise<number> {
   for (let i = 0; i < limit; i++) {


### PR DESCRIPTION
## Summary
- Score LAN interfaces so VPN/tunnel (utun/tailscale/etc.) no longer wins over shared Wi-Fi for `mentra-miniapp dev` / release QRs
- Embed optional mDNS hostname in the QR and teach the Mentra App scanner/launcher to retry alternate hosts when the raw IP goes stale
- Faster LAN IP polling while the CLI is running; shared `./lan` export + unit tests

## Test plan
- [x] `bun test sdk/miniapp-cli/src/lan.test.ts`
- [x] `bun test mobile/modules/engine/src/utils/__tests__/devMiniappLaunch.test.ts`
- [ ] `mentra-miniapp dev` with VPN up — QR should show Wi-Fi IP, not utun
- [ ] Scan QR on phone; after DHCP/Wi-Fi IP change, relaunch still reaches via mDNS when available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev miniapp launch, persistence, and QR identity across the mobile engine and CLI; regressions could block dev installs or point at wrong hosts, but scope is dev-only tooling rather than production auth or payments.
> 
> **Overview**
> Improves **miniapp dev connectivity** when laptops use VPN/tunnels or DHCP changes the Wi‑Fi address.
> 
> The CLI adds shared **`@mentra/miniapp-cli/lan`** logic that **scores network interfaces** so dev/release QRs prefer real Wi‑Fi/Ethernet over `utun`/Tailscale-style tunnels. Dev QRs can include an **`mdns` hostname** (`ComputerName.local`), and **`mentra-miniapp dev`** polls LAN IP every ~2s, rebuilds on change, and reprints the QR. Example miniapp dev uses the **workspace CLI** instead of `bunx`.
> 
> On the phone, **`decideDevLaunchRoute`** retries **alternate hosts** (Metro/`EXPO_PUBLIC_LOCAL_MINIAPP_HOST`, stored mDNS) when the saved IP fails, then **persists the working URL** (and rehosts dev-served icons). Scanner, developer URL, offline “Try again”, launcher, and dev registration flows use **`resolvedUrl`** and optional **`mdnsHost`** storage so home-tile relaunches survive IP churn without a rescan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af386d13fb3b7021e9c2a933037dfd48d9d8625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->