### PR TITLE
Harden PR Agent Orchestrator against handoff spam and red-CI handoffs

### DIFF
--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -143,6 +143,21 @@ jobs:
               return;
             }
 
+            // Late CI completions on a PR already in human handoff only burn
+            // runners. Skip the full Plan job unless agent-resume is present.
+            // Mirrors scripts/pr-agent/src/handoff-gate.ts.
+            if (context.eventName === 'workflow_run') {
+              const labelNames = (pr.labels ?? []).map((l) =>
+                typeof l === 'string' ? l : l.name,
+              );
+              const hasHandoff = labelNames.includes('ready-for-human-review');
+              const hasResume = labelNames.includes('agent-resume');
+              if (hasHandoff && !hasResume) {
+                core.setOutput('pr_number', '');
+                return;
+              }
+            }
+
             core.setOutput('pr_number', String(pr.number));
             core.setOutput('head_sha', workflowRunSha ?? pr.head.sha);
             core.setOutput('head_ref', pr.head.ref);
@@ -316,7 +331,13 @@ jobs:
       - review-standards
       - review-depth
       - review-bugbot
-    if: always() && needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true'
+    # Require plan.result == success so a cancelled Plan (empty outputs) cannot
+    # revive Aggregate — empty should_skip != 'true' used to pass after cancel.
+    if: >
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.should_skip != 'true' &&
+      needs.plan.outputs.recheck_only != 'true'
     runs-on: ubuntu-latest
     outputs:
       should_fix: ${{ steps.agg.outputs.should_fix }}
@@ -394,7 +415,9 @@ jobs:
     name: Wait for CI
     needs: [resolve-context, plan, aggregate, fix]
     if: |
-      always() && needs.plan.outputs.should_skip != 'true' &&
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.should_skip != 'true' &&
       (needs.fix.result == 'success' || needs.fix.result == 'skipped') &&
       needs.aggregate.outputs.should_handoff != 'true'
     runs-on: ubuntu-latest
@@ -421,7 +444,9 @@ jobs:
     name: Recheck handoff after CI
     needs: [resolve-context, plan, aggregate, fix, wait-ci]
     if: |
-      always() && needs.plan.outputs.should_skip != 'true' &&
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.should_skip != 'true' &&
       (needs.plan.outputs.recheck_only == 'true' ||
         (needs.aggregate.result == 'success' &&
           needs.aggregate.outputs.should_handoff != 'true' &&
@@ -452,7 +477,9 @@ jobs:
     name: Finalize handoff
     needs: [resolve-context, plan, aggregate, recheck-handoff]
     if: |
-      always() && (
+      always() &&
+      needs.plan.result == 'success' &&
+      (
         needs.plan.outputs.should_handoff == 'true' ||
         (needs.aggregate.result == 'success' && needs.aggregate.outputs.should_handoff == 'true') ||
         (needs.recheck-handoff.result == 'success' && needs.recheck-handoff.outputs.should_handoff == 'true')

--- a/scripts/pr-agent/package.json
+++ b/scripts/pr-agent/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "cli": "tsx src/cli.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@connectrpc/connect-node": "^1.6.1",

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -143,10 +143,19 @@ export function aggregateCycle(
     stagnationFixRounds = 0;
   }
 
+  // When path-scoped CI is red and the fixer still has budget, do not let the
+  // shared cycle counter force a human-ready handoff (#3224 / #3671). The
+  // fixer's own maxFixRounds cap governs that case instead.
+  const deferCycleCapForCiFix =
+    ciFailed && state.fixRound < config.limits.maxFixRounds;
+
   if (state.fixRound >= config.limits.maxFixRounds) {
     status = 'budget_exhausted';
     handoffReason = 'budget_exhausted';
-  } else if (state.cycle >= config.limits.maxOrchestratorCycles) {
+  } else if (
+    state.cycle >= config.limits.maxOrchestratorCycles &&
+    !deferCycleCapForCiFix
+  ) {
     status = 'budget_exhausted';
     handoffReason = 'budget_exhausted';
   } else if (newBlockingCount >= config.limits.maxNewBlockingPerCycle) {
@@ -162,6 +171,7 @@ export function aggregateCycle(
 
   const cleanHandoff =
     ciGreen &&
+    !ciFailed &&
     openCount === 0 &&
     consecutiveNoNewReviews >= config.limits.consecutiveNoNewReviewsForHandoff;
 

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -7,6 +7,7 @@ import {
   fetchWorkflowStatuses,
   getChangedFiles,
   getPrHeadSha,
+  isCiFailed,
   isCiGreen,
   pollCiUntilSettled,
   requiredWorkflowsForPaths,
@@ -26,7 +27,7 @@ import {
   saveState,
   upsertMarkerComment,
 } from './state.js';
-import { MARKER_REVIEW, type ReviewSlot } from './types.js';
+import { MARKER_HANDOFF, MARKER_REVIEW, type ReviewSlot } from './types.js';
 
 const repoRoot = process.env.GITHUB_WORKSPACE ?? process.cwd();
 const owner = process.env.GITHUB_REPOSITORY_OWNER!;
@@ -178,16 +179,17 @@ async function cmdFinalize() {
   await saveState(octokit, owner, repo, prNumber, finalState, commentId);
 
   const body = buildHandoffComment(reason, finalState, ciChecks);
-  await octokit.issues.createComment({
-    owner,
-    repo,
-    issue_number: prNumber,
-    body,
-  });
+  // Upsert so late CI re-triggers edit one handoff comment instead of spamming.
+  await upsertMarkerComment(octokit, owner, repo, prNumber, MARKER_HANDOFF, body);
 
   await ensureLabel(octokit, owner, repo, prNumber, 'ready-for-human-review');
   if (reason !== 'human_handoff') {
     await ensureLabel(octokit, owner, repo, prNumber, 'agent-needs-human');
+  }
+  if (isCiFailed(ciChecks)) {
+    await ensureLabel(octokit, owner, repo, prNumber, 'agent-ci-failing');
+  } else {
+    await removeLabel(octokit, owner, repo, prNumber, 'agent-ci-failing');
   }
   await removeLabel(octokit, owner, repo, prNumber, 'agent-in-progress');
 }

--- a/scripts/pr-agent/src/handoff-gate.ts
+++ b/scripts/pr-agent/src/handoff-gate.ts
@@ -1,0 +1,16 @@
+/**
+ * Decide whether a workflow_run-triggered orchestrator invocation should
+ * bail before Plan (blank pr_number) because the PR is already sitting in
+ * human handoff and late CI completions would only burn runner time.
+ *
+ * pull_request / workflow_dispatch must never take this shortcut — humans
+ * may push new commits or apply agent-resume, and those events need Plan.
+ */
+export function shouldBlankPrForWorkflowRunHandoff(
+  eventName: string,
+  labelNames: string[],
+): boolean {
+  if (eventName !== 'workflow_run') return false;
+  const labels = new Set(labelNames);
+  return labels.has('ready-for-human-review') && !labels.has('agent-resume');
+}

--- a/scripts/pr-agent/src/handoff.ts
+++ b/scripts/pr-agent/src/handoff.ts
@@ -1,4 +1,4 @@
-import type { CiCheckStatus } from './ci-gates.js';
+import { isCiFailed, type CiCheckStatus } from './ci-gates.js';
 import { openBlocking } from './findings.js';
 import type { Finding, PrAgentState } from './types.js';
 import { MARKER_HANDOFF } from './types.js';
@@ -9,12 +9,21 @@ export function buildHandoffComment(
   ciChecks: CiCheckStatus[],
 ): string {
   const open = openBlocking(state.openFindings);
-  const reasonText =
+  const ciFailed = isCiFailed(ciChecks);
+
+  let reasonText =
     reason === 'human_handoff'
       ? 'Clean handoff — CI green, no blocking findings, models have no further reviews.'
       : reason === 'budget_exhausted'
         ? 'Budget exhausted — fix or review cycle cap reached.'
         : 'Diverging — stagnation or review churn detected.';
+
+  if (ciFailed) {
+    reasonText =
+      reason === 'human_handoff'
+        ? 'Handoff with failing CI — path-scoped checks are red; do not merge until CI is green.'
+        : `${reasonText} Path-scoped CI is failing — do not merge until CI is green.`;
+  }
 
   const ciTable =
     ciChecks.length === 0
@@ -40,6 +49,10 @@ export function buildHandoffComment(
           .slice(0, 20)
           .map((f) => `- (\`${f.file}\`) ${f.message}`)
           .join('\n');
+
+  const footer = ciFailed
+    ? '**CI is failing.** Do not merge until path-scoped checks are green. Label `agent-resume` after pushing fixes to re-run the loop.'
+    : '**Humans merge when ready.** Agents do not auto-merge. Label `agent-resume` to re-run the loop after new commits.';
 
   return `${MARKER_HANDOFF}
 ## PR Agent Handoff
@@ -68,6 +81,6 @@ ${nits}
 
 ---
 
-**Humans merge when ready.** Agents do not auto-merge. Label \`agent-resume\` to re-run the loop after new commits.
+${footer}
 `;
 }

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -9,7 +9,13 @@ import {
   removeLabel,
   saveState,
 } from './state.js';
-import { getChangedFiles } from './ci-gates.js';
+import {
+  fetchWorkflowStatuses,
+  getChangedFiles,
+  getPrHeadSha,
+  isCiFailed,
+  requiredWorkflowsForPaths,
+} from './ci-gates.js';
 import type { PlanOutput } from './types.js';
 
 export async function runPlan(repoRoot: string): Promise<PlanOutput> {
@@ -88,6 +94,7 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
     await removeLabel(octokit, owner, repo, prNumber, 'agent-resume');
     await removeLabel(octokit, owner, repo, prNumber, 'ready-for-human-review');
     await removeLabel(octokit, owner, repo, prNumber, 'agent-needs-human');
+    await removeLabel(octokit, owner, repo, prNumber, 'agent-ci-failing');
     await saveState(octokit, owner, repo, prNumber, state, commentId);
   }
 
@@ -144,6 +151,38 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
   }
 
   if (state.cycle >= config.limits.maxOrchestratorCycles) {
+    // Mirror aggregate: when CI is red and the fixer still has rounds left,
+    // do not force budget_exhausted — continue with reviews skipped so
+    // aggregate can set shouldFix and the fixer can react to the CI failure.
+    let ciFailed = process.env.CI_TRIGGER_FAILED === 'true';
+    if (!ciFailed && state.fixRound < config.limits.maxFixRounds) {
+      try {
+        const ref = await getPrHeadSha(octokit, owner, repo, prNumber);
+        const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
+        const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
+        const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, ref, required);
+        ciFailed = isCiFailed(ciChecks);
+      } catch (err) {
+        console.warn('plan: failed to fetch CI status for cycle-cap deferral', err);
+      }
+    }
+
+    if (ciFailed && state.fixRound < config.limits.maxFixRounds) {
+      console.log(
+        `Cycle cap reached (${state.cycle}) but CI failed with fixRound=${state.fixRound}; deferring handoff for fixer`,
+      );
+      await saveState(octokit, owner, repo, prNumber, state, commentId);
+      return {
+        runBugbot: false,
+        runStandards: false,
+        runDepth: false,
+        activePair: [],
+        state,
+        shouldSkip: false,
+        skipReason: 'max cycles deferred for CI fix',
+      };
+    }
+
     const exhausted = { ...state, status: 'budget_exhausted' as const };
     await saveState(octokit, owner, repo, prNumber, exhausted, commentId);
     return {

--- a/scripts/pr-agent/src/state.ts
+++ b/scripts/pr-agent/src/state.ts
@@ -87,8 +87,35 @@ export async function saveState(
   issueNumber: number,
   state: PrAgentState,
   commentId?: number,
-): Promise<void> {
-  const body = formatStateComment(state);
+): Promise<{ wrote: boolean; revision: number }> {
+  const localRevision = state.revision ?? 0;
+
+  if (commentId) {
+    // Compare-and-swap: refuse to overwrite a newer revision written by a
+    // concurrent orchestrator run (the #3465 lost-update failure mode).
+    try {
+      const { data } = await octokit.issues.getComment({
+        owner,
+        repo,
+        comment_id: commentId,
+      });
+      const remote = data.body ? parseStateFromComment(data.body) : null;
+      const remoteRevision = remote?.revision ?? 0;
+      if (remote && remoteRevision > localRevision) {
+        console.log(
+          `Skipping stale state write: local revision ${localRevision} < remote ${remoteRevision}`,
+        );
+        return { wrote: false, revision: remoteRevision };
+      }
+    } catch (err) {
+      console.warn('saveState: failed to re-read state comment before write', err);
+    }
+  }
+
+  const nextRevision = localRevision + 1;
+  const nextState: PrAgentState = { ...state, revision: nextRevision };
+  const body = formatStateComment(nextState);
+
   if (commentId) {
     await octokit.issues.updateComment({
       owner,
@@ -96,7 +123,7 @@ export async function saveState(
       comment_id: commentId,
       body,
     });
-    return;
+    return { wrote: true, revision: nextRevision };
   }
   await octokit.issues.createComment({
     owner,
@@ -104,6 +131,7 @@ export async function saveState(
     issue_number: issueNumber,
     body,
   });
+  return { wrote: true, revision: nextRevision };
 }
 
 export async function upsertMarkerComment(

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -37,6 +37,11 @@ export const PrAgentStateSchema = z.object({
   fingerprintReopenCounts: z.record(z.number()).default({}),
   /** Fingerprints a human marked as false positive via `agent-resolve <id>`. */
   mutedFingerprints: z.array(z.string()).default([]),
+  /**
+   * Monotonic counter bumped on every successful state comment write.
+   * Used by saveState to refuse lost-update overwrites from stale concurrent runs.
+   */
+  revision: z.number().default(0),
 });
 
 export type PrAgentState = z.infer<typeof PrAgentStateSchema>;

--- a/scripts/pr-agent/tests/aggregate.test.ts
+++ b/scripts/pr-agent/tests/aggregate.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { aggregateCycle } from '../src/aggregate.js';
+import { resetConfigCache } from '../src/config.js';
+import {
+  ciFailedChecks,
+  ciGreenChecks,
+  makeState,
+  repoRoot,
+} from './helpers.js';
+
+afterEach(() => {
+  delete process.env.CI_TRIGGER_FAILED;
+  resetConfigCache();
+});
+
+describe('aggregateCycle cycle-cap vs CI-red fixer budget', () => {
+  test('does not hand off when cycle>=max, CI failed, and fix rounds remain', () => {
+    const state = makeState({
+      cycle: 8,
+      fixRound: 4,
+      status: 'in_progress',
+      consecutiveNoNewReviews: 0,
+    });
+
+    const result = aggregateCycle(
+      repoRoot,
+      state,
+      {},
+      ciFailedChecks(),
+      [],
+    );
+
+    expect(result.ciFailed).toBe(true);
+    expect(result.shouldHandoff).toBe(false);
+    expect(result.shouldFix).toBe(true);
+    expect(result.state.status).toBe('in_progress');
+    expect(result.handoffReason).toBeUndefined();
+  });
+
+  test('hands off budget_exhausted when cycle>=max, CI failed, but fix rounds exhausted', () => {
+    const state = makeState({
+      cycle: 8,
+      fixRound: 5,
+      status: 'in_progress',
+    });
+
+    const result = aggregateCycle(
+      repoRoot,
+      state,
+      {},
+      ciFailedChecks(),
+      [],
+    );
+
+    expect(result.ciFailed).toBe(true);
+    expect(result.shouldHandoff).toBe(true);
+    expect(result.shouldFix).toBe(false);
+    expect(result.handoffReason).toBe('budget_exhausted');
+    expect(result.state.status).toBe('budget_exhausted');
+  });
+
+  test('still hands off budget_exhausted when cycle>=max and CI is green', () => {
+    const state = makeState({
+      cycle: 8,
+      fixRound: 1,
+      status: 'in_progress',
+      consecutiveNoNewReviews: 0,
+    });
+
+    const result = aggregateCycle(
+      repoRoot,
+      state,
+      {},
+      ciGreenChecks(),
+      [],
+    );
+
+    expect(result.ciFailed).toBe(false);
+    expect(result.shouldHandoff).toBe(true);
+    expect(result.shouldFix).toBe(false);
+    expect(result.handoffReason).toBe('budget_exhausted');
+  });
+
+  test('honors CI_TRIGGER_FAILED env even when check list looks green', () => {
+    process.env.CI_TRIGGER_FAILED = 'true';
+    const state = makeState({
+      cycle: 8,
+      fixRound: 2,
+      status: 'in_progress',
+    });
+
+    const result = aggregateCycle(
+      repoRoot,
+      state,
+      {},
+      ciGreenChecks(),
+      [],
+    );
+
+    expect(result.ciFailed).toBe(true);
+    expect(result.shouldHandoff).toBe(false);
+    expect(result.shouldFix).toBe(true);
+  });
+});

--- a/scripts/pr-agent/tests/handoff.test.ts
+++ b/scripts/pr-agent/tests/handoff.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { buildHandoffComment } from '../src/handoff.js';
+import { MARKER_HANDOFF } from '../src/types.js';
+import { upsertMarkerComment } from '../src/state.js';
+import {
+  ciFailedChecks,
+  ciGreenChecks,
+  makeState,
+} from './helpers.js';
+
+describe('buildHandoffComment', () => {
+  test('always includes MARKER_HANDOFF', () => {
+    const body = buildHandoffComment(
+      'budget_exhausted',
+      makeState({ cycle: 8, fixRound: 1 }),
+      ciGreenChecks(),
+    );
+    expect(body.startsWith(MARKER_HANDOFF)).toBe(true);
+  });
+
+  test('states CI failure plainly when checks are red', () => {
+    const body = buildHandoffComment(
+      'budget_exhausted',
+      makeState({ cycle: 9, fixRound: 4 }),
+      ciFailedChecks(),
+    );
+    expect(body).toContain('Path-scoped CI is failing');
+    expect(body).toContain('**CI is failing.**');
+    expect(body).not.toContain('**Humans merge when ready.**');
+  });
+
+  test('keeps clean merge-ready footer when CI is green', () => {
+    const body = buildHandoffComment(
+      'human_handoff',
+      makeState({ cycle: 4, fixRound: 0, consecutiveNoNewReviews: 2 }),
+      ciGreenChecks(),
+    );
+    expect(body).toContain('Clean handoff');
+    expect(body).toContain('**Humans merge when ready.**');
+    expect(body).not.toContain('**CI is failing.**');
+  });
+});
+
+describe('upsertMarkerComment handoff spam fix', () => {
+  test('second upsert updates existing comment instead of creating another', async () => {
+    const createCalls: unknown[] = [];
+    const updateCalls: unknown[] = [];
+    let storedBody: string | null = null;
+
+    const octokit = {
+      issues: {
+        listComments: async () => ({
+          data: storedBody
+            ? [{ id: 42, body: storedBody }]
+            : [],
+        }),
+        createComment: async (args: { body: string }) => {
+          createCalls.push(args);
+          storedBody = args.body;
+          return { data: { id: 42, body: args.body } };
+        },
+        updateComment: async (args: { comment_id: number; body: string }) => {
+          updateCalls.push(args);
+          storedBody = args.body;
+          return { data: { id: args.comment_id, body: args.body } };
+        },
+      },
+    } as any;
+
+    const first = buildHandoffComment(
+      'budget_exhausted',
+      makeState({ cycle: 8 }),
+      ciFailedChecks(),
+    );
+    await upsertMarkerComment(octokit, 'o', 'r', 1, MARKER_HANDOFF, first);
+
+    const second = buildHandoffComment(
+      'budget_exhausted',
+      makeState({ cycle: 9 }),
+      ciFailedChecks(),
+    );
+    await upsertMarkerComment(octokit, 'o', 'r', 1, MARKER_HANDOFF, second);
+
+    expect(createCalls).toHaveLength(1);
+    expect(updateCalls).toHaveLength(1);
+    expect((updateCalls[0] as { comment_id: number }).comment_id).toBe(42);
+    expect(storedBody).toContain('Review cycles | 9');
+  });
+});

--- a/scripts/pr-agent/tests/helpers.ts
+++ b/scripts/pr-agent/tests/helpers.ts
@@ -1,0 +1,49 @@
+import { join } from 'node:path';
+import { PrAgentStateSchema, type PrAgentState } from '../src/types.js';
+import type { CiCheckStatus } from '../src/ci-gates.js';
+
+/** Monorepo root (parent of scripts/pr-agent). */
+export const repoRoot = join(import.meta.dir, '../../..');
+
+export function makeState(overrides: Partial<PrAgentState> = {}): PrAgentState {
+  return PrAgentStateSchema.parse(overrides);
+}
+
+export function ciFailedChecks(
+  name = 'Mobile App Quality Checks',
+): CiCheckStatus[] {
+  return [
+    {
+      name,
+      status: 'completed',
+      conclusion: 'failure',
+      required: true,
+    },
+  ];
+}
+
+export function ciGreenChecks(
+  name = 'Mobile App Quality Checks',
+): CiCheckStatus[] {
+  return [
+    {
+      name,
+      status: 'completed',
+      conclusion: 'success',
+      required: true,
+    },
+  ];
+}
+
+export function ciPendingChecks(
+  name = 'Mobile App Quality Checks',
+): CiCheckStatus[] {
+  return [
+    {
+      name,
+      status: 'in_progress',
+      conclusion: null,
+      required: true,
+    },
+  ];
+}

--- a/scripts/pr-agent/tests/state.test.ts
+++ b/scripts/pr-agent/tests/state.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  formatStateComment,
+  parseStateFromComment,
+  saveState,
+} from '../src/state.js';
+import { makeState } from './helpers.js';
+
+describe('saveState revision CAS', () => {
+  test('refuses to overwrite a newer remote revision', async () => {
+    const remote = makeState({
+      cycle: 25,
+      totalReviewerRuns: 31,
+      revision: 7,
+    });
+    const local = makeState({
+      cycle: 2,
+      totalReviewerRuns: 2,
+      revision: 5,
+    });
+
+    let updated: string | null = null;
+    const octokit = {
+      issues: {
+        getComment: async () => ({
+          data: { id: 99, body: formatStateComment(remote) },
+        }),
+        updateComment: async (args: { body: string }) => {
+          updated = args.body;
+          return { data: { id: 99, body: args.body } };
+        },
+        createComment: async () => {
+          throw new Error('should not create');
+        },
+      },
+    } as any;
+
+    const result = await saveState(octokit, 'o', 'r', 1, local, 99);
+
+    expect(result.wrote).toBe(false);
+    expect(result.revision).toBe(7);
+    expect(updated).toBeNull();
+  });
+
+  test('writes when local revision is ahead of remote', async () => {
+    const remote = makeState({
+      cycle: 10,
+      totalReviewerRuns: 10,
+      revision: 7,
+    });
+    const local = makeState({
+      cycle: 11,
+      totalReviewerRuns: 11,
+      revision: 8,
+    });
+
+    let updatedBody = '';
+    const octokit = {
+      issues: {
+        getComment: async () => ({
+          data: { id: 99, body: formatStateComment(remote) },
+        }),
+        updateComment: async (args: { body: string }) => {
+          updatedBody = args.body;
+          return { data: { id: 99, body: args.body } };
+        },
+      },
+    } as any;
+
+    const result = await saveState(octokit, 'o', 'r', 1, local, 99);
+
+    expect(result.wrote).toBe(true);
+    expect(result.revision).toBe(9);
+    const parsed = parseStateFromComment(updatedBody);
+    expect(parsed?.revision).toBe(9);
+    expect(parsed?.cycle).toBe(11);
+    expect(parsed?.totalReviewerRuns).toBe(11);
+  });
+
+  test('stale concurrent writer cannot regress cycle/totalReviewerRuns (#3465)', async () => {
+    // Simulate: remote already advanced to cycle 25 / revision 20;
+    // a cancelled run still holding revision 2 tries to write cycle 3.
+    let remoteBody = formatStateComment(
+      makeState({ cycle: 25, totalReviewerRuns: 31, revision: 20 }),
+    );
+
+    const staleLocal = makeState({
+      cycle: 3,
+      totalReviewerRuns: 3,
+      revision: 2,
+    });
+
+    const octokit = {
+      issues: {
+        getComment: async () => ({
+          data: { id: 1, body: remoteBody },
+        }),
+        updateComment: async (args: { body: string }) => {
+          remoteBody = args.body;
+          return { data: { id: 1, body: args.body } };
+        },
+      },
+    } as any;
+
+    const result = await saveState(octokit, 'o', 'r', 3465, staleLocal, 1);
+    expect(result.wrote).toBe(false);
+
+    const still = parseStateFromComment(remoteBody);
+    expect(still?.cycle).toBe(25);
+    expect(still?.totalReviewerRuns).toBe(31);
+    expect(still?.revision).toBe(20);
+  });
+});

--- a/scripts/pr-agent/tests/workflow-guards.test.ts
+++ b/scripts/pr-agent/tests/workflow-guards.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { shouldBlankPrForWorkflowRunHandoff } from '../src/handoff-gate.js';
+import { repoRoot } from './helpers.js';
+
+const workflowPath = join(
+  repoRoot,
+  '.github/workflows/pr-agent-orchestrator.yml',
+);
+
+/** Slice from `  jobId:` through the line before the next 2-space job key. */
+function jobBlock(workflow: string, jobId: string): string {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((l) => l === `  ${jobId}:`);
+  if (start < 0) throw new Error(`job ${jobId} not found in workflow`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^  [a-z][a-z0-9_-]*:$/.test(lines[i]!)) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+describe('workflow cancelled-Plan guards', () => {
+  const workflow = readFileSync(workflowPath, 'utf8');
+
+  for (const jobId of [
+    'aggregate',
+    'wait-ci',
+    'recheck-handoff',
+    'finalize',
+  ] as const) {
+    test(`${jobId} requires needs.plan.result == 'success'`, () => {
+      const block = jobBlock(workflow, jobId);
+      // Empty should_skip after a cancelled Plan used to evaluate as != 'true'
+      // and revive Aggregate/Finalize — plan.result success is the real gate.
+      expect(block).toContain("needs.plan.result == 'success'");
+    });
+  }
+
+  test('resolve-context blanks pr_number for handoff on workflow_run', () => {
+    expect(workflow).toContain("context.eventName === 'workflow_run'");
+    expect(workflow).toContain("ready-for-human-review");
+    expect(workflow).toContain('agent-resume');
+    // After resolving the PR, handoff-without-resume blanks pr_number.
+    expect(workflow).toMatch(
+      /hasHandoff && !hasResume[\s\S]*?core\.setOutput\('pr_number', ''\)/,
+    );
+  });
+});
+
+describe('shouldBlankPrForWorkflowRunHandoff', () => {
+  test('blanks workflow_run when ready-for-human-review and no agent-resume', () => {
+    expect(
+      shouldBlankPrForWorkflowRunHandoff('workflow_run', [
+        'ready-for-human-review',
+        'agent-needs-human',
+      ]),
+    ).toBe(true);
+  });
+
+  test('does not blank when agent-resume is present', () => {
+    expect(
+      shouldBlankPrForWorkflowRunHandoff('workflow_run', [
+        'ready-for-human-review',
+        'agent-resume',
+      ]),
+    ).toBe(false);
+  });
+
+  test('never blanks pull_request events for this reason', () => {
+    expect(
+      shouldBlankPrForWorkflowRunHandoff('pull_request', [
+        'ready-for-human-review',
+      ]),
+    ).toBe(false);
+  });
+
+  test('does not blank workflow_run without handoff label', () => {
+    expect(
+      shouldBlankPrForWorkflowRunHandoff('workflow_run', ['agent-in-progress']),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Field AAR on the last 10 PRs opened by `nic-olo` found **49 handoff comments** where roughly 8 were warranted, plus PRs labeled `ready-for-human-review` while path-scoped CI was still red (notably #3224 and #3671). Finding quality and the fixer were fine; the plumbing around handoff was leaking.

This PR hardens five failure modes and adds the first `bun:test` suite for `scripts/pr-agent` (20 tests).

## Defects fixed

1. **Handoff comment spam** — `finalize` now upserts via `MARKER_HANDOFF` instead of `createComment` on every late CI re-trigger.
2. **Cancelled Plan revived Aggregate/Finalize** — job `if:` guards now require `needs.plan.result == 'success'` so empty outputs after cancel cannot pass `should_skip != 'true'`.
3. **Red CI waved through as human-ready** — `cycle >= maxOrchestratorCycles` no longer forces `budget_exhausted` when `ciFailed` and `fixRound < maxFixRounds`. Plan mirrors the same deferral so the fixer can still run.
4. **Lost-update state corruption (#3465)** — `PrAgentState.revision` + compare-and-swap in `saveState` refuse stale overwrites.
5. **Late `workflow_run` wasted runners** — resolve-context blanks `pr_number` when the PR already has `ready-for-human-review` and no `agent-resume`.

Also: handoff body states CI failure plainly and applies `agent-ci-failing` when path-scoped checks are red (cleared on `agent-resume`).

## Test plan

- [x] `cd scripts/pr-agent && bun test` — 20 pass, 0 fail
- [x] `cd scripts/pr-agent && bun run typecheck` — clean
- [ ] After merge, confirm a follow-up CI completion on a handed-off PR (#3671-style) edits one handoff comment instead of appending
- [ ] After merge, confirm a red-CI PR at cycle cap still gets fixer rounds before human-ready labeling (#3224-style)

## Evidence from the AAR (not in this PR)

| PR | Handoffs | Notes |
|----|----------|-------|
| #3465 | 20 | Cycles reported to 25; state comment left at cycle 2 / totalReviewerRuns 31 |
| #3501 | 8 | Clean then spam to cycle 14 |
| #3667 | 7 | Final handoff posted after merge |
| #3224 | 4 | Handed off with Mobile CI failure, fixRound 4/5 |
| #3671 | 3 | Budget exhausted while CI still `in_progress` |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-594c1a74-849b-4866-a761-aa6af1d287f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-594c1a74-849b-4866-a761-aa6af1d287f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

