### PR TITLE
Make legacy BES OTA recovery fail closed

### DIFF
--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -395,6 +395,9 @@ dependencies {
     // JSON handling
     implementation 'org.json:json:20210307'
     
+    // Decode the exact LZMA-alone chunks used by BES release OTA artifacts before authorization.
+    implementation 'org.tukaani:xz:1.9'
+
     // AVIF encoding/decoding support
     implementation 'com.github.awxkee:avif-coder:1.7.3'
     implementation 'androidx.heifwriter:heifwriter:1.1.0'

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -153,8 +153,8 @@ public class AsgConstants {
      * rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: OTA completion ck chunks packed to 256-263 bytes and none
      * survived). 240 = 253 - {@link #K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}. BES firmware >=
      * 17.26.7.23 advertises {@code wire_caps.notify_cap} (the measured single-notification payload
-     * cap) and the budget becomes notify_cap minus the same margin — see Legacy v1 string frames
-     * never grow from negotiated notify capacity.
+     * cap) and the budget becomes notify_cap minus the same margin: legacy v1 string frames never
+     * grow from negotiated notify capacity.
      */
     public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -153,8 +153,8 @@ public class AsgConstants {
      * rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: OTA completion ck chunks packed to 256-263 bytes and none
      * survived). 240 = 253 - {@link #K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}. BES firmware >=
      * 17.26.7.23 advertises {@code wire_caps.notify_cap} (the measured single-notification payload
-     * cap) and the budget becomes notify_cap minus the same margin — see
-     * MessageChunker.setStringChunkBudgetFromNotifyCap.
+     * cap) and the budget becomes notify_cap minus the same margin — see Legacy v1 string frames
+     * never grow from negotiated notify capacity.
      */
     public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -158,6 +158,19 @@ public class AsgConstants {
      */
     public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
 
+    /** Exact BES release artifact container accepted by the ASG OTA validator. */
+    public static final String BES_OTA_ARTIFACT_FORMAT = "bes-lzma-chunks-v1";
+
+    /** Mentra Live BES build target required in release metadata and the image payload. */
+    public static final String BES_OTA_PRODUCT = "best1502x_ibrt_bpone";
+
+    /**
+     * Exclusive decompressed destination limit in the deployed ota_copy bootloader:
+     * NEW_IMAGE_FLASH_OFFSET (0x200000) - OTA_CODE_OFFSET (0x20000). Images at or above this size
+     * overwrite the adjacent staging region and must never be sent to BES.
+     */
+    public static final int BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES = 0x1E0000;
+
     /**
      * Safety margin subtracted from the BLE notification payload cap when sizing packed v1 STRING
      * ck chunks, absorbing BES re-framing variance between the UART frame we send and the

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -2,7 +2,6 @@ package com.mentra.asg_client.io.bes;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.events.BesOtaProgressEvent;
 import com.mentra.asg_client.io.bes.protocol.*;
@@ -11,16 +10,16 @@ import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesUartTransportCoordinator;
 import com.mentra.asg_client.io.bluetooth.utils.ByteUtil;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidationException;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.utils.WakeLockManager;
-
-import org.greenrobot.eventbus.EventBus;
-import org.json.JSONObject;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import org.greenrobot.eventbus.EventBus;
+import org.json.JSONObject;
 
 /**
  * Manages BES2700 firmware OTA updates Handles file loading, packet transmission, state tracking,
@@ -40,6 +39,9 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     // longer, treat the transfer as failed rather than extending the operation timeout.
     private static final long BES_TOTAL_TIMEOUT_MS = 300000;
     private static final long BES_AUTH_TIMEOUT_MS = 30000; // 30 seconds authorization timeout
+    private static final long BES_AUTH_RECOVERY_PROBE_INTERVAL_MS = 1000;
+    private static final int BES_AUTH_RECOVERY_PROBE_MAX_ATTEMPTS = 3;
+    private static final long BES_APPLY_WAIT_TIMEOUT_MS = 60_000;
     private Context mContext;
 
     private long operationStartTime = 0;
@@ -80,8 +82,18 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     private int confirmSentPos = 0;
     private boolean bWait4Confirm = false;
     private volatile boolean isWaitingForAuthorization = false;
+    private boolean authorizationReserved = false;
+    private boolean authorizationRecoveryProbePending = false;
+    private int authorizationRecoveryProbeAttempts = 0;
+    private android.os.Handler authorizationRecoveryProbeHandler;
+    private Runnable authorizationRecoveryProbeRunnable;
+    private android.os.Handler applyWaitHandler;
+    private Runnable applyWaitRunnable;
+    private String activeOwnerSessionId = "";
+    private ValidatedBesArtifact activeArtifact;
 
     private final Runnable otaAppliedCallback;
+    private final BesOtaStateStore stateStore;
     private final BesUartTransportCoordinator transportCoordinator;
     private BesUartTransportCoordinator.OperationLease transportLease;
     private BesOtaCommandListener mListener;
@@ -103,6 +115,10 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                         ? k900BluetoothManager.getTransportCoordinator()
                         : null;
         this.mContext = context.getApplicationContext();
+        BesOtaStateStore sharedStore =
+                k900BluetoothManager != null ? k900BluetoothManager.getBesOtaStateStore() : null;
+        this.stateStore = sharedStore != null ? sharedStore : new BesOtaStateStore(this.mContext);
+        resumeDurableApplyWaitIfNeeded();
     }
 
     /**
@@ -110,7 +126,9 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
      */
     @Override
     public boolean isBesOtaInProgress() {
-        return isBesOtaInProgress;
+        BesOtaStateStore.Snapshot snapshot = stateStore.read();
+        return isBesOtaInProgress
+                || (snapshot.isValid() && snapshot.getState() != BesOtaStateStore.State.TERMINAL);
     }
 
     /**
@@ -281,15 +299,95 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     /**
      * Start firmware update process
      *
-     * @param filePath Path to firmware .bin file
+     * @param artifact fully validated release artifact
+     * @param ownerSessionId top-level OTA session owner
      * @return true if started successfully
      */
     @Override
-    public boolean startFirmwareUpdate(String filePath) {
-        Log.i(TAG, "startFirmwareUpdate: " + filePath);
+    public boolean startFirmwareUpdate(ValidatedBesArtifact artifact, String ownerSessionId) {
+        synchronized (mTransferGate) {
+            if (isBesOtaInProgress || isWaitingForAuthorization || activeArtifact != null) {
+                Log.e(TAG, "BES OTA is already active");
+                return false;
+            }
+            String owner = ownerSessionId == null ? "" : ownerSessionId.trim();
+            if (artifact == null || owner.isEmpty()) {
+                Log.e(TAG, "BES OTA requires a validated artifact and owning session");
+                return false;
+            }
+            activeArtifact = artifact;
+            activeOwnerSessionId = owner;
+            return startFirmwareUpdateLocked();
+        }
+    }
+
+    @Override
+    public JSONObject getAuthoritativeStatus() {
+        BesOtaStateStore.Snapshot snapshot = stateStore.read();
+        if (snapshot.isIdle()) {
+            return null;
+        }
+        try {
+            JSONObject status = new JSONObject();
+            status.put("type", "ota_status");
+            if (snapshot.isCorrupt()) {
+                status.put(
+                        "sid",
+                        activeOwnerSessionId.isEmpty()
+                                ? "bes-state-uncertain"
+                                : activeOwnerSessionId);
+                status.put("st", "bes");
+                status.put("phase", "install");
+                status.put("status", "failed");
+                status.put("err", "install_failed");
+                return status;
+            }
+            status.put("sid", snapshot.getOwnerSessionId());
+            status.put("st", "bes");
+            status.put("phase", "install");
+            if (snapshot.getState() == BesOtaStateStore.State.TERMINAL) {
+                boolean success =
+                        snapshot.getTerminalStatus() == BesOtaStateStore.TerminalStatus.SUCCESS;
+                status.put("status", success ? "complete" : "failed");
+                if (success) {
+                    status.put("op", 100);
+                } else {
+                    status.put("err", "install_failed");
+                }
+            } else {
+                status.put("status", "in_progress");
+                status.put(
+                        "op", snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING ? 99 : 0);
+            }
+            return status;
+        } catch (Exception e) {
+            Log.e(TAG, "Could not project authoritative BES OTA status", e);
+            return null;
+        }
+    }
+
+    @Override
+    public boolean prepareForNewOtaSession() {
+        boolean framedProof =
+                k900BluetoothManager != null && k900BluetoothManager.isFramedPathProven();
+        BesOtaStateStore.StartDecision decision =
+                stateStore.prepareForNewSession(stateStore.currentBootId(), framedProof);
+        Log.i(TAG, "BES OTA new-session decision: " + decision);
+        return decision == BesOtaStateStore.StartDecision.ADMIT;
+    }
+
+    private boolean startFirmwareUpdateLocked() {
+        String filePath = activeArtifact.getFile().getAbsolutePath();
+        Log.i(
+                TAG,
+                "startFirmwareUpdate artifact="
+                        + activeArtifact.getArtifactId()
+                        + " target="
+                        + activeArtifact.getTargetVersion());
 
         if (!init(filePath)) {
             Log.e(TAG, "Failed to initialize firmware update");
+            clearRunIdentityLocked();
             return false;
         }
 
@@ -332,17 +430,48 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                                         public boolean onLeaseAcquired(
                                                 BesUartTransportCoordinator.OperationLease lease) {
                                             synchronized (mTransferGate) {
-                                                if (!isWaitingForAuthorization) {
+                                                if (!isWaitingForAuthorization
+                                                        || activeArtifact == null
+                                                        || activeOwnerSessionId.isEmpty()) {
                                                     return false;
                                                 }
                                                 transportLease = lease;
-                                                return true;
+                                                try {
+                                                    activeArtifact.revalidateFileDigest();
+                                                } catch (ValidationException e) {
+                                                    Log.e(
+                                                            TAG,
+                                                            "BES artifact changed before"
+                                                                    + " authorization",
+                                                            e);
+                                                    return false;
+                                                }
+                                                BesOtaStateStore.TransitionResult reserved =
+                                                        stateStore.reserveAuthorization(
+                                                                activeOwnerSessionId,
+                                                                stateStore.currentBootId(),
+                                                                activeArtifact);
+                                                authorizationReserved =
+                                                        reserved
+                                                                == BesOtaStateStore.TransitionResult
+                                                                        .APPLIED;
+                                                if (authorizationReserved) {
+                                                    k900BluetoothManager.setLiveBesOtaOwner(
+                                                            activeOwnerSessionId);
+                                                } else {
+                                                    Log.e(
+                                                            TAG,
+                                                            "Could not reserve BES authorization: "
+                                                                    + reserved);
+                                                }
+                                                return authorizationReserved;
                                             }
                                         }
 
                                         @Override
-                                        public void onWriteComplete(boolean success) {
-                                            onAuthorizationWriteComplete(success);
+                                        public void onWriteComplete(
+                                                boolean attempted, boolean success) {
+                                            onAuthorizationWriteComplete(attempted, success);
                                         }
                                     });
             if (queued) {
@@ -377,18 +506,33 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         }
     }
 
-    private void onAuthorizationWriteComplete(boolean success) {
+    private void onAuthorizationWriteComplete(boolean attempted, boolean success) {
         synchronized (mTransferGate) {
             if (!isWaitingForAuthorization) {
                 return;
             }
-            if (!success) {
+            if (!authorizationReserved) {
                 EventBus.getDefault()
                         .post(
                                 BesOtaProgressEvent.createFailed(
-                                        "Failed to write BES OTA authorization request"));
+                                        "BES OTA authorization could not be reserved"));
                 cleanupLocked();
                 return;
+            }
+            if (!attempted) {
+                Log.e(TAG, "mh_ota was reserved but could not be submitted");
+                failDurablyLocked("authorization_not_attempted");
+                cleanupLocked();
+                return;
+            }
+            if (!success) {
+                // sendMessageInternalLocked can report false after a partial UART write. Because
+                // mh_ota is mode-changing and uncorrelated, local failure does not prove BES did
+                // not receive it. Keep the one reservation and wait for hm_ota exactly as on a
+                // locally successful write; retrying mh_ota in this boot is forbidden.
+                Log.w(
+                        TAG,
+                        "mh_ota write result is ambiguous; waiting for hm_ota without resending");
             }
 
             authTimeoutHandler = new android.os.Handler(android.os.Looper.getMainLooper());
@@ -403,16 +547,168 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                                     "BES OTA authorization timeout after "
                                             + BES_AUTH_TIMEOUT_MS
                                             + "ms");
-                            EventBus.getDefault()
-                                    .post(
-                                            BesOtaProgressEvent.createFailed(
-                                                    "BES chip did not respond to authorization"
-                                                            + " request"));
-                            cleanupLocked();
+                            authTimeoutHandler = null;
+                            authTimeoutRunnable = null;
+                            beginAuthorizationRecoveryProbeLocked();
                         }
                     };
             authTimeoutHandler.postDelayed(authTimeoutRunnable, BES_AUTH_TIMEOUT_MS);
         }
+    }
+
+    /**
+     * Reconcile a missing framed hm_ota without repeating the mode-changing request. The 0x99 query
+     * is read-only in raw OTA mode and contains no framed K900 marker in normal mode.
+     */
+    private void beginAuthorizationRecoveryProbeLocked() {
+        if (transportCoordinator == null
+                || !transportCoordinator.promoteOtaAuthorizationToTransfer(transportLease)) {
+            failDurablyLocked("authorization_unreconciled");
+            cleanupLocked();
+            return;
+        }
+        Log.w(TAG, "hm_ota missing; probing raw OTA protocol without resending mh_ota");
+        isWaitingForAuthorization = false;
+        authorizationRecoveryProbePending = true;
+        authorizationRecoveryProbeAttempts = 0;
+        sendNextAuthorizationRecoveryProbeLocked();
+    }
+
+    private void sendNextAuthorizationRecoveryProbeLocked() {
+        if (!authorizationRecoveryProbePending) {
+            return;
+        }
+        if (authorizationRecoveryProbeAttempts >= BES_AUTH_RECOVERY_PROBE_MAX_ATTEMPTS) {
+            failDurablyLocked("authorization_unreconciled");
+            cleanupLocked();
+            return;
+        }
+        authorizationRecoveryProbeAttempts++;
+        boolean sent = send(SCmd_GetProtocolVersion());
+        Log.w(
+                TAG,
+                "Raw BES OTA state probe "
+                        + authorizationRecoveryProbeAttempts
+                        + "/"
+                        + BES_AUTH_RECOVERY_PROBE_MAX_ATTEMPTS
+                        + " writeResult="
+                        + sent);
+        authorizationRecoveryProbeHandler =
+                new android.os.Handler(android.os.Looper.getMainLooper());
+        String expectedOwner = activeOwnerSessionId;
+        authorizationRecoveryProbeRunnable =
+                () -> {
+                    synchronized (mTransferGate) {
+                        if (!expectedOwner.equals(activeOwnerSessionId)) {
+                            return;
+                        }
+                        sendNextAuthorizationRecoveryProbeLocked();
+                    }
+                };
+        authorizationRecoveryProbeHandler.postDelayed(
+                authorizationRecoveryProbeRunnable, BES_AUTH_RECOVERY_PROBE_INTERVAL_MS);
+    }
+
+    private void cancelAuthorizationRecoveryProbeLocked() {
+        if (authorizationRecoveryProbeHandler != null
+                && authorizationRecoveryProbeRunnable != null) {
+            authorizationRecoveryProbeHandler.removeCallbacks(authorizationRecoveryProbeRunnable);
+        }
+        authorizationRecoveryProbeHandler = null;
+        authorizationRecoveryProbeRunnable = null;
+        authorizationRecoveryProbePending = false;
+        authorizationRecoveryProbeAttempts = 0;
+    }
+
+    private void failDurablyLocked(String code) {
+        if (authorizationReserved && !activeOwnerSessionId.isEmpty()) {
+            BesOtaStateStore.TransitionResult result = stateStore.fail(activeOwnerSessionId, code);
+            if (result != BesOtaStateStore.TransitionResult.APPLIED
+                    && result != BesOtaStateStore.TransitionResult.ALREADY_TERMINAL) {
+                Log.e(TAG, "Could not persist BES OTA failure " + code + ": " + result);
+            }
+        }
+        EventBus.getDefault().post(BesOtaProgressEvent.createFailed(code));
+    }
+
+    private void resumeDurableApplyWaitIfNeeded() {
+        synchronized (mTransferGate) {
+            BesOtaStateStore.Snapshot snapshot = stateStore.read();
+            String bootId = stateStore.currentBootId();
+            if (!snapshot.isValid()
+                    || snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
+                    || bootId == null
+                    || !bootId.equals(snapshot.getAuthorizationBootId())) {
+                return;
+            }
+            activeOwnerSessionId = snapshot.getOwnerSessionId();
+            authorizationReserved = true;
+            isBesOtaInProgress = true;
+            if (k900BluetoothManager != null) {
+                k900BluetoothManager.setLiveBesOtaOwner(activeOwnerSessionId);
+            }
+            armApplyWaitLocked();
+        }
+    }
+
+    private void armApplyWaitLocked() {
+        cancelApplyWaitLocked();
+        applyWaitHandler = new android.os.Handler(android.os.Looper.getMainLooper());
+        String expectedOwner = activeOwnerSessionId;
+        applyWaitRunnable =
+                () -> {
+                    synchronized (mTransferGate) {
+                        BesOtaStateStore.Snapshot snapshot = stateStore.read();
+                        String bootId = stateStore.currentBootId();
+                        if (!expectedOwner.equals(activeOwnerSessionId)
+                                || !snapshot.isValid()
+                                || snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
+                                || !expectedOwner.equals(snapshot.getOwnerSessionId())
+                                || bootId == null
+                                || !bootId.equals(snapshot.getAuthorizationBootId())) {
+                            return;
+                        }
+                        Log.e(TAG, "BES did not leave the authorization boot after apply");
+                        failDurablyLocked("apply_reboot_timeout");
+                        if (transportCoordinator != null) {
+                            transportCoordinator.quarantineCurrentSession();
+                        }
+                        isBesOtaInProgress = false;
+                        if (k900BluetoothManager != null) {
+                            k900BluetoothManager.setLiveBesOtaOwner("");
+                        }
+                        clearRunIdentityLocked();
+                    }
+                };
+        applyWaitHandler.postDelayed(applyWaitRunnable, BES_APPLY_WAIT_TIMEOUT_MS);
+    }
+
+    private void cancelApplyWaitLocked() {
+        if (applyWaitHandler != null && applyWaitRunnable != null) {
+            applyWaitHandler.removeCallbacks(applyWaitRunnable);
+        }
+        applyWaitHandler = null;
+        applyWaitRunnable = null;
+    }
+
+    private void releaseAfterApplyAcknowledgedLocked() {
+        cancelAuthorizationRecoveryProbeLocked();
+        if (responseWatchdogHandler != null && responseWatchdogRunnable != null) {
+            responseWatchdogHandler.removeCallbacks(responseWatchdogRunnable);
+            responseWatchdogRunnable = null;
+        }
+        responseWatchdogDeadlineMs = 0;
+        operationStartTime = 0;
+        synchronized (mLeaseGate) {
+            WakeLockManager.release(WakeLockManager.WakeOwner.BES_OTA);
+        }
+        isWaitingForAuthorization = false;
+        transportLease = null;
+        bInit = false;
+        fileData = null;
+        sentPos = 0;
+        confirmTimes = 0;
+        armApplyWaitLocked();
     }
 
     /**
@@ -440,12 +736,25 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     }
 
     private void cleanupLocked() {
+        if (authorizationReserved && !activeOwnerSessionId.isEmpty()) {
+            BesOtaStateStore.Snapshot current = stateStore.read();
+            if (current.isValid() && current.getState() == BesOtaStateStore.State.AUTH_ATTEMPTED) {
+                BesOtaStateStore.TransitionResult result =
+                        stateStore.fail(activeOwnerSessionId, "install_failed");
+                if (result != BesOtaStateStore.TransitionResult.APPLIED
+                        && result != BesOtaStateStore.TransitionResult.ALREADY_TERMINAL) {
+                    Log.e(TAG, "Could not persist fallback BES OTA failure: " + result);
+                }
+            }
+        }
         // Cancel authorization timeout if pending
         if (authTimeoutHandler != null && authTimeoutRunnable != null) {
             authTimeoutHandler.removeCallbacks(authTimeoutRunnable);
             authTimeoutHandler = null;
             authTimeoutRunnable = null;
         }
+        cancelAuthorizationRecoveryProbeLocked();
+        cancelApplyWaitLocked();
 
         // Cancel the response watchdog; cleanup is the single funnel for every terminal
         // path (apply success, CRC failure, watchdog abort), so no timer outlives the run.
@@ -466,13 +775,29 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         Log.i(TAG, "BES OTA wakelock released");
         isWaitingForAuthorization = false;
         if (transportCoordinator != null) {
-            transportCoordinator.endOta(transportLease);
+            BesOtaStateStore.UartPolicy policy =
+                    stateStore.uartPolicy(stateStore.currentBootId(), false, activeOwnerSessionId);
+            if (authorizationReserved && policy != BesOtaStateStore.UartPolicy.NORMAL) {
+                transportCoordinator.quarantineOta(transportLease);
+            } else {
+                transportCoordinator.endOta(transportLease);
+            }
         }
         transportLease = null;
         bInit = false;
         fileData = null;
         sentPos = 0;
         confirmTimes = 0;
+        if (k900BluetoothManager != null) {
+            k900BluetoothManager.setLiveBesOtaOwner("");
+        }
+        clearRunIdentityLocked();
+    }
+
+    private void clearRunIdentityLocked() {
+        authorizationReserved = false;
+        activeOwnerSessionId = "";
+        activeArtifact = null;
     }
 
     /**
@@ -489,8 +814,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
             if (!transportCoordinator.promoteOtaAuthorizationToTransfer(transportLease)) {
                 Log.e(TAG, "Could not promote UART to BES OTA transfer mode");
-                EventBus.getDefault()
-                        .post(BesOtaProgressEvent.createFailed("BES UART is no longer ready"));
+                failDurablyLocked("uart_not_ready");
                 cleanupLocked();
                 return;
             }
@@ -517,8 +841,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                 Log.i(TAG, "BES OTA protocol started successfully");
             } else {
                 Log.e(TAG, "Failed to send first protocol command");
-                EventBus.getDefault()
-                        .post(BesOtaProgressEvent.createFailed("Failed to start protocol"));
+                failDurablyLocked("protocol_start_failed");
                 cleanupLocked();
             }
         }
@@ -534,8 +857,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                 authTimeoutHandler = null;
                 authTimeoutRunnable = null;
             }
-            EventBus.getDefault()
-                    .post(BesOtaProgressEvent.createFailed("BES chip denied OTA authorization"));
+            failDurablyLocked("authorization_denied");
             cleanupLocked();
         }
     }
@@ -874,6 +1196,10 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         BesOtaMessage otaMsg = parseRecv(data, 0, size);
         if (otaMsg != null) {
             if (!otaMsg.error) {
+                if (transportCoordinator != null
+                        && transportCoordinator.onSafetyRawProtocolResponse(otaMsg.cmd)) {
+                    return;
+                }
                 dealOtaRecvCmd(otaMsg);
             } else {
                 Log.e(TAG, "Received error in OTA message");
@@ -940,13 +1266,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                         } catch (Exception ignored) {
                             // Trace logging must never affect the abort itself.
                         }
-                        EventBus.getDefault()
-                                .post(
-                                        BesOtaProgressEvent.createFailed(
-                                                "No response from BES for "
-                                                        + (AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS
-                                                                / 1000)
-                                                        + "s"));
+                        failDurablyLocked("response_timeout");
                         cleanup();
                     }
                 };
@@ -978,10 +1298,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                     "BES firmware update timeout — chip may be unresponsive (elapsed: "
                             + (android.os.SystemClock.elapsedRealtime() - operationStartTime)
                             + "ms)");
-            EventBus.getDefault()
-                    .post(
-                            BesOtaProgressEvent.createFailed(
-                                    "BES firmware update timeout — chip may be unresponsive"));
+            failDurablyLocked("total_timeout");
             cleanup();
             return;
         }
@@ -997,6 +1314,11 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         }
 
         if (msg.cmd == BesProtocolConstants.RCMD_GET_PROTOCOL_VERSION) {
+            if (authorizationRecoveryProbePending) {
+                Log.i(TAG, "Raw BES OTA mode proven after missing hm_ota");
+                cancelAuthorizationRecoveryProbeLocked();
+                rearmResponseWatchdog();
+            }
             byte[] data = SCmd_SetUser();
             Log.d(
                     TAG,
@@ -1173,12 +1495,19 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                 }
             } else {
                 Log.e(TAG, "Segment verify error");
-                EventBus.getDefault()
-                        .post(BesOtaProgressEvent.createFailed("Segment verification failed"));
+                failDurablyLocked("segment_verify_failed");
                 cleanup();
             }
         } else if (msg.cmd == BesProtocolConstants.RCMD_SEND_FINISH) {
             if (msg.len == 1 && msg.body != null && msg.body[0] == 1) {
+                BesOtaStateStore.TransitionResult applyPending =
+                        stateStore.markApplyPending(activeOwnerSessionId);
+                if (applyPending != BesOtaStateStore.TransitionResult.APPLIED) {
+                    Log.e(TAG, "Refusing BES apply because durable commit failed: " + applyPending);
+                    failDurablyLocked("apply_persistence_failed");
+                    cleanup();
+                    return;
+                }
                 byte[] data = SCmd_OtaApply();
                 Log.d(
                         TAG,
@@ -1186,7 +1515,13 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                                 + (data != null
                                         ? ByteUtil.outputHexString(data, 0, data.length)
                                         : "null"));
-                send(data);
+                armApplyWaitLocked();
+                boolean sent = send(data);
+                if (!sent) {
+                    // APPLY_PENDING was committed first. A local write failure is ambiguous, so
+                    // retrying 0x92 could apply twice; retain the record and wait for reboot.
+                    Log.w(TAG, "OtaApply write result is ambiguous; not retrying 0x92");
+                }
             } else {
                 Log.e(TAG, "❌ ========== WHOLE CRC32 CHECK FAILED ==========");
                 Log.e(
@@ -1214,26 +1549,21 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                     Log.e(TAG, "❌ SIZE MISMATCH! sentPos=" + sentPos + " != fileLen=" + fileLen);
                 }
                 Log.e(TAG, "❌ =============================================");
-                EventBus.getDefault()
-                        .post(
-                                BesOtaProgressEvent.createFailed(
-                                        "Whole CRC32 check failed - data corruption?"));
+                failDurablyLocked("whole_image_verify_failed");
                 cleanup();
             }
         } else if (msg.cmd == BesProtocolConstants.RCMD_APPLY) {
             if (msg.len == 1 && msg.body != null && msg.body[0] == 1) {
-                Log.i(TAG, "BES firmware update SUCCESS! BES will reboot.");
-                EventBus.getDefault().post(BesOtaProgressEvent.createFinished());
+                Log.i(TAG, "BES accepted apply; awaiting reboot and exact version verification");
+                releaseAfterApplyAcknowledgedLocked();
                 if (otaAppliedCallback != null) {
                     otaAppliedCallback.run();
                 }
             } else {
                 Log.e(TAG, "Apply firmware error");
-                EventBus.getDefault()
-                        .post(BesOtaProgressEvent.createFailed("Failed to apply firmware"));
+                failDurablyLocked("apply_rejected");
+                cleanup();
             }
-            // Cleanup regardless
-            cleanup();
         }
     }
 
@@ -1259,8 +1589,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             addSentSize(payloadSize);
         } else {
             Log.e(TAG, "❌ Failed to send file data packet at sentPos=" + sentPos);
-            EventBus.getDefault()
-                    .post(BesOtaProgressEvent.createFailed("Failed to send firmware data"));
+            failDurablyLocked("data_send_failed");
             cleanup();
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -1,0 +1,798 @@
+package com.mentra.asg_client.io.bes;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.Locale;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Single durable authority for legacy BES OTA admission, apply, verification, and terminal state.
+ *
+ * <p>The deployed BES protocol cannot correlate {@code hm_ota} with a request. Safety therefore
+ * comes from exclusion: once authorization is reserved, no second request is allowed in the same
+ * Linux boot. Every mutation is an owner-checked whole-record commit performed under one lock.
+ */
+public final class BesOtaStateStore {
+    private static final String TAG = "BesOtaStateStore";
+    private static final String PREFS_NAME = "bes_ota_state";
+    private static final String RECORD_KEY = "record";
+    private static final String BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
+    private static final int SCHEMA = 1;
+    private static final Object TRANSITION_LOCK = new Object();
+
+    public enum State {
+        AUTH_ATTEMPTED,
+        APPLY_PENDING,
+        TERMINAL
+    }
+
+    public enum TerminalStatus {
+        SUCCESS,
+        FAILURE
+    }
+
+    public enum TransitionResult {
+        APPLIED,
+        ALREADY_APPLIED,
+        ALREADY_TERMINAL,
+        REJECTED,
+        PERSISTENCE_FAILURE
+    }
+
+    public enum StartDecision {
+        ADMIT,
+        ACTIVE,
+        RESTART_REQUIRED,
+        PATH_PROOF_REQUIRED,
+        CORRUPT,
+        PERSISTENCE_FAILURE
+    }
+
+    public enum VerificationDecision {
+        NOT_PENDING,
+        WAIT_FOR_REBOOT,
+        CLAIMED,
+        RESUME,
+        SECOND_BOOT_FAILED,
+        PERSISTENCE_FAILURE
+    }
+
+    public enum StartupDecision {
+        NORMAL,
+        QUARANTINED,
+        RECOVERY_PROBE_ONLY,
+        VERSION_PROBE_ONLY,
+        APPLY_WAIT,
+        TERMINAL_AVAILABLE,
+        PERSISTENCE_FAILURE
+    }
+
+    public enum UartPolicy {
+        NORMAL,
+        OTA_OWNER_ONLY,
+        RECOVERY_PROBE_ONLY,
+        VERSION_PROBE_ONLY,
+        QUARANTINED
+    }
+
+    interface Storage {
+        String get();
+
+        boolean put(String value);
+
+        boolean remove();
+    }
+
+    interface BootIdProvider {
+        String currentBootId();
+    }
+
+    private final Storage storage;
+    private final BootIdProvider bootIdProvider;
+    private boolean persistenceUncertain;
+
+    public BesOtaStateStore(Context context) {
+        Context applicationContext = context.getApplicationContext();
+        SharedPreferences preferences =
+                applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        this.storage =
+                new Storage() {
+                    @Override
+                    public String get() {
+                        return preferences.getString(RECORD_KEY, null);
+                    }
+
+                    @Override
+                    public boolean put(String value) {
+                        return preferences.edit().putString(RECORD_KEY, value).commit();
+                    }
+
+                    @Override
+                    public boolean remove() {
+                        return preferences.edit().remove(RECORD_KEY).commit();
+                    }
+                };
+        this.bootIdProvider = new ProcBootIdProvider();
+    }
+
+    BesOtaStateStore(Storage storage, BootIdProvider bootIdProvider) {
+        if (storage == null || bootIdProvider == null) {
+            throw new IllegalArgumentException("storage and bootIdProvider are required");
+        }
+        this.storage = storage;
+        this.bootIdProvider = bootIdProvider;
+    }
+
+    public String currentBootId() {
+        return canonicalBootId(bootIdProvider.currentBootId());
+    }
+
+    public Snapshot read() {
+        synchronized (TRANSITION_LOCK) {
+            return readLocked();
+        }
+    }
+
+    /** Retire an eligible terminal before a new top-level OTA session becomes visible. */
+    public StartDecision prepareForNewSession(
+            String currentBootId, boolean framedPathProvenForCurrentSession) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot snapshot = readLocked();
+            if (snapshot.isCorrupt()) {
+                return StartDecision.CORRUPT;
+            }
+            if (snapshot.isIdle()) {
+                return StartDecision.ADMIT;
+            }
+            if (snapshot.state == State.AUTH_ATTEMPTED || snapshot.state == State.APPLY_PENDING) {
+                return StartDecision.ACTIVE;
+            }
+            if (snapshot.terminalStatus == TerminalStatus.SUCCESS) {
+                return removeLocked() ? StartDecision.ADMIT : StartDecision.PERSISTENCE_FAILURE;
+            }
+            String boot = canonicalBootId(currentBootId);
+            if (boot == null || boot.equals(snapshot.authorizationBootId)) {
+                return StartDecision.RESTART_REQUIRED;
+            }
+            if (!framedPathProvenForCurrentSession) {
+                return StartDecision.PATH_PROOF_REQUIRED;
+            }
+            return removeLocked() ? StartDecision.ADMIT : StartDecision.PERSISTENCE_FAILURE;
+        }
+    }
+
+    /** Commit the one authorization attempt before the first possible {@code mh_ota} byte. */
+    public TransitionResult reserveAuthorization(
+            String ownerSessionId, String currentBootId, ValidatedBesArtifact artifact) {
+        if (artifact == null) {
+            return TransitionResult.REJECTED;
+        }
+        return reserveAuthorization(
+                ownerSessionId,
+                currentBootId,
+                artifact.getTargetVersion(),
+                artifact.getArtifactId(),
+                artifact.getCompressedSha256());
+    }
+
+    TransitionResult reserveAuthorization(
+            String ownerSessionId,
+            String currentBootId,
+            String targetVersion,
+            String artifactId,
+            String artifactSha256) {
+        synchronized (TRANSITION_LOCK) {
+            if (!readLocked().isIdle()) {
+                return TransitionResult.REJECTED;
+            }
+            String owner = canonicalNonempty(ownerSessionId);
+            String boot = canonicalBootId(currentBootId);
+            String target = canonicalVersion(targetVersion);
+            String identity = canonicalNonempty(artifactId);
+            String digest = artifactSha256 == null ? null : artifactSha256.toLowerCase(Locale.US);
+            if (owner == null
+                    || boot == null
+                    || target == null
+                    || identity == null
+                    || digest == null
+                    || !digest.matches("[0-9a-f]{64}")) {
+                return TransitionResult.REJECTED;
+            }
+            Snapshot reserved =
+                    Snapshot.valid(
+                            State.AUTH_ATTEMPTED,
+                            owner,
+                            boot,
+                            null,
+                            target,
+                            identity,
+                            digest,
+                            null,
+                            null,
+                            System.currentTimeMillis());
+            return putLocked(reserved)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
+    public TransitionResult markApplyPending(String ownerSessionId) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            if (!current.isOwnedActive(State.AUTH_ATTEMPTED, ownerSessionId)) {
+                return terminalOrRejected(current);
+            }
+            Snapshot next = current.withState(State.APPLY_PENDING, null);
+            return putLocked(next)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
+    /** Claim exactly one post-apply Linux boot for target-version verification. */
+    public VerificationDecision claimOrResumeVerificationBoot(String currentBootId) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            if (!current.isValid() || current.state != State.APPLY_PENDING) {
+                return VerificationDecision.NOT_PENDING;
+            }
+            String boot = canonicalBootId(currentBootId);
+            if (boot == null) {
+                return VerificationDecision.PERSISTENCE_FAILURE;
+            }
+            if (boot.equals(current.authorizationBootId)) {
+                return VerificationDecision.WAIT_FOR_REBOOT;
+            }
+            if (current.verificationBootId == null) {
+                Snapshot claimed = current.withVerificationBoot(boot);
+                return putLocked(claimed)
+                        ? VerificationDecision.CLAIMED
+                        : VerificationDecision.PERSISTENCE_FAILURE;
+            }
+            if (boot.equals(current.verificationBootId)) {
+                return VerificationDecision.RESUME;
+            }
+            Snapshot failed =
+                    current.asTerminal(TerminalStatus.FAILURE, "verification_boot_changed");
+            return putLocked(failed)
+                    ? VerificationDecision.SECOND_BOOT_FAILED
+                    : VerificationDecision.PERSISTENCE_FAILURE;
+        }
+    }
+
+    /** Exact post-apply readback is the only success transition. */
+    public TransitionResult completeVerified(
+            String ownerSessionId, String currentBootId, String actualVersion) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            if (!current.isOwnedActive(State.APPLY_PENDING, ownerSessionId)) {
+                return terminalOrRejected(current);
+            }
+            String boot = canonicalBootId(currentBootId);
+            String actual = canonicalVersion(actualVersion);
+            if (boot == null
+                    || current.verificationBootId == null
+                    || !boot.equals(current.verificationBootId)) {
+                return TransitionResult.REJECTED;
+            }
+            boolean matches = current.targetVersion.equals(actual);
+            Snapshot terminal =
+                    current.asTerminal(
+                            matches ? TerminalStatus.SUCCESS : TerminalStatus.FAILURE,
+                            matches ? "verified" : "version_mismatch");
+            return putLocked(terminal)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
+    /** Monotonic owner-checked failure transition. Failure never erases authorization history. */
+    public TransitionResult fail(String ownerSessionId, String stableCode) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            if (current.isCorrupt() || current.isIdle()) {
+                return TransitionResult.REJECTED;
+            }
+            if (current.state == State.TERMINAL) {
+                return current.ownerSessionId.equals(canonicalNonempty(ownerSessionId))
+                        ? TransitionResult.ALREADY_TERMINAL
+                        : TransitionResult.REJECTED;
+            }
+            if (!current.ownerSessionId.equals(canonicalNonempty(ownerSessionId))) {
+                return TransitionResult.REJECTED;
+            }
+            String code = canonicalCode(stableCode);
+            Snapshot terminal =
+                    current.asTerminal(
+                            TerminalStatus.FAILURE, code != null ? code : "install_failed");
+            return putLocked(terminal)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
+    /** Reconcile a process start before ordinary UART traffic is admitted. */
+    public StartupDecision reconcileStartup(String currentBootId) {
+        synchronized (TRANSITION_LOCK) {
+            String boot = canonicalBootId(currentBootId);
+            Snapshot current = readLocked();
+            if (current.isCorrupt()) {
+                if (boot == null) {
+                    return StartupDecision.PERSISTENCE_FAILURE;
+                }
+                Snapshot repaired =
+                        Snapshot.valid(
+                                State.TERMINAL,
+                                "corrupt-state",
+                                boot,
+                                null,
+                                "0.0.0.0",
+                                "unknown",
+                                repeat('0', 64),
+                                TerminalStatus.FAILURE,
+                                "corrupt_state",
+                                System.currentTimeMillis());
+                return putLocked(repaired)
+                        ? StartupDecision.QUARANTINED
+                        : StartupDecision.PERSISTENCE_FAILURE;
+            }
+            if (current.isIdle()) {
+                return StartupDecision.NORMAL;
+            }
+            if (boot == null) {
+                return StartupDecision.QUARANTINED;
+            }
+            if (current.state == State.AUTH_ATTEMPTED) {
+                Snapshot failed = current.asTerminal(TerminalStatus.FAILURE, "interrupted");
+                if (!putLocked(failed)) {
+                    return StartupDecision.PERSISTENCE_FAILURE;
+                }
+                return boot.equals(current.authorizationBootId)
+                        ? StartupDecision.QUARANTINED
+                        : StartupDecision.RECOVERY_PROBE_ONLY;
+            }
+            if (current.state == State.APPLY_PENDING) {
+                if (boot.equals(current.authorizationBootId)) {
+                    return StartupDecision.APPLY_WAIT;
+                }
+                VerificationDecision decision = claimOrResumeVerificationBoot(boot);
+                if (decision == VerificationDecision.CLAIMED
+                        || decision == VerificationDecision.RESUME) {
+                    return StartupDecision.VERSION_PROBE_ONLY;
+                }
+                return decision == VerificationDecision.PERSISTENCE_FAILURE
+                        ? StartupDecision.PERSISTENCE_FAILURE
+                        : StartupDecision.QUARANTINED;
+            }
+            if (current.terminalStatus == TerminalStatus.SUCCESS) {
+                return StartupDecision.TERMINAL_AVAILABLE;
+            }
+            return boot.equals(current.authorizationBootId)
+                    ? StartupDecision.QUARANTINED
+                    : StartupDecision.RECOVERY_PROBE_ONLY;
+        }
+    }
+
+    public UartPolicy uartPolicy(
+            String currentBootId,
+            boolean framedPathProvenForCurrentSession,
+            String liveOwnerSessionId) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            if (current.isCorrupt()) {
+                return UartPolicy.QUARANTINED;
+            }
+            if (current.isIdle()) {
+                return UartPolicy.NORMAL;
+            }
+            String boot = canonicalBootId(currentBootId);
+            if (boot == null) {
+                return UartPolicy.QUARANTINED;
+            }
+            boolean liveOwner =
+                    current.ownerSessionId.equals(canonicalNonempty(liveOwnerSessionId));
+            if (current.state == State.AUTH_ATTEMPTED) {
+                if (boot.equals(current.authorizationBootId) && liveOwner) {
+                    return UartPolicy.OTA_OWNER_ONLY;
+                }
+                return boot.equals(current.authorizationBootId)
+                        ? UartPolicy.QUARANTINED
+                        : UartPolicy.RECOVERY_PROBE_ONLY;
+            }
+            if (current.state == State.APPLY_PENDING) {
+                if (boot.equals(current.authorizationBootId)) {
+                    return liveOwner ? UartPolicy.OTA_OWNER_ONLY : UartPolicy.QUARANTINED;
+                }
+                return UartPolicy.VERSION_PROBE_ONLY;
+            }
+            if (current.terminalStatus == TerminalStatus.SUCCESS) {
+                return UartPolicy.NORMAL;
+            }
+            if (boot.equals(current.authorizationBootId)) {
+                return UartPolicy.QUARANTINED;
+            }
+            return framedPathProvenForCurrentSession
+                    ? UartPolicy.NORMAL
+                    : UartPolicy.RECOVERY_PROBE_ONLY;
+        }
+    }
+
+    private Snapshot readLocked() {
+        if (persistenceUncertain) {
+            return Snapshot.corrupt("prior commit failed");
+        }
+        String raw = storage.get();
+        if (raw == null || raw.trim().isEmpty()) {
+            return Snapshot.idle();
+        }
+        try {
+            return Snapshot.fromJson(new JSONObject(raw));
+        } catch (Exception e) {
+            Log.e(TAG, "Stored BES OTA state is invalid", e);
+            return Snapshot.corrupt(e.getMessage());
+        }
+    }
+
+    private boolean putLocked(Snapshot snapshot) {
+        boolean committed = storage.put(snapshot.toJson().toString());
+        if (!committed) {
+            persistenceUncertain = true;
+            Log.e(TAG, "BES OTA state commit failed; remaining fail-closed for this process");
+        } else {
+            Log.i(
+                    TAG,
+                    "Committed BES OTA state="
+                            + snapshot.state
+                            + " owner="
+                            + snapshot.ownerSessionId
+                            + " target="
+                            + snapshot.targetVersion
+                            + (snapshot.terminalCode != null
+                                    ? " terminal=" + snapshot.terminalCode
+                                    : ""));
+        }
+        return committed;
+    }
+
+    private boolean removeLocked() {
+        boolean committed = storage.remove();
+        if (!committed) {
+            persistenceUncertain = true;
+            Log.e(TAG, "BES OTA state retirement failed; remaining fail-closed");
+        }
+        return committed;
+    }
+
+    private static TransitionResult terminalOrRejected(Snapshot snapshot) {
+        return snapshot.isValid() && snapshot.state == State.TERMINAL
+                ? TransitionResult.ALREADY_TERMINAL
+                : TransitionResult.REJECTED;
+    }
+
+    public static String canonicalVersion(String value) {
+        if (value == null) {
+            return null;
+        }
+        String[] parts = value.trim().split("\\.", -1);
+        if (parts.length != 4) {
+            return null;
+        }
+        StringBuilder canonical = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (parts[i].isEmpty() || !parts[i].matches("[0-9]{1,3}")) {
+                return null;
+            }
+            int component;
+            try {
+                component = Integer.parseInt(parts[i]);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            if (component < 0 || component > 255) {
+                return null;
+            }
+            if (i > 0) {
+                canonical.append('.');
+            }
+            canonical.append(component);
+        }
+        return canonical.toString();
+    }
+
+    private static String canonicalBootId(String value) {
+        String result = canonicalNonempty(value);
+        return result != null && result.length() <= 128 ? result : null;
+    }
+
+    private static String canonicalNonempty(String value) {
+        if (value == null) {
+            return null;
+        }
+        String result = value.trim();
+        return result.isEmpty() ? null : result;
+    }
+
+    private static String canonicalCode(String value) {
+        String result = canonicalNonempty(value);
+        return result != null && result.matches("[a-z0-9_]{1,64}") ? result : null;
+    }
+
+    private static String repeat(char value, int count) {
+        StringBuilder result = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+
+    private static final class ProcBootIdProvider implements BootIdProvider {
+        @Override
+        public String currentBootId() {
+            try (BufferedReader reader = new BufferedReader(new FileReader(BOOT_ID_PATH))) {
+                return reader.readLine();
+            } catch (Exception e) {
+                Log.e(TAG, "Could not read Linux boot ID", e);
+                return null;
+            }
+        }
+    }
+
+    /** Immutable validated state snapshot. */
+    public static final class Snapshot {
+        private final boolean idle;
+        private final String corruption;
+        private final State state;
+        private final String ownerSessionId;
+        private final String authorizationBootId;
+        private final String verificationBootId;
+        private final String targetVersion;
+        private final String artifactId;
+        private final String artifactSha256;
+        private final TerminalStatus terminalStatus;
+        private final String terminalCode;
+        private final long updatedAtMs;
+
+        private Snapshot(
+                boolean idle,
+                String corruption,
+                State state,
+                String ownerSessionId,
+                String authorizationBootId,
+                String verificationBootId,
+                String targetVersion,
+                String artifactId,
+                String artifactSha256,
+                TerminalStatus terminalStatus,
+                String terminalCode,
+                long updatedAtMs) {
+            this.idle = idle;
+            this.corruption = corruption;
+            this.state = state;
+            this.ownerSessionId = ownerSessionId;
+            this.authorizationBootId = authorizationBootId;
+            this.verificationBootId = verificationBootId;
+            this.targetVersion = targetVersion;
+            this.artifactId = artifactId;
+            this.artifactSha256 = artifactSha256;
+            this.terminalStatus = terminalStatus;
+            this.terminalCode = terminalCode;
+            this.updatedAtMs = updatedAtMs;
+        }
+
+        static Snapshot idle() {
+            return new Snapshot(
+                    true, null, null, null, null, null, null, null, null, null, null, 0);
+        }
+
+        static Snapshot corrupt(String diagnostic) {
+            return new Snapshot(
+                    false,
+                    diagnostic != null ? diagnostic : "invalid",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    0);
+        }
+
+        static Snapshot valid(
+                State state,
+                String ownerSessionId,
+                String authorizationBootId,
+                String verificationBootId,
+                String targetVersion,
+                String artifactId,
+                String artifactSha256,
+                TerminalStatus terminalStatus,
+                String terminalCode,
+                long updatedAtMs) {
+            return new Snapshot(
+                    false,
+                    null,
+                    state,
+                    ownerSessionId,
+                    authorizationBootId,
+                    verificationBootId,
+                    targetVersion,
+                    artifactId,
+                    artifactSha256,
+                    terminalStatus,
+                    terminalCode,
+                    updatedAtMs);
+        }
+
+        static Snapshot fromJson(JSONObject json) throws JSONException {
+            if (json.getInt("schema") != SCHEMA) {
+                throw new JSONException("unknown schema");
+            }
+            State state = State.valueOf(json.getString("state"));
+            String owner = canonicalNonempty(json.getString("owner_session_id"));
+            String authBoot = canonicalBootId(json.getString("authorization_boot_id"));
+            String target = canonicalVersion(json.getString("target_version"));
+            String artifactId = canonicalNonempty(json.getString("artifact_id"));
+            String sha = json.getString("artifact_sha256").toLowerCase(Locale.US);
+            String verification =
+                    json.isNull("verification_boot_id")
+                            ? null
+                            : canonicalBootId(json.getString("verification_boot_id"));
+            TerminalStatus terminal =
+                    json.isNull("terminal_status")
+                            ? null
+                            : TerminalStatus.valueOf(json.getString("terminal_status"));
+            String code =
+                    json.isNull("terminal_code")
+                            ? null
+                            : canonicalCode(json.getString("terminal_code"));
+            if (owner == null
+                    || authBoot == null
+                    || target == null
+                    || artifactId == null
+                    || !sha.matches("[0-9a-f]{64}")
+                    || (state == State.TERMINAL) != (terminal != null && code != null)
+                    || (state != State.TERMINAL && (terminal != null || code != null))) {
+                throw new JSONException("invalid BES OTA state fields");
+            }
+            return valid(
+                    state,
+                    owner,
+                    authBoot,
+                    verification,
+                    target,
+                    artifactId,
+                    sha,
+                    terminal,
+                    code,
+                    json.optLong("updated_at_ms", 0));
+        }
+
+        JSONObject toJson() {
+            try {
+                JSONObject json = new JSONObject();
+                json.put("schema", SCHEMA);
+                json.put("state", state.name());
+                json.put("owner_session_id", ownerSessionId);
+                json.put("authorization_boot_id", authorizationBootId);
+                json.put(
+                        "verification_boot_id",
+                        verificationBootId == null ? JSONObject.NULL : verificationBootId);
+                json.put("target_version", targetVersion);
+                json.put("artifact_id", artifactId);
+                json.put("artifact_sha256", artifactSha256);
+                json.put(
+                        "terminal_status",
+                        terminalStatus == null ? JSONObject.NULL : terminalStatus.name());
+                json.put("terminal_code", terminalCode == null ? JSONObject.NULL : terminalCode);
+                json.put("updated_at_ms", updatedAtMs);
+                return json;
+            } catch (JSONException e) {
+                throw new IllegalStateException("Could not encode BES OTA state", e);
+            }
+        }
+
+        Snapshot withState(State nextState, String verificationBootId) {
+            return valid(
+                    nextState,
+                    ownerSessionId,
+                    authorizationBootId,
+                    verificationBootId,
+                    targetVersion,
+                    artifactId,
+                    artifactSha256,
+                    null,
+                    null,
+                    System.currentTimeMillis());
+        }
+
+        Snapshot withVerificationBoot(String bootId) {
+            return valid(
+                    state,
+                    ownerSessionId,
+                    authorizationBootId,
+                    bootId,
+                    targetVersion,
+                    artifactId,
+                    artifactSha256,
+                    terminalStatus,
+                    terminalCode,
+                    System.currentTimeMillis());
+        }
+
+        Snapshot asTerminal(TerminalStatus status, String code) {
+            return valid(
+                    State.TERMINAL,
+                    ownerSessionId,
+                    authorizationBootId,
+                    verificationBootId,
+                    targetVersion,
+                    artifactId,
+                    artifactSha256,
+                    status,
+                    code,
+                    System.currentTimeMillis());
+        }
+
+        boolean isOwnedActive(State expectedState, String owner) {
+            return isValid()
+                    && state == expectedState
+                    && ownerSessionId.equals(canonicalNonempty(owner));
+        }
+
+        public boolean isIdle() {
+            return idle;
+        }
+
+        public boolean isCorrupt() {
+            return corruption != null;
+        }
+
+        public boolean isValid() {
+            return !idle && corruption == null;
+        }
+
+        public State getState() {
+            return state;
+        }
+
+        public String getOwnerSessionId() {
+            return ownerSessionId;
+        }
+
+        public String getAuthorizationBootId() {
+            return authorizationBootId;
+        }
+
+        public String getVerificationBootId() {
+            return verificationBootId;
+        }
+
+        public String getTargetVersion() {
+            return targetVersion;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public String getArtifactSha256() {
+            return artifactSha256;
+        }
+
+        public TerminalStatus getTerminalStatus() {
+            return terminalStatus;
+        }
+
+        public String getTerminalCode() {
+            return terminalCode;
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -3,12 +3,15 @@ package com.mentra.asg_client.io.bes;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
+
 import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.util.Locale;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Single durable authority for legacy BES OTA admission, apply, verification, and terminal state.
@@ -427,8 +430,11 @@ public final class BesOtaStateStore {
             return Snapshot.corrupt("prior commit failed");
         }
         String raw = storage.get();
-        if (raw == null || raw.trim().isEmpty()) {
+        if (raw == null) {
             return Snapshot.idle();
+        }
+        if (raw.trim().isEmpty()) {
+            return Snapshot.corrupt("empty state");
         }
         try {
             return Snapshot.fromJson(new JSONObject(raw));
@@ -641,8 +647,9 @@ public final class BesOtaStateStore {
             String target = canonicalVersion(json.getString("target_version"));
             String artifactId = canonicalNonempty(json.getString("artifact_id"));
             String sha = json.getString("artifact_sha256").toLowerCase(Locale.US);
+            boolean hasVerificationBoot = !json.isNull("verification_boot_id");
             String verification =
-                    json.isNull("verification_boot_id")
+                    !hasVerificationBoot
                             ? null
                             : canonicalBootId(json.getString("verification_boot_id"));
             TerminalStatus terminal =
@@ -658,6 +665,7 @@ public final class BesOtaStateStore {
                     || target == null
                     || artifactId == null
                     || !sha.matches("[0-9a-f]{64}")
+                    || (hasVerificationBoot && verification == null)
                     || (state == State.TERMINAL) != (terminal != null && code != null)
                     || (state != State.TERMINAL && (terminal != null || code != null))) {
                 throw new JSONException("invalid BES OTA state fields");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.bluetooth.managers;
 
 import android.content.Context;
 import android.util.Log;
+
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.BesOtaStateStore;
 import com.mentra.asg_client.io.bes.BesOtaUartListener;
@@ -27,6 +28,10 @@ import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrat
 import com.mentra.asg_client.service.utils.SysProp;
 import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.utils.WakeLockManager;
+
+import org.greenrobot.eventbus.EventBus;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -39,8 +44,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import org.greenrobot.eventbus.EventBus;
-import org.json.JSONObject;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -255,11 +258,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // Initialize every callback dependency before the serial receive thread starts.
         messageParser = new BesMessageParser();
         fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
-
-        // Couple the v1 string chunk budget to the caps lifecycle before any transition can
-        // fire: every path that clears the caps (including reopen failures that never reach the
-        // serial callbacks) then also restores the fallback budget.
-        MessageChunker.followLinkState(linkState);
 
         // Create the communication manager
         comManager = new SerialPortBridge(context);
@@ -1384,8 +1382,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
         }
         if (advertised != null && advertised.notifyCap > 0) {
-            // The string chunk budget follows the caps automatically: the MessageChunker
-            // subscription (followLinkState in the constructor) re-derives it on this transition.
+            // Diagnostic only. Legacy v1 strings stay at the fixed conservative ceiling;
+            // negotiated capacity is used only by the higher-capacity protocol.
             Log.i(TAG, "📏 BES wire_caps advertised notify_cap=" + advertised.notifyCap);
         }
         return advertised;
@@ -1770,6 +1768,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         // Close transport state before releasing the file lease so cleanup cannot resume a
         // deferred baud transition on a port that is already going down.
+        framedPathProven = false;
         linkState.serialClosed();
         transportCoordinator.onSerialClosed();
         if (currentFileTransfer != null && currentFileTransfer.isActive) {
@@ -1986,6 +1985,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.d(TAG, "🔌 =========================================");
         Log.d(TAG, "🔌 Serial path: " + serialPath);
 
+        // A proof belongs to one exact SerialSession. Never let an sr_syvr from the
+        // previous file descriptor authorize traffic on a newly adopted session.
+        framedPathProven = false;
         linkState.serialReady();
         transportCoordinator.onSerialReady(session);
         Log.d(TAG, "🔌 ✅ Serial port marked as open");
@@ -2021,6 +2023,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (bSucc) {
             linkState.serialReady();
         } else {
+            framedPathProven = false;
             linkState.serialClosed();
             transportCoordinator.onSerialClosed();
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2,9 +2,10 @@ package com.mentra.asg_client.io.bluetooth.managers;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.io.bes.BesOtaStateStore;
 import com.mentra.asg_client.io.bes.BesOtaUartListener;
+import com.mentra.asg_client.io.bes.events.BesOtaProgressEvent;
 import com.mentra.asg_client.io.bluetooth.core.BaseBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesMessageParser;
@@ -26,9 +27,6 @@ import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrat
 import com.mentra.asg_client.service.utils.SysProp;
 import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.utils.WakeLockManager;
-
-import org.json.JSONObject;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -41,6 +39,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.greenrobot.eventbus.EventBus;
+import org.json.JSONObject;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -51,14 +51,18 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     private final SerialPortBridge comManager;
     private final BesUartTransportCoordinator transportCoordinator;
+    private final BesOtaStateStore besOtaStateStore;
+    private final String currentBootId;
+    private volatile String liveBesOtaOwner = "";
+    private volatile boolean framedPathProven;
     private volatile BesOtaUartListener besOtaUartListener;
 
     public interface BesOtaAuthorizationCallback {
         /** Called on the outbound worker before the authorization request is written. */
         boolean onLeaseAcquired(BesUartTransportCoordinator.OperationLease lease);
 
-        /** Called after the authorization request write attempt finishes. */
-        void onWriteComplete(boolean success);
+        /** Reports whether submission was attempted separately from the local write result. */
+        void onWriteComplete(boolean attempted, boolean success);
     }
 
     // Single owner of the transport-side link facts (serial open, link proven at current baud,
@@ -238,6 +242,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     public K900BluetoothManager(Context context) {
         super(context);
 
+        besOtaStateStore = new BesOtaStateStore(context);
+        currentBootId = besOtaStateStore.currentBootId();
+        BesOtaStateStore.StartupDecision startupDecision =
+                besOtaStateStore.reconcileStartup(currentBootId);
+        Log.i(TAG, "BES OTA startup reconciliation: " + startupDecision);
+
         // Create the notification manager
         notificationManager = new DebugNotificationManager(context);
         notificationManager.showDeviceTypeNotification(true);
@@ -253,7 +263,25 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         // Create the communication manager
         comManager = new SerialPortBridge(context);
-        transportCoordinator = new BesUartTransportCoordinator(new UartCoordinatorHost());
+        transportCoordinator =
+                new BesUartTransportCoordinator(
+                        new UartCoordinatorHost(),
+                        new BesUartTransportCoordinator.SafetyState() {
+                            @Override
+                            public BesUartTransportCoordinator.SafetyPolicy currentPolicy() {
+                                return currentBesOtaSafetyPolicy();
+                            }
+
+                            @Override
+                            public void onRawOtaModeProven() {
+                                onBesRawOtaModeProvenAfterRestart();
+                            }
+
+                            @Override
+                            public void onRecoveryFailed() {
+                                onBesRecoveryFailed();
+                            }
+                        });
         comManager.registerListener(this);
         comManager.start();
     }
@@ -298,6 +326,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         @Override
         public void invalidateLinkProof() {
+            framedPathProven = false;
             linkState.streamDiscontinuity();
         }
 
@@ -1117,11 +1146,64 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     /** Register the raw BES OTA parser; routing remains owned by the transport coordinator. */
     public void registerBesOtaListener(BesOtaUartListener listener) {
         besOtaUartListener = listener;
+        if (listener != null) {
+            transportCoordinator.startSafetyRecovery();
+        }
     }
 
     /** Coordinator that owns every UART transition and long-lived transport operation. */
     public BesUartTransportCoordinator getTransportCoordinator() {
         return transportCoordinator;
+    }
+
+    public BesOtaStateStore getBesOtaStateStore() {
+        return besOtaStateStore;
+    }
+
+    public void setLiveBesOtaOwner(String ownerSessionId) {
+        liveBesOtaOwner = ownerSessionId == null ? "" : ownerSessionId.trim();
+    }
+
+    public boolean isFramedPathProven() {
+        return framedPathProven;
+    }
+
+    private BesUartTransportCoordinator.SafetyPolicy currentBesOtaSafetyPolicy() {
+        BesOtaStateStore.UartPolicy policy =
+                besOtaStateStore.uartPolicy(currentBootId, framedPathProven, liveBesOtaOwner);
+        switch (policy) {
+            case NORMAL:
+                return BesUartTransportCoordinator.SafetyPolicy.NORMAL;
+            case OTA_OWNER_ONLY:
+                return BesUartTransportCoordinator.SafetyPolicy.OTA_OWNER_ONLY;
+            case RECOVERY_PROBE_ONLY:
+                return BesUartTransportCoordinator.SafetyPolicy.RECOVERY_PROBE_ONLY;
+            case VERSION_PROBE_ONLY:
+                return BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
+            case QUARANTINED:
+            default:
+                return BesUartTransportCoordinator.SafetyPolicy.QUARANTINED;
+        }
+    }
+
+    private void onBesRawOtaModeProvenAfterRestart() {
+        BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
+        if (snapshot.isValid() && snapshot.getState() != BesOtaStateStore.State.TERMINAL) {
+            BesOtaStateStore.TransitionResult result =
+                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), "raw_mode_after_restart");
+            Log.e(TAG, "BES raw-mode recovery result: " + result);
+        }
+        EventBus.getDefault().post(BesOtaProgressEvent.createFailed("raw_mode_after_restart"));
+    }
+
+    private void onBesRecoveryFailed() {
+        BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
+        if (snapshot.isValid() && snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
+            BesOtaStateStore.TransitionResult result =
+                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), "verification_timeout");
+            Log.e(TAG, "BES post-apply recovery timed out: " + result);
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed("verification_timeout"));
+        }
     }
 
     /**
@@ -1138,23 +1220,24 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     BesUartTransportCoordinator.OperationLease lease =
                             transportCoordinator.beginOtaAuthorization();
                     if (lease == null) {
-                        callback.onWriteComplete(false);
+                        callback.onWriteComplete(false, false);
                         return;
                     }
                     if (!callback.onLeaseAcquired(lease)) {
                         transportCoordinator.endOta(lease);
-                        callback.onWriteComplete(false);
+                        callback.onWriteComplete(false, false);
                         return;
                     }
 
                     publishOutboundMessage(payload, true);
+                    boolean attempted = true;
                     boolean sent =
                             transportCoordinator.runOtaAuthorizationWrite(
                                     lease, () -> sendMessageInternalLocked(payload));
-                    if (!sent) {
-                        transportCoordinator.endOta(lease);
-                    }
-                    callback.onWriteComplete(sent);
+                    // Once the durable reservation exists, a false local result is ambiguous and
+                    // the lease must remain exclusive while the manager waits for hm_ota/raw
+                    // reconciliation. Never release it here and never resend mh_ota.
+                    callback.onWriteComplete(attempted, sent);
                 });
     }
 
@@ -1191,6 +1274,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             extractBaudSwitchVersion(bData),
                             receiveSession,
                             () -> {
+                                framedPathProven = true;
+                                reconcileBesOtaVersionProof(extractDisplayBesVersion(bData));
                                 // Presence must precede caps: the edge invalidates the previous
                                 // phone session's notify_cap, then this reply installs the current
                                 // session's measured value. The coordinator session check makes
@@ -1448,6 +1533,51 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         if (!v.isEmpty()) {
             cacheBesFirmwareVersion(v);
+        }
+    }
+
+    private static String extractDisplayBesVersion(JSONObject bData) {
+        if (bData == null) {
+            return "";
+        }
+        String version = bData.optString("version", "").trim();
+        return version.isEmpty() ? bData.optString("dpj", "").trim() : version;
+    }
+
+    private void reconcileBesOtaVersionProof(String actualVersion) {
+        BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
+        if (!snapshot.isValid()
+                || snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
+                || currentBootId == null
+                || currentBootId.equals(snapshot.getAuthorizationBootId())) {
+            return;
+        }
+        BesOtaStateStore.VerificationDecision verification =
+                besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
+        if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
+                && verification != BesOtaStateStore.VerificationDecision.RESUME) {
+            Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
+            return;
+        }
+        BesOtaStateStore.TransitionResult completed =
+                besOtaStateStore.completeVerified(
+                        snapshot.getOwnerSessionId(), currentBootId, actualVersion);
+        if (completed != BesOtaStateStore.TransitionResult.APPLIED) {
+            Log.e(TAG, "Could not commit BES post-apply version proof: " + completed);
+            return;
+        }
+        BesOtaStateStore.Snapshot terminal = besOtaStateStore.read();
+        if (terminal.getTerminalStatus() == BesOtaStateStore.TerminalStatus.SUCCESS) {
+            Log.i(TAG, "BES target version verified after reboot: " + actualVersion);
+            EventBus.getDefault().post(BesOtaProgressEvent.createFinished());
+        } else {
+            Log.e(
+                    TAG,
+                    "BES version mismatch after reboot expected="
+                            + terminal.getTargetVersion()
+                            + " actual="
+                            + actualVersion);
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed("version_mismatch"));
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -1,11 +1,7 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
 import android.util.Log;
-
 import com.mentra.asg_client.AsgConstants;
-
-import org.json.JSONObject;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.concurrent.CancellationException;
@@ -16,6 +12,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.json.JSONObject;
 
 /**
  * Single policy owner for the ASG-to-BES UART.
@@ -36,7 +33,9 @@ public final class BesUartTransportCoordinator {
         WAITING_FAST_REOPEN,
         VERIFYING_FAST,
         READY_FAST,
-        RECOVERING
+        RECOVERING,
+        SAFETY_RECOVERING,
+        QUARANTINED
     }
 
     /** Long-lived operation currently preventing transport reconfiguration. */
@@ -75,6 +74,24 @@ public final class BesUartTransportCoordinator {
         REJECTED,
         NORMAL,
         OTA
+    }
+
+    /** Durable BES OTA policy projected by the one authoritative state store. */
+    public enum SafetyPolicy {
+        NORMAL,
+        OTA_OWNER_ONLY,
+        RECOVERY_PROBE_ONLY,
+        VERSION_PROBE_ONLY,
+        QUARANTINED
+    }
+
+    @FunctionalInterface
+    public interface SafetyState {
+        SafetyPolicy currentPolicy();
+
+        default void onRawOtaModeProven() {}
+
+        default void onRecoveryFailed() {}
     }
 
     /** A physical write performed on the FIFO UART lane without holding the state monitor. */
@@ -129,6 +146,7 @@ public final class BesUartTransportCoordinator {
 
     private final Object monitor = new Object();
     private final Host host;
+    private final SafetyState safetyState;
     private final BesUartIoLane ioLane = new BesUartIoLane();
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private final ArrayDeque<FutureTask<Boolean>> deferredNormalWrites = new ArrayDeque<>();
@@ -142,6 +160,11 @@ public final class BesUartTransportCoordinator {
     private long phaseGeneration = 0;
     private SerialSession versionSession;
     private SerialSession fastSwitchAttemptSession;
+    // Fast baud is an optional optimization. Once its negotiation or runtime proof fails, keep
+    // this coordinator at the universally supported 460800 rendezvous baud for the rest of the
+    // process. Serial recovery creates a new SerialSession, so a per-session attempt marker alone
+    // would immediately retry cs_baud and can starve every ordinary K900 command in a loop.
+    private boolean fastBaudSuppressed;
     private int recoveryIndex = 0;
     private int recoveryRetryAttempt = 0;
     private String firmwareVersion = "";
@@ -153,12 +176,21 @@ public final class BesUartTransportCoordinator {
 
     private ScheduledFuture<?> phaseTimeout;
     private ScheduledFuture<?> healthTimeout;
+    private int safetyRawProbeAttempts;
 
     public BesUartTransportCoordinator(Host host) {
+        this(host, () -> SafetyPolicy.NORMAL);
+    }
+
+    public BesUartTransportCoordinator(Host host, SafetyState safetyState) {
         if (host == null) {
             throw new IllegalArgumentException("host is required");
         }
+        if (safetyState == null) {
+            throw new IllegalArgumentException("safetyState is required");
+        }
         this.host = host;
+        this.safetyState = safetyState;
     }
 
     public State getState() {
@@ -188,7 +220,9 @@ public final class BesUartTransportCoordinator {
     /** Route bytes only when they belong to the descriptor currently owned by this coordinator. */
     public InboundRoute inboundRoute(SerialSession session) {
         synchronized (monitor) {
-            if (!isCurrentSerialSessionLocked(session) || state == State.CLOSED) {
+            if (!isCurrentSerialSessionLocked(session)
+                    || state == State.CLOSED
+                    || state == State.QUARANTINED) {
                 return InboundRoute.REJECTED;
             }
             return otaRawRouting ? InboundRoute.OTA : InboundRoute.NORMAL;
@@ -205,6 +239,31 @@ public final class BesUartTransportCoordinator {
     public boolean isCurrentSerialSession(SerialSession session) {
         synchronized (monitor) {
             return isCurrentSerialSessionLocked(session);
+        }
+    }
+
+    /** Begin bounded raw-first recovery after the raw parser listener is registered. */
+    public void startSafetyRecovery() {
+        synchronized (monitor) {
+            if (state != State.SAFETY_RECOVERING || !otaRawRouting) {
+                return;
+            }
+            safetyRawProbeAttempts = 0;
+            long phase = ++phaseGeneration;
+            scheduleNextSafetyRawProbeLocked(phase);
+        }
+    }
+
+    /** Consume only a complete raw protocol-version response during bounded recovery. */
+    public boolean onSafetyRawProtocolResponse(byte command) {
+        synchronized (monitor) {
+            if (state != State.SAFETY_RECOVERING || command != (byte) 0x9A) {
+                return false;
+            }
+            Log.e(TAG, "BES still answers the raw OTA parser after restart");
+            safetyState.onRawOtaModeProven();
+            quarantineCurrentSessionLocked();
+            return true;
         }
     }
 
@@ -240,6 +299,22 @@ public final class BesUartTransportCoordinator {
             versionProbeDeferred = false;
             cancelOutboundDrainLocked();
             serialSession = session;
+            SafetyPolicy policy = safetyState.currentPolicy();
+            if (policy == SafetyPolicy.QUARANTINED || policy == SafetyPolicy.OTA_OWNER_ONLY) {
+                state = State.QUARANTINED;
+                phaseGeneration++;
+                Log.e(TAG, "UART quarantined by durable BES OTA state: " + policy);
+                return;
+            }
+            if (policy == SafetyPolicy.RECOVERY_PROBE_ONLY
+                    || policy == SafetyPolicy.VERSION_PROBE_ONLY) {
+                state = State.SAFETY_RECOVERING;
+                otaRawRouting = true;
+                safetyRawProbeAttempts = 0;
+                phaseGeneration++;
+                Log.w(TAG, "Awaiting raw-first BES OTA recovery probe: " + policy);
+                return;
+            }
             long phase = ++phaseGeneration;
             Log.i(TAG, "Serial ready; discovering BES at rendezvous baud");
             scheduleProbeBurstLocked(
@@ -276,6 +351,63 @@ public final class BesUartTransportCoordinator {
         }
     }
 
+    private void scheduleNextSafetyRawProbeLocked(long phase) {
+        if (phase != phaseGeneration || state != State.SAFETY_RECOVERING) {
+            return;
+        }
+        if (safetyRawProbeAttempts >= 3) {
+            phaseTimeout =
+                    executor.schedule(() -> finishSafetyRawSilence(phase), 1, TimeUnit.SECONDS);
+            return;
+        }
+        safetyRawProbeAttempts++;
+        int attempt = safetyRawProbeAttempts;
+        ioLane.submit(
+                () -> {
+                    boolean sent = host.writeRawBytes(new byte[] {(byte) 0x99, 0, 0, 0, 0});
+                    Log.w(TAG, "Safety raw 0x99 probe " + attempt + "/3 sent=" + sent);
+                });
+        phaseTimeout =
+                executor.schedule(
+                        () -> {
+                            synchronized (monitor) {
+                                scheduleNextSafetyRawProbeLocked(phase);
+                            }
+                        },
+                        1,
+                        TimeUnit.SECONDS);
+    }
+
+    private void finishSafetyRawSilence(long phase) {
+        synchronized (monitor) {
+            if (phase != phaseGeneration || state != State.SAFETY_RECOVERING) {
+                return;
+            }
+            // Raw silence is not proof of framed mode. Release A sends exactly one source-audited
+            // cs_syvr and accepts only its current-session sr_syvr. Physical compatibility remains
+            // a mandatory internal-staging rollout gate before production promotion.
+            otaRawRouting = false;
+            host.resetParser();
+            state = State.DISCOVERING;
+            long framedPhase = ++phaseGeneration;
+            scheduleProbeBurstLocked(framedPhase, AsgConstants.UART_RENDEZVOUS_BAUD, 0, 1, 0);
+            phaseTimeout =
+                    executor.schedule(
+                            () -> quarantineSafetyRecoveryIfCurrent(framedPhase),
+                            AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS,
+                            TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void quarantineSafetyRecoveryIfCurrent(long phase) {
+        synchronized (monitor) {
+            if (phase == phaseGeneration && state == State.DISCOVERING) {
+                safetyState.onRecoveryFailed();
+                quarantineCurrentSessionLocked();
+            }
+        }
+    }
+
     /**
      * Consume an {@code sr_syvr}. The preparation callback runs only for the current serial session
      * and before any resulting baud transition. A reply that starts a baud switch never creates a
@@ -286,6 +418,7 @@ public final class BesUartTransportCoordinator {
         synchronized (monitor) {
             if (!isCurrentSerialSessionLocked(receiveSession)
                     || state == State.CLOSED
+                    || state == State.QUARANTINED
                     || state == State.SWITCH_REQUESTED
                     || state == State.WAITING_FAST_REOPEN
                     || !host.isSerialOpen()) {
@@ -293,6 +426,12 @@ public final class BesUartTransportCoordinator {
             }
             if (beforeTransition != null) {
                 beforeTransition.run();
+            }
+            SafetyPolicy policy = safetyState.currentPolicy();
+            if (policy != SafetyPolicy.NORMAL) {
+                state = State.QUARANTINED;
+                Log.e(TAG, "sr_syvr did not resolve durable BES OTA policy: " + policy);
+                return SystemVersionResult.IGNORED;
             }
             firmwareVersion = version == null ? "" : version.trim();
             versionSession = serialSession;
@@ -307,6 +446,7 @@ public final class BesUartTransportCoordinator {
             if (baud == AsgConstants.UART_FAST_BAUD) {
                 state = State.READY_FAST;
                 scheduleHealthCheckLocked();
+                monitor.notifyAll();
                 Log.i(TAG, "UART link ready at fast baud " + baud);
                 return SystemVersionResult.READY;
             }
@@ -317,6 +457,7 @@ public final class BesUartTransportCoordinator {
             }
 
             advanceLocked();
+            monitor.notifyAll();
             if (isReadyLocked()) {
                 Log.i(TAG, "UART link ready at rendezvous baud " + baud);
                 return SystemVersionResult.READY;
@@ -334,6 +475,7 @@ public final class BesUartTransportCoordinator {
             }
             cancelPhaseTimeoutLocked();
             if (status != 0 || acknowledgedBaud != AsgConstants.UART_FAST_BAUD) {
+                fastBaudSuppressed = true;
                 state = State.READY_RENDEZVOUS;
                 Log.w(
                         TAG,
@@ -361,6 +503,13 @@ public final class BesUartTransportCoordinator {
     public void onValidFrame(SerialSession receiveSession) {
         synchronized (monitor) {
             if (!isCurrentSerialSessionLocked(receiveSession)) {
+                return;
+            }
+            SafetyPolicy policy = safetyState.currentPolicy();
+            if (policy == SafetyPolicy.RECOVERY_PROBE_ONLY
+                    || policy == SafetyPolicy.VERSION_PROBE_ONLY) {
+                // During durable recovery, only the exact fresh sr_syvr requested after raw
+                // silence proves framed mode. Arbitrary valid traffic cannot reopen the UART.
                 return;
             }
             discardedBytes = 0;
@@ -407,7 +556,14 @@ public final class BesUartTransportCoordinator {
     public boolean runNormalWrite(WriteAction action) {
         Future<Boolean> write;
         synchronized (monitor) {
-            if (!isReadyLocked() || action == null) {
+            SafetyPolicy policy = safetyState.currentPolicy();
+            boolean otaOwnedDeferral =
+                    policy == SafetyPolicy.OTA_OWNER_ONLY
+                            && (operation == Operation.OTA_AUTHORIZATION
+                                    || operation == Operation.OTA_TRANSFER);
+            if (!isReadyLocked()
+                    || action == null
+                    || (policy != SafetyPolicy.NORMAL && !otaOwnedDeferral)) {
                 Log.w(TAG, "Rejecting normal write state=" + state + " operation=" + operation);
                 return false;
             }
@@ -504,11 +660,72 @@ public final class BesUartTransportCoordinator {
     }
 
     public OperationLease beginOtaAuthorization() {
+        if (!ensureRendezvousForOta()) {
+            return null;
+        }
         OperationLease lease = beginOperation(Operation.OTA_AUTHORIZATION, false);
         if (lease != null) {
             Log.i(TAG, "BES OTA authorization owns stable UART");
         }
         return lease;
+    }
+
+    /**
+     * BES OTA deliberately uses the one universally supported baud. If ordinary traffic had
+     * negotiated the optional fast baud, reopen at 460800 and require a fresh sr_syvr before the
+     * authorization lease can be acquired. This wait runs on the ordered outbound worker; the
+     * serial reader remains free to deliver the proof.
+     */
+    private boolean ensureRendezvousForOta() {
+        synchronized (monitor) {
+            if (safetyState.currentPolicy() != SafetyPolicy.NORMAL
+                    || operation != Operation.NONE
+                    || state == State.CLOSED
+                    || state == State.QUARANTINED) {
+                return false;
+            }
+            fastBaudSuppressed = true;
+            if (state == State.READY_RENDEZVOUS
+                    && versionSession == serialSession
+                    && host.currentBaud() == AsgConstants.UART_RENDEZVOUS_BAUD) {
+                return true;
+            }
+            if (state == State.READY_FAST
+                    || state == State.SWITCH_REQUESTED
+                    || state == State.WAITING_FAST_REOPEN
+                    || state == State.VERIFYING_FAST
+                    || state == State.RECOVERING) {
+                cancelAllTimersLocked();
+                host.invalidateLinkProof();
+                serialSession = null;
+                versionSession = null;
+                state = State.DISCOVERING;
+                long phase = ++phaseGeneration;
+                ioLane.submit(() -> reconnectAfterOta(phase));
+            }
+
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (state != State.READY_RENDEZVOUS) {
+                if (state == State.CLOSED
+                        || state == State.QUARANTINED
+                        || safetyState.currentPolicy() != SafetyPolicy.NORMAL) {
+                    return false;
+                }
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    Log.e(TAG, "Timed out proving 460800 UART before BES OTA");
+                    return false;
+                }
+                try {
+                    TimeUnit.NANOSECONDS.timedWait(monitor, remainingNanos);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
+            return versionSession == serialSession
+                    && host.currentBaud() == AsgConstants.UART_RENDEZVOUS_BAUD;
+        }
     }
 
     /** Write the single normal-framed request owned by the OTA authorization lease. */
@@ -569,9 +786,48 @@ public final class BesUartTransportCoordinator {
             host.setFastReceive(false);
             operation = Operation.NONE;
             operationLease = null;
-            flushDeferredNormalWritesLocked();
-            resumeAfterOutboundDrainLocked();
+            if (safetyState.currentPolicy() == SafetyPolicy.NORMAL) {
+                flushDeferredNormalWritesLocked();
+                resumeAfterOutboundDrainLocked();
+            } else {
+                cancelDeferredNormalWritesLocked("durable BES OTA quarantine");
+                state = State.QUARANTINED;
+            }
         }
+    }
+
+    /** One-way same-boot quarantine after an authorization reservation existed. */
+    public boolean quarantineOta(OperationLease lease) {
+        synchronized (monitor) {
+            if (operationLease != lease
+                    || (operation != Operation.OTA_AUTHORIZATION
+                            && operation != Operation.OTA_TRANSFER)) {
+                quarantineCurrentSessionLocked();
+                return false;
+            }
+            quarantineCurrentSessionLocked();
+            return true;
+        }
+    }
+
+    public void quarantineCurrentSession() {
+        synchronized (monitor) {
+            quarantineCurrentSessionLocked();
+        }
+    }
+
+    private void quarantineCurrentSessionLocked() {
+        cancelAllTimersLocked();
+        cancelDeferredNormalWritesLocked("BES OTA state is ambiguous");
+        cancelOutboundDrainLocked();
+        phaseGeneration++;
+        otaRawRouting = false;
+        host.setFastReceive(false);
+        operation = Operation.NONE;
+        operationLease = null;
+        state = State.QUARANTINED;
+        monitor.notifyAll();
+        Log.e(TAG, "UART quarantined by durable BES OTA policy");
     }
 
     /**
@@ -592,6 +848,13 @@ public final class BesUartTransportCoordinator {
             cancelOutboundDrainLocked();
             host.invalidateLinkProof();
             serialSession = null;
+            if (safetyState.currentPolicy() == SafetyPolicy.OTA_OWNER_ONLY
+                    || safetyState.currentPolicy() == SafetyPolicy.QUARANTINED) {
+                state = State.QUARANTINED;
+                phaseGeneration++;
+                Log.i(TAG, "BES apply accepted; waiting for a new Linux boot");
+                return;
+            }
             state = State.DISCOVERING;
             long phase = ++phaseGeneration;
             ioLane.submit(() -> reconnectAfterOta(phase));
@@ -801,6 +1064,7 @@ public final class BesUartTransportCoordinator {
         if (state != State.READY_RENDEZVOUS
                 || operation != Operation.NONE
                 || outboundDrainPending
+                || fastBaudSuppressed
                 || versionSession != serialSession
                 || fastSwitchAttemptSession == serialSession
                 || firmwareVersion.isEmpty()
@@ -913,6 +1177,13 @@ public final class BesUartTransportCoordinator {
                 scheduleHealthCheckLocked();
             }
             return;
+        }
+        if (state == State.SWITCH_REQUESTED
+                || state == State.WAITING_FAST_REOPEN
+                || state == State.VERIFYING_FAST
+                || state == State.READY_FAST) {
+            fastBaudSuppressed = true;
+            Log.w(TAG, "Suppressing optional fast baud after failed proof: " + reason);
         }
         cancelAllTimersLocked();
         host.invalidateLinkProof();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -1,7 +1,11 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
 import android.util.Log;
+
 import com.mentra.asg_client.AsgConstants;
+
+import org.json.JSONObject;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.concurrent.CancellationException;
@@ -12,7 +16,6 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.json.JSONObject;
 
 /**
  * Single policy owner for the ASG-to-BES UART.
@@ -177,6 +180,7 @@ public final class BesUartTransportCoordinator {
     private ScheduledFuture<?> phaseTimeout;
     private ScheduledFuture<?> healthTimeout;
     private int safetyRawProbeAttempts;
+    private boolean safetyRecoveryListenerReady;
 
     public BesUartTransportCoordinator(Host host) {
         this(host, () -> SafetyPolicy.NORMAL);
@@ -245,13 +249,21 @@ public final class BesUartTransportCoordinator {
     /** Begin bounded raw-first recovery after the raw parser listener is registered. */
     public void startSafetyRecovery() {
         synchronized (monitor) {
+            // Listener registration and serial readiness can arrive in either order. Remember the
+            // registration so a later onSerialReady transition cannot strand the state machine in
+            // SAFETY_RECOVERING without ever sending its bounded probes.
+            safetyRecoveryListenerReady = true;
             if (state != State.SAFETY_RECOVERING || !otaRawRouting) {
                 return;
             }
-            safetyRawProbeAttempts = 0;
-            long phase = ++phaseGeneration;
-            scheduleNextSafetyRawProbeLocked(phase);
+            armSafetyRecoveryProbesLocked();
         }
+    }
+
+    private void armSafetyRecoveryProbesLocked() {
+        safetyRawProbeAttempts = 0;
+        long phase = ++phaseGeneration;
+        scheduleNextSafetyRawProbeLocked(phase);
     }
 
     /** Consume only a complete raw protocol-version response during bounded recovery. */
@@ -312,7 +324,12 @@ public final class BesUartTransportCoordinator {
                 otaRawRouting = true;
                 safetyRawProbeAttempts = 0;
                 phaseGeneration++;
-                Log.w(TAG, "Awaiting raw-first BES OTA recovery probe: " + policy);
+                if (safetyRecoveryListenerReady) {
+                    Log.w(TAG, "Starting raw-first BES OTA recovery probe: " + policy);
+                    armSafetyRecoveryProbesLocked();
+                } else {
+                    Log.w(TAG, "Awaiting raw parser listener before BES OTA recovery: " + policy);
+                }
                 return;
             }
             long phase = ++phaseGeneration;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -1,13 +1,16 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
 import android.util.Log;
+
 import com.mentra.asg_client.AsgConstants;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Splits large JSON messages into compact chunks that fit through the K900/BES BLE path.
@@ -38,7 +41,7 @@ public class MessageChunker {
     /** Compatibility no-op: the legacy v1 budget is always the conservative fixed ceiling. */
     public static void resetStringChunkBudget() {}
 
-    /** Compatibility no-op: link-state transitions cannot change the fixed legacy v1 ceiling. */
+    /** Compatibility no-op for old callers; production no longer subscribes to link caps. */
     public static void followLinkState(LinkStateMachine linkState) {}
 
     public static boolean needsChunking(String message) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -12,7 +12,8 @@ import org.json.JSONObject;
 /**
  * Splits large JSON messages into compact chunks that fit through the K900/BES BLE path.
  *
- * <p>v1: JSON chunk envelope (t="ck"). v2: binary fragments ({@link BesWireFormat#CMD_TYPE_BINARY_MSG}).
+ * <p>v1: JSON chunk envelope (t="ck"). v2: binary fragments ({@link
+ * BesWireFormat#CMD_TYPE_BINARY_MSG}).
  */
 public class MessageChunker {
     private static final String TAG = "MessageChunker";
@@ -20,90 +21,25 @@ public class MessageChunker {
     private static final int MESSAGE_SIZE_THRESHOLD_V1 = 200;
     private static final int INITIAL_CHUNK_DATA_SIZE = 80;
     private static final int MIN_CHUNK_DATA_SIZE = 4;
+
     /** Budget for v2 binary fragments — these are reassembled phone-side, so MTU_TARGET holds. */
     public static final int MAX_PACKED_CHUNK_SIZE = BesWireFormat.MAX_PACKED_FRAME_SIZE;
-
-    /**
-     * Budget for v1 STRING ck chunks. Unlike binary fragments, a v1 string frame must survive
-     * the phone leg as ONE BLE notification (the BES relays it unfragmented and the phone parses
-     * per-notification) — so the real ceiling is the notification payload cap, not MTU_TARGET.
-     * Defaults to the conservative worst-case budget
-     * ({@link AsgConstants#K900_STRING_CHUNK_MAX_FRAME_BYTES}); BES firmware >= 17.26.7.23
-     * advertises the true cap via {@code wire_caps.notify_cap} and
-     * {@link #setStringChunkBudgetFromNotifyCap(int)} raises the budget accordingly.
-     */
-    private static final java.util.concurrent.atomic.AtomicInteger STRING_CHUNK_BUDGET =
-            new java.util.concurrent.atomic.AtomicInteger(
-                    AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES);
 
     private static final AtomicLong CHUNK_SEQUENCE = new AtomicLong();
 
     /** Current maximum packed frame size for a v1 STRING ck chunk. */
     public static int maxPackedStringChunkSize() {
-        return STRING_CHUNK_BUDGET.get();
+        return AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES;
     }
 
-    /**
-     * Adopt the BES-measured notification cap ({@code wire_caps.notify_cap}) as the v1 string
-     * chunk ceiling, keeping the same re-framing safety margin the 240-byte fallback encodes
-     * (240 = 253 - {@link AsgConstants#K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}). The advertised
-     * value is validated against the firmware contract range [253, 509] rather than trusted
-     * blindly: below the floor it is malformed and ignored (the budget must never shrink below
-     * the hardware-validated fallback), above the ceiling it is clamped down (an oversized
-     * advertisement would size chunks beyond what the transport carries — the exact silent
-     * truncation class this budget exists to prevent).
-     */
-    public static void setStringChunkBudgetFromNotifyCap(int notifyCap) {
-        if (notifyCap < AsgConstants.K900_BLE_NOTIFY_CAP_FLOOR_BYTES) {
-            Log.w(
-                    TAG,
-                    "Ignoring notify_cap="
-                            + notifyCap
-                            + " below the contract floor "
-                            + AsgConstants.K900_BLE_NOTIFY_CAP_FLOOR_BYTES);
-            return;
-        }
-        int accepted = notifyCap;
-        if (accepted > AsgConstants.K900_BLE_NOTIFY_CAP_CEILING_BYTES) {
-            Log.w(
-                    TAG,
-                    "Clamping notify_cap="
-                            + notifyCap
-                            + " to the contract ceiling "
-                            + AsgConstants.K900_BLE_NOTIFY_CAP_CEILING_BYTES);
-            accepted = AsgConstants.K900_BLE_NOTIFY_CAP_CEILING_BYTES;
-        }
-        STRING_CHUNK_BUDGET.set(
-                accepted - AsgConstants.K900_STRING_CHUNK_BUDGET_MARGIN_BYTES);
-    }
+    /** Compatibility no-op: {@code notify_cap} cannot raise the legacy v1 ceiling. */
+    public static void setStringChunkBudgetFromNotifyCap(int notifyCap) {}
 
-    /** Restore the conservative fallback budget (the negotiated cap died with the caps). */
-    public static void resetStringChunkBudget() {
-        STRING_CHUNK_BUDGET.set(AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES);
-    }
+    /** Compatibility no-op: the legacy v1 budget is always the conservative fixed ceiling. */
+    public static void resetStringChunkBudget() {}
 
-    /**
-     * Couple the string chunk budget to the link state machine's negotiated caps lifecycle: on
-     * every observable transition the budget is re-derived from the current caps snapshot —
-     * notify_cap advertised means the negotiated budget, caps cleared means the fallback. Tying
-     * the budget to the machine (rather than to one serial callback) guarantees it can never go
-     * stale on ANY path that clears the caps: {@code onSerialClose}, a failed
-     * {@code onSerialOpen}, and reopen failures all drive the machine's serialClosed transition
-     * directly, and a subsequent reconnect to firmware that omits notify_cap must not inherit a
-     * previous session's larger budget (that would reintroduce silent notification truncation).
-     * Replay-on-subscribe applies the current caps immediately. Call once per machine.
-     */
-    public static void followLinkState(LinkStateMachine linkState) {
-        linkState.addListener(
-                (state, provenCaps, phonePresence) -> {
-                    int notifyCap = linkState.getNegotiatedCaps().notifyCap;
-                    if (notifyCap > 0) {
-                        setStringChunkBudgetFromNotifyCap(notifyCap);
-                    } else {
-                        resetStringChunkBudget();
-                    }
-                });
-    }
+    /** Compatibility no-op: link-state transitions cannot change the fixed legacy v1 ceiling. */
+    public static void followLinkState(LinkStateMachine linkState) {}
 
     public static boolean needsChunking(String message) {
         if (message == null) {
@@ -178,7 +114,8 @@ public class MessageChunker {
         }
 
         byte[] messageBytes = BesWireFormat.buildOutboundPayloadBytes(originalJson);
-        List<byte[]> payloadChunks = splitUtf8Bytes(messageBytes, BesWireFormat.MAX_FRAGMENT_PAYLOAD);
+        List<byte[]> payloadChunks =
+                splitUtf8Bytes(messageBytes, BesWireFormat.MAX_FRAGMENT_PAYLOAD);
         int totalFragments = payloadChunks.size();
         List<byte[]> frames = new ArrayList<>(totalFragments);
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -283,12 +283,20 @@ public class OtaHelper {
         return controller != null ? controller.getAuthoritativeStatus() : null;
     }
 
-    public void sendAuthoritativeBesStatusToPhone() {
+    /**
+     * Project durable BES state when one exists.
+     *
+     * @return true when a durable projection exists, even if the phone is currently disconnected
+     */
+    public boolean sendAuthoritativeBesStatusToPhone() {
         JSONObject status = getAuthoritativeBesStatus();
-        if (status == null || phoneConnectionProvider == null || !isPhoneConnected()) {
-            return;
+        if (status == null) {
+            return false;
         }
-        phoneConnectionProvider.sendOtaStatus(status);
+        if (phoneConnectionProvider != null && isPhoneConnected()) {
+            phoneConnectionProvider.sendOtaStatus(status);
+        }
+        return true;
     }
 
     public OtaSessionManager getSessionManager() {
@@ -2128,6 +2136,7 @@ public class OtaHelper {
             String firmwareUrl = firmwareInfo.optString("url", firmwareInfo.optString("firmwareUrl", ""));
             if (firmwareUrl.isEmpty()) {
                 Log.e(TAG, "BES firmware URL missing in JSON (expected 'url' or 'firmwareUrl')");
+                sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
                 return false;
             }
 
@@ -2153,6 +2162,7 @@ public class OtaHelper {
                         sessionState != null ? sessionState.optString("sid", "").trim() : "";
                 if (ownerSessionId.isEmpty()) {
                     Log.e(TAG, "BES OTA has no owning top-level session");
+                    sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
                     return false;
                 }
                 Log.i(TAG, "Starting validated BES firmware update artifact="
@@ -2163,12 +2173,14 @@ public class OtaHelper {
                     return true;
                 } else {
                     Log.e(TAG, "Failed to start BES firmware update");
+                    sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
                     if (firmwareFile.exists() && !firmwareFile.delete()) {
                         Log.w(TAG, "Failed deleting BES firmware after install start failure");
                     }
                 }
             } else {
                 Log.e(TAG, "BesOtaManager not available");
+                sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
                 File firmwareFile = new File(OtaConstants.BES_FIRMWARE_PATH);
                 if (firmwareFile.exists() && !firmwareFile.delete()) {
                     Log.w(TAG, "Failed deleting BES firmware when manager unavailable");
@@ -2176,6 +2188,9 @@ public class OtaHelper {
             }
         } catch (Exception e) {
             Log.e(TAG, "Failed to update BES firmware", e);
+            if (isPhoneInitiatedOta) {
+                sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
+            }
             File firmwareFile = new File(OtaConstants.BES_FIRMWARE_PATH);
             if (firmwareFile.exists() && !firmwareFile.delete()) {
                 Log.w(TAG, "Failed deleting BES firmware after exception");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -18,12 +18,13 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.events.BatteryStatusEvent;
-import com.mentra.asg_client.di.hilt.AsgClientEntryPoint;
 import com.mentra.asg_client.io.ota.events.DownloadProgressEvent;
 import com.mentra.asg_client.io.ota.events.InstallationProgressEvent;
 import com.mentra.asg_client.io.ota.events.MtkOtaProgressEvent;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -233,6 +234,9 @@ public class OtaHelper {
      *   "complete"      → shows "Update installed"
      */
     public void onPhoneConnected() {
+        // Durable BES truth is read at delivery time; EventBus and process-local retry timers are
+        // only wake-ups and never become a second terminal store.
+        sendAuthoritativeBesStatusToPhone();
         if (sessionManager == null || phoneConnectionProvider == null) return;
         String pendingStatus = sessionManager.consumePendingApkStatus();
         if (pendingStatus == null) return;
@@ -247,6 +251,10 @@ public class OtaHelper {
 
     public JSONObject getOtaSessionState() {
         try {
+            JSONObject besStatus = getAuthoritativeBesStatus();
+            if (besStatus != null) {
+                return besStatus;
+            }
             // Phone bridge (MentraLive.java) reads all fields from the top level, so we flatten
             // the session state directly into the message rather than nesting under "data".
             JSONObject sessionState = sessionManager != null ? sessionManager.getSessionState() : null;
@@ -268,6 +276,19 @@ public class OtaHelper {
         } catch (JSONException e) {
             return null;
         }
+    }
+
+    private JSONObject getAuthoritativeBesStatus() {
+        IBesOtaController controller = getOtaController();
+        return controller != null ? controller.getAuthoritativeStatus() : null;
+    }
+
+    public void sendAuthoritativeBesStatusToPhone() {
+        JSONObject status = getAuthoritativeBesStatus();
+        if (status == null || phoneConnectionProvider == null || !isPhoneConnected()) {
+            return;
+        }
+        phoneConnectionProvider.sendOtaStatus(status);
     }
 
     public OtaSessionManager getSessionManager() {
@@ -427,6 +448,13 @@ public class OtaHelper {
 
         // Immediately acknowledge receipt so the phone cancels its retry timer.
         sendOtaStartAck();
+
+        IBesOtaController besController = getOtaController();
+        if (besController != null && !besController.prepareForNewOtaSession()) {
+            Log.w(TAG, "BES durable state blocks a new OTA session");
+            sendAuthoritativeBesStatusToPhone();
+            return;
+        }
 
         // If OTA already in progress, do not start a parallel pipeline. The phone
         // will receive the current status and can keep retrying/querying normally.
@@ -2117,14 +2145,24 @@ public class OtaHelper {
             Log.i(TAG, "BES firmware ready - starting install phase");
             IBesOtaController manager = besOtaRegistry.getInstance();
             if (manager != null) {
-                Log.i(TAG, "Starting BES firmware update from: " + OtaConstants.BES_FIRMWARE_PATH);
-                boolean started = manager.startFirmwareUpdate(OtaConstants.BES_FIRMWARE_PATH);
+                File firmwareFile = new File(OtaConstants.BES_FIRMWARE_PATH);
+                ValidatedBesArtifact artifact =
+                        BesFirmwareArtifactValidator.validate(firmwareFile, firmwareInfo);
+                JSONObject sessionState = sessionManager != null ? sessionManager.getSessionState() : null;
+                String ownerSessionId =
+                        sessionState != null ? sessionState.optString("sid", "").trim() : "";
+                if (ownerSessionId.isEmpty()) {
+                    Log.e(TAG, "BES OTA has no owning top-level session");
+                    return false;
+                }
+                Log.i(TAG, "Starting validated BES firmware update artifact="
+                        + artifact.getArtifactId() + " target=" + artifact.getTargetVersion());
+                boolean started = manager.startFirmwareUpdate(artifact, ownerSessionId);
                 if (started) {
                     Log.i(TAG, "BES firmware update initiated successfully");
                     return true;
                 } else {
                     Log.e(TAG, "Failed to start BES firmware update");
-                    File firmwareFile = new File(OtaConstants.BES_FIRMWARE_PATH);
                     if (firmwareFile.exists() && !firmwareFile.delete()) {
                         Log.w(TAG, "Failed deleting BES firmware after install start failure");
                     }
@@ -2818,8 +2856,11 @@ public class OtaHelper {
     }
 
     private void sendOtaStatus() {
-        if (phoneConnectionProvider == null || !isPhoneConnected() || sessionManager == null) return;
-        JSONObject sessionState = sessionManager.getSessionState();
+        if (phoneConnectionProvider == null || !isPhoneConnected()) return;
+        JSONObject sessionState = getAuthoritativeBesStatus();
+        if (sessionState == null && sessionManager != null) {
+            sessionState = sessionManager.getSessionState();
+        }
         if (sessionState == null) {
             sessionState = buildMinimalOtaStatusJson();
             if (sessionState == null) {
@@ -3063,50 +3104,9 @@ public class OtaHelper {
      * @return true if install started successfully
      */
     public static boolean debugInstallBesFirmware(Context context) {
-        try {
-            IBesOtaRegistry registry =
-                    dagger.hilt.android.EntryPointAccessors.fromApplication(
-                                    context.getApplicationContext(), AsgClientEntryPoint.class)
-                            .besOtaRegistry();
-            // Check if BES OTA is already in progress - don't interrupt it!
-            IBesOtaController activeController = registry.getInstance();
-            if (activeController != null && activeController.isBesOtaInProgress()) {
-                Log.w(TAG, "DEBUG: BES OTA already in progress - skipping to avoid interruption");
-                return false;
-            }
-
-            File firmwareFile = new File(OtaConstants.BES_FIRMWARE_PATH);
-
-            if (!firmwareFile.exists()) {
-                Log.e(TAG, "DEBUG: BES firmware file not found at: " + OtaConstants.BES_FIRMWARE_PATH);
-                return false;
-            }
-
-            Log.w(TAG, "⚠️ DEBUG: Force installing BES firmware from: " + OtaConstants.BES_FIRMWARE_PATH);
-            Log.w(TAG, "⚠️ DEBUG: File size: " + firmwareFile.length() + " bytes");
-            Log.w(TAG, "⚠️ DEBUG: Skipping all checks - version, mutual exclusion, SHA256");
-
-            // Get the active BES OTA controller
-            IBesOtaController manager = registry.getInstance();
-            if (manager == null) {
-                Log.e(TAG, "DEBUG: BES OTA controller not available - is this a K900 device?");
-                return false;
-            }
-
-            Log.i(TAG, "DEBUG: Starting BES firmware update via BES OTA controller");
-            boolean started = manager.startFirmwareUpdate(OtaConstants.BES_FIRMWARE_PATH);
-
-            if (started) {
-                Log.i(TAG, "DEBUG: BES firmware install initiated - monitor BesOtaProgressEvent for progress");
-                return true;
-            } else {
-                Log.e(TAG, "DEBUG: BesOtaManager.startFirmwareUpdate() returned false");
-                return false;
-            }
-
-        } catch (Exception e) {
-            Log.e(TAG, "DEBUG: Failed to install BES firmware", e);
-            return false;
-        }
+        // The release-A safety contract requires manifest validation, durable ownership, and
+        // pre-authorization state persistence. A raw-file debug entry point bypasses all three.
+        Log.e(TAG, "DEBUG BES install is disabled; use the phone-started validated OTA flow");
+        return false;
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -2136,7 +2136,12 @@ public class OtaHelper {
             String firmwareUrl = firmwareInfo.optString("url", firmwareInfo.optString("firmwareUrl", ""));
             if (firmwareUrl.isEmpty()) {
                 Log.e(TAG, "BES firmware URL missing in JSON (expected 'url' or 'firmwareUrl')");
-                sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
+                // This is a deterministic manifest-admission failure: no BES command has been
+                // queued, so it must not enter the install/reboot-required recovery branch.
+                if (isPhoneInitiatedOta) {
+                    sendProgressToPhone(
+                            "download", 0, 0, 0, "FAILED", "firmware_verify_failed");
+                }
                 return false;
             }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/interfaces/IBesOtaController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/interfaces/IBesOtaController.java
@@ -1,6 +1,8 @@
 package com.mentra.asg_client.io.ota.interfaces;
 
 import androidx.annotation.Nullable;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
+import org.json.JSONObject;
 
 /**
  * Operations on the BES coprocessor OTA subsystem. Implemented by the vendor-specific OTA manager
@@ -42,10 +44,18 @@ public interface IBesOtaController {
     /**
      * Begin a firmware update.
      *
-     * @param filePath path to the firmware binary
+     * @param artifact fully validated immutable release artifact
+     * @param ownerSessionId top-level OTA session that owns the durable BES transaction
      * @return true if the update was started successfully
      */
-    boolean startFirmwareUpdate(String filePath);
+    boolean startFirmwareUpdate(ValidatedBesArtifact artifact, String ownerSessionId);
+
+    /** Authoritative BES OTA projection, or null when no durable BES transaction exists. */
+    @Nullable
+    JSONObject getAuthoritativeStatus();
+
+    /** Apply terminal retirement/restart rules before a new top-level OTA session is admitted. */
+    boolean prepareForNewOtaSession();
 
     /** Called by the MCU event subscriber when BES authorizes the update. */
     void onAuthorizationGranted();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -64,6 +64,11 @@ public class OtaService extends Service {
             EventBus.getDefault().register(this);
         }
 
+        // Startup may follow the BES-triggered reboot, before any EventBus subscriber existed.
+        // The durable store is truth, so replay its current projection rather than relying on the
+        // event that originally committed it.
+        otaHelper.sendAuthoritativeBesStatusToPhone();
+
         Log.i(TAG, "OTA service initialized - waiting for phone-initiated ota_start");
     }
 
@@ -230,7 +235,8 @@ public class OtaService extends Service {
                 // whether a BES update follows), NOT from session state — so it is correct on both
                 // the session path and the legacy/no-session path below. consume*() clears the flag
                 // so a duplicate/late SUCCESS event can't schedule a second reboot.
-                boolean shouldRebootAfterMtk = otaHelper != null && otaHelper.consumeRebootAfterMtkInstall();
+                boolean shouldRebootAfterMtk =
+                        otaHelper != null && otaHelper.consumeRebootAfterMtkInstall();
 
                 if (otaHelper != null) {
                     otaHelper.sendMtkInstallProgressToPhone("FINISHED", 100, null);
@@ -242,7 +248,8 @@ public class OtaService extends Service {
                         // can decide whether to start another round.
                         Log.i(
                                 TAG,
-                                "📱 MTK complete (no session) - notifying phone via legacy broadcast");
+                                "📱 MTK complete (no session) - notifying phone via legacy"
+                                        + " broadcast");
                         sendMtkUpdateCompleteMessage();
                     }
                 } else {
@@ -277,20 +284,26 @@ public class OtaService extends Service {
     /**
      * Reboot the device to apply a staged MTK-only firmware update.
      *
-     * MTK A/B updates do not change ro.custom.ota.version until the device reboots. When MTK is
+     * <p>MTK A/B updates do not change ro.custom.ota.version until the device reboots. When MTK is
      * bundled with a BES update the BES install power-cycles the device for us; for an MTK-only
      * update nothing else triggers the reboot, so the device would otherwise keep re-offering the
      * same patch (current firmware still matches the patch's start_firmware) in a loop.
      *
-     * Delayed so the phone receives the BLE "complete" status before the connection drops.
+     * <p>Delayed so the phone receives the BLE "complete" status before the connection drops.
      */
     private void scheduleMtkRebootToApplyUpdate() {
-        Log.i(TAG, "🔄 MTK was the final OTA step (no BES update) - rebooting in "
-                + (MTK_REBOOT_DELAY_MS / 1000) + "s to apply staged firmware");
-        new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            Log.i(TAG, "🔄 Rebooting now to apply staged MTK firmware update");
-            SystemControllerFactory.get(this).reboot();
-        }, MTK_REBOOT_DELAY_MS);
+        Log.i(
+                TAG,
+                "🔄 MTK was the final OTA step (no BES update) - rebooting in "
+                        + (MTK_REBOOT_DELAY_MS / 1000)
+                        + "s to apply staged firmware");
+        new Handler(Looper.getMainLooper())
+                .postDelayed(
+                        () -> {
+                            Log.i(TAG, "🔄 Rebooting now to apply staged MTK firmware update");
+                            SystemControllerFactory.get(this).reboot();
+                        },
+                        MTK_REBOOT_DELAY_MS);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -313,14 +326,17 @@ public class OtaService extends Service {
             case FINISHED:
                 Log.i(TAG, "BES firmware update finished successfully");
                 updateNotification("BES firmware updated successfully");
-                // Note: BES chip will send sr_adota with progress=100 or type=success
+                if (otaHelper != null) {
+                    otaHelper.sendAuthoritativeBesStatusToPhone();
+                    otaHelper.deleteDownloadedArtifactForType("bes");
+                }
                 break;
             case FAILED:
                 Log.e(TAG, "BES firmware update failed: " + event.getErrorMessage());
                 updateNotification("BES firmware update failed: " + event.getErrorMessage());
                 // Try to notify phone of failure (might work if UART recovers)
                 if (otaHelper != null) {
-                    otaHelper.sendBesInstallProgressToPhone("FAILED", 0, event.getErrorMessage());
+                    otaHelper.sendAuthoritativeBesStatusToPhone();
                     otaHelper.deleteDownloadedArtifactForType("bes");
                 }
                 break;
@@ -375,14 +391,15 @@ public class OtaService extends Service {
                 if (isApkInstallRestart) {
                     Log.i(
                             TAG,
-                            "📱 Active APK install session found without restart guard — resuming next step");
+                            "📱 Active APK install session found without restart guard — resuming"
+                                    + " next step");
                     resumeFromSession(sessionManager);
                     return;
                 }
                 Log.i(
                         TAG,
-                        "📱 Active OTA session found without restart guard but not APK install restart "
-                                + "(step="
+                        "📱 Active OTA session found without restart guard but not APK install"
+                                + " restart (step="
                                 + currentStepIndex
                                 + " type="
                                 + currentStepType

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -13,7 +13,9 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.util.Log;
+
 import androidx.core.app.NotificationCompat;
+
 import com.mentra.asg_client.events.BatteryStatusEvent;
 import com.mentra.asg_client.io.bes.events.BesOtaProgressEvent;
 import com.mentra.asg_client.io.ota.events.DownloadProgressEvent;
@@ -23,11 +25,14 @@ import com.mentra.asg_client.io.ota.helpers.OtaHelper;
 import com.mentra.asg_client.io.ota.session.OtaSessionManager;
 import com.mentra.asg_client.io.ota.utils.OtaConstants;
 import com.mentra.asg_client.service.system.core.SystemControllerFactory;
+
 import dagger.hilt.android.AndroidEntryPoint;
-import javax.inject.Inject;
+
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+
+import javax.inject.Inject;
 
 @AndroidEntryPoint
 public class OtaService extends Service {
@@ -336,7 +341,13 @@ public class OtaService extends Service {
                 updateNotification("BES firmware update failed: " + event.getErrorMessage());
                 // Try to notify phone of failure (might work if UART recovers)
                 if (otaHelper != null) {
-                    otaHelper.sendAuthoritativeBesStatusToPhone();
+                    if (!otaHelper.sendAuthoritativeBesStatusToPhone()) {
+                        // Failures before mh_ota has been durably reserved intentionally have no
+                        // BES record. They still belong to the active top-level OTA session and
+                        // must terminate its phone UI instead of disappearing.
+                        otaHelper.sendBesInstallProgressToPhone(
+                                "FAILED", event.getProgress(), event.getErrorMessage());
+                    }
                     otaHelper.deleteDownloadedArtifactForType("bes");
                 }
                 break;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
@@ -2,6 +2,10 @@ package com.mentra.asg_client.io.ota.utils;
 
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.BesOtaStateStore;
+
+import org.json.JSONObject;
+import org.tukaani.xz.LZMAInputStream;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -12,8 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Locale;
 import java.util.zip.CRC32;
-import org.json.JSONObject;
-import org.tukaani.xz.LZMAInputStream;
 
 /** Fail-closed admission gate for a release-packaged Mentra Live BES OTA artifact. */
 public final class BesFirmwareArtifactValidator {
@@ -22,6 +24,11 @@ public final class BesFirmwareArtifactValidator {
             "CRC32_OF_IMAGE=0x".getBytes(StandardCharsets.US_ASCII);
     private static final int CRC_HEX_LENGTH = 8;
     private static final int LZMA_ALONE_HEADER_LENGTH = 13;
+    // The release packer uses `lzma -9`, whose LZMA-alone header declares a 64 MiB
+    // dictionary even though the BES image is under 2 MiB. Admit that exact ceiling,
+    // but reject hostile headers before the decoder allocates its dictionary.
+    private static final long MAX_LZMA_DICTIONARY_BYTES = 64L * 1024 * 1024;
+    private static final int MAX_LZMA_DECODER_MEMORY_KIB = 70 * 1024;
 
     private BesFirmwareArtifactValidator() {}
 
@@ -142,9 +149,15 @@ public final class BesFirmwareArtifactValidator {
             if (chunkSize < LZMA_ALONE_HEADER_LENGTH || (long) position + chunkSize > data.length) {
                 throw new ValidationException("Invalid or truncated BES OTA LZMA chunk");
             }
+            long dictionarySize = readLittleEndianUnsignedInt(data, position + 1);
+            if (dictionarySize <= 0 || dictionarySize > MAX_LZMA_DICTIONARY_BYTES) {
+                throw new ValidationException(
+                        "BES OTA LZMA dictionary exceeds the admission limit: " + dictionarySize);
+            }
 
             ByteArrayInputStream compressed = new ByteArrayInputStream(data, position, chunkSize);
-            try (LZMAInputStream lzma = new LZMAInputStream(compressed)) {
+            try (LZMAInputStream lzma =
+                    new LZMAInputStream(compressed, MAX_LZMA_DECODER_MEMORY_KIB)) {
                 byte[] buffer = new byte[8192];
                 int read;
                 while ((read = lzma.read(buffer)) != -1) {
@@ -191,12 +204,21 @@ public final class BesFirmwareArtifactValidator {
 
     private static void assertProduct(byte[] raw, String product) throws ValidationException {
         byte[] revInfo = "REV_INFO=".getBytes(StandardCharsets.US_ASCII);
-        byte[] productSuffix = (":" + product).getBytes(StandardCharsets.US_ASCII);
+        String productSuffix = ":" + product;
         int revOffset = indexOf(raw, revInfo, 0);
         while (revOffset >= 0) {
             int searchEnd = Math.min(raw.length, revOffset + 192);
-            int productOffset = indexOf(raw, productSuffix, revOffset + revInfo.length);
-            if (productOffset >= 0 && productOffset < searchEnd) {
+            int valueStart = revOffset + revInfo.length;
+            int valueEnd = valueStart;
+            while (valueEnd < searchEnd
+                    && raw[valueEnd] != 0
+                    && raw[valueEnd] != '\n'
+                    && raw[valueEnd] != '\r') {
+                valueEnd++;
+            }
+            String revision =
+                    new String(raw, valueStart, valueEnd - valueStart, StandardCharsets.US_ASCII);
+            if (revision.endsWith(productSuffix)) {
                 return;
             }
             revOffset = indexOf(raw, revInfo, revOffset + 1);
@@ -311,6 +333,13 @@ public final class BesFirmwareArtifactValidator {
                 | ((data[offset + 1] & 0xFF) << 16)
                 | ((data[offset + 2] & 0xFF) << 8)
                 | (data[offset + 3] & 0xFF);
+    }
+
+    private static long readLittleEndianUnsignedInt(byte[] data, int offset) {
+        return ((long) data[offset] & 0xFF)
+                | (((long) data[offset + 1] & 0xFF) << 8)
+                | (((long) data[offset + 2] & 0xFF) << 16)
+                | (((long) data[offset + 3] & 0xFF) << 24);
     }
 
     /** Validation failure safe to log in full while the phone receives a stable short code. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
@@ -1,0 +1,395 @@
+package com.mentra.asg_client.io.ota.utils;
+
+import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.io.bes.BesOtaStateStore;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.zip.CRC32;
+import org.json.JSONObject;
+import org.tukaani.xz.LZMAInputStream;
+
+/** Fail-closed admission gate for a release-packaged Mentra Live BES OTA artifact. */
+public final class BesFirmwareArtifactValidator {
+    private static final byte[] MAGIC = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+    private static final byte[] CRC_PREFIX =
+            "CRC32_OF_IMAGE=0x".getBytes(StandardCharsets.US_ASCII);
+    private static final int CRC_HEX_LENGTH = 8;
+    private static final int LZMA_ALONE_HEADER_LENGTH = 13;
+
+    private BesFirmwareArtifactValidator() {}
+
+    /**
+     * Validate artifact identity, compressed bytes, complete container structure, decompressed
+     * bytes, product, and target version. Every metadata field is mandatory; legacy manifests fail
+     * closed before {@code mh_ota} can be sent.
+     */
+    public static ValidatedBesArtifact validate(File artifact, JSONObject metadata)
+            throws ValidationException {
+        try {
+            if (artifact == null || !artifact.isFile()) {
+                throw new ValidationException("BES OTA artifact is missing");
+            }
+            if (metadata == null) {
+                throw new ValidationException("BES OTA release metadata is missing");
+            }
+
+            String format = requiredString(metadata, "format");
+            if (!AsgConstants.BES_OTA_ARTIFACT_FORMAT.equals(format)) {
+                throw new ValidationException("Unsupported BES OTA artifact format: " + format);
+            }
+
+            String product = requiredString(metadata, "product");
+            if (!AsgConstants.BES_OTA_PRODUCT.equals(product)) {
+                throw new ValidationException("Wrong BES OTA product: " + product);
+            }
+
+            String artifactId = requiredString(metadata, "artifact_id");
+            validateImmutableUrl(metadata, artifactId);
+
+            long compressedSize = requiredPositiveLong(metadata, "compressed_size");
+            if (compressedSize != artifact.length()) {
+                throw new ValidationException(
+                        "Compressed size mismatch: expected "
+                                + compressedSize
+                                + ", got "
+                                + artifact.length());
+            }
+
+            byte[] container = readArtifact(artifact);
+            String compressedSha256 = requiredSha256(metadata, "sha256");
+            assertSha256(container, compressedSha256, "compressed");
+
+            long expectedRawSize = requiredPositiveLong(metadata, "decompressed_size");
+            if (expectedRawSize >= AsgConstants.BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES) {
+                throw new ValidationException(
+                        "Decompressed BES image is not OTA-safe: " + expectedRawSize + " bytes");
+            }
+
+            byte[] raw = unpackAndValidateContainer(container);
+            if (raw.length != expectedRawSize) {
+                throw new ValidationException(
+                        "Decompressed size mismatch: expected "
+                                + expectedRawSize
+                                + ", got "
+                                + raw.length);
+            }
+            String decompressedSha256 = requiredSha256(metadata, "decompressed_sha256");
+            assertSha256(raw, decompressedSha256, "decompressed");
+            assertProduct(raw, product);
+            String targetVersion = requiredString(metadata, "version");
+            String canonicalTarget = BesOtaStateStore.canonicalVersion(targetVersion);
+            if (canonicalTarget == null || !canonicalTarget.equals(targetVersion)) {
+                throw new ValidationException(
+                        "BES target version must be canonical major.minor.patch.build");
+            }
+            assertVersion(raw, targetVersion, metadata.getLong("version_offset"));
+            return new ValidatedBesArtifact(
+                    artifact,
+                    artifactId,
+                    compressedSha256,
+                    decompressedSha256,
+                    targetVersion,
+                    compressedSize,
+                    expectedRawSize);
+        } catch (ValidationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ValidationException("Invalid BES OTA artifact: " + e.getMessage(), e);
+        }
+    }
+
+    private static byte[] readArtifact(File artifact) throws IOException, ValidationException {
+        if (artifact.length() <= 0 || artifact.length() > Integer.MAX_VALUE) {
+            throw new ValidationException("Invalid BES OTA artifact size: " + artifact.length());
+        }
+        byte[] bytes = new byte[(int) artifact.length()];
+        int offset = 0;
+        try (FileInputStream input = new FileInputStream(artifact)) {
+            while (offset < bytes.length) {
+                int read = input.read(bytes, offset, bytes.length - offset);
+                if (read < 0) {
+                    throw new IOException("Unexpected end of BES OTA artifact");
+                }
+                offset += read;
+            }
+            if (input.read() != -1) {
+                throw new IOException("BES OTA artifact changed while being read");
+            }
+        }
+        return bytes;
+    }
+
+    private static byte[] unpackAndValidateContainer(byte[] data) throws Exception {
+        if (data.length < MAGIC.length || !startsWith(data, 0, MAGIC)) {
+            throw new ValidationException("BES OTA container magic is invalid");
+        }
+
+        int position = MAGIC.length;
+        ByteArrayOutputStream raw = new ByteArrayOutputStream();
+        while (!startsWith(data, position, CRC_PREFIX)) {
+            if (position + 4 > data.length) {
+                throw new ValidationException("BES OTA container ended before a chunk header");
+            }
+            int chunkSize = readBigEndianInt(data, position);
+            position += 4;
+            if (chunkSize < LZMA_ALONE_HEADER_LENGTH || (long) position + chunkSize > data.length) {
+                throw new ValidationException("Invalid or truncated BES OTA LZMA chunk");
+            }
+
+            ByteArrayInputStream compressed = new ByteArrayInputStream(data, position, chunkSize);
+            try (LZMAInputStream lzma = new LZMAInputStream(compressed)) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = lzma.read(buffer)) != -1) {
+                    if ((long) raw.size() + read
+                            >= AsgConstants.BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES) {
+                        throw new ValidationException(
+                                "Decompressed BES image reaches the OTA bootloader limit");
+                    }
+                    raw.write(buffer, 0, read);
+                }
+            }
+            if (compressed.available() != 0) {
+                throw new ValidationException("BES OTA LZMA chunk has trailing bytes");
+            }
+            position += chunkSize;
+        }
+
+        validateCrcTrailer(data, position);
+        return raw.toByteArray();
+    }
+
+    private static void validateCrcTrailer(byte[] data, int prefixOffset)
+            throws ValidationException {
+        int hexOffset = prefixOffset + CRC_PREFIX.length;
+        int newlineOffset = hexOffset + CRC_HEX_LENGTH;
+        if (newlineOffset >= data.length
+                || data.length != newlineOffset + 1
+                || data[newlineOffset] != '\n') {
+            throw new ValidationException("BES OTA CRC trailer is incomplete or has extra bytes");
+        }
+
+        String storedHex = new String(data, hexOffset, CRC_HEX_LENGTH, StandardCharsets.US_ASCII);
+        if (!storedHex.matches("[0-9A-Fa-f]{8}") || "00000000".equals(storedHex)) {
+            throw new ValidationException("BES OTA CRC trailer is invalid or unpatched");
+        }
+
+        CRC32 crc = new CRC32();
+        crc.update(data, 0, hexOffset);
+        long expected = Long.parseUnsignedLong(storedHex, 16);
+        if (crc.getValue() != expected) {
+            throw new ValidationException("BES OTA embedded CRC32 does not match the artifact");
+        }
+    }
+
+    private static void assertProduct(byte[] raw, String product) throws ValidationException {
+        byte[] revInfo = "REV_INFO=".getBytes(StandardCharsets.US_ASCII);
+        byte[] productSuffix = (":" + product).getBytes(StandardCharsets.US_ASCII);
+        int revOffset = indexOf(raw, revInfo, 0);
+        while (revOffset >= 0) {
+            int searchEnd = Math.min(raw.length, revOffset + 192);
+            int productOffset = indexOf(raw, productSuffix, revOffset + revInfo.length);
+            if (productOffset >= 0 && productOffset < searchEnd) {
+                return;
+            }
+            revOffset = indexOf(raw, revInfo, revOffset + 1);
+        }
+        throw new ValidationException(
+                "Decompressed image does not identify the Mentra Live BES product");
+    }
+
+    private static void assertVersion(byte[] raw, String version, long offsetLong)
+            throws ValidationException {
+        String[] parts = version.split("\\.", -1);
+        if (parts.length != 4 || offsetLong < 0 || offsetLong > raw.length - 4L) {
+            throw new ValidationException("Invalid BES target version metadata");
+        }
+        int offset = (int) offsetLong;
+        for (int i = 0; i < parts.length; i++) {
+            int component;
+            try {
+                component = Integer.parseInt(parts[i]);
+            } catch (NumberFormatException e) {
+                throw new ValidationException("Invalid BES target version: " + version);
+            }
+            if (component < 0 || component > 255 || (raw[offset + i] & 0xFF) != component) {
+                throw new ValidationException(
+                        "Decompressed image target version does not match " + version);
+            }
+        }
+    }
+
+    private static void validateImmutableUrl(JSONObject metadata, String artifactId)
+            throws Exception {
+        if (!artifactId.matches("[A-Za-z0-9._-]{1,128}")) {
+            throw new ValidationException("Invalid BES OTA artifact_id");
+        }
+        String urlValue = metadata.optString("url", metadata.optString("firmwareUrl", "")).trim();
+        URI uri = new URI(urlValue);
+        if (!"https".equalsIgnoreCase(uri.getScheme())
+                || uri.getHost() == null
+                || uri.getRawQuery() != null
+                || uri.getRawFragment() != null
+                || uri.getPath() == null
+                || !uri.getPath().endsWith("/" + artifactId)) {
+            throw new ValidationException(
+                    "BES OTA URL must be immutable HTTPS and end with artifact_id");
+        }
+    }
+
+    private static String requiredString(JSONObject metadata, String key)
+            throws ValidationException {
+        String value = metadata.optString(key, "").trim();
+        if (value.isEmpty()) {
+            throw new ValidationException("Missing BES OTA metadata: " + key);
+        }
+        return value;
+    }
+
+    private static long requiredPositiveLong(JSONObject metadata, String key)
+            throws ValidationException {
+        if (!metadata.has(key)) {
+            throw new ValidationException("Missing BES OTA metadata: " + key);
+        }
+        long value = metadata.optLong(key, -1);
+        if (value <= 0) {
+            throw new ValidationException("Invalid BES OTA metadata: " + key);
+        }
+        return value;
+    }
+
+    private static String requiredSha256(JSONObject metadata, String key)
+            throws ValidationException {
+        String value = requiredString(metadata, key).toLowerCase(Locale.US);
+        if (!value.matches("[0-9a-f]{64}")) {
+            throw new ValidationException("Invalid BES OTA SHA-256 metadata: " + key);
+        }
+        return value;
+    }
+
+    private static void assertSha256(byte[] bytes, String expected, String label) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+        StringBuilder actual = new StringBuilder(digest.length * 2);
+        for (byte value : digest) {
+            actual.append(String.format(Locale.US, "%02x", value & 0xFF));
+        }
+        if (!actual.toString().equals(expected)) {
+            throw new ValidationException(label + " BES OTA SHA-256 mismatch");
+        }
+    }
+
+    private static boolean startsWith(byte[] haystack, int offset, byte[] needle) {
+        if (offset < 0 || offset > haystack.length - needle.length) {
+            return false;
+        }
+        for (int i = 0; i < needle.length; i++) {
+            if (haystack[offset + i] != needle[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle, int fromIndex) {
+        for (int i = Math.max(0, fromIndex); i <= haystack.length - needle.length; i++) {
+            if (startsWith(haystack, i, needle)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int readBigEndianInt(byte[] data, int offset) {
+        return ((data[offset] & 0xFF) << 24)
+                | ((data[offset + 1] & 0xFF) << 16)
+                | ((data[offset + 2] & 0xFF) << 8)
+                | (data[offset + 3] & 0xFF);
+    }
+
+    /** Validation failure safe to log in full while the phone receives a stable short code. */
+    public static final class ValidatedBesArtifact {
+        private final File file;
+        private final String artifactId;
+        private final String compressedSha256;
+        private final String decompressedSha256;
+        private final String targetVersion;
+        private final long compressedSize;
+        private final long decompressedSize;
+
+        private ValidatedBesArtifact(
+                File file,
+                String artifactId,
+                String compressedSha256,
+                String decompressedSha256,
+                String targetVersion,
+                long compressedSize,
+                long decompressedSize) {
+            this.file = file;
+            this.artifactId = artifactId;
+            this.compressedSha256 = compressedSha256;
+            this.decompressedSha256 = decompressedSha256;
+            this.targetVersion = targetVersion;
+            this.compressedSize = compressedSize;
+            this.decompressedSize = decompressedSize;
+        }
+
+        /** Close the validation-to-use race before authorization is reserved. */
+        public void revalidateFileDigest() throws ValidationException {
+            try {
+                if (!file.isFile() || file.length() != compressedSize) {
+                    throw new ValidationException("BES OTA artifact changed after validation");
+                }
+                assertSha256(readArtifact(file), compressedSha256, "compressed");
+            } catch (ValidationException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ValidationException("Could not revalidate BES OTA artifact", e);
+            }
+        }
+
+        public File getFile() {
+            return file;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public String getCompressedSha256() {
+            return compressedSha256;
+        }
+
+        public String getDecompressedSha256() {
+            return decompressedSha256;
+        }
+
+        public String getTargetVersion() {
+            return targetVersion;
+        }
+
+        public long getCompressedSize() {
+            return compressedSize;
+        }
+
+        public long getDecompressedSize() {
+            return decompressedSize;
+        }
+    }
+
+    public static final class ValidationException extends Exception {
+        ValidationException(String message) {
+            super(message);
+        }
+
+        ValidationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
@@ -39,7 +39,8 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
             Log.e(TAG, "❌ Firmware file not found at: " + OtaConstants.BES_FIRMWARE_PATH);
             Log.e(
                     TAG,
-                    "Push file first: adb push firmware.bin /storage/emulated/0/asg/bes_firmware.bin");
+                    "Push file first: adb push firmware.bin"
+                            + " /storage/emulated/0/asg/bes_firmware.bin");
             return;
         }
 
@@ -61,14 +62,8 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
             return;
         }
 
-        // Start the update
-        Log.i(TAG, "🚀 Starting BES firmware update...");
-        boolean started = manager.startFirmwareUpdate(OtaConstants.BES_FIRMWARE_PATH);
-
-        if (started) {
-            Log.i(TAG, "✅ BES OTA started - monitor logcat for progress");
-        } else {
-            Log.e(TAG, "❌ BES OTA failed to start");
-        }
+        // Raw-path starts bypass release metadata, artifact identity, and durable session
+        // ownership. Use the phone-driven staging OTA flow so the same safety gate is exercised.
+        Log.e(TAG, "❌ Direct BES OTA broadcast is disabled; use a validated staging manifest");
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
@@ -4,20 +4,13 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
-import com.mentra.asg_client.di.hilt.AsgClientEntryPoint;
-import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
-import com.mentra.asg_client.io.ota.utils.OtaConstants;
-import dagger.hilt.android.EntryPointAccessors;
-import java.io.File;
 
 /**
- * Debug receiver for testing BES firmware updates directly via adb.
+ * Compatibility receiver that rejects the retired direct BES OTA adb entry point.
  *
- * <p>Usage: 1. Push firmware file: adb push firmware.bin /storage/emulated/0/asg/bes_firmware.bin
- * 2. Trigger update: adb shell am broadcast -a com.mentra.DEBUG_BES_OTA
- *
- * <p>This bypasses all cloud/phone logic and directly triggers BesOtaManager. FOR
- * DEVELOPMENT/TESTING ONLY.
+ * <p>Direct installs cannot prove immutable release metadata or durable session ownership. Use a
+ * phone-driven staging manifest so development tests exercise the production admission gate. The
+ * old action remains registered only so existing scripts fail loudly.
  */
 public class DebugBesOtaReceiver extends BroadcastReceiver {
     private static final String TAG = "DebugBesOtaReceiver";
@@ -32,35 +25,6 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
         Log.w(TAG, "========================================");
         Log.w(TAG, "⚠️ DEBUG BES OTA TRIGGERED VIA ADB ⚠️");
         Log.w(TAG, "========================================");
-
-        // Check if file exists
-        File firmwareFile = new File(OtaConstants.BES_FIRMWARE_PATH);
-        if (!firmwareFile.exists()) {
-            Log.e(TAG, "❌ Firmware file not found at: " + OtaConstants.BES_FIRMWARE_PATH);
-            Log.e(
-                    TAG,
-                    "Push file first: adb push firmware.bin"
-                            + " /storage/emulated/0/asg/bes_firmware.bin");
-            return;
-        }
-
-        Log.i(TAG, "✅ Firmware file found: " + firmwareFile.length() + " bytes");
-
-        // Get the active BES OTA controller
-        IBesOtaController manager =
-                EntryPointAccessors.fromApplication(context, AsgClientEntryPoint.class)
-                        .besOtaRegistry()
-                        .getInstance();
-        if (manager == null) {
-            Log.e(TAG, "❌ BES OTA controller not initialized - is AsgClientService running?");
-            return;
-        }
-
-        // Check if already in progress
-        if (manager.isBesOtaInProgress()) {
-            Log.w(TAG, "⚠️ BES OTA already in progress - skipping");
-            return;
-        }
 
         // Raw-path starts bypass release metadata, artifact identity, and durable session
         // ownership. Use the phone-driven staging OTA flow so the same safety gate is exercised.

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -8,6 +8,7 @@ import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkState
 import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.models.NetworkInfo;
 import com.mentra.asg_client.io.ota.helpers.OtaHelper;
+import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 import com.mentra.asg_client.service.communication.reliability.ReliableMessageManager;
 import java.nio.charset.StandardCharsets;
@@ -88,7 +89,9 @@ public class CommunicationManager
         Log.d(TAG, "🔄 =========================================");
         Log.d(TAG, "🔄 SEND WIFI STATUS OVER BLE");
         Log.d(TAG, "🔄 =========================================");
-        Log.d(TAG, "🔄 WiFi connected: " + isConnected + (error != null ? ", error: " + error : ""));
+        Log.d(
+                TAG,
+                "🔄 WiFi connected: " + isConnected + (error != null ? ", error: " + error : ""));
 
         if (transport != null && transport.isConnected()) {
             Log.d(TAG, "🔄 ✅ Transport available and connected");
@@ -184,8 +187,7 @@ public class CommunicationManager
             try {
                 // Send networks in chunks of 4 to avoid BLE message size issues
                 int CHUNK_SIZE = 4;
-                List<String> scanNetworks =
-                        networks != null ? networks : Collections.emptyList();
+                List<String> scanNetworks = networks != null ? networks : Collections.emptyList();
 
                 // Split and send in chunks
                 for (int i = 0; i < scanNetworks.size(); i += CHUNK_SIZE) {
@@ -211,7 +213,8 @@ public class CommunicationManager
                                     + jsonString.getBytes(StandardCharsets.UTF_8).length
                                     + " bytes");
 
-                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent =
+                            transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -235,7 +238,8 @@ public class CommunicationManager
 
                     String jsonString = response.toString();
                     Log.d(TAG, "📡 📤 Sending empty WiFi scan result: " + jsonString);
-                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent =
+                            transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -301,7 +305,8 @@ public class CommunicationManager
                                     + network.getSignalStrength()
                                     + "dBm)");
 
-                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent =
+                            transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -326,7 +331,8 @@ public class CommunicationManager
 
                     String jsonString = response.toString();
                     Log.d(TAG, "📡 📤 Sending empty enhanced WiFi scan result: " + jsonString);
-                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent =
+                            transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -649,7 +655,13 @@ public class CommunicationManager
 
         try {
             if (isTerminal) {
-                boolean sent = reliableManager.sendMessage(status);
+                // Keep the state-rich snapshot in diagnostics, but put only the fields the phone
+                // needs to end the flow on the critical wire. This must remain one legacy v1
+                // notification even after ReliableMessageManager appends its mId.
+                BleTraceLogger.logEvent(
+                        "glasses_to_phone", "ota_diagnostic", "terminal_status", status);
+                JSONObject compactStatus = compactTerminalOtaStatus(status);
+                boolean sent = reliableManager.sendMessage(compactStatus);
                 Log.i(TAG, "📱 OTA Status (reliable): " + statusValue + " sent=" + sent);
             } else {
                 String jsonString = status.toString();
@@ -659,5 +671,43 @@ public class CommunicationManager
         } catch (Exception e) {
             Log.e(TAG, "📱 Error sending OTA status", e);
         }
+    }
+
+    static JSONObject compactTerminalOtaStatus(JSONObject status) throws JSONException {
+        JSONObject compact = new JSONObject();
+        compact.put("type", "ota_status");
+        compact.put("status", status.optString("status", "failed"));
+
+        String sessionId = status.optString("sid", status.optString("session_id", ""));
+        if (!sessionId.isEmpty()) {
+            compact.put("sid", sessionId);
+        }
+
+        String stepType = status.optString("st", status.optString("step_type", ""));
+        if (!stepType.isEmpty()) {
+            compact.put("st", stepType);
+        }
+        String phase = status.optString("phase", "");
+        if (!phase.isEmpty()) {
+            compact.put("phase", phase);
+        }
+
+        if ("complete".equals(compact.optString("status"))) {
+            int overall = status.optInt("op", status.optInt("overall_percent", 100));
+            compact.put("op", overall);
+        }
+
+        if ("failed".equals(compact.optString("status"))) {
+            String error = status.optString("err", status.optString("error_message", ""));
+            compact.put("err", compactErrorCode(error, phase));
+        }
+        return compact;
+    }
+
+    private static String compactErrorCode(String error, String phase) {
+        if (error != null && error.matches("[a-z0-9_]{1,48}")) {
+            return error;
+        }
+        return "download".equals(phase) ? "download_failed" : "install_failed";
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -1,6 +1,7 @@
 package com.mentra.asg_client.service.communication.managers;
 
 import android.util.Log;
+
 import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
@@ -11,11 +12,13 @@ import com.mentra.asg_client.io.ota.helpers.OtaHelper;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 import com.mentra.asg_client.service.communication.reliability.ReliableMessageManager;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Manages all communication operations (Bluetooth, WiFi status, etc.). Follows Single
@@ -705,7 +708,7 @@ public class CommunicationManager
     }
 
     private static String compactErrorCode(String error, String phase) {
-        if (error != null && error.matches("[a-z0-9_]{1,48}")) {
+        if (error.matches("[a-z0-9_]{1,48}")) {
             return error;
         }
         return "download".equals(phase) ? "download_failed" : "install_failed";

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -1,0 +1,316 @@
+package com.mentra.asg_client.io.bes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mentra.asg_client.io.bes.BesOtaStateStore.Snapshot;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.StartDecision;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.StartupDecision;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.State;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.TerminalStatus;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.TransitionResult;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.UartPolicy;
+import com.mentra.asg_client.io.bes.BesOtaStateStore.VerificationDecision;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class BesOtaStateStoreTest {
+    private static final String OWNER = "session-a";
+    private static final String OTHER_OWNER = "session-b";
+    private static final String BOOT_A = "boot-a";
+    private static final String BOOT_B = "boot-b";
+    private static final String BOOT_C = "boot-c";
+    private static final String TARGET = "26.7.30.4";
+    private static final String ARTIFACT = "bes-26.7.30.4-update_ota.bin";
+    private static final String SHA =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private FakeStorage storage;
+    private FakeBootIdProvider bootIds;
+    private BesOtaStateStore store;
+
+    @Before
+    public void setUp() {
+        storage = new FakeStorage();
+        bootIds = new FakeBootIdProvider(BOOT_A);
+        store = new BesOtaStateStore(storage, bootIds);
+    }
+
+    @Test
+    public void absentRecordIsIdleAndNormal() {
+        assertThat(store.read().isIdle()).isTrue();
+        assertThat(store.uartPolicy(BOOT_A, false, null)).isEqualTo(UartPolicy.NORMAL);
+        assertThat(store.prepareForNewSession(BOOT_A, false)).isEqualTo(StartDecision.ADMIT);
+    }
+
+    @Test
+    public void reservationCommitsOneAuthorizationOwnerAndBoot() {
+        assertThat(reserve()).isEqualTo(TransitionResult.APPLIED);
+
+        Snapshot snapshot = store.read();
+        assertThat(snapshot.getState()).isEqualTo(State.AUTH_ATTEMPTED);
+        assertThat(snapshot.getOwnerSessionId()).isEqualTo(OWNER);
+        assertThat(snapshot.getAuthorizationBootId()).isEqualTo(BOOT_A);
+        assertThat(snapshot.getTargetVersion()).isEqualTo(TARGET);
+        assertThat(store.uartPolicy(BOOT_A, false, OWNER)).isEqualTo(UartPolicy.OTA_OWNER_ONLY);
+    }
+
+    @Test
+    public void duplicateReservationInSameOrLaterBootIsRejected() {
+        assertThat(reserve()).isEqualTo(TransitionResult.APPLIED);
+
+        assertThat(reserve()).isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.reserveAuthorization(OTHER_OWNER, BOOT_B, TARGET, ARTIFACT, SHA))
+                .isEqualTo(TransitionResult.REJECTED);
+    }
+
+    @Test
+    public void reservationCommitFailureConsumesNoAuthorizationInStorage() {
+        storage.failNextPut = true;
+
+        assertThat(reserve()).isEqualTo(TransitionResult.PERSISTENCE_FAILURE);
+        assertThat(storage.raw).isNull();
+        assertThat(store.read().isCorrupt()).isTrue();
+        assertThat(store.uartPolicy(BOOT_A, false, OWNER)).isEqualTo(UartPolicy.QUARANTINED);
+    }
+
+    @Test
+    public void applyRequiresExpectedOwnerAndState() {
+        reserve();
+
+        assertThat(store.markApplyPending(OTHER_OWNER)).isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.markApplyPending(OWNER)).isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.markApplyPending(OWNER)).isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.read().getState()).isEqualTo(State.APPLY_PENDING);
+    }
+
+    @Test
+    public void firstPostApplyBootIsClaimedAndSameBootCanResume() {
+        reserveAndMarkApply();
+
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_A))
+                .isEqualTo(VerificationDecision.WAIT_FOR_REBOOT);
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_B))
+                .isEqualTo(VerificationDecision.CLAIMED);
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_B))
+                .isEqualTo(VerificationDecision.RESUME);
+        assertThat(store.read().getVerificationBootId()).isEqualTo(BOOT_B);
+    }
+
+    @Test
+    public void secondUnverifiedBootBecomesMonotonicFailure() {
+        reserveAndMarkApply();
+        store.claimOrResumeVerificationBoot(BOOT_B);
+
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_C))
+                .isEqualTo(VerificationDecision.SECOND_BOOT_FAILED);
+        assertThat(store.read().getState()).isEqualTo(State.TERMINAL);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("verification_boot_changed");
+    }
+
+    @Test
+    public void exactClaimedBootAndVersionAreRequiredForSuccess() {
+        reserveAndMarkApply();
+        store.claimOrResumeVerificationBoot(BOOT_B);
+
+        assertThat(store.completeVerified(OWNER, BOOT_A, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.completeVerified(OTHER_OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.completeVerified(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+    }
+
+    @Test
+    public void unexpectedNewerVersionIsStillFailure() {
+        reserveAndMarkApply();
+        store.claimOrResumeVerificationBoot(BOOT_B);
+
+        assertThat(store.completeVerified(OWNER, BOOT_B, "26.7.31.0"))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("version_mismatch");
+    }
+
+    @Test
+    public void terminalFailureIsIdempotentButCannotBeFlipped() {
+        reserve();
+        assertThat(store.fail(OWNER, "authorization_denied")).isEqualTo(TransitionResult.APPLIED);
+
+        assertThat(store.fail(OWNER, "response_timeout"))
+                .isEqualTo(TransitionResult.ALREADY_TERMINAL);
+        assertThat(store.fail(OTHER_OWNER, "response_timeout"))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.read().getTerminalCode()).isEqualTo("authorization_denied");
+    }
+
+    @Test
+    public void failedTerminalCannotRetireInAuthorizationBoot() {
+        reserve();
+        store.fail(OWNER, "install_failed");
+
+        assertThat(store.prepareForNewSession(BOOT_A, true))
+                .isEqualTo(StartDecision.RESTART_REQUIRED);
+        assertThat(store.read().isValid()).isTrue();
+    }
+
+    @Test
+    public void failedTerminalRequiresNewBootAndFramedProofBeforeRetirement() {
+        reserve();
+        store.fail(OWNER, "install_failed");
+
+        assertThat(store.prepareForNewSession(BOOT_B, false))
+                .isEqualTo(StartDecision.PATH_PROOF_REQUIRED);
+        assertThat(store.prepareForNewSession(BOOT_B, true)).isEqualTo(StartDecision.ADMIT);
+        assertThat(store.read().isIdle()).isTrue();
+    }
+
+    @Test
+    public void successfulTerminalCanRetireWithoutAnotherBoot() {
+        completeSuccessfully();
+
+        assertThat(store.prepareForNewSession(BOOT_B, false)).isEqualTo(StartDecision.ADMIT);
+        assertThat(store.read().isIdle()).isTrue();
+    }
+
+    @Test
+    public void activeHardwareCannotBeSupersededByNewStart() {
+        reserve();
+        assertThat(store.prepareForNewSession(BOOT_A, true)).isEqualTo(StartDecision.ACTIVE);
+        store.markApplyPending(OWNER);
+        assertThat(store.prepareForNewSession(BOOT_B, true)).isEqualTo(StartDecision.ACTIVE);
+    }
+
+    @Test
+    public void sameBootProcessRestartRecordsFailureAndQuarantines() {
+        reserve();
+
+        assertThat(store.reconcileStartup(BOOT_A)).isEqualTo(StartupDecision.QUARANTINED);
+        assertThat(store.read().getState()).isEqualTo(State.TERMINAL);
+        assertThat(store.read().getTerminalCode()).isEqualTo("interrupted");
+        assertThat(store.uartPolicy(BOOT_A, false, null)).isEqualTo(UartPolicy.QUARANTINED);
+    }
+
+    @Test
+    public void laterBootProcessRestartRequiresRecoveryProof() {
+        reserve();
+
+        assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.RECOVERY_PROBE_ONLY);
+        assertThat(store.uartPolicy(BOOT_B, false, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+        assertThat(store.uartPolicy(BOOT_B, true, null)).isEqualTo(UartPolicy.NORMAL);
+    }
+
+    @Test
+    public void postApplyStartupClaimsOnlyFirstVerificationBoot() {
+        reserveAndMarkApply();
+
+        assertThat(store.reconcileStartup(BOOT_A)).isEqualTo(StartupDecision.APPLY_WAIT);
+        assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.VERSION_PROBE_ONLY);
+        assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.VERSION_PROBE_ONLY);
+        assertThat(store.reconcileStartup(BOOT_C)).isEqualTo(StartupDecision.QUARANTINED);
+    }
+
+    @Test
+    public void corruptAndUnknownSchemaFailClosedAndCanBeRepaired() throws Exception {
+        storage.raw = "{not-json";
+        assertThat(store.read().isCorrupt()).isTrue();
+        assertThat(store.prepareForNewSession(BOOT_A, true)).isEqualTo(StartDecision.CORRUPT);
+        assertThat(store.reconcileStartup(BOOT_A)).isEqualTo(StartupDecision.QUARANTINED);
+        assertThat(store.read().getTerminalCode()).isEqualTo("corrupt_state");
+
+        JSONObject unknown = new JSONObject(storage.raw);
+        unknown.put("schema", 99);
+        FakeStorage secondStorage = new FakeStorage();
+        secondStorage.raw = unknown.toString();
+        BesOtaStateStore second =
+                new BesOtaStateStore(secondStorage, new FakeBootIdProvider(BOOT_A));
+        assertThat(second.read().isCorrupt()).isTrue();
+    }
+
+    @Test
+    public void failedTransitionCommitDoesNotErasePreviousStoredRecord() {
+        reserve();
+        String reserved = storage.raw;
+        storage.failNextPut = true;
+
+        assertThat(store.markApplyPending(OWNER)).isEqualTo(TransitionResult.PERSISTENCE_FAILURE);
+        assertThat(storage.raw).isEqualTo(reserved);
+        assertThat(store.read().isCorrupt()).isTrue();
+    }
+
+    @Test
+    public void versionCanonicalizationIsExactAndBounded() {
+        assertThat(BesOtaStateStore.canonicalVersion("026.007.030.004")).isEqualTo("26.7.30.4");
+        assertThat(BesOtaStateStore.canonicalVersion("26.7.30")).isNull();
+        assertThat(BesOtaStateStore.canonicalVersion("26.7.30.256")).isNull();
+        assertThat(BesOtaStateStore.canonicalVersion("26.7.x.4")).isNull();
+    }
+
+    private TransitionResult reserve() {
+        return store.reserveAuthorization(OWNER, BOOT_A, TARGET, ARTIFACT, SHA);
+    }
+
+    private void reserveAndMarkApply() {
+        assertThat(reserve()).isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.markApplyPending(OWNER)).isEqualTo(TransitionResult.APPLIED);
+    }
+
+    private void completeSuccessfully() {
+        reserveAndMarkApply();
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_B))
+                .isEqualTo(VerificationDecision.CLAIMED);
+        assertThat(store.completeVerified(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+    }
+
+    private static final class FakeStorage implements BesOtaStateStore.Storage {
+        String raw;
+        boolean failNextPut;
+        boolean failNextRemove;
+
+        @Override
+        public String get() {
+            return raw;
+        }
+
+        @Override
+        public boolean put(String value) {
+            if (failNextPut) {
+                failNextPut = false;
+                return false;
+            }
+            raw = value;
+            return true;
+        }
+
+        @Override
+        public boolean remove() {
+            if (failNextRemove) {
+                failNextRemove = false;
+                return false;
+            }
+            raw = null;
+            return true;
+        }
+    }
+
+    private static final class FakeBootIdProvider implements BesOtaStateStore.BootIdProvider {
+        String bootId;
+
+        FakeBootIdProvider(String bootId) {
+            this.bootId = bootId;
+        }
+
+        @Override
+        public String currentBootId() {
+            return bootId;
+        }
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -10,6 +10,7 @@ import com.mentra.asg_client.io.bes.BesOtaStateStore.TerminalStatus;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.TransitionResult;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.UartPolicy;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.VerificationDecision;
+
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -232,6 +233,28 @@ public class BesOtaStateStoreTest {
         BesOtaStateStore second =
                 new BesOtaStateStore(secondStorage, new FakeBootIdProvider(BOOT_A));
         assertThat(second.read().isCorrupt()).isTrue();
+    }
+
+    @Test
+    public void blankPersistedRecordIsCorruptNotIdle() {
+        storage.raw = "   ";
+
+        assertThat(store.read().isCorrupt()).isTrue();
+        assertThat(store.prepareForNewSession(BOOT_A, true)).isEqualTo(StartDecision.CORRUPT);
+        assertThat(store.uartPolicy(BOOT_A, true, null)).isEqualTo(UartPolicy.QUARANTINED);
+    }
+
+    @Test
+    public void malformedPersistedVerificationBootCannotBeClaimedAgain() throws Exception {
+        reserveAndMarkApply();
+        JSONObject persisted = new JSONObject(storage.raw);
+        persisted.put("verification_boot_id", "   ");
+        storage.raw = persisted.toString();
+
+        assertThat(store.read().isCorrupt()).isTrue();
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_B))
+                .isEqualTo(VerificationDecision.NOT_PENDING);
+        assertThat(store.uartPolicy(BOOT_B, true, null)).isEqualTo(UartPolicy.QUARANTINED);
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -3,16 +3,7 @@ package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.app.Application;
-
 import com.mentra.asg_client.AsgConstants;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Queue;
@@ -23,17 +14,25 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(application = Application.class, sdk = 33)
 public class BesUartTransportCoordinatorTest {
     private FakeHost host;
+    private FakeSafetyState safety;
     private BesUartTransportCoordinator coordinator;
 
     @Before
     public void setUp() {
         host = new FakeHost();
-        coordinator = new BesUartTransportCoordinator(host);
+        safety = new FakeSafetyState();
+        coordinator = new BesUartTransportCoordinator(host, safety);
     }
 
     @After
@@ -385,6 +384,69 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
+    public void durableRecovery_rawReplyQuarantinesWithoutFramedProbe() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.RECOVERY_PROBE_ONLY;
+        coordinator.onSerialReady(host.session);
+
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.SAFETY_RECOVERING);
+        assertThat(coordinator.inboundRoute(host.session))
+                .isEqualTo(BesUartTransportCoordinator.InboundRoute.OTA);
+
+        coordinator.startSafetyRecovery();
+        awaitRawWriteCount(1);
+        assertThat(coordinator.onSafetyRawProtocolResponse((byte) 0x9A)).isTrue();
+
+        assertThat(safety.rawModeProven).isTrue();
+        assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.QUARANTINED);
+        assertThat(countControlCommands("cs_syvr")).isZero();
+    }
+
+    @Test
+    public void durableRecovery_rawSilenceAllowsOneFreshFramedProof() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
+        coordinator.onSerialReady(host.session);
+        coordinator.startSafetyRecovery();
+
+        awaitRawWriteCount(3);
+        awaitControlCommandCount("cs_syvr", 1, 5_000);
+        assertThat(host.rawWrites)
+                .allMatch(
+                        bytes ->
+                                java.util.Arrays.equals(
+                                        bytes, new byte[] {(byte) 0x99, 0, 0, 0, 0}));
+        assertThat(countControlCommands("cs_syvr")).isEqualTo(1);
+
+        assertThat(
+                        coordinator.onSystemVersion(
+                                "17.26.7.4",
+                                coordinator.getSerialSession(),
+                                () ->
+                                        safety.policy =
+                                                BesUartTransportCoordinator.SafetyPolicy.NORMAL))
+                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.READY_RENDEZVOUS);
+    }
+
+    @Test
+    public void durableRecovery_totalSilenceFailsClosed() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
+        coordinator.onSerialReady(host.session);
+        coordinator.startSafetyRecovery();
+
+        long deadline =
+                System.currentTimeMillis() + AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS + 5_000;
+        while (System.currentTimeMillis() < deadline && !safety.recoveryFailed) {
+            Thread.sleep(10);
+        }
+
+        assertThat(safety.recoveryFailed).isTrue();
+        assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.QUARANTINED);
+        assertThat(countControlCommands("cs_syvr")).isEqualTo(1);
+    }
+
+    @Test
     public void otaPromotion_drainsAuthorizationWriteBeforeRawRouting() throws Exception {
         coordinator.onSerialReady(host.session);
         assertThat(systemVersion("17.26.7.4"))
@@ -478,7 +540,7 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
-    public void recoveryAtRendezvous_canNegotiateFastAgain() throws Exception {
+    public void failedFastLink_recoversAtRendezvousWithoutNegotiatingAgain() throws Exception {
         establishFastLink();
 
         coordinator.onDiscardedBytes(
@@ -487,11 +549,11 @@ public class BesUartTransportCoordinatorTest {
         assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.RECOVERING);
 
         assertThat(systemVersion("17.26.7.23"))
-                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.TRANSITIONING);
+                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
         assertThat(coordinator.getState())
-                .isEqualTo(BesUartTransportCoordinator.State.SWITCH_REQUESTED);
-        awaitControlCommandCount("cs_baud", 2);
-        assertThat(countControlCommands("cs_baud")).isEqualTo(2);
+                .isEqualTo(BesUartTransportCoordinator.State.READY_RENDEZVOUS);
+        assertThat(coordinator.runNormalWrite(() -> true)).isTrue();
+        assertThat(countControlCommands("cs_baud")).isEqualTo(1);
     }
 
     @Test
@@ -534,8 +596,10 @@ public class BesUartTransportCoordinatorTest {
                 .isEqualTo(BesUartTransportCoordinator.State.READY_RENDEZVOUS);
         awaitControlCommandCount("cs_syvr", AsgConstants.UART_RUNTIME_RECOVERY_PROBES_PER_BAUD);
         assertThat(systemVersion("17.26.7.23"))
-                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.TRANSITIONING);
-        awaitControlCommandCount("cs_baud", 1);
+                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.READY_RENDEZVOUS);
+        assertThat(countControlCommands("cs_baud")).isZero();
     }
 
     @Test
@@ -694,11 +758,24 @@ public class BesUartTransportCoordinatorTest {
     }
 
     private void awaitControlCommandCount(String command, int expected) throws Exception {
-        long deadline = System.currentTimeMillis() + 1_000;
+        awaitControlCommandCount(command, expected, 1_000);
+    }
+
+    private void awaitControlCommandCount(String command, int expected, long timeoutMs)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline && countControlCommands(command) < expected) {
             Thread.sleep(10);
         }
         assertThat(countControlCommands(command)).isGreaterThanOrEqualTo(expected);
+    }
+
+    private void awaitRawWriteCount(int expected) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline && host.rawWrites.size() < expected) {
+            Thread.sleep(10);
+        }
+        assertThat(host.rawWrites.size()).isGreaterThanOrEqualTo(expected);
     }
 
     private void awaitOpenAttemptCount(int baud, int expected) throws Exception {
@@ -825,6 +902,28 @@ public class BesUartTransportCoordinatorTest {
 
         void runNextOutboundDrain() {
             outboundDrains.remove().run();
+        }
+    }
+
+    private static final class FakeSafetyState implements BesUartTransportCoordinator.SafetyState {
+        volatile BesUartTransportCoordinator.SafetyPolicy policy =
+                BesUartTransportCoordinator.SafetyPolicy.NORMAL;
+        volatile boolean rawModeProven;
+        volatile boolean recoveryFailed;
+
+        @Override
+        public BesUartTransportCoordinator.SafetyPolicy currentPolicy() {
+            return policy;
+        }
+
+        @Override
+        public void onRawOtaModeProven() {
+            rawModeProven = true;
+        }
+
+        @Override
+        public void onRecoveryFailed() {
+            recoveryFailed = true;
         }
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -3,7 +3,16 @@ package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.app.Application;
+
 import com.mentra.asg_client.AsgConstants;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Queue;
@@ -14,12 +23,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(application = Application.class, sdk = 33)
@@ -400,6 +403,20 @@ public class BesUartTransportCoordinatorTest {
         assertThat(safety.rawModeProven).isTrue();
         assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.QUARANTINED);
         assertThat(countControlCommands("cs_syvr")).isZero();
+    }
+
+    @Test
+    public void durableRecovery_listenerBeforeSerialStillStartsRawProbes() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.RECOVERY_PROBE_ONLY;
+
+        coordinator.startSafetyRecovery();
+        coordinator.onSerialReady(host.session);
+
+        awaitRawWriteCount(1);
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.SAFETY_RECOVERING);
+        assertThat(coordinator.inboundRoute(host.session))
+                .isEqualTo(BesUartTransportCoordinator.InboundRoute.OTA);
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -13,12 +13,11 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
- * Regression test for incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: v1 ck chunks were sized
- * against MTU_TARGET (509) but a v1 string frame must survive the phone leg as a single
- * BLE notification (~253-byte ATT payload). The OTA completion ota_status packed to
- * 256-263-byte chunk frames, every one was truncated on the wire, and the phone failed a
- * successful update. Every packed v1 ck chunk must stay within
- * {@link MessageChunker#MAX_PACKED_STRING_CHUNK_SIZE}.
+ * Regression test for incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: v1 ck chunks were sized against
+ * MTU_TARGET (509) but a v1 string frame must survive the phone leg as a single BLE notification
+ * (~253-byte ATT payload). The OTA completion ota_status packed to 256-263-byte chunk frames, every
+ * one was truncated on the wire, and the phone failed a successful update. Every packed v1 ck chunk
+ * must stay within {@link MessageChunker#MAX_PACKED_STRING_CHUNK_SIZE}.
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
@@ -37,7 +36,10 @@ public class StringChunkBudgetTest {
         MessageChunker.resetStringChunkBudget();
     }
 
-    /** The 251-byte ota_status completion shape from the incident, quote-dense like the real payload. */
+    /**
+     * The 251-byte ota_status completion shape from the incident, quote-dense like the real
+     * payload.
+     */
     private static String incidentShapedOtaStatus() {
         return "{\"sid\":\"d017b9b1\",\"ts\":1,\"cs\":1,\"st\":\"apk\",\"sq\":[\"apk\"],"
                 + "\"phase\":\"install\",\"sp\":100,\"op\":100,\"status\":\"complete\","
@@ -67,7 +69,8 @@ public class StringChunkBudgetTest {
             // measure the packed frame exactly as the send path produces it.
             byte[] packed = BesWireFormat.formatMessageForTransmission(chunk.toString());
             assertThat(packed).isNotNull();
-            assertThat(packed.length).isLessThanOrEqualTo(MessageChunker.maxPackedStringChunkSize());
+            assertThat(packed.length)
+                    .isLessThanOrEqualTo(MessageChunker.maxPackedStringChunkSize());
 
             reassembled =
                     reassembler.addChunk(
@@ -94,7 +97,7 @@ public class StringChunkBudgetTest {
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
 
-    // ---- negotiated notify_cap budget (BES firmware >= 17.26.7.23) ----
+    // ---- Release A fixed envelope: notify_cap is advisory only ----
 
     @Test
     public void budgetDefaultsToTheConservativeFallback() {
@@ -104,39 +107,20 @@ public class StringChunkBudgetTest {
     }
 
     @Test
-    public void advertisedNotifyCapRaisesTheBudgetByTheSameMargin() {
+    public void advertisedNotifyCapCannotRaiseTheBudget() {
         MessageChunker.setStringChunkBudgetFromNotifyCap(509);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
         MessageChunker.setStringChunkBudgetFromNotifyCap(253);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(253 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
     }
 
     @Test
-    public void notifyCapAboveTheContractCeilingIsClampedToTheCeiling() {
-        // The BES contract is max(253, min(ATT MTU - 3, 509)); an oversized advertisement must
-        // not size chunks beyond what the transport carries.
+    public void malformedNotifyCapsCannotChangeTheBudget() {
         MessageChunker.setStringChunkBudgetFromNotifyCap(1000);
-
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
-    }
-
-    @Test
-    public void notifyCapContractBoundariesAreAcceptedExactly() {
-        MessageChunker.setStringChunkBudgetFromNotifyCap(253);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(253 - 13);
-
-        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
-    }
-
-    @Test
-    public void notifyCapBelowTheContractFloorIsIgnored() {
-        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
         MessageChunker.setStringChunkBudgetFromNotifyCap(200);
-
-        // The malformed advertisement must not shrink the budget below the validated fallback.
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+        MessageChunker.setStringChunkBudgetFromNotifyCap(-1);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
     }
 
     @Test
@@ -149,7 +133,7 @@ public class StringChunkBudgetTest {
     }
 
     @Test
-    public void chunksStillFitAndRoundTripUnderARaisedBudget() throws Exception {
+    public void chunksStillFitAndRoundTripAfterLargeAdvertisement() throws Exception {
         MessageChunker.setStringChunkBudgetFromNotifyCap(509);
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
@@ -163,11 +147,11 @@ public class StringChunkBudgetTest {
         machine.srSyvrParsed(
                 new LinkStateMachine.BesCaps(
                         false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
         // A discontinuity (baud reopen) keeps the negotiated caps — and the budget with them.
         machine.streamDiscontinuity();
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
         // EVERY close path (onSerialClose, failed onSerialOpen, reopen failures) funnels
         // through the machine's serialClosed transition: caps cleared MUST mean fallback
@@ -184,9 +168,7 @@ public class StringChunkBudgetTest {
 
     @Test
     public void budgetFollowsThePhoneSessionLifecycle() {
-        // notify_cap derives from the phone BLE session's negotiated ATT MTU, so the budget
-        // must not outlive that session: a reconnecting phone can negotiate a SMALLER MTU, and
-        // the old 496 budget would silently truncate its notifications.
+        // Session changes and advertisements must not alter the fixed release-A envelope.
         LinkStateMachine machine = new LinkStateMachine();
         MessageChunker.followLinkState(machine);
         machine.serialReady();
@@ -194,7 +176,7 @@ public class StringChunkBudgetTest {
         machine.srSyvrParsed(
                 new LinkStateMachine.BesCaps(
                         false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
         // Phone disconnects: back to the fallback.
         machine.phonePresenceReported(false);
@@ -204,11 +186,11 @@ public class StringChunkBudgetTest {
         machine.phonePresenceReported(true);
         assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
-        // A fresh advertisement (measured for the new session's MTU) re-arms the budget.
+        // A fresh advertisement remains advisory.
         machine.srSyvrParsed(
                 new LinkStateMachine.BesCaps(
                         false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 260));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(260 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
     }
 
     @Test
@@ -221,7 +203,7 @@ public class StringChunkBudgetTest {
         machine.srSyvrParsed(
                 new LinkStateMachine.BesCaps(
                         false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
         // onBesOtaApplied drives exactly these two machine transitions.
         machine.streamDiscontinuity();

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -1,0 +1,266 @@
+package com.mentra.asg_client.io.ota.utils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mentra.asg_client.AsgConstants;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.zip.CRC32;
+import org.json.JSONObject;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.LZMAOutputStream;
+
+public class BesFirmwareArtifactValidatorTest {
+    private static final byte[] CRC_PREFIX =
+            "CRC32_OF_IMAGE=0x".getBytes(StandardCharsets.US_ASCII);
+    private static final int VERSION_OFFSET = 64;
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void releasePackagedArtifactWithExactIdentityPasses() throws Exception {
+        TestArtifact artifact = createArtifact();
+
+        BesFirmwareArtifactValidator.validate(artifact.file, artifact.metadata);
+    }
+
+    @Test
+    public void externalReleaseArtifactCanBeCheckedAgainstItsRawBuildOutput() throws Exception {
+        String artifactPath = System.getenv("BES_RELEASE_ARTIFACT");
+        String rawPath = System.getenv("BES_RELEASE_RAW");
+        String version = System.getenv("BES_RELEASE_VERSION");
+        String versionOffset = System.getenv("BES_RELEASE_VERSION_OFFSET");
+        Assume.assumeTrue(
+                artifactPath != null
+                        && rawPath != null
+                        && version != null
+                        && versionOffset != null);
+
+        File artifact = new File(artifactPath);
+        byte[] container = Files.readAllBytes(artifact.toPath());
+        byte[] raw = Files.readAllBytes(new File(rawPath).toPath());
+        JSONObject metadata = new JSONObject();
+        metadata.put("format", AsgConstants.BES_OTA_ARTIFACT_FORMAT);
+        metadata.put("product", AsgConstants.BES_OTA_PRODUCT);
+        metadata.put("artifact_id", artifact.getName());
+        metadata.put("url", "https://releases.example.invalid/" + artifact.getName());
+        metadata.put("compressed_size", container.length);
+        metadata.put("sha256", sha256(container));
+        metadata.put("decompressed_size", raw.length);
+        metadata.put("decompressed_sha256", sha256(raw));
+        metadata.put("version", version);
+        metadata.put("version_offset", Long.parseLong(versionOffset));
+
+        BesFirmwareArtifactValidator.validate(artifact, metadata);
+    }
+
+    @Test
+    public void legacyManifestWithoutAdmissionMetadataFailsClosed() throws Exception {
+        TestArtifact artifact = createArtifact();
+        JSONObject legacy = new JSONObject();
+        legacy.put("url", artifact.metadata.getString("url"));
+        legacy.put("sha256", artifact.metadata.getString("sha256"));
+
+        assertThatThrownBy(() -> BesFirmwareArtifactValidator.validate(artifact.file, legacy))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("format");
+    }
+
+    @Test
+    public void decompressedImageAtBootloaderLimitFailsBeforeAuthorization() throws Exception {
+        TestArtifact artifact = createArtifact();
+        artifact.metadata.put(
+                "decompressed_size", AsgConstants.BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES);
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("not OTA-safe");
+    }
+
+    @Test
+    public void corruptContainerFailsEvenWhenManifestHashMatchesCorruptBytes() throws Exception {
+        TestArtifact artifact = createArtifact();
+        byte[] corrupt = java.nio.file.Files.readAllBytes(artifact.file.toPath());
+        corrupt[0] = 0;
+        write(artifact.file, corrupt);
+        artifact.metadata.put("sha256", sha256(corrupt));
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("magic");
+    }
+
+    @Test
+    public void overflowingChunkLengthFailsAsTruncatedContainer() throws Exception {
+        TestArtifact artifact = createArtifact();
+        byte[] corrupt = {
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            0x7F,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF
+        };
+        write(artifact.file, corrupt);
+        artifact.metadata.put("compressed_size", corrupt.length);
+        artifact.metadata.put("sha256", sha256(corrupt));
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("Invalid or truncated BES OTA LZMA chunk");
+    }
+
+    @Test
+    public void wrongEmbeddedProductOrVersionFailsClosed() throws Exception {
+        TestArtifact artifact = createArtifact();
+        artifact.metadata.put("product", "different_product");
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("Wrong BES OTA product");
+
+        artifact.metadata.put("product", AsgConstants.BES_OTA_PRODUCT);
+        artifact.metadata.put("version", "17.26.7.25");
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("target version");
+    }
+
+    @Test
+    public void nonCanonicalTargetVersionFailsBeforeAuthorization() throws Exception {
+        TestArtifact artifact = createArtifact();
+        artifact.metadata.put("version", "017.26.7.24");
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("canonical");
+    }
+
+    @Test
+    public void validatedArtifactDetectsSameSizeReplacementBeforeReservation() throws Exception {
+        TestArtifact artifact = createArtifact();
+        BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
+                BesFirmwareArtifactValidator.validate(artifact.file, artifact.metadata);
+        byte[] replaced = Files.readAllBytes(artifact.file.toPath());
+        replaced[replaced.length / 2] ^= 0x01;
+        write(artifact.file, replaced);
+
+        assertThatThrownBy(validated::revalidateFileDigest)
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("SHA-256");
+    }
+
+    private TestArtifact createArtifact() throws Exception {
+        byte[] raw = new byte[512];
+        for (int i = 0; i < raw.length; i++) {
+            raw[i] = (byte) (i * 31);
+        }
+        raw[VERSION_OFFSET] = 17;
+        raw[VERSION_OFFSET + 1] = 26;
+        raw[VERSION_OFFSET + 2] = 7;
+        raw[VERSION_OFFSET + 3] = 24;
+        byte[] revision =
+                ("REV_INFO=release-a:" + AsgConstants.BES_OTA_PRODUCT)
+                        .getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(revision, 0, raw, 192, revision.length);
+
+        ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+        try (LZMAOutputStream lzma =
+                new LZMAOutputStream(compressed, new LZMA2Options(), raw.length)) {
+            lzma.write(raw);
+        }
+
+        byte[] chunk = compressed.toByteArray();
+        ByteArrayOutputStream containerHead = new ByteArrayOutputStream();
+        containerHead.write(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        writeBigEndianInt(containerHead, chunk.length);
+        containerHead.write(chunk);
+        containerHead.write(CRC_PREFIX);
+
+        CRC32 crc = new CRC32();
+        byte[] crcInput = containerHead.toByteArray();
+        crc.update(crcInput);
+        containerHead.write(
+                String.format(Locale.US, "%08X\n", crc.getValue())
+                        .getBytes(StandardCharsets.US_ASCII));
+        byte[] container = containerHead.toByteArray();
+
+        String artifactId = "release-a-test-update_ota.bin";
+        File file = temporaryFolder.newFile(artifactId);
+        write(file, container);
+
+        JSONObject metadata = new JSONObject();
+        metadata.put("format", AsgConstants.BES_OTA_ARTIFACT_FORMAT);
+        metadata.put("product", AsgConstants.BES_OTA_PRODUCT);
+        metadata.put("artifact_id", artifactId);
+        metadata.put("url", "https://releases.example.invalid/" + artifactId);
+        metadata.put("compressed_size", container.length);
+        metadata.put("sha256", sha256(container));
+        metadata.put("decompressed_size", raw.length);
+        metadata.put("decompressed_sha256", sha256(raw));
+        metadata.put("version", "17.26.7.24");
+        metadata.put("version_offset", VERSION_OFFSET);
+        return new TestArtifact(file, metadata);
+    }
+
+    private static void writeBigEndianInt(ByteArrayOutputStream output, int value) {
+        output.write((value >>> 24) & 0xFF);
+        output.write((value >>> 16) & 0xFF);
+        output.write((value >>> 8) & 0xFF);
+        output.write(value & 0xFF);
+    }
+
+    private static void write(File file, byte[] bytes) throws Exception {
+        try (FileOutputStream output = new FileOutputStream(file, false)) {
+            output.write(bytes);
+        }
+    }
+
+    private static String sha256(byte[] bytes) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+        StringBuilder value = new StringBuilder(digest.length * 2);
+        for (byte b : digest) {
+            value.append(String.format(Locale.US, "%02x", b & 0xFF));
+        }
+        return value.toString();
+    }
+
+    private static final class TestArtifact {
+        final File file;
+        final JSONObject metadata;
+
+        TestArtifact(File file, JSONObject metadata) {
+            this.file = file;
+            this.metadata = metadata;
+        }
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -3,6 +3,15 @@ package com.mentra.asg_client.io.ota.utils;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mentra.asg_client.AsgConstants;
+
+import org.json.JSONObject;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.LZMAOutputStream;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -11,13 +20,6 @@ import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.Locale;
 import java.util.zip.CRC32;
-import org.json.JSONObject;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.tukaani.xz.LZMA2Options;
-import org.tukaani.xz.LZMAOutputStream;
 
 public class BesFirmwareArtifactValidatorTest {
     private static final byte[] CRC_PREFIX =
@@ -131,6 +133,42 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
+    public void oversizedLzmaDictionaryFailsBeforeDecoderAllocation() throws Exception {
+        TestArtifact artifact = createArtifact();
+        byte[] hostile = Files.readAllBytes(artifact.file.toPath());
+        // Container magic (4), chunk length (4), LZMA properties (1), then LE dictionary size.
+        hostile[9] = 0;
+        hostile[10] = 0;
+        hostile[11] = 0;
+        hostile[12] = 0x40; // 1 GiB
+        write(artifact.file, hostile);
+        artifact.metadata.put("sha256", sha256(hostile));
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("dictionary exceeds");
+    }
+
+    @Test
+    public void productMustTerminateTheSameRevisionRecord() throws Exception {
+        byte[] raw = createRaw("release-a:different_product");
+        byte[] misleadingSuffix =
+                (":" + AsgConstants.BES_OTA_PRODUCT).getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(misleadingSuffix, 0, raw, 300, misleadingSuffix.length);
+        TestArtifact artifact = createArtifact(raw);
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validate(
+                                        artifact.file, artifact.metadata))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("does not identify");
+    }
+
+    @Test
     public void wrongEmbeddedProductOrVersionFailsClosed() throws Exception {
         TestArtifact artifact = createArtifact();
         artifact.metadata.put("product", "different_product");
@@ -180,6 +218,10 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     private TestArtifact createArtifact() throws Exception {
+        return createArtifact(createRaw("release-a:" + AsgConstants.BES_OTA_PRODUCT));
+    }
+
+    private byte[] createRaw(String revisionValue) {
         byte[] raw = new byte[512];
         for (int i = 0; i < raw.length; i++) {
             raw[i] = (byte) (i * 31);
@@ -188,11 +230,13 @@ public class BesFirmwareArtifactValidatorTest {
         raw[VERSION_OFFSET + 1] = 26;
         raw[VERSION_OFFSET + 2] = 7;
         raw[VERSION_OFFSET + 3] = 24;
-        byte[] revision =
-                ("REV_INFO=release-a:" + AsgConstants.BES_OTA_PRODUCT)
-                        .getBytes(StandardCharsets.US_ASCII);
+        byte[] revision = ("REV_INFO=" + revisionValue).getBytes(StandardCharsets.US_ASCII);
         System.arraycopy(revision, 0, raw, 192, revision.length);
+        raw[192 + revision.length] = 0;
+        return raw;
+    }
 
+    private TestArtifact createArtifact(byte[] raw) throws Exception {
         ByteArrayOutputStream compressed = new ByteArrayOutputStream();
         try (LZMAOutputStream lzma =
                 new LZMAOutputStream(compressed, new LZMA2Options(), raw.length)) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/communication/managers/CommunicationManagerOtaTerminalTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/communication/managers/CommunicationManagerOtaTerminalTest.java
@@ -1,0 +1,86 @@
+package com.mentra.asg_client.service.communication.managers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesWireFormat;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.MessageChunker;
+import java.nio.charset.StandardCharsets;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class CommunicationManagerOtaTerminalTest {
+    @Before
+    public void setUp() {
+        BesWireFormat.resetBinaryProtocol();
+    }
+
+    @After
+    public void tearDown() {
+        BesWireFormat.resetBinaryProtocol();
+    }
+
+    @Test
+    public void completeStatusFitsOneLegacyNotificationAfterReliableMessageId() throws Exception {
+        JSONObject verbose = new JSONObject();
+        verbose.put("type", "ota_status");
+        verbose.put("status", "complete");
+        verbose.put("sid", "d017b9b1");
+        verbose.put("st", "bes");
+        verbose.put("phase", "install");
+        verbose.put("op", 100);
+        verbose.put("diagnostic", "not allowed on the critical terminal wire");
+
+        assertSingleLegacyFrame(CommunicationManager.compactTerminalOtaStatus(verbose));
+    }
+
+    @Test
+    public void failedStatusNormalizesVerboseErrorsAndFitsOneLegacyNotification() throws Exception {
+        JSONObject verbose = new JSONObject();
+        verbose.put("type", "ota_status");
+        verbose.put("status", "failed");
+        verbose.put("sid", "12345678");
+        verbose.put("st", "bes");
+        verbose.put("phase", "install");
+        verbose.put("op", 99);
+        verbose.put("glasses_time_ms", Long.MAX_VALUE);
+        verbose.put("error_message", "Ambiguous UART write failure with a very long diagnostic");
+
+        JSONObject compact = CommunicationManager.compactTerminalOtaStatus(verbose);
+
+        assertThat(compact.getString("err")).isEqualTo("install_failed");
+        assertThat(compact.has("op")).isFalse();
+        assertSingleLegacyFrame(compact);
+    }
+
+    @Test
+    public void existingCompactErrorCodeSurvivesTerminalCompaction() throws Exception {
+        JSONObject status = new JSONObject();
+        status.put("type", "ota_status");
+        status.put("status", "failed");
+        status.put("st", "bes");
+        status.put("phase", "install");
+        status.put("error_message", "firmware_verify_failed");
+
+        JSONObject compact = CommunicationManager.compactTerminalOtaStatus(status);
+
+        assertThat(compact.getString("err")).isEqualTo("firmware_verify_failed");
+        assertSingleLegacyFrame(compact);
+    }
+
+    private static void assertSingleLegacyFrame(JSONObject terminal) throws Exception {
+        terminal.put("mId", Long.MAX_VALUE);
+        String json = terminal.toString();
+
+        assertThat(json.getBytes(StandardCharsets.UTF_8).length).isLessThanOrEqualTo(200);
+        assertThat(MessageChunker.needsChunking(json)).isFalse();
+        assertThat(BesWireFormat.formatMessageForTransmission(json).length)
+                .isLessThanOrEqualTo(MessageChunker.maxPackedStringChunkSize());
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapper.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapper.kt
@@ -1,0 +1,26 @@
+package com.mentra.bluetoothsdk.sgcs
+
+internal data class BesOtaProgressMapping(
+    val status: String,
+    val progress: Int,
+    val errorMessage: String? = null,
+)
+
+/**
+ * BES reports transfer/apply acceptance directly over BLE, before the glasses power cycle. That
+ * signal is useful progress but cannot prove which image booted. Only ASG's fresh sr_syvr readback
+ * may produce phone-visible FINISHED/complete.
+ */
+internal fun mapBesOtaProgress(
+    type: String,
+    rawProgress: Int,
+    roundedProgress: Int,
+    message: String?,
+): BesOtaProgressMapping {
+    return when {
+        type == "error" || type == "fail" ->
+            BesOtaProgressMapping("FAILED", roundedProgress, message ?: "BES update failed")
+        type == "success" || rawProgress >= 100 -> BesOtaProgressMapping("PROGRESS", 100)
+        else -> BesOtaProgressMapping("PROGRESS", roundedProgress)
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapper.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapper.kt
@@ -19,7 +19,11 @@ internal fun mapBesOtaProgress(
 ): BesOtaProgressMapping {
     return when {
         type == "error" || type == "fail" ->
-            BesOtaProgressMapping("FAILED", roundedProgress, message ?: "BES update failed")
+            BesOtaProgressMapping(
+                "FAILED",
+                roundedProgress,
+                message?.takeIf { it.isNotBlank() } ?: "BES update failed",
+            )
         type == "success" || rawProgress >= 100 -> BesOtaProgressMapping("PROGRESS", 100)
         else -> BesOtaProgressMapping("PROGRESS", roundedProgress)
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -4488,55 +4488,28 @@ class MentraLive : SGCManager() {
                                         "%"
                         )
 
-                        // Determine status and error message based on type
-                        val besOtaStatus: String
-                        val besOtaProgressVal: Int
-                        var besOtaErrorMessage: String? = null
-
-                        // Order matters here: check completion (rawProgress >= 100 OR success)
-                        // BEFORE
-                        // type=="update", because some BES firmware emits the final 100% tick with
-                        // type=="update" rather than type=="success". Treating that as PROGRESS
-                        // would
-                        // leave the UI stuck at 100% forever.
-                        if ("success" == type || rawProgress >= 100) {
-                            besOtaStatus = "FINISHED"
-                            besOtaProgressVal = 100
+                        val mapping =
+                            mapBesOtaProgress(
+                                type,
+                                rawProgress,
+                                progress,
+                                bodyObj.optString("message", "BES update failed"),
+                            )
+                        val besOtaStatus = mapping.status
+                        val besOtaProgressVal = mapping.progress
+                        val besOtaErrorMessage = mapping.errorMessage
+                        if ("FAILED" == besOtaStatus) {
                             lastBesOtaProgress = -1 // Reset for next OTA
-                        } else if ("error" == type || "fail" == type) {
-                            besOtaStatus = "FAILED"
-                            besOtaProgressVal = progress
-                            besOtaErrorMessage = bodyObj.optString("message", "BES update failed")
-                            lastBesOtaProgress = -1 // Reset for next OTA
-                        } else if ("update" == type) {
-                            besOtaStatus = "PROGRESS"
-                            besOtaProgressVal = progress
                         } else {
-                            // Unknown type, treat as progress
-                            besOtaStatus = "PROGRESS"
-                            besOtaProgressVal = progress
+                            lastBesOtaProgress = besOtaProgressVal
                         }
 
-                        val syntheticStatus: String
-                        if ("FINISHED" == besOtaStatus) {
-                            // The glasses power-cycle right after the final BES tick, so a
-                            // session whose BES step is the LAST step never gets a follow-up
-                            // ota_status from the glasses — consumers mapping on this synthetic
-                            // status would otherwise never see a terminal state. Emit "complete"
-                            // for the final step; mid-session BES steps keep "step_complete" so
-                            // session-level trackers advance normally. Unknown sessions
-                            // (cachedOtaTotalSteps == 0, e.g. legacy glasses that never sent an
-                            // ota_status) conservatively keep "step_complete".
-                            syntheticStatus =
-                                    if (cachedOtaTotalSteps > 0 &&
-                                                    cachedOtaCurrentStep >= cachedOtaTotalSteps
-                                    )
-                                            "complete"
-                                    else "step_complete"
-                        } else if ("FAILED" == besOtaStatus) {
-                            syntheticStatus = "failed"
+                        val syntheticStatus = if ("FAILED" == besOtaStatus) {
+                            "failed"
                         } else {
-                            syntheticStatus = "in_progress"
+                            // success/100 means apply was accepted, not that the target booted.
+                            // ASG sends the existing terminal ota_status after fresh sr_syvr proof.
+                            "in_progress"
                         }
                         val sid = if (cachedOtaSessionId != null) cachedOtaSessionId!! else ""
                         val totalSteps = if (cachedOtaTotalSteps > 0) cachedOtaTotalSteps else 1

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapperTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapperTest.kt
@@ -32,6 +32,14 @@ class BesOtaProgressMapperTest {
     }
 
     @Test
+    fun blankBesErrorUsesStableFallback() {
+        val mapping = mapBesOtaProgress("error", 65, 65, "   ")
+
+        assertEquals("FAILED", mapping.status)
+        assertEquals("BES update failed", mapping.errorMessage)
+    }
+
+    @Test
     fun ordinaryUpdateProgressRemainsNonterminal() {
         val mapping = mapBesOtaProgress("update", 42, 40, null)
 

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapperTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/BesOtaProgressMapperTest.kt
@@ -1,0 +1,51 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BesOtaProgressMapperTest {
+    @Test
+    fun successIsNonterminalUntilAsgVerifiesRebootedVersion() {
+        val mapping = mapBesOtaProgress("success", 0, 0, null)
+
+        assertEquals("PROGRESS", mapping.status)
+        assertEquals(100, mapping.progress)
+        assertNull(mapping.errorMessage)
+    }
+
+    @Test
+    fun hundredPercentUpdateIsAlsoNonterminal() {
+        val mapping = mapBesOtaProgress("update", 100, 100, null)
+
+        assertEquals("PROGRESS", mapping.status)
+        assertEquals(100, mapping.progress)
+    }
+
+    @Test
+    fun explicitBesErrorRemainsTerminalFailure() {
+        val mapping = mapBesOtaProgress("error", 65, 65, "CRC failed")
+
+        assertEquals("FAILED", mapping.status)
+        assertEquals(65, mapping.progress)
+        assertEquals("CRC failed", mapping.errorMessage)
+    }
+
+    @Test
+    fun ordinaryUpdateProgressRemainsNonterminal() {
+        val mapping = mapBesOtaProgress("update", 42, 40, null)
+
+        assertEquals("PROGRESS", mapping.status)
+        assertEquals(40, mapping.progress)
+        assertNull(mapping.errorMessage)
+    }
+
+    @Test
+    fun failAliasRemainsTerminalFailure() {
+        val mapping = mapBesOtaProgress("fail", 25, 25, "apply failed")
+
+        assertEquals("FAILED", mapping.status)
+        assertEquals(25, mapping.progress)
+        assertEquals("apply failed", mapping.errorMessage)
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -3011,51 +3011,23 @@ class MentraLive: NSObject, SGCManager {
                     "LIVE: 📱 BES OTA progress via sr_adota - type: \(type), raw: \(rawProgress)%, rounded: \(progress)%"
                 )
 
-                // Determine status and error message based on type
-                var besOtaStatus: String
                 var besOtaProgressVal: Int
                 var besOtaErrorMessage: String? = nil
 
-                // Order matters here: check completion (rawProgress >= 100 OR success) BEFORE
-                // type=="update", because some BES firmware emits the final 100% tick with
-                // type=="update" rather than type=="success". Treating that as PROGRESS would
-                // leave the UI stuck at 100% forever.
-                if type == "success" || rawProgress >= 100 {
-                    besOtaStatus = "FINISHED"
-                    besOtaProgressVal = 100
-                    lastBesOtaProgress = -1 // Reset for next OTA
-                } else if type == "error" || type == "fail" {
-                    besOtaStatus = "FAILED"
+                let failed = type == "error" || type == "fail"
+                if failed {
                     besOtaProgressVal = progress
                     besOtaErrorMessage = bodyObj["message"] as? String ?? "BES update failed"
                     lastBesOtaProgress = -1 // Reset for next OTA
-                } else if type == "update" {
-                    besOtaStatus = "PROGRESS"
-                    besOtaProgressVal = progress
                 } else {
-                    // Unknown type, treat as progress
-                    besOtaStatus = "PROGRESS"
-                    besOtaProgressVal = progress
+                    // BES success/100 proves transfer/apply acceptance, not which image booted.
+                    // ASG sends the existing terminal ota_status only after a fresh sr_syvr
+                    // exactly matches the target version after reboot.
+                    besOtaProgressVal = (type == "success" || rawProgress >= 100) ? 100 : progress
+                    lastBesOtaProgress = besOtaProgressVal
                 }
 
-                let syntheticStatus: String
-                if besOtaStatus == "FINISHED" {
-                    // The glasses power-cycle right after the final BES tick, so a session
-                    // whose BES step is the LAST step never gets a follow-up ota_status from
-                    // the glasses — consumers mapping on this synthetic status would otherwise
-                    // never see a terminal state. Emit "complete" for the final step;
-                    // mid-session BES steps keep "step_complete" so session-level trackers
-                    // advance normally. Unknown sessions (cachedOtaTotalSteps == 0, e.g.
-                    // legacy glasses that never sent an ota_status) conservatively keep
-                    // "step_complete".
-                    syntheticStatus = (cachedOtaTotalSteps > 0 && cachedOtaCurrentStep >= cachedOtaTotalSteps)
-                        ? "complete"
-                        : "step_complete"
-                } else if besOtaStatus == "FAILED" {
-                    syntheticStatus = "failed"
-                } else {
-                    syntheticStatus = "in_progress"
-                }
+                let syntheticStatus = failed ? "failed" : "in_progress"
                 let sid = cachedOtaSessionId ?? ""
                 let totalSteps = cachedOtaTotalSteps > 0 ? cachedOtaTotalSteps : 1
                 let currentStep = cachedOtaCurrentStep > 0 ? cachedOtaCurrentStep : 1

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -9,6 +9,7 @@ import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 
 import OtaProgressScreen from "@/app/ota/progress"
 import {MINIMUM_OTA_STATUS_BUILD, OtaProgressMessages} from "@mentra/engine"
+import {BES_INSTALL_RESTART_MESSAGE} from "@/utils/otaErrorMapping"
 
 const mockReplace = jest.fn()
 
@@ -213,6 +214,29 @@ describe("progress.tsx display states", () => {
     expect(getByText("Retry")).toBeDefined()
   })
 
+  it("requires a glasses restart for the existing generic BES install failure", () => {
+    setGlassesConnected()
+    const {getByText, queryByText} = render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "bes",
+        phase: "install",
+        stepPercent: 0,
+        overallPercent: 0,
+        status: "failed",
+        error: "install_failed",
+      })
+    })
+
+    expect(getByText(BES_INSTALL_RESTART_MESSAGE)).toBeDefined()
+    expect(getByText("Done")).toBeDefined()
+    expect(queryByText("Retry")).toBeNull()
+  })
+
   it("shows disconnected state when not connected and not terminal", () => {
     setGlassesDisconnected()
     const {getByText} = render(<OtaProgressScreen />)
@@ -371,7 +395,7 @@ describe("progress.tsx watchdog timers", () => {
 
   it("fails progress stall after PROGRESS_TIMEOUT_MS with frozen ota_status", async () => {
     setGlassesConnected()
-    const {getByText} = render(<OtaProgressScreen />)
+    const {getByText, queryByText} = render(<OtaProgressScreen />)
 
     act(() => {
       useGlassesStore.getState().setOtaStatus({
@@ -391,7 +415,9 @@ describe("progress.tsx watchdog timers", () => {
     })
 
     expect(getByText("Update Failed")).toBeDefined()
-    expect(getByText(OtaProgressMessages.stalledOrStuck)).toBeDefined()
+    expect(getByText(BES_INSTALL_RESTART_MESSAGE)).toBeDefined()
+    expect(getByText("Done")).toBeDefined()
+    expect(queryByText("Retry")).toBeNull()
   })
 
   it("queries the resumed session without starting a second OTA after a multi-step APK reconnect", async () => {

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -1,4 +1,4 @@
-import {engine} from "@mentra/engine"
+import {engine, SETTINGS, useSetting} from "@mentra/engine"
 import {useCallback, useEffect} from "react"
 import {View, ActivityIndicator} from "react-native"
 
@@ -8,9 +8,13 @@ import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useConnectionOverlayConfig} from "@/contexts/ConnectionOverlayContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
-import {getOtaErrorMessage, shouldShowChangeWifiForOtaDownloadFailure} from "@/utils/otaErrorMapping"
+import {
+  BES_INSTALL_RESTART_MESSAGE,
+  getOtaErrorMessage,
+  shouldRequireGlassesRebootForBesFailure,
+  shouldShowChangeWifiForOtaDownloadFailure,
+} from "@/utils/otaErrorMapping"
 import {useNavigationStore} from "@/stores/navigation"
-import {SETTINGS, useSetting} from "@mentra/engine"
 
 /**
  * Pure renderer over the island OTA install state machine
@@ -38,8 +42,7 @@ export default function OtaProgressScreen() {
 
   focusEffectPreventBack()
 
-  const isFirmwareCompleting =
-    (!connected && displayState === "restarting") || versionChangePhase === "restarting"
+  const isFirmwareCompleting = (!connected && displayState === "restarting") || versionChangePhase === "restarting"
 
   const {setConfig, clearConfig} = useConnectionOverlayConfig()
   useEffect(() => {
@@ -105,7 +108,11 @@ export default function OtaProgressScreen() {
           <View className="h-4" />
           <ActivityIndicator size="large" color={theme.colors.foreground} />
           <View className="h-4" />
-          <Text tx="ota:versionChangeKeepNearby" className="text-sm text-center" style={{color: theme.colors.textDim}} />
+          <Text
+            tx="ota:versionChangeKeepNearby"
+            className="text-sm text-center"
+            style={{color: theme.colors.textDim}}
+          />
           <View className="h-2" />
           <Text tx="ota:downgradeDuration" className="text-sm text-center" style={{color: theme.colors.textDim}} />
         </View>
@@ -136,10 +143,10 @@ export default function OtaProgressScreen() {
       const isApkOnlyInstalling = otaStatus?.stepType === "apk" && otaStatus?.phase === "install" && totalSteps === 1
 
       const rawPercent = isDownload
-        ? (otaStatus?.stepPercent ?? 0)
+        ? otaStatus?.stepPercent ?? 0
         : totalSteps >= 2
-          ? (otaStatus?.overallPercent ?? 0)
-          : (otaStatus?.stepPercent ?? 0)
+        ? otaStatus?.overallPercent ?? 0
+        : otaStatus?.stepPercent ?? 0
       // Legacy (< 37) MTK install stall simulation (WP 8C-e): the coordinator projects a
       // display-only percent while the MTK system install goes quiet; render whichever is
       // further along. Null for unified sessions and outside legacy MTK installs.
@@ -256,7 +263,10 @@ export default function OtaProgressScreen() {
     }
 
     if (displayState === "failed") {
-      const displayedError = errorMsg || getOtaErrorMessage(otaStatus?.error)
+      const requiresGlassesReboot = shouldRequireGlassesRebootForBesFailure(otaStatus, otaProgress, errorMsg)
+      const displayedError = requiresGlassesReboot
+        ? BES_INSTALL_RESTART_MESSAGE
+        : errorMsg || getOtaErrorMessage(otaStatus?.error)
       const showChangeWifi = shouldShowChangeWifiForOtaDownloadFailure(otaStatus, otaProgress, errorMsg)
       return (
         <>
@@ -268,7 +278,11 @@ export default function OtaProgressScreen() {
             <Text text={displayedError} className="text-sm text-center text-secondary-foreground" />
           </View>
           <View className="gap-3">
+            {requiresGlassesReboot ? (
+              <Button preset="primary" text="Done" flexContainer onPress={handleDone} />
+            ) : (
             <Button preset="primary" text="Retry" flexContainer onPress={handleRetry} />
+            )}
             {showChangeWifi ? (
               <Button preset="secondary" text="Change WiFi" flexContainer onPress={handleChangeWifi} />
             ) : null}

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -1,8 +1,11 @@
 import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk-internal"
 
-import {OtaProgressMessages} from "@mentra/engine"
-
-import {getOtaErrorMessage, shouldShowChangeWifiForOtaDownloadFailure} from "@/utils/otaErrorMapping"
+import {
+  BES_INSTALL_RESTART_MESSAGE,
+  getOtaErrorMessage,
+  shouldRequireGlassesRebootForBesFailure,
+  shouldShowChangeWifiForOtaDownloadFailure,
+} from "@/utils/otaErrorMapping"
 
 function baseOtaStatus(overrides: Partial<OtaStatus> = {}): OtaStatus {
   return {
@@ -71,6 +74,12 @@ describe("getOtaErrorMessage", () => {
     expect(getOtaErrorMessage("install_failed")).toBe("Install failed — please try again")
   })
 
+  it("keeps the BES restart instruction as phone-side UI copy", () => {
+    expect(BES_INSTALL_RESTART_MESSAGE).toBe(
+      "Restart your glasses to safely exit firmware update mode before trying again",
+    )
+  })
+
   it("returns generic message for undefined error", () => {
     expect(getOtaErrorMessage(undefined)).toBe("Update failed")
   })
@@ -81,6 +90,55 @@ describe("getOtaErrorMessage", () => {
 
   it("returns generic message for empty string", () => {
     expect(getOtaErrorMessage("")).toBe("Update failed")
+  })
+})
+
+describe("shouldRequireGlassesRebootForBesFailure", () => {
+  it("infers restart-required from an existing generic BES install failure", () => {
+    expect(
+      shouldRequireGlassesRebootForBesFailure(
+        baseOtaStatus({stepType: "bes", phase: "install", status: "failed", error: "install_failed"}),
+        null,
+        "",
+      ),
+    ).toBe(true)
+  })
+
+  it("infers reboot-required when the phone watchdog fires during BES install", () => {
+    expect(
+      shouldRequireGlassesRebootForBesFailure(
+        baseOtaStatus({stepType: "bes", phase: "install", status: "in_progress"}),
+        null,
+        "Update appears stalled",
+      ),
+    ).toBe(true)
+  })
+
+  it("does not require reboot for download or non-BES failures", () => {
+    expect(
+      shouldRequireGlassesRebootForBesFailure(
+        baseOtaStatus({stepType: "bes", phase: "download", error: "download_failed"}),
+        null,
+        "",
+      ),
+    ).toBe(false)
+    expect(
+      shouldRequireGlassesRebootForBesFailure(
+        baseOtaStatus({stepType: "apk", phase: "install", error: "install_failed"}),
+        null,
+        "",
+      ),
+    ).toBe(false)
+  })
+
+  it("does not require restart while BES install remains healthy", () => {
+    expect(
+      shouldRequireGlassesRebootForBesFailure(
+        baseOtaStatus({stepType: "bes", phase: "install", status: "in_progress"}),
+        null,
+        "",
+      ),
+    ).toBe(false)
   })
 })
 
@@ -121,14 +179,14 @@ describe("shouldShowChangeWifiForOtaDownloadFailure", () => {
       shouldShowChangeWifiForOtaDownloadFailure(
         baseOtaStatus({status: "in_progress", phase: "download"}),
         null,
-        OtaProgressMessages.globalTimeout,
+        "Update timed out",
       ),
     ).toBe(true)
     expect(
       shouldShowChangeWifiForOtaDownloadFailure(
         baseOtaStatus({status: "in_progress", phase: "download"}),
         null,
-        OtaProgressMessages.stalledOrStuck,
+        "Update appears stalled",
       ),
     ).toBe(true)
   })
@@ -138,14 +196,14 @@ describe("shouldShowChangeWifiForOtaDownloadFailure", () => {
       shouldShowChangeWifiForOtaDownloadFailure(
         baseOtaStatus({status: "in_progress", phase: "install"}),
         null,
-        OtaProgressMessages.globalTimeout,
+        "Update timed out",
       ),
     ).toBe(false)
   })
 
   it("is false for BLE / ack errors with no download phase in store", () => {
-    expect(shouldShowChangeWifiForOtaDownloadFailure(null, null, OtaProgressMessages.noAckResponse)).toBe(false)
-    expect(shouldShowChangeWifiForOtaDownloadFailure(null, null, OtaProgressMessages.sendOtaStartFailed)).toBe(false)
+    expect(shouldShowChangeWifiForOtaDownloadFailure(null, null, "No acknowledgement")).toBe(false)
+    expect(shouldShowChangeWifiForOtaDownloadFailure(null, null, "Could not start update")).toBe(false)
   })
 
   it("is false when nothing indicates a download-step failure", () => {

--- a/mobile/src/utils/otaErrorMapping.ts
+++ b/mobile/src/utils/otaErrorMapping.ts
@@ -1,5 +1,8 @@
 import type {OtaProgress, OtaStatus} from "@mentra/engine"
 
+export const BES_INSTALL_RESTART_MESSAGE =
+  "Restart your glasses to safely exit firmware update mode before trying again"
+
 function isDownloadPhaseSnapshot(
   otaStatus: OtaStatus | null | undefined,
   otaProgress: OtaProgress | null | undefined,
@@ -58,4 +61,20 @@ export function getOtaErrorMessage(error?: string): string {
     default:
       return error || "Update failed"
   }
+}
+
+/**
+ * Once a BES install has started, any failure conservatively requires a glasses restart. This
+ * avoids adding a BES-specific error code to the wire protocol and, more importantly, never offers
+ * an unsafe retry when a generic failure or silence may mean BES entered its raw OTA parser.
+ */
+export function shouldRequireGlassesRebootForBesFailure(
+  otaStatus: OtaStatus | null | undefined,
+  _otaProgress: OtaProgress | null | undefined,
+  localErrorMessage: string,
+): boolean {
+  if (otaStatus?.stepType !== "bes" || otaStatus.phase !== "install") {
+    return false
+  }
+  return otaStatus.status === "failed" || Boolean(localErrorMessage)
 }


### PR DESCRIPTION
## Summary

- replace overlapping process-local BES OTA handoff state with one durable, owner-checked state record
- commit authorization before the only possible `mh_ota`, never resend it in the same Linux boot, and reconcile a missing `hm_ota` with bounded read-only raw probes
- commit apply-pending before `0x92`, keep `0x93` nonterminal, and report success only after a fresh post-boot `sr_syvr` exactly matches the target
- pin legacy v1 frames to the proven 240-byte envelope and compact terminal `ota_status`
- make direct BES 100/success nonterminal in the Android Bluetooth SDK and require a glasses restart after an ambiguous BES install failure
- validate release-packaged BES containers, identities, hashes, product, and embedded version before authorization

This supersedes #3668. Review of that PR exposed overlapping state ownership and stale callback hazards; this branch rebuilds the flow from the durable-state specification instead of stacking more handoff patches.

## Safety invariants

- at most one `mh_ota` attempt per Linux boot
- no ordinary UART traffic while durable state says the parser may be raw
- no apply before its durable record commits
- no terminal success from progress, local write success, or `0x93`
- no new top-level OTA session can supersede active BES hardware
- persistence errors, corrupt state, raw replies after restart, and total probe silence all fail closed

## Mandatory rollout gates

This is the internal Release-A implementation, not permission to enable BES firmware eligibility in production.

- Existing BES manifest entries do not contain the strict admission metadata and are intentionally rejected. Release A manifests must offer the ASG APK only until Release B publishes a validated BES artifact.
- The raw-first recovery sequence is source-audited, but prior USB/UART observations are treated as provisional. Internal staging must physically prove that three raw `0x99` probes followed by one framed `cs_syvr` cannot mutate supported BES firmware, and must prove the power-cycle/exact-version path before production promotion.
- Keep SWD/JTAG recovery available for all initial BES-enabled canaries.

## Validation

- `./scripts/check-android-compile.sh asg`
- `./gradlew :app:testDebugUnitTest`
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.sgcs.BesOtaProgressMapperTest`
- `bun run test --runInBand src/utils/__tests__/otaErrorMapping.test.ts src/app/ota/__tests__/progress.test.tsx`
- `git diff --check`

The ASG workflow currently has `spotlessCheck` disabled. A normal-clone Spotless audit was still run: all scoped Java files were corrected except `OtaHelper`, where the repository's `origin/dev` ratchet would format hundreds of unrelated lines because this PR targets the older `staging` ancestor. That file is intentionally kept to its functional diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes BES coprocessor firmware OTA, UART routing, and cross-reboot persistence—incorrect state transitions or probe logic could brick or strand devices until recovery.
> 
> **Overview**
> **Replaces ad-hoc BES install handoffs with a single durable state record** (boot ID, owning OTA session, artifact identity) that gates new phone sessions, projects authoritative `ota_status`, and drives UART safety policy until terminal success or failure.
> 
> **Admission and transfer:** BES installs now require **manifest-validated** `bes-lzma-chunks-v1` artifacts (LZMA decode via `xz`, size/product/version checks) and a top-level session owner. **`mh_ota` is reserved in storage before the first byte**, never resent in the same Linux boot; ambiguous writes wait for `hm_ota` or bounded raw **0x99** probes. **Apply-pending commits before `0x92`**; apply ack is non-terminal with a reboot wait; **success/failure is decided only after post-reboot `sr_syvr` matches the target version**.
> 
> **Transport and phone UX:** UART coordinator adds **quarantine / recovery / version-probe** modes tied to durable state; OTA forces **460800 rendezvous** when needed. Legacy v1 string chunks stay at the **fixed 240-byte** ceiling (no `notify_cap` scaling). Terminal BLE `ota_status` is **compacted** for reliable delivery. **Direct adb/debug BES installs are disabled** so only the validated phone flow runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2cc6c51ecac2d0db24a06f17027d685ec0d6480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->