### PR TITLE
Fix Mentra Live reconnect queue after BES reboot

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -807,6 +807,7 @@ class MentraLive : SGCManager() {
         if (isEqual) {
             if (state == ConnTypes.DISCONNECTED) {
                 resetWireNegotiationState()
+                resetPendingAckState()
                 // Queued writes are session-bound: transmitting them into the NEXT session
                 // (e.g. a stale handshake whose reply activates v2 before the new session
                 // negotiated) is the bug class this clear removes. Higher layers re-send
@@ -854,6 +855,7 @@ class MentraLive : SGCManager() {
             DeviceStore.apply("glasses", "signalStrength", -1)
             DeviceStore.apply("glasses", "signalStrengthUpdatedAt", 0L)
             resetWireNegotiationState()
+            resetPendingAckState()
             sendQueue.clear() // see the disconnect reset above: stale writes die with the session
 
             // Drop OTA caches when fully disconnected — avoids leaking session/step state
@@ -2565,6 +2567,19 @@ class MentraLive : SGCManager() {
         Bridge.log(
                 "LIVE: 📋 Tracking message " + messageId + " for ACK (timeout: " + timeoutMs + "ms)"
         )
+    }
+
+    /**
+     * Drops ACK retries from the BLE session that just ended. Android's send queue does not wait
+     * for this map, but its delayed timeout callbacks would otherwise retry old-session messages
+     * after the glasses reconnect. Clearing the map makes those callbacks harmless no-ops.
+     */
+    private fun resetPendingAckState() {
+        val pendingCount = pendingMessages.size
+        pendingMessages.clear()
+        if (pendingCount > 0) {
+            Bridge.log("LIVE: Cleared $pendingCount pending ACK message(s) because BLE session ended")
+        }
     }
 
     /** Check if a message has been acknowledged */

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -310,7 +310,11 @@ class MentraLive : SGCManager() {
             val queuedAtMs: Long
     )
 
-    private data class QueuedBleWrite(val data: ByteArray, val trace: BleWriteTrace?)
+    private data class QueuedBleWrite(
+            val data: ByteArray,
+            val trace: BleWriteTrace?,
+            val sessionGeneration: Long
+    )
 
     private var sendQueue = ConcurrentLinkedQueue<QueuedBleWrite>()
     private val bleWriteTraceSequence = AtomicLong(1)
@@ -612,6 +616,7 @@ class MentraLive : SGCManager() {
     // Message tracking for reliable delivery
     private val pendingMessages = ConcurrentHashMap<Long, PendingMessage>()
     private val messageIdCounter = AtomicLong(1)
+    private val bleSessionGeneration = AtomicLong(0)
 
     // Esoteric message ID generation
     private val secureRandom = SecureRandom()
@@ -637,7 +642,8 @@ class MentraLive : SGCManager() {
             val messageData: String,
             val timestamp: Long,
             val retryCount: Int,
-            val retryRunnable: Runnable
+            val retryRunnable: Runnable,
+            val sessionGeneration: Long
     )
 
     private var lc3AudioFileStream: FileOutputStream? = null
@@ -1178,6 +1184,26 @@ class MentraLive : SGCManager() {
         }
     }
 
+    /**
+     * Reject callbacks delivered by a GATT object from an earlier connection attempt. Without
+     * this identity check, a late disconnect can tear down the active connection and clear its
+     * session-bound send state.
+     */
+    private fun isCurrentGattCallback(gatt: BluetoothGatt): Boolean {
+        if (gatt === bluetoothGatt) {
+            return true
+        }
+
+        Log.w(TAG, "🔌 Ignoring callback from stale BluetoothGatt")
+        Bridge.log("LIVE: 🔌 Ignoring callback from stale BluetoothGatt session")
+        try {
+            gatt.close()
+        } catch (e: Exception) {
+            Log.w(TAG, "🔌 Failed to close stale BluetoothGatt: " + e)
+        }
+        return false
+    }
+
     /** Connect to a specific BLE device */
     private fun connectToDevice(device: BluetoothDevice?) {
         if (device == null) {
@@ -1500,6 +1526,10 @@ class MentraLive : SGCManager() {
                         status: Int,
                         newState: Int
                 ) {
+                    if (!isCurrentGattCallback(gatt)) {
+                        return
+                    }
+
                     // Cancel the connection timeout
                     if (connectionTimeoutRunnable != null) {
                         connectionTimeoutHandler.removeCallbacks(connectionTimeoutRunnable!!)
@@ -2312,8 +2342,20 @@ class MentraLive : SGCManager() {
             return
         }
 
-        // Send the next item from the queue
-        val queuedWrite = sendQueue.poll()
+        // Send the next item from this BLE session. A retry can race disconnect teardown and land
+        // after sendQueue.clear(); the generation check is the deterministic backstop.
+        var queuedWrite = sendQueue.poll()
+        val currentGeneration = bleSessionGeneration.get()
+        while (queuedWrite != null && queuedWrite.sessionGeneration != currentGeneration) {
+            Bridge.log(
+                    "LIVE: Dropping stale queued write from BLE session " +
+                            queuedWrite.sessionGeneration +
+                            " (current: " +
+                            currentGeneration +
+                            ")"
+            )
+            queuedWrite = sendQueue.poll()
+        }
         if (queuedWrite != null) {
             // Update last send time before sending
             lastSendTimeMs = currentTimeMs
@@ -2340,25 +2382,35 @@ class MentraLive : SGCManager() {
 
     /** Send data through BLE */
     private fun sendDataInternal(write: QueuedBleWrite?) {
-        if (!isConnected || bluetoothGatt == null || txCharacteristic == null || write == null) {
+        if (!isConnected || write == null) {
+            return
+        }
+        if (write.sessionGeneration != bleSessionGeneration.get()) {
+            Bridge.log("LIVE: Dropping stale BLE write before GATT transmission")
+            return
+        }
+
+        val gatt = bluetoothGatt
+        val characteristic = txCharacteristic
+        if (gatt == null || characteristic == null) {
             return
         }
 
         try {
             val writeStartedAtMs = System.currentTimeMillis()
-            txCharacteristic!!.value = write.data
+            characteristic.value = write.data
             inFlightBleWriteTrace = write.trace
             inFlightBleWriteStartedAtMs = writeStartedAtMs
-            val writeAccepted = bluetoothGatt!!.writeCharacteristic(txCharacteristic)
+            val writeAccepted = gatt.writeCharacteristic(characteristic)
             logBleWriteTrace(
                     "write_call",
                     write.trace,
                     mapOf(
                             "writeAccepted" to writeAccepted,
                             "currentMtu" to currentMtu,
-                            "writeType" to txCharacteristic!!.writeType,
+                            "writeType" to characteristic.writeType,
                             "queueSize" to sendQueue.size,
-                            "characteristicUuid" to txCharacteristic!!.uuid.toString()
+                            "characteristicUuid" to characteristic.uuid.toString()
                     )
             )
             if (!writeAccepted) {
@@ -2381,7 +2433,11 @@ class MentraLive : SGCManager() {
     }
 
     /** Queue data to be sent */
-    private fun queueData(data: ByteArray?, trace: BleWriteTrace? = null) {
+    private fun queueData(
+            data: ByteArray?,
+            trace: BleWriteTrace? = null,
+            sessionGeneration: Long = bleSessionGeneration.get()
+    ) {
         if (data != null) {
             val queuedTrace =
                     trace?.copy(
@@ -2390,7 +2446,7 @@ class MentraLive : SGCManager() {
                                             trace.queuedAtMs
                                     else System.currentTimeMillis()
                     )
-            sendQueue.add(QueuedBleWrite(data, queuedTrace))
+            sendQueue.add(QueuedBleWrite(data, queuedTrace, sessionGeneration))
             logBleChunkTrace(
                     "queued",
                     queuedTrace,
@@ -2434,6 +2490,7 @@ class MentraLive : SGCManager() {
     private fun sendJson(json: JSONObject?, wakeup: Boolean) {
         if (json != null) {
             try {
+                val sessionGeneration = bleSessionGeneration.get()
                 if (buildNumberInt < 5) {
                     val jsonStr = json.toString()
                     // Bridge.log("LIVE: 📤 Sending JSON with esoteric message ID: " + jsonStr);
@@ -2449,7 +2506,7 @@ class MentraLive : SGCManager() {
                             json,
                             jsonStr.length
                     )
-                    sendDataToGlasses(jsonStr, wakeup)
+                    sendDataToGlasses(jsonStr, wakeup, sessionGeneration)
                 } else {
                     // Add esoteric message ID to the JSON
                     val messageId = generateEsotericMessageId()
@@ -2491,7 +2548,7 @@ class MentraLive : SGCManager() {
                     }
 
                     // Track the message for ACK with appropriate timeout
-                    trackMessageForAck(messageId, jsonStr, ackTimeout)
+                    trackMessageForAck(messageId, jsonStr, ackTimeout, sessionGeneration)
 
                     // Send the data
                     if ("take_photo" == json.optString("type", "")) {
@@ -2510,7 +2567,7 @@ class MentraLive : SGCManager() {
                             json,
                             jsonStr.length
                     )
-                    sendDataToGlasses(jsonStr, wakeup)
+                    sendDataToGlasses(jsonStr, wakeup, sessionGeneration)
                 }
             } catch (e: JSONException) {
                 Log.e(TAG, "Error adding message ID to JSON", e)
@@ -2530,14 +2587,14 @@ class MentraLive : SGCManager() {
         return list
     }
 
-    /** Track a message for ACK response */
-    private fun trackMessageForAck(messageId: Long, messageData: String) {
-        trackMessageForAck(messageId, messageData, ACK_TIMEOUT_MS)
-    }
-
     /** Track a message for ACK response with custom timeout */
-    private fun trackMessageForAck(messageId: Long, messageData: String, timeoutMs: Long) {
-        if (!isConnected) {
+    private fun trackMessageForAck(
+            messageId: Long,
+            messageData: String,
+            timeoutMs: Long,
+            sessionGeneration: Long
+    ) {
+        if (!isConnected || sessionGeneration != bleSessionGeneration.get()) {
             Bridge.log("LIVE: Not connected, skipping ACK tracking for message " + messageId)
             return
         }
@@ -2554,15 +2611,21 @@ class MentraLive : SGCManager() {
         }
 
         // Create retry runnable
-        val retryRunnable = Runnable { retryMessage(messageId) }
+        val retryRunnable = Runnable { retryMessage(messageId, sessionGeneration) }
 
         // Create pending message
         val pendingMessage =
-                PendingMessage(messageData, System.currentTimeMillis(), 0, retryRunnable)
+                PendingMessage(
+                        messageData,
+                        System.currentTimeMillis(),
+                        0,
+                        retryRunnable,
+                        sessionGeneration
+                )
         pendingMessages[messageId] = pendingMessage
 
         // Schedule ACK timeout with custom timeout
-        handler.postDelayed({ checkMessageAck(messageId) }, timeoutMs)
+        handler.postDelayed({ checkMessageAck(messageId, sessionGeneration) }, timeoutMs)
 
         Bridge.log(
                 "LIVE: 📋 Tracking message " + messageId + " for ACK (timeout: " + timeoutMs + "ms)"
@@ -2570,22 +2633,28 @@ class MentraLive : SGCManager() {
     }
 
     /**
-     * Drops ACK retries from the BLE session that just ended. Android's send queue does not wait
-     * for this map, but its delayed timeout callbacks would otherwise retry old-session messages
-     * after the glasses reconnect. Clearing the map makes those callbacks harmless no-ops.
+     * Ends the current BLE send session before clearing its ACK state. Scheduled callbacks capture
+     * the old generation, and queued retries retain it, so a retry racing this clear cannot become
+     * valid in the next session.
      */
     private fun resetPendingAckState() {
+        val nextGeneration = bleSessionGeneration.incrementAndGet()
         val pendingCount = pendingMessages.size
         pendingMessages.clear()
         if (pendingCount > 0) {
-            Bridge.log("LIVE: Cleared $pendingCount pending ACK message(s) because BLE session ended")
+            Bridge.log(
+                    "LIVE: Cleared $pendingCount pending ACK message(s); BLE session is now $nextGeneration"
+            )
         }
     }
 
     /** Check if a message has been acknowledged */
-    private fun checkMessageAck(messageId: Long) {
+    private fun checkMessageAck(messageId: Long, sessionGeneration: Long) {
         val pendingMessage = pendingMessages[messageId]
-        if (pendingMessage != null) {
+        if (pendingMessage != null &&
+                        pendingMessage.sessionGeneration == sessionGeneration &&
+                        sessionGeneration == bleSessionGeneration.get()
+        ) {
             Log.w(
                     TAG,
                     "⏰ ACK timeout for message " +
@@ -2606,7 +2675,7 @@ class MentraLive : SGCManager() {
                                 MAX_RETRY_ATTEMPTS +
                                 ")"
                 )
-                retryMessage(messageId)
+                retryMessage(messageId, sessionGeneration)
             } else {
                 // Max retries reached
                 Log.e(
@@ -2617,22 +2686,31 @@ class MentraLive : SGCManager() {
                                 MAX_RETRY_ATTEMPTS +
                                 " attempts"
                 )
-                pendingMessages.remove(messageId)
+                pendingMessages.remove(messageId, pendingMessage)
             }
+        } else if (pendingMessage != null && pendingMessage.sessionGeneration == sessionGeneration) {
+            pendingMessages.remove(messageId, pendingMessage)
         }
     }
 
     /** Retry a message */
-    private fun retryMessage(messageId: Long) {
+    private fun retryMessage(messageId: Long, sessionGeneration: Long) {
         val pendingMessage = pendingMessages[messageId]
         if (pendingMessage == null) {
             Log.w(TAG, "Message " + messageId + " no longer tracked for retry")
             return
         }
+        if (pendingMessage.sessionGeneration != sessionGeneration ||
+                        sessionGeneration != bleSessionGeneration.get()
+        ) {
+            pendingMessages.remove(messageId, pendingMessage)
+            Bridge.log("LIVE: Dropping stale ACK retry for message $messageId")
+            return
+        }
 
         if (pendingMessage.retryCount >= MAX_RETRY_ATTEMPTS) {
             Log.e(TAG, "Max retries reached for message " + messageId)
-            pendingMessages.remove(messageId)
+            pendingMessages.remove(messageId, pendingMessage)
             return
         }
 
@@ -2642,11 +2720,18 @@ class MentraLive : SGCManager() {
                         pendingMessage.messageData,
                         System.currentTimeMillis(),
                         pendingMessage.retryCount + 1,
-                        pendingMessage.retryRunnable
+                        pendingMessage.retryRunnable,
+                        sessionGeneration
                 )
 
-        // Update the tracked message
-        pendingMessages[messageId] = retryMessage
+        // Replace only the entry inspected above. An ACK or disconnect may have removed it.
+        if (!pendingMessages.replace(messageId, pendingMessage, retryMessage)) {
+            return
+        }
+        if (sessionGeneration != bleSessionGeneration.get()) {
+            pendingMessages.remove(messageId, retryMessage)
+            return
+        }
 
         // Send the message again
         Bridge.log(
@@ -2656,10 +2741,10 @@ class MentraLive : SGCManager() {
                         retryMessage.retryCount +
                         ")"
         )
-        sendDataToGlasses(pendingMessage.messageData, false)
+        sendDataToGlasses(pendingMessage.messageData, false, sessionGeneration)
 
         // Schedule next ACK check
-        handler.postDelayed({ checkMessageAck(messageId) }, ACK_TIMEOUT_MS)
+        handler.postDelayed({ checkMessageAck(messageId, sessionGeneration) }, ACK_TIMEOUT_MS)
     }
 
     /** Process ACK response from glasses */
@@ -7558,8 +7643,20 @@ class MentraLive : SGCManager() {
      * @param data The string data to be sent to the glasses
      */
     fun sendDataToGlasses(data: String?, wakeup: Boolean) {
+        sendDataToGlasses(data, wakeup, bleSessionGeneration.get())
+    }
+
+    private fun sendDataToGlasses(
+            data: String?,
+            wakeup: Boolean,
+            sessionGeneration: Long
+    ) {
         if (data == null || data.isEmpty()) {
             Log.e(TAG, "Cannot send empty data to glasses")
+            return
+        }
+        if (sessionGeneration != bleSessionGeneration.get()) {
+            Bridge.log("LIVE: Dropping send request from stale BLE session $sessionGeneration")
             return
         }
 
@@ -7588,7 +7685,13 @@ class MentraLive : SGCManager() {
             }
 
             if (useBinaryWireProtocol && buildNumberInt >= 5) {
-                sendDataToGlassesBinary(wireData, wakeup, commandTraceInfo, isPhotoRequest)
+                sendDataToGlassesBinary(
+                        wireData,
+                        wakeup,
+                        commandTraceInfo,
+                        isPhotoRequest,
+                        sessionGeneration
+                )
                 return
             }
 
@@ -7667,7 +7770,7 @@ class MentraLive : SGCManager() {
                     )
 
                     // Queue the chunk for sending
-                    queueData(packedData, trace)
+                    queueData(packedData, trace, sessionGeneration)
 
                     // Add small delay between chunks to avoid overwhelming the connection
                     if (i < chunks.size - 1) {
@@ -7708,7 +7811,7 @@ class MentraLive : SGCManager() {
                 )
 
                 // Queue the data for sending
-                queueData(packedData, trace)
+                queueData(packedData, trace, sessionGeneration)
                 if (isPhotoRequest) {
                     Bridge.log(
                             "LIVE: PHOTO PIPELINE BLE handoff — packedLen=" +
@@ -7726,7 +7829,8 @@ class MentraLive : SGCManager() {
             data: String,
             wakeup: Boolean,
             commandTraceInfo: OutgoingBleCommandTraceInfo,
-            isPhotoRequest: Boolean
+            isPhotoRequest: Boolean,
+            sessionGeneration: Long
     ) {
         val payloadBytes = data.toByteArray(StandardCharsets.UTF_8)
         var messageId = 0
@@ -7778,7 +7882,7 @@ class MentraLive : SGCManager() {
                             "wireProtocol" to "v2"
                     )
             )
-            queueData(packedData, trace)
+            queueData(packedData, trace, sessionGeneration)
 
             if (i < fragments.size - 1) {
                 try {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1297,6 +1297,7 @@ class MentraLive: NSObject, SGCManager {
         // a previous pairing into the next one (would otherwise surface as wrong overall_percent
         // or stale lastBesOtaProgress on the next OTA).
         if state == ConnTypes.DISCONNECTED {
+            resetPendingAckState(reason: "BLE session ended")
             resetWireNegotiationState()
             resetAncsRelayState()
             // Queued writes are session-bound: transmitting them into the NEXT session
@@ -1940,6 +1941,18 @@ class MentraLive: NSObject, SGCManager {
 
     private var pending: PendingMessage?
     private var pendingMessageTimer: Timer?
+
+    /// ACK state belongs to the BLE session that sent the message. If the link drops while an ACK
+    /// is outstanding, keeping `pending` set permanently blocks the command queue because the
+    /// timeout timer is stopped during disconnect. Release both together before reconnecting.
+    private func resetPendingAckState(reason: String) {
+        pendingMessageTimer?.invalidate()
+        pendingMessageTimer = nil
+
+        guard let pendingMessage = pending else { return }
+        pending = nil
+        Bridge.log("LIVE: Cleared pending ACK mId \(pendingMessage.id) because \(reason)")
+    }
 
     actor CommandQueue {
         private var commands: [PendingMessage] = []
@@ -5153,8 +5166,7 @@ class MentraLive: NSObject, SGCManager {
         stopReadinessCheckLoop()
         stopConnectionTimeout()
         stopMicBeat() // Stop LC3 audio micbeat
-        pendingMessageTimer?.invalidate()
-        pendingMessageTimer = nil
+        resetPendingAckState(reason: "transport timers stopped")
         reconnectionWorkItem?.cancel()
         reconnectionWorkItem = nil
     }


### PR DESCRIPTION
## Summary

- clear the iOS pending ACK gate and its timer when a Mentra Live BLE session ends, allowing the new session to drain commands after reconnect
- clear Android pending ACK tracking on disconnect so delayed callbacks cannot retry messages from the previous BLE session
- keep platform behavior aligned while preserving the intentional architecture difference: iOS serializes ACK-required writes behind one pending message; Android does not block its send queue on the ACK map

## Root cause

The iOS command worker dequeues only while `pending == nil`. During the BES reboot, the disconnect path stopped `pendingMessageTimer` but did not clear `pending`. That canceled the only timeout which could release the gate, so the new BLE session could receive glasses traffic but every new `phone_ready` remained queued forever.

Android does not have the same queue wedge, but its `pendingMessages` map was also session-bound state that survived a reconnect. Its delayed timeout callbacks could therefore retry an old-session payload into the new session. The Android half of this change discards that state for parity without changing queue semantics.

## Device evidence

Captured from Mentra Live ADB device `0123456789ABCDEF` and the USB-connected iPhone. These raw captures remain local and are not added to the repository.

The glasses completed boot and started ASG client:

```text
logcat-post-bes-20260804-164900.txt:2220: 08-04 23:39:19.488   721   773 I ActivityManager: Start proc 1358:com.mentra.asg_client/u0a59 for broadcast {com.mentra.asg_client/com.mentra.asg_client.AsgClientBootReceiver}
```

The updated BES firmware was running and the OTA service independently confirmed it was current:

```text
logcat-post-bes-20260804-164900.txt:5247: 08-04 23:45:17.054  5471  5523 I K900BluetoothManager: 📋 Caching BES firmware version: 17.26.7.9
logcat-post-bes-20260804-164900.txt:6189: 08-04 23:45:27.354  5471  5579 I ASGClientOTA: BES firmware is up to date (current: 17.26.7.9, server: 17.26.07.09)
```

The iPhone still had an active BLE link (`RSSI -36`) and received glasses-to-phone K900/version traffic, including ASG build 39 and BES 17.26.7.9:

```text
iphone-syslog-post-bes-20260804-164900.txt:18: 2026-08-04 16:43:39.214 I  Mentra[13823:256c24c] [com.facebook.react.log:javascript] 'CORE:', 'LIVE: 📶 RSSI: -36 dBm'
iphone-syslog-post-bes-20260804-164900.txt:184: 2026-08-04 16:45:17.812 I  Mentra[13823:256c1e6] [com.mentra.bluetoothsdk:MentraBleTrace] BLE_TRACE direction=glasses_to_phone layer=sdk_ble_event source=processJsonObject(_:)(MentraBluetoothSDK/MentraLive.swift:2403) type=k900 payload={"B":"","C":"<non-json C payload>","V":true}
iphone-syslog-post-bes-20260804-164900.txt:187: 2026-08-04 16:45:18.924 I  Mentra[13823:256c1e6] [com.mentra.bluetoothsdk:MentraBleTrace] BLE_TRACE direction=glasses_to_phone layer=sdk_ble_event source=processJsonObject(_:)(MentraBluetoothSDK/MentraLive.swift:2403) type=version_info_1 payload={"device_model":"Mentra Live","app_version":"39.0","system_time_ms":1785887118090,"build_number":"39","type":"version_info_1","android_version":"11"}
iphone-syslog-post-bes-20260804-164900.txt:195: 2026-08-04 16:45:19.135 I  Mentra[13823:256c1e6] [com.mentra.bluetoothsdk:MentraBleTrace] BLE_TRACE direction=glasses_to_phone layer=sdk_ble_event source=processJsonObject(_:)(MentraBluetoothSDK/MentraLive.swift:2403) type=version_info_3 payload={"bes_fw_version":"17.26.7.9","bt_mac_address":"","mtk_fw_version":"MentraLive_20260709","type":"version_info_3"}
```

Despite that healthy inbound traffic, outbound `phone_ready` messages only accumulated: queue depth rose from 131 to 189, and no corresponding write stage appeared:

```text
iphone-syslog-post-bes-20260804-164900.txt:4: 2026-08-04 16:43:31.713 I  Mentra[13823:256c1e6] [com.mentra.bluetoothsdk:MentraBleTrace] BLE_TRACE direction=phone_to_glasses layer=sdk_ble_chunk source=logBleTrace(layer:stage:trace:extra:)(MentraBluetoothSDK/MentraLive.swift:4227) type=phone_ready payload={"chunked":false,"stage":"queued","packedBytes":87,"queuedAtMs":1785887011696.1279,"sequence":674,"level":"warning","wakeup":true,"commandType":"phone_ready","messageId":171,"payloadBytes":58,"warningReason":"queue_depth","queueSizeAfterAdd":131}
iphone-syslog-post-bes-20260804-164900.txt:282: 2026-08-04 16:45:56.712 I  Mentra[13823:256c1e6] [com.mentra.bluetoothsdk:MentraBleTrace] BLE_TRACE direction=phone_to_glasses layer=sdk_ble_chunk source=logBleTrace(layer:stage:trace:extra:)(MentraBluetoothSDK/MentraLive.swift:4227) type=phone_ready payload={"commandType":"phone_ready","messageId":229,"packedBytes":87,"chunked":false,"warningReason":"queue_depth","sequence":732,"queueSizeAfterAdd":189,"stage":"queued","wakeup":true,"queuedAtMs":1785887156690.928,"level":"warning","payloadBytes":58}
```

Finally the glasses declared the phone disconnected because it never received the queued heartbeats/readiness messages:

```text
logcat-post-bes-20260804-164900.txt:6306: 08-04 23:45:53.320  5471  5471 W AsgClientServiceV2: ⚠️ Heartbeat timeout - marking as disconnected
```

Note: Factory Test was opened manually only after the OTA flow was already stuck, to inspect installed versions; it was not the initiating event.

## Review follow-up

- ignore connection-state callbacks from non-current BluetoothGatt objects before they cancel timeouts or mutate active-session state
- attach a BLE-session generation to ACK entries, retry callbacks, and queued writes; stale generations are rejected before enqueue and again before GATT transmission

## Validation

- `swiftformat --lint mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift`
- `./scripts/export-bluetooth-sdk-ios-spm.sh --target <temporary-directory> --verify`
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `cd mobile/android && ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --no-daemon --console=plain`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Mentra Live BLE connect/disconnect, GATT callbacks, and reliable-send paths; mistakes could drop legitimate retries or block outbound traffic after reconnect.
> 
> **Overview**
> Fixes Mentra Live getting stuck after a BES reboot/reconnect by treating BLE sends and ACK tracking as **session-scoped** instead of carrying state across disconnects.
> 
> On **iOS**, disconnect and timer teardown now call **`resetPendingAckState`**, which clears the single in-flight **`pending`** ACK gate and its timer. That unblocks the command worker (it only drains when `pending == nil`), so new sessions can actually transmit queued messages like **`phone_ready`** instead of piling up forever.
> 
> On **Android**, disconnect bumps a **`bleSessionGeneration`** and clears **`pendingMessages`**, and queued writes, ACK timeouts/retries, and **`sendDataToGlasses`** paths drop anything tagged with an older generation. A new **`isCurrentGattCallback`** guard ignores late GATT events from superseded connection attempts so they cannot tear down the active link or clear the wrong session’s queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de675b9c016dbfa105e9a814555e8e331ab2209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

