### PR TITLE
Harden BES OTA bootstrap compatibility

### DIFF
--- a/.github/scripts/validate-asg-ota-manifest.sh
+++ b/.github/scripts/validate-asg-ota-manifest.sh
@@ -12,6 +12,7 @@ fi
 
 jq -e '
   .apps["com.mentra.asg_client"] as $app
+  | .bes_firmware as $bes
   | ($app | type == "object")
     and ($app.versionCode | type == "number" and . > 0)
     and ($app.versionName | type == "string" and length > 0)
@@ -19,7 +20,18 @@ jq -e '
     and ($app.apkSize | type == "number" and . > 0)
     and ($app.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
     and (.mtk_patches | type == "array" and length > 0)
-    and (.bes_firmware | type == "object")
+    and ($bes | type == "object")
+    and ($bes.version | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$"))
+    and ($bes.url | type == "string" and test("^https://[^?#[:space:]]+$"))
+    and ($bes.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
+    and ($bes.format == "bes-lzma-chunks-v1")
+    and ($bes.product == "best1502x_ibrt_bpone")
+    and ($bes.artifact_id | type == "string" and test("^[A-Za-z0-9._-]{1,128}$"))
+    and ($bes.url | endswith("/" + $bes.artifact_id))
+    and ($bes.compressed_size | type == "number" and . > 0)
+    and ($bes.decompressed_size | type == "number" and . > 0 and . < 1966080)
+    and ($bes.decompressed_sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
+    and ($bes.version_offset | type == "number" and . >= 0)
 ' "$manifest_path" >/dev/null
 
 if [[ "$check_apk" == "--check-apk" ]]; then

--- a/.github/scripts/validate-asg-ota-manifest.sh
+++ b/.github/scripts/validate-asg-ota-manifest.sh
@@ -11,6 +11,15 @@ if [[ "$check_apk" != "" && "$check_apk" != "--check-apk" ]]; then
 fi
 
 jq -e '
+  def canonical_bes_version:
+    if type != "string" then false
+    else split(".") as $parts
+      | ($parts | length == 4)
+        and all($parts[];
+          test("^(0|[1-9][0-9]{0,2})$")
+          and (tonumber <= 255))
+    end;
+
   .apps["com.mentra.asg_client"] as $app
   | .bes_firmware as $bes
   | ($app | type == "object")
@@ -21,17 +30,11 @@ jq -e '
     and ($app.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
     and (.mtk_patches | type == "array" and length > 0)
     and ($bes | type == "object")
-    and ($bes.version | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$"))
-    and ($bes.url | type == "string" and test("^https://[^?#[:space:]]+$"))
+    and ($bes.version | canonical_bes_version)
+    and ($bes.url
+      | type == "string"
+        and test("^https://[^/?#[:space:]]+(?:/[^/?#[:space:]]*)*/[A-Za-z0-9._-]{1,128}$"))
     and ($bes.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
-    and ($bes.format == "bes-lzma-chunks-v1")
-    and ($bes.product == "best1502x_ibrt_bpone")
-    and ($bes.artifact_id | type == "string" and test("^[A-Za-z0-9._-]{1,128}$"))
-    and ($bes.url | endswith("/" + $bes.artifact_id))
-    and ($bes.compressed_size | type == "number" and . > 0)
-    and ($bes.decompressed_size | type == "number" and . > 0 and . < 1966080)
-    and ($bes.decompressed_sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
-    and ($bes.version_offset | type == "number" and . >= 0)
 ' "$manifest_path" >/dev/null
 
 if [[ "$check_apk" == "--check-apk" ]]; then

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -158,10 +158,7 @@ public class AsgConstants {
      */
     public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
 
-    /** Exact BES release artifact container accepted by the ASG OTA validator. */
-    public static final String BES_OTA_ARTIFACT_FORMAT = "bes-lzma-chunks-v1";
-
-    /** Mentra Live BES build target required in release metadata and the image payload. */
+    /** Mentra Live BES build target required in the decompressed image payload. */
     public static final String BES_OTA_PRODUCT = "best1502x_ibrt_bpone";
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -497,10 +497,12 @@ public final class BesUartTransportCoordinator {
             int requestedBaud = baudTransitionTarget;
             if (status != 0 || requestedBaud == 0 || acknowledgedBaud != requestedBaud) {
                 fastBaudSuppressed = true;
-                state =
-                        host.currentBaud() == AsgConstants.UART_FAST_BAUD
-                                ? State.READY_FAST
-                                : State.READY_RENDEZVOUS;
+                if (host.currentBaud() == AsgConstants.UART_FAST_BAUD) {
+                    state = State.READY_FAST;
+                    scheduleHealthCheckLocked();
+                } else {
+                    state = State.READY_RENDEZVOUS;
+                }
                 baudTransitionTarget = 0;
                 monitor.notifyAll();
                 Log.w(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -169,7 +169,7 @@ public final class BesUartTransportCoordinator {
     private int recoveryRetryAttempt = 0;
     private String firmwareVersion = "";
     // Target owned by the one in-flight cs_baud transaction. Fast-baud promotion and the
-    // mandatory pre-OTA return to rendezvous use the same acknowledged transition machinery.
+    // mandatory pre-OTA return to rendezvous use the same request-and-prove machinery.
     private int baudTransitionTarget;
     private long discardedBytes = 0;
     private int discardEvents = 0;
@@ -1138,6 +1138,10 @@ public final class BesUartTransportCoordinator {
                             () -> reopenBaudAndVerifyIfCurrent(phase, "sr_baud_timeout"),
                             AsgConstants.UART_BAUD_ACK_TIMEOUT_MS,
                             TimeUnit.MILLISECONDS);
+            // sr_baud lets us reopen sooner, but it is not the safety proof: BES may switch before
+            // its old-baud acknowledgement reaches ASG. A fresh sr_syvr requested and received
+            // after reopening at targetBaud proves both the switch and the return UART path. If
+            // that proof fails, recovery scans both known baud rates and OTA remains blocked.
             Log.i(TAG, "Requested UART baud " + baudTransitionTarget);
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -1,11 +1,7 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
 import android.util.Log;
-
 import com.mentra.asg_client.AsgConstants;
-
-import org.json.JSONObject;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.concurrent.CancellationException;
@@ -16,6 +12,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.json.JSONObject;
 
 /**
  * Single policy owner for the ASG-to-BES UART.
@@ -171,6 +168,9 @@ public final class BesUartTransportCoordinator {
     private int recoveryIndex = 0;
     private int recoveryRetryAttempt = 0;
     private String firmwareVersion = "";
+    // Target owned by the one in-flight cs_baud transaction. Fast-baud promotion and the
+    // mandatory pre-OTA return to rendezvous use the same acknowledged transition machinery.
+    private int baudTransitionTarget;
     private long discardedBytes = 0;
     private int discardEvents = 0;
     private boolean versionProbeDeferred = false;
@@ -305,6 +305,7 @@ public final class BesUartTransportCoordinator {
             state = State.DISCOVERING;
             versionSession = null;
             fastSwitchAttemptSession = null;
+            baudTransitionTarget = 0;
             firmwareVersion = "";
             discardedBytes = 0;
             discardEvents = 0;
@@ -356,6 +357,7 @@ public final class BesUartTransportCoordinator {
             serialSession = null;
             versionSession = null;
             fastSwitchAttemptSession = null;
+            baudTransitionTarget = 0;
             firmwareVersion = "";
             versionProbeDeferred = false;
             cancelOutboundDrainLocked();
@@ -460,6 +462,7 @@ public final class BesUartTransportCoordinator {
             recoveryRetryAttempt = 0;
 
             int baud = host.currentBaud();
+            baudTransitionTarget = 0;
             if (baud == AsgConstants.UART_FAST_BAUD) {
                 state = State.READY_FAST;
                 scheduleHealthCheckLocked();
@@ -491,15 +494,23 @@ public final class BesUartTransportCoordinator {
                 return false;
             }
             cancelPhaseTimeoutLocked();
-            if (status != 0 || acknowledgedBaud != AsgConstants.UART_FAST_BAUD) {
+            int requestedBaud = baudTransitionTarget;
+            if (status != 0 || requestedBaud == 0 || acknowledgedBaud != requestedBaud) {
                 fastBaudSuppressed = true;
-                state = State.READY_RENDEZVOUS;
+                state =
+                        host.currentBaud() == AsgConstants.UART_FAST_BAUD
+                                ? State.READY_FAST
+                                : State.READY_RENDEZVOUS;
+                baudTransitionTarget = 0;
+                monitor.notifyAll();
                 Log.w(
                         TAG,
-                        "Fast-baud request rejected status="
+                        "Baud request rejected status="
                                 + status
-                                + " baud="
-                                + acknowledgedBaud);
+                                + " acknowledged="
+                                + acknowledgedBaud
+                                + " requested="
+                                + requestedBaud);
                 return true;
             }
 
@@ -508,10 +519,12 @@ public final class BesUartTransportCoordinator {
             long phase = ++phaseGeneration;
             phaseTimeout =
                     executor.schedule(
-                            () -> reopenFastAndVerifyIfCurrent(phase, "sr_baud"),
+                            () -> reopenBaudAndVerifyIfCurrent(phase, "sr_baud"),
                             AsgConstants.UART_BAUD_REOPEN_DELAY_MS,
                             TimeUnit.MILLISECONDS);
-            Log.i(TAG, "Fast-baud request accepted; waiting to reopen ASG UART");
+            Log.i(
+                    TAG,
+                    "Baud request accepted for " + requestedBaud + "; waiting to reopen ASG UART");
             return true;
         }
     }
@@ -707,26 +720,26 @@ public final class BesUartTransportCoordinator {
                     && host.currentBaud() == AsgConstants.UART_RENDEZVOUS_BAUD) {
                 return true;
             }
-            if (state == State.READY_FAST
-                    || state == State.SWITCH_REQUESTED
-                    || state == State.WAITING_FAST_REOPEN
-                    || state == State.VERIFYING_FAST
-                    || state == State.RECOVERING) {
-                cancelAllTimersLocked();
-                host.invalidateLinkProof();
-                serialSession = null;
-                versionSession = null;
-                state = State.DISCOVERING;
-                long phase = ++phaseGeneration;
-                ioLane.submit(() -> reconnectAfterOta(phase));
-            }
 
             long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
-            while (state != State.READY_RENDEZVOUS) {
+            boolean rendezvousSwitchAttempted = false;
+            while (true) {
                 if (state == State.CLOSED
                         || state == State.QUARANTINED
                         || safetyState.currentPolicy() != SafetyPolicy.NORMAL) {
                     return false;
+                }
+                if (state == State.READY_RENDEZVOUS) {
+                    return versionSession == serialSession
+                            && host.currentBaud() == AsgConstants.UART_RENDEZVOUS_BAUD;
+                }
+                if (state == State.READY_FAST) {
+                    if (rendezvousSwitchAttempted) {
+                        Log.e(TAG, "BES rejected or failed the pre-OTA rendezvous transition");
+                        return false;
+                    }
+                    rendezvousSwitchAttempted = true;
+                    beginBaudSwitchLocked(AsgConstants.UART_RENDEZVOUS_BAUD);
                 }
                 long remainingNanos = deadlineNanos - System.nanoTime();
                 if (remainingNanos <= 0) {
@@ -740,8 +753,6 @@ public final class BesUartTransportCoordinator {
                     return false;
                 }
             }
-            return versionSession == serialSession
-                    && host.currentBaud() == AsgConstants.UART_RENDEZVOUS_BAUD;
         }
     }
 
@@ -1092,13 +1103,18 @@ public final class BesUartTransportCoordinator {
     }
 
     private void beginFastSwitchLocked() {
+        beginBaudSwitchLocked(AsgConstants.UART_FAST_BAUD);
+    }
+
+    private void beginBaudSwitchLocked(int targetBaud) {
         fastSwitchAttemptSession = serialSession;
+        baudTransitionTarget = targetBaud;
         state = State.SWITCH_REQUESTED;
         host.invalidateLinkProof();
         long phase = ++phaseGeneration;
         ioLane.submit(
                 () -> {
-                    boolean sent = host.writeControlCommand(buildBaudRequest());
+                    boolean sent = host.writeControlCommand(buildBaudRequest(targetBaud));
                     onBaudRequestWriteComplete(phase, sent);
                 });
     }
@@ -1117,14 +1133,14 @@ public final class BesUartTransportCoordinator {
             }
             phaseTimeout =
                     executor.schedule(
-                            () -> reopenFastAndVerifyIfCurrent(phase, "sr_baud_timeout"),
+                            () -> reopenBaudAndVerifyIfCurrent(phase, "sr_baud_timeout"),
                             AsgConstants.UART_BAUD_ACK_TIMEOUT_MS,
                             TimeUnit.MILLISECONDS);
-            Log.i(TAG, "Requested fast UART baud " + AsgConstants.UART_FAST_BAUD);
+            Log.i(TAG, "Requested UART baud " + baudTransitionTarget);
         }
     }
 
-    private void reopenFastAndVerifyIfCurrent(long phase, String reason) {
+    private void reopenBaudAndVerifyIfCurrent(long phase, String reason) {
         synchronized (monitor) {
             if (phase != phaseGeneration
                     || (state != State.SWITCH_REQUESTED && state != State.WAITING_FAST_REOPEN)) {
@@ -1139,39 +1155,47 @@ public final class BesUartTransportCoordinator {
             host.invalidateLinkProof();
             state = State.VERIFYING_FAST;
             long reopenPhase = ++phaseGeneration;
-            ioLane.submit(() -> performFastReopen(reopenPhase, reason));
+            ioLane.submit(() -> performBaudReopen(reopenPhase, reason));
         }
     }
 
-    private void performFastReopen(long reopenPhase, String reason) {
+    private void performBaudReopen(long reopenPhase, String reason) {
+        int targetBaud;
         synchronized (monitor) {
             if (reopenPhase != phaseGeneration || state != State.VERIFYING_FAST) {
                 return;
             }
+            targetBaud = baudTransitionTarget;
         }
 
-        SerialSession opened = replacePhysicalSession(AsgConstants.UART_FAST_BAUD);
+        SerialSession opened = replacePhysicalSession(targetBaud);
         boolean closeOpened = false;
         synchronized (monitor) {
             if (reopenPhase != phaseGeneration || state != State.VERIFYING_FAST) {
                 closeOpened = opened != null;
             } else if (!adoptAndStartSessionLocked(opened)) {
                 closeOpened = opened != null;
-                startRecoveryLocked("fast_reopen_failed");
+                startRecoveryLocked("baud_reopen_failed");
             } else {
                 long verifyPhase = ++phaseGeneration;
                 scheduleProbeBurstLocked(
                         verifyPhase,
-                        AsgConstants.UART_FAST_BAUD,
+                        targetBaud,
                         0,
                         AsgConstants.UART_RECOVERY_PROBES_PER_BURST,
                         AsgConstants.UART_RECOVERY_PROBE_SPACING_MS);
                 phaseTimeout =
                         executor.schedule(
-                                () -> startRecoveryIfCurrent(verifyPhase, "fast_probe_timeout"),
+                                () -> startRecoveryIfCurrent(verifyPhase, "baud_probe_timeout"),
                                 AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS,
                                 TimeUnit.MILLISECONDS);
-                Log.i(TAG, "Reopened fast UART; verifying link (reason=" + reason + ")");
+                Log.i(
+                        TAG,
+                        "Reopened UART at "
+                                + targetBaud
+                                + "; verifying link (reason="
+                                + reason
+                                + ")");
             }
         }
         if (closeOpened) {
@@ -1470,10 +1494,10 @@ public final class BesUartTransportCoordinator {
         }
     }
 
-    private static byte[] buildBaudRequest() {
+    private static byte[] buildBaudRequest(int targetBaud) {
         try {
             JSONObject body = new JSONObject();
-            body.put("baud", AsgConstants.UART_FAST_BAUD);
+            body.put("baud", targetBaud);
             JSONObject command = new JSONObject();
             command.put("C", "cs_baud");
             command.put("V", 1);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.ota.utils;
 
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.BesOtaStateStore;
+import com.mentra.asg_client.io.bes.util.BesOtaUtil;
 
 import org.json.JSONObject;
 import org.tukaani.xz.LZMAInputStream;
@@ -33,9 +34,8 @@ public final class BesFirmwareArtifactValidator {
     private BesFirmwareArtifactValidator() {}
 
     /**
-     * Validate artifact identity, compressed bytes, complete container structure, decompressed
-     * bytes, product, and target version. Every metadata field is mandatory; legacy manifests fail
-     * closed before {@code mh_ota} can be sent.
+     * Validate the existing manifest contract plus every safety property that can be proven from
+     * the downloaded artifact itself. Validation completes before {@code mh_ota} can be sent.
      */
     public static ValidatedBesArtifact validate(File artifact, JSONObject metadata)
             throws ValidationException {
@@ -47,64 +47,28 @@ public final class BesFirmwareArtifactValidator {
                 throw new ValidationException("BES OTA release metadata is missing");
             }
 
-            String format = requiredString(metadata, "format");
-            if (!AsgConstants.BES_OTA_ARTIFACT_FORMAT.equals(format)) {
-                throw new ValidationException("Unsupported BES OTA artifact format: " + format);
-            }
-
-            String product = requiredString(metadata, "product");
-            if (!AsgConstants.BES_OTA_PRODUCT.equals(product)) {
-                throw new ValidationException("Wrong BES OTA product: " + product);
-            }
-
-            String artifactId = requiredString(metadata, "artifact_id");
-            validateImmutableUrl(metadata, artifactId);
-
-            long compressedSize = requiredPositiveLong(metadata, "compressed_size");
-            if (compressedSize != artifact.length()) {
-                throw new ValidationException(
-                        "Compressed size mismatch: expected "
-                                + compressedSize
-                                + ", got "
-                                + artifact.length());
-            }
+            String artifactId = artifactIdFromUrl(metadata);
+            long compressedSize = artifact.length();
 
             byte[] container = readArtifact(artifact);
             String compressedSha256 = requiredSha256(metadata, "sha256");
             assertSha256(container, compressedSha256, "compressed");
 
-            long expectedRawSize = requiredPositiveLong(metadata, "decompressed_size");
-            if (expectedRawSize >= AsgConstants.BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES) {
-                throw new ValidationException(
-                        "Decompressed BES image is not OTA-safe: " + expectedRawSize + " bytes");
-            }
-
             byte[] raw = unpackAndValidateContainer(container);
-            if (raw.length != expectedRawSize) {
-                throw new ValidationException(
-                        "Decompressed size mismatch: expected "
-                                + expectedRawSize
-                                + ", got "
-                                + raw.length);
-            }
-            String decompressedSha256 = requiredSha256(metadata, "decompressed_sha256");
-            assertSha256(raw, decompressedSha256, "decompressed");
-            assertProduct(raw, product);
+            assertProduct(raw, AsgConstants.BES_OTA_PRODUCT);
             String targetVersion = requiredString(metadata, "version");
             String canonicalTarget = BesOtaStateStore.canonicalVersion(targetVersion);
             if (canonicalTarget == null || !canonicalTarget.equals(targetVersion)) {
                 throw new ValidationException(
                         "BES target version must be canonical major.minor.patch.build");
             }
-            assertVersion(raw, targetVersion, metadata.getLong("version_offset"));
             return new ValidatedBesArtifact(
                     artifact,
                     artifactId,
                     compressedSha256,
-                    decompressedSha256,
                     targetVersion,
                     compressedSize,
-                    expectedRawSize);
+                    raw.length);
         } catch (ValidationException e) {
             throw e;
         } catch (Exception e) {
@@ -113,7 +77,7 @@ public final class BesFirmwareArtifactValidator {
     }
 
     private static byte[] readArtifact(File artifact) throws IOException, ValidationException {
-        if (artifact.length() <= 0 || artifact.length() > Integer.MAX_VALUE) {
+        if (artifact.length() <= 0 || artifact.length() > BesOtaUtil.MAX_FILE_SIZE) {
             throw new ValidationException("Invalid BES OTA artifact size: " + artifact.length());
         }
         byte[] bytes = new byte[(int) artifact.length()];
@@ -227,32 +191,7 @@ public final class BesFirmwareArtifactValidator {
                 "Decompressed image does not identify the Mentra Live BES product");
     }
 
-    private static void assertVersion(byte[] raw, String version, long offsetLong)
-            throws ValidationException {
-        String[] parts = version.split("\\.", -1);
-        if (parts.length != 4 || offsetLong < 0 || offsetLong > raw.length - 4L) {
-            throw new ValidationException("Invalid BES target version metadata");
-        }
-        int offset = (int) offsetLong;
-        for (int i = 0; i < parts.length; i++) {
-            int component;
-            try {
-                component = Integer.parseInt(parts[i]);
-            } catch (NumberFormatException e) {
-                throw new ValidationException("Invalid BES target version: " + version);
-            }
-            if (component < 0 || component > 255 || (raw[offset + i] & 0xFF) != component) {
-                throw new ValidationException(
-                        "Decompressed image target version does not match " + version);
-            }
-        }
-    }
-
-    private static void validateImmutableUrl(JSONObject metadata, String artifactId)
-            throws Exception {
-        if (!artifactId.matches("[A-Za-z0-9._-]{1,128}")) {
-            throw new ValidationException("Invalid BES OTA artifact_id");
-        }
+    private static String artifactIdFromUrl(JSONObject metadata) throws Exception {
         String urlValue = metadata.optString("url", metadata.optString("firmwareUrl", "")).trim();
         URI uri = new URI(urlValue);
         if (!"https".equalsIgnoreCase(uri.getScheme())
@@ -260,10 +199,15 @@ public final class BesFirmwareArtifactValidator {
                 || uri.getRawQuery() != null
                 || uri.getRawFragment() != null
                 || uri.getPath() == null
-                || !uri.getPath().endsWith("/" + artifactId)) {
+                || uri.getPath().endsWith("/")) {
             throw new ValidationException(
-                    "BES OTA URL must be immutable HTTPS and end with artifact_id");
+                    "BES OTA URL must identify an HTTPS artifact without query or fragment");
         }
+        String artifactId = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
+        if (!artifactId.matches("[A-Za-z0-9._-]{1,128}")) {
+            throw new ValidationException("BES OTA URL has an invalid artifact name");
+        }
+        return artifactId;
     }
 
     private static String requiredString(JSONObject metadata, String key)
@@ -271,18 +215,6 @@ public final class BesFirmwareArtifactValidator {
         String value = metadata.optString(key, "").trim();
         if (value.isEmpty()) {
             throw new ValidationException("Missing BES OTA metadata: " + key);
-        }
-        return value;
-    }
-
-    private static long requiredPositiveLong(JSONObject metadata, String key)
-            throws ValidationException {
-        if (!metadata.has(key)) {
-            throw new ValidationException("Missing BES OTA metadata: " + key);
-        }
-        long value = metadata.optLong(key, -1);
-        if (value <= 0) {
-            throw new ValidationException("Invalid BES OTA metadata: " + key);
         }
         return value;
     }
@@ -347,7 +279,6 @@ public final class BesFirmwareArtifactValidator {
         private final File file;
         private final String artifactId;
         private final String compressedSha256;
-        private final String decompressedSha256;
         private final String targetVersion;
         private final long compressedSize;
         private final long decompressedSize;
@@ -356,14 +287,12 @@ public final class BesFirmwareArtifactValidator {
                 File file,
                 String artifactId,
                 String compressedSha256,
-                String decompressedSha256,
                 String targetVersion,
                 long compressedSize,
                 long decompressedSize) {
             this.file = file;
             this.artifactId = artifactId;
             this.compressedSha256 = compressedSha256;
-            this.decompressedSha256 = decompressedSha256;
             this.targetVersion = targetVersion;
             this.compressedSize = compressedSize;
             this.decompressedSize = decompressedSize;
@@ -393,10 +322,6 @@ public final class BesFirmwareArtifactValidator {
 
         public String getCompressedSha256() {
             return compressedSha256;
-        }
-
-        public String getDecompressedSha256() {
-            return decompressedSha256;
         }
 
         public String getTargetVersion() {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -3,16 +3,7 @@ package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.app.Application;
-
 import com.mentra.asg_client.AsgConstants;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Queue;
@@ -23,6 +14,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(application = Application.class, sdk = 33)
@@ -507,6 +504,64 @@ public class BesUartTransportCoordinatorTest {
             releaseWrite.countDown();
             callers.shutdownNow();
             coordinator.endOta(otaLease);
+        }
+    }
+
+    @Test
+    public void otaAuthorization_returnsFastLinkToProvenRendezvousBeforeLease() throws Exception {
+        establishFastLink();
+
+        ExecutorService caller = Executors.newSingleThreadExecutor();
+        Future<BesUartTransportCoordinator.OperationLease> leaseFuture =
+                caller.submit(coordinator::beginOtaAuthorization);
+        try {
+            awaitControlCommandCount("cs_baud", 2);
+            String downshift = host.controlCommands.get(host.controlCommands.size() - 1);
+            assertThat(downshift).contains("cs_baud").contains("460800");
+
+            SerialSession fastSession = coordinator.getSerialSession();
+            assertThat(
+                            coordinator.onBaudResponse(
+                                    0, AsgConstants.UART_RENDEZVOUS_BAUD, fastSession))
+                    .isTrue();
+            awaitSerialSessionAtBaud(AsgConstants.UART_RENDEZVOUS_BAUD);
+            assertThat(systemVersion("17.26.7.23"))
+                    .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+
+            BesUartTransportCoordinator.OperationLease lease = leaseFuture.get(2, TimeUnit.SECONDS);
+            assertThat(lease).isNotNull();
+            assertThat(coordinator.getState())
+                    .isEqualTo(BesUartTransportCoordinator.State.READY_RENDEZVOUS);
+            assertThat(host.currentBaud()).isEqualTo(AsgConstants.UART_RENDEZVOUS_BAUD);
+            coordinator.endOta(lease);
+        } finally {
+            caller.shutdownNow();
+        }
+    }
+
+    @Test
+    public void otaAuthorization_rejectedRendezvousTransitionFailsClosed() throws Exception {
+        establishFastLink();
+
+        ExecutorService caller = Executors.newSingleThreadExecutor();
+        Future<BesUartTransportCoordinator.OperationLease> leaseFuture =
+                caller.submit(coordinator::beginOtaAuthorization);
+        try {
+            awaitControlCommandCount("cs_baud", 2);
+            assertThat(
+                            coordinator.onBaudResponse(
+                                    1,
+                                    AsgConstants.UART_RENDEZVOUS_BAUD,
+                                    coordinator.getSerialSession()))
+                    .isTrue();
+
+            assertThat(leaseFuture.get(2, TimeUnit.SECONDS)).isNull();
+            assertThat(coordinator.getOperation())
+                    .isEqualTo(BesUartTransportCoordinator.Operation.NONE);
+            assertThat(coordinator.getState())
+                    .isEqualTo(BesUartTransportCoordinator.State.READY_FAST);
+        } finally {
+            caller.shutdownNow();
         }
     }
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -817,6 +817,7 @@ public class BesUartTransportCoordinatorTest {
                                 0, AsgConstants.UART_FAST_BAUD, coordinator.getSerialSession()))
                 .isTrue();
         awaitState(BesUartTransportCoordinator.State.VERIFYING_FAST);
+        awaitSerialSessionAtBaud(AsgConstants.UART_FAST_BAUD);
         assertThat(systemVersion("17.26.7.23"))
                 .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
     }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -24,8 +24,6 @@ import java.util.zip.CRC32;
 public class BesFirmwareArtifactValidatorTest {
     private static final byte[] CRC_PREFIX =
             "CRC32_OF_IMAGE=0x".getBytes(StandardCharsets.US_ASCII);
-    private static final int VERSION_OFFSET = 64;
-
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
@@ -36,59 +34,46 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
-    public void externalReleaseArtifactCanBeCheckedAgainstItsRawBuildOutput() throws Exception {
+    public void externalReleaseArtifactCanBeValidated() throws Exception {
         String artifactPath = System.getenv("BES_RELEASE_ARTIFACT");
-        String rawPath = System.getenv("BES_RELEASE_RAW");
         String version = System.getenv("BES_RELEASE_VERSION");
-        String versionOffset = System.getenv("BES_RELEASE_VERSION_OFFSET");
-        Assume.assumeTrue(
-                artifactPath != null
-                        && rawPath != null
-                        && version != null
-                        && versionOffset != null);
+        Assume.assumeTrue(artifactPath != null && version != null);
 
         File artifact = new File(artifactPath);
         byte[] container = Files.readAllBytes(artifact.toPath());
-        byte[] raw = Files.readAllBytes(new File(rawPath).toPath());
         JSONObject metadata = new JSONObject();
-        metadata.put("format", AsgConstants.BES_OTA_ARTIFACT_FORMAT);
-        metadata.put("product", AsgConstants.BES_OTA_PRODUCT);
-        metadata.put("artifact_id", artifact.getName());
         metadata.put("url", "https://releases.example.invalid/" + artifact.getName());
-        metadata.put("compressed_size", container.length);
         metadata.put("sha256", sha256(container));
-        metadata.put("decompressed_size", raw.length);
-        metadata.put("decompressed_sha256", sha256(raw));
         metadata.put("version", version);
-        metadata.put("version_offset", Long.parseLong(versionOffset));
 
         BesFirmwareArtifactValidator.validate(artifact, metadata);
     }
 
     @Test
-    public void legacyManifestWithoutAdmissionMetadataFailsClosed() throws Exception {
+    public void existingManifestShapePasses() throws Exception {
         TestArtifact artifact = createArtifact();
-        JSONObject legacy = new JSONObject();
-        legacy.put("url", artifact.metadata.getString("url"));
-        legacy.put("sha256", artifact.metadata.getString("sha256"));
+        JSONObject existing = new JSONObject();
+        existing.put("version", artifact.metadata.getString("version"));
+        existing.put("url", artifact.metadata.getString("url"));
+        existing.put("sha256", artifact.metadata.getString("sha256"));
 
-        assertThatThrownBy(() -> BesFirmwareArtifactValidator.validate(artifact.file, legacy))
-                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
-                .hasMessageContaining("format");
+        BesFirmwareArtifactValidator.validate(artifact.file, existing);
     }
 
     @Test
     public void decompressedImageAtBootloaderLimitFailsBeforeAuthorization() throws Exception {
-        TestArtifact artifact = createArtifact();
-        artifact.metadata.put(
-                "decompressed_size", AsgConstants.BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES);
+        TestArtifact artifact =
+                createArtifact(
+                        createRaw(
+                                AsgConstants.BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES,
+                                "release-a:" + AsgConstants.BES_OTA_PRODUCT));
 
         assertThatThrownBy(
                         () ->
                                 BesFirmwareArtifactValidator.validate(
                                         artifact.file, artifact.metadata))
                 .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
-                .hasMessageContaining("not OTA-safe");
+                .hasMessageContaining("bootloader limit");
     }
 
     @Test
@@ -121,7 +106,6 @@ public class BesFirmwareArtifactValidatorTest {
             (byte) 0xFF
         };
         write(artifact.file, corrupt);
-        artifact.metadata.put("compressed_size", corrupt.length);
         artifact.metadata.put("sha256", sha256(corrupt));
 
         assertThatThrownBy(
@@ -169,25 +153,15 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
-    public void wrongEmbeddedProductOrVersionFailsClosed() throws Exception {
-        TestArtifact artifact = createArtifact();
-        artifact.metadata.put("product", "different_product");
+    public void wrongEmbeddedProductFailsClosed() throws Exception {
+        TestArtifact artifact = createArtifact(createRaw("release-a:different_product"));
 
         assertThatThrownBy(
                         () ->
                                 BesFirmwareArtifactValidator.validate(
                                         artifact.file, artifact.metadata))
                 .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
-                .hasMessageContaining("Wrong BES OTA product");
-
-        artifact.metadata.put("product", AsgConstants.BES_OTA_PRODUCT);
-        artifact.metadata.put("version", "17.26.7.25");
-        assertThatThrownBy(
-                        () ->
-                                BesFirmwareArtifactValidator.validate(
-                                        artifact.file, artifact.metadata))
-                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
-                .hasMessageContaining("target version");
+                .hasMessageContaining("does not identify");
     }
 
     @Test
@@ -222,14 +196,14 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     private byte[] createRaw(String revisionValue) {
-        byte[] raw = new byte[512];
+        return createRaw(512, revisionValue);
+    }
+
+    private byte[] createRaw(int size, String revisionValue) {
+        byte[] raw = new byte[size];
         for (int i = 0; i < raw.length; i++) {
             raw[i] = (byte) (i * 31);
         }
-        raw[VERSION_OFFSET] = 17;
-        raw[VERSION_OFFSET + 1] = 26;
-        raw[VERSION_OFFSET + 2] = 7;
-        raw[VERSION_OFFSET + 3] = 24;
         byte[] revision = ("REV_INFO=" + revisionValue).getBytes(StandardCharsets.US_ASCII);
         System.arraycopy(revision, 0, raw, 192, revision.length);
         raw[192 + revision.length] = 0;
@@ -263,16 +237,9 @@ public class BesFirmwareArtifactValidatorTest {
         write(file, container);
 
         JSONObject metadata = new JSONObject();
-        metadata.put("format", AsgConstants.BES_OTA_ARTIFACT_FORMAT);
-        metadata.put("product", AsgConstants.BES_OTA_PRODUCT);
-        metadata.put("artifact_id", artifactId);
         metadata.put("url", "https://releases.example.invalid/" + artifactId);
-        metadata.put("compressed_size", container.length);
         metadata.put("sha256", sha256(container));
-        metadata.put("decompressed_size", raw.length);
-        metadata.put("decompressed_sha256", sha256(raw));
         metadata.put("version", "17.26.7.24");
-        metadata.put("version_offset", VERSION_OFFSET);
         return new TestArtifact(file, metadata);
     }
 

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -64,40 +64,55 @@ UART transport is owned by `ComManager` (the K900 UART driver). When BES OTA is 
 - **UART:** `/dev/ttyS1` at 460800 baud
 - **Pacing:** fast-mode, ~5 ms sleep between packets
 
-## Server-side `version.json`
+## Combined OTA manifest
 
-Add a `bes_firmware` block alongside the existing `apps` block:
+The phone sends one manifest URL in `ota_start`. ASG 39 and newer persist that URL before doing
+any installation. If the manifest contains a newer ASG APK, the old client installs the APK and
+stops; after restart, the new client resumes the same top-level session and only then considers BES
+firmware. Therefore every manifest admitted for an ASG bootstrap must be valid for both the old
+client that starts it and the new client that resumes it.
+
+The staging workflow builds `staging_live_version.json` from the ASG artifact plus
+`ota_manifests/firmware_live.json`. The BES block is a release-artifact identity contract, not only a
+download URL and compressed hash:
 
 ```json
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 1000,
-      "versionName": "1.0.0",
-      "apkUrl": "https://example.com/asg_client_v1.0.0.apk",
-      "sha256": "abc123...",
-      "releaseNotes": "ASG Client updates"
+      "versionCode": 123,
+      "versionName": "1.2.3",
+      "apkUrl": "https://example.com/asg_client_v1.2.3.apk",
+      "apkSize": 12345678,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     }
   },
   "bes_firmware": {
-    "versionCode": 10203,
-    "versionName": "1.2.3",
-    "firmwareUrl": "https://example.com/bes_firmware_v1.2.3.bin",
-    "sha256": "abc123def456...",
-    "fileSize": 1048576,
-    "releaseNotes": "BES firmware bug fixes and improvements"
+    "version": "26.7.30.4",
+    "url": "https://firmware.example.com/bes_firmware_26.7.30.4.bin",
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "format": "bes-lzma-chunks-v1",
+    "product": "best1502x_ibrt_bpone",
+    "artifact_id": "bes_firmware_26.7.30.4.bin",
+    "compressed_size": 1137045,
+    "decompressed_size": 1955836,
+    "decompressed_sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+    "version_offset": 1813248
   }
 }
 ```
 
-| Field          | Description                                        |
-| -------------- | -------------------------------------------------- |
-| `versionCode`  | Integer for comparison                             |
-| `versionName`  | Human-readable string                              |
-| `firmwareUrl`  | Direct `.bin` URL                                  |
-| `sha256`       | Hex SHA-256 of the `.bin`                          |
-| `fileSize`     | Bytes; must be ≤ `BesOtaUtil.MAX_FILE_SIZE` (2 MB) |
-| `releaseNotes` | Free text                                          |
+The immutable HTTPS URL must end with `artifact_id`. `sha256` and `compressed_size` describe the
+downloaded release container. `format`, `product`, `decompressed_size`, `decompressed_sha256`, and
+`version_offset` prove that its complete decompressed image is the intended Mentra Live image and
+target version. The decompressed image must be strictly smaller than the BES bootloader limit
+(`1966080` bytes). Missing or inconsistent fields fail before UART is reserved or `mh_ota` is sent.
+
+Validate a locally composed manifest with:
+
+```bash
+.github/scripts/validate-asg-ota-manifest.sh path/to/staging_live_version.json
+```
 
 ## EventBus integration
 
@@ -119,30 +134,50 @@ Stored under `/storage/emulated/0/asg/`:
 
 - `bes_firmware.bin` — currently downloaded firmware
 
-## Testing
+## Internal staging test
 
-A test script ships with the repo:
+Do not use `scripts/test-bes-ota.sh`: its direct ADB broadcast entry point is intentionally disabled
+and it bypasses the phone-owned session contract this flow needs to exercise.
 
-```bash
-./scripts/test-bes-ota.sh path/to/firmware.bin
-```
+1. Land the candidate ASG and strict `firmware_live.json` metadata on `staging` so the staging
+   workflow publishes one combined, immutable-per-run manifest and embeds its URL in that run's
+   Mentra App artifact.
+2. Install that staging Mentra App on the phone. Begin with glasses on ASG 39 and the oldest BES
+   version admitted by the rollout. ASG 39 is the bootstrap boundary that honors the manifest URL
+   carried by `ota_start`.
+3. Start the update from the Mentra App. Confirm ASG 39 persists the session and manifest URL,
+   installs the newer ASG APK first, and does not start BES in the old process.
+4. After the ASG restart, confirm the new client resumes the same session and manifest, proves the
+   old BES UART path, explicitly returns BES from negotiated fast baud to 460800, validates the BES
+   artifact, and only then sends one `mh_ota`.
+5. Follow logs with an explicit device selector:
 
-Manual procedure:
+   ```bash
+   adb -s 0123456789ABCDEF logcat \
+     -s OtaHelper BesOtaManager BesOtaUartListener K900BluetoothManager BesUartTransport
+   ```
 
-1. Upload `firmware.bin` to a server.
-2. Update `version.json` with the new metadata, including a fresh sha256.
-3. `sha256sum bes_firmware.bin` to compute the hash.
-4. Wait for the 30-minute auto-check or restart the app to trigger an immediate check.
-5. `adb logcat | grep BesOtaManager` to watch progress.
-6. Confirm BES reboots after `Apply` and the new version is reported on next `request_version`.
+6. Confirm the BES transfer reaches Apply, the glasses reconnect, and a fresh version reply reports
+   the target. Repeat from both supported deployed BES baselines and include power loss/restart at
+   every persisted boundary in the release matrix.
+
+The rolling `staging_live_version.json` is useful for discovery, but record and test the immutable
+per-run manifest URL embedded in the phone artifact. Never infer the tested manifest from the ASG
+version name after the fact.
 
 ## Troubleshooting
 
 - **Update never starts** — confirm BES OTA path is initialized (`BesOtaManager` log line at startup). Check WiFi, battery (≥ 5%), and that no APK update is currently running.
 - **Stall mid-transfer** — UART instability or BES not responding. The transfer is response-driven, so a lost response no longer stalls silently: a dead-man watchdog aborts the transfer after 30 seconds without any BES response (`AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS`), runs the normal cleanup (OTA mode exited, wake leases released), posts a failure the phone surfaces as "Update failed", and emits a `bes_ota_response_timeout` lifecycle trace with the transfer position (`sentPos`, `confirmedSegments`). The BES stays on its current firmware — the recovery is simply retrying the whole OTA from the phone. If aborts recur, look for `BesOtaUartListener` logs and check the Infinity Cable; loose connections kill UART traffic.
-- **`File too big`** — firmware exceeds 2 MB.
-- **`SHA-256 mismatch`** — the downloaded `.bin` doesn't match `version.json`. The file is deleted; verify your hash and re-upload.
-- **Stuck in OTA mode** — if `mbOtaUpdating` doesn't get cleared (rare), normal BLE traffic stays blocked. The response watchdog's cleanup clears it on any stalled transfer; if it somehow persists outside a transfer, restart the app.
+- **Artifact admission failure** — the combined manifest or downloaded release artifact does not
+  satisfy the strict identity contract. BES has not seen `mh_ota`; correct the manifest/artifact and
+  Retry is safe.
+- **Install-phase failure** — ASG may have queued `mh_ota`, so local write failure or silence is
+  ambiguous. Do not resend it in the same boot. The UI requires a glasses restart before another
+  attempt so BES and ASG return to a known framed UART state.
+- **Stuck in OTA mode** — a persisted nonterminal BES session deliberately owns/quarantines UART
+  until raw-versus-framed recovery resolves. A raw `0x9a` proves BES is still in OTA mode; only the
+  exact fresh `sr_syvr` requested by the audited framed probe can prove normal mode.
 
 ## Logcat tags
 

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -73,8 +73,8 @@ firmware. Therefore every manifest admitted for an ASG bootstrap must be valid f
 client that starts it and the new client that resumes it.
 
 The staging workflow builds `staging_live_version.json` from the ASG artifact plus
-`ota_manifests/firmware_live.json`. The BES block is a release-artifact identity contract, not only a
-download URL and compressed hash:
+`ota_manifests/firmware_live.json`. Keep the established BES block limited to its target version,
+download URL, and compressed hash:
 
 ```json
 {
@@ -87,26 +87,31 @@ download URL and compressed hash:
       "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     }
   },
+  "mtk_patches": [
+    {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://example.com/mtk_ota_update.zip",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ],
   "bes_firmware": {
     "version": "26.7.30.4",
     "url": "https://firmware.example.com/bes_firmware_26.7.30.4.bin",
-    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    "format": "bes-lzma-chunks-v1",
-    "product": "best1502x_ibrt_bpone",
-    "artifact_id": "bes_firmware_26.7.30.4.bin",
-    "compressed_size": 1137045,
-    "decompressed_size": 1955836,
-    "decompressed_sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-    "version_offset": 1813248
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   }
 }
 ```
 
-The immutable HTTPS URL must end with `artifact_id`. `sha256` and `compressed_size` describe the
-downloaded release container. `format`, `product`, `decompressed_size`, `decompressed_sha256`, and
-`version_offset` prove that its complete decompressed image is the intended Mentra Live image and
-target version. The decompressed image must be strictly smaller than the BES bootloader limit
-(`1966080` bytes). Missing or inconsistent fields fail before UART is reserved or `mh_ota` is sent.
+Before reserving UART or sending `mh_ota`, ASG checks the manifest's canonical four-byte target
+version, HTTPS artifact URL without a query or fragment, and SHA-256. It then inspects the downloaded
+bytes directly:
+the release container must have valid chunk structure and CRC, bounded LZMA decoder requirements,
+a decompressed image strictly smaller than the BES bootloader limit (`1966080` bytes), and the
+Mentra Live product marker. This keeps release authoring simple while still rejecting malformed,
+oversized, or wrong-product artifacts before BES sees them. The manifest version remains the target
+used for eligibility and the required post-reboot version readback; the image format has no stable,
+documented version offset, so ASG does not guess one.
 
 Validate a locally composed manifest with:
 
@@ -139,7 +144,7 @@ Stored under `/storage/emulated/0/asg/`:
 Do not use `scripts/test-bes-ota.sh`: its direct ADB broadcast entry point is intentionally disabled
 and it bypasses the phone-owned session contract this flow needs to exercise.
 
-1. Land the candidate ASG and strict `firmware_live.json` metadata on `staging` so the staging
+1. Land the candidate ASG and `firmware_live.json` on `staging` so the staging
    workflow publishes one combined, immutable-per-run manifest and embeds its URL in that run's
    Mentra App artifact.
 2. Install that staging Mentra App on the phone. Begin with glasses on ASG 39 and the oldest BES
@@ -169,9 +174,9 @@ version name after the fact.
 
 - **Update never starts** — confirm BES OTA path is initialized (`BesOtaManager` log line at startup). Check WiFi, battery (≥ 5%), and that no APK update is currently running.
 - **Stall mid-transfer** — UART instability or BES not responding. The transfer is response-driven, so a lost response no longer stalls silently: a dead-man watchdog aborts the transfer after 30 seconds without any BES response (`AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS`), runs the normal cleanup (OTA mode exited, wake leases released), posts a failure the phone surfaces as "Update failed", and emits a `bes_ota_response_timeout` lifecycle trace with the transfer position (`sentPos`, `confirmedSegments`). The BES stays on its current firmware — the recovery is simply retrying the whole OTA from the phone. If aborts recur, look for `BesOtaUartListener` logs and check the Infinity Cable; loose connections kill UART traffic.
-- **Artifact admission failure** — the combined manifest or downloaded release artifact does not
-  satisfy the strict identity contract. BES has not seen `mh_ota`; correct the manifest/artifact and
-  Retry is safe.
+- **Artifact admission failure** — the combined manifest is invalid, or direct inspection found a
+  corrupt, oversized, or wrong-product release artifact. BES has not seen `mh_ota`; correct the
+  manifest/artifact and Retry is safe.
 - **Install-phase failure** — ASG may have queued `mh_ota`, so local write failure or silence is
   ambiguous. Do not resend it in the same boot. The UI requires a glasses restart before another
   attempt so BES and ASG return to a known framed UART state.

--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -46,6 +46,13 @@
   "bes_firmware": {
     "version": "26.7.30.4",
     "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.30.4.bin",
-    "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c"
+    "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c",
+    "format": "bes-lzma-chunks-v1",
+    "product": "best1502x_ibrt_bpone",
+    "artifact_id": "bes_firmware_26.7.30.4.bin",
+    "compressed_size": 1137045,
+    "decompressed_size": 1955836,
+    "decompressed_sha256": "5924a0da5ab3c545b210dab26bc9552eef56a273652c32bad64bfb3912d0810a",
+    "version_offset": 1813248
   }
 }

--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -46,13 +46,6 @@
   "bes_firmware": {
     "version": "26.7.30.4",
     "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.30.4.bin",
-    "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c",
-    "format": "bes-lzma-chunks-v1",
-    "product": "best1502x_ibrt_bpone",
-    "artifact_id": "bes_firmware_26.7.30.4.bin",
-    "compressed_size": 1137045,
-    "decompressed_size": 1955836,
-    "decompressed_sha256": "5924a0da5ab3c545b210dab26bc9552eef56a273652c32bad64bfb3912d0810a",
-    "version_offset": 1813248
+    "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c"
   }
 }


### PR DESCRIPTION
## Motivation and compatibility scope

This follow-up to merged PR #3675 establishes one invariant for every BES OTA: ASG may send `mh_ota` only after it has proven bidirectional framed UART communication with BES at the universally supported 460,800-baud rendezvous rate.

This is not an ASG-39-specific fast-baud workaround. ASG 39 was published before ASG gained fast-baud negotiation, but it is still an important bootstrap boundary because it accepts the manifest URL supplied by `ota_start`, installs the ASG APK first, and lets the new ASG resume the same top-level update.

The invariant is needed for all reachable starting states:

1. **ASG 39 -> new ASG.** ASG 39 leaves BES at 460,800, but the newly installed ASG may negotiate 1,152,000 during startup before the persisted BES update resumes. If it has not negotiated fast, the precondition is already satisfied and no baud change is made.
2. **Later fast-capable ASG -> new ASG.** BES may already be operating at 1,152,000 when the APK is replaced. Restarting the Android ASG process does not reboot the independent BES MCU, so BES can retain that runtime baud across the APK handoff. The new ASG discovers the surviving link and must explicitly return it to 460,800 before OTA.
3. **Future BES updates.** Even after installing newer BES firmware, ordinary operation may negotiate the link back to 1,152,000. Therefore this cannot be gated on an old ASG or BES version; every BES OTA must check the actual current link state.

The resulting policy is deliberately simple:

```text
proven at 460800  -> proceed
proven at 1152000 -> request 460800, reopen, obtain fresh sr_syvr proof, proceed
unknown/unproven  -> fail closed without sending mh_ota
```

## Changes

- keep the established BES manifest schema unchanged (`version`, `url`, and `sha256`)
- inspect the downloaded artifact directly before UART authorization: HTTPS artifact identity, compressed SHA-256 and size bound, container structure/CRC, bounded LZMA decoding, decompressed bootloader-size limit, and Mentra Live product marker
- return a negotiated 1,152,000-baud BES link to 460,800 with `cs_baud` plus a fresh target-baud `sr_syvr` proof before acquiring the OTA authorization lease
- fail closed without sending `mh_ota` if that 460,800 link cannot be proven
- replace the stale direct-ADB BES test instructions with the phone-driven staging procedure

## Why `sr_syvr` is the proof

`sr_baud` is the acknowledgement to `cs_baud`, transmitted at the old baud before BES changes its UART configuration. It lets ASG reopen sooner when received, but it cannot be mandatory: BES may successfully transmit the acknowledgement and switch before the old-baud reply reaches ASG.

ASG therefore reopens at the requested target baud, sends a new system-version query, and requires its corresponding fresh `sr_syvr`. Receiving that response at 460,800 proves both that BES changed baud and that the return UART path works. A stale or unsolicited response is not accepted. If no proof arrives, recovery scans both known rates and `beginOtaAuthorization` cannot return a lease, so `mh_ota` remains blocked.

## Artifact admission without manifest expansion

The BES manifest remains:

```json
{
  "version": "26.7.30.4",
  "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.30.4.bin",
  "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c"
}
```

ASG derives the safety properties from the downloaded bytes rather than adding release-authored `format`, `product`, `artifact_id`, compressed/decompressed sizes and hashes, or `version_offset` fields. The manifest version remains the eligibility target and is verified against the version BES reports after reboot.

This keeps BES release authoring unchanged while still rejecting corrupt, malformed, oversized, excessive-decoder-memory, or wrong-product artifacts before BES sees `mh_ota`.

## Evidence

- ASG 39 APK was published June 26, before fast-baud ASG support landed in July; the compatibility argument above does not assume ASG 39 negotiated fast baud
- connected hardware reports ASG 39 and BES 17.26.7.9
- deployed BES 17.26.7.9 source accepts `cs_baud` at both 1,152,000 and 460,800, sends `sr_baud` before switching, and implements the existing `mh_ota` / raw OTA protocol
- fetched `bes_firmware_26.7.30.4.bin` from the firmware CDN, verified SHA-256 `9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c`, and passed it through the simplified direct artifact validator
- `firmware_live.json` remains unchanged relative to `staging`

## Checks

- `./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesUartTransportCoordinatorTest --tests com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidatorTest`
- focused real-release-artifact validator test with `BES_RELEASE_ARTIFACT` / `BES_RELEASE_VERSION`
- `./scripts/check-android-compile.sh asg`
- combined-manifest validator accepts the current schema and rejects a noncanonical BES version
- `bash -n .github/scripts/validate-asg-ota-manifest.sh`
- `git diff --check`

## Deliberate non-changes

- no phone message or OTA UI changes
- no OTA pinning or APK-before-BES ordering changes
- no BES firmware changes
- no same-boot `mh_ota` resend
- no new BES manifest fields

## Remaining release gate

Run the phone-driven staging matrix on physical hardware before enabling BES eligibility. Test both ASG 39 and a fast-baud-capable intermediate ASG as the starting APK, and observe the APK restart/resume plus the pre-BES-OTA 460,800 proof. No OTA command was sent during the source/device audit.
