### PR TITLE
Keep K900 v1 and v2 control frames within 240 bytes

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -163,9 +163,6 @@ public class AsgConstants {
      */
     public static final int BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES = 0x1E0000;
 
-    /** Safety margin retained below the BES-advertised notification payload limit. */
-    public static final int K900_CONTROL_FRAME_SAFETY_MARGIN_BYTES = 13;
-
     /** Rendezvous baud shared by every ASG and BES firmware generation. */
     public static final int UART_RENDEZVOUS_BAUD = 460800;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -145,18 +145,13 @@ public class AsgConstants {
     public static final int OTA_COMPLETION_RESEND_ATTEMPTS = 15;
 
     /**
-     * FALLBACK maximum packed frame size for a v1 K900 STRING ck chunk, used until the BES
-     * advertises its true notification cap. The BES relays v1 string frames to the phone in a
-     * single unfragmented BLE notification, and the worst-case ATT payload on that link is 253
-     * bytes (ATT MTU 256) regardless of the MTU the phone requested — a packed chunk over that cap
-     * is silently truncated on the wire and the phone drops it as unparseable (incident
-     * rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: OTA completion ck chunks packed to 256-263 bytes and none
-     * survived). 240 = 253 - {@link #K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}. BES firmware >=
-     * 17.26.7.23 advertises {@code wire_caps.notify_cap} (the measured single-notification payload
-     * cap) and the budget becomes notify_cap minus the same margin: legacy v1 string frames never
-     * grow from negotiated notify capacity.
+     * Maximum packed K900 control-message frame relayed in one BLE notification. This applies to
+     * both v1 JSON chunks and v2 binary fragments: phone-side v2 reassembly cannot recover a frame
+     * that BES could not deliver atomically. The 240-byte ceiling is the hardware-proven envelope
+     * from incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E and remains a local upper bound even when old
+     * firmware advertises a larger, bearer-specific {@code wire_caps.notify_cap}.
      */
-    public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
+    public static final int K900_CONTROL_MAX_PACKED_FRAME_BYTES = 240;
 
     /** Mentra Live BES build target required in the decompressed image payload. */
     public static final String BES_OTA_PRODUCT = "best1502x_ibrt_bpone";
@@ -168,29 +163,8 @@ public class AsgConstants {
      */
     public static final int BES_OTA_MAX_DECOMPRESSED_IMAGE_BYTES = 0x1E0000;
 
-    /**
-     * Safety margin subtracted from the BLE notification payload cap when sizing packed v1 STRING
-     * ck chunks, absorbing BES re-framing variance between the UART frame we send and the
-     * notification the BES actually emits (240 = 253 - 13 was the hardware-validated budget for the
-     * worst-case 253-byte cap).
-     */
-    public static final int K900_STRING_CHUNK_BUDGET_MARGIN_BYTES = 13;
-
-    /**
-     * Contract floor of {@code wire_caps.notify_cap} (BES firmware >= 17.26.7.23 computes max(253,
-     * min(ATT MTU - 3, 509))). An advertised value below this is malformed and is ignored in favor
-     * of the fallback budget.
-     */
-    public static final int K900_BLE_NOTIFY_CAP_FLOOR_BYTES = 253;
-
-    /**
-     * Contract ceiling of {@code wire_caps.notify_cap} (see {@link
-     * #K900_BLE_NOTIFY_CAP_FLOOR_BYTES}: the BES computes max(253, min(ATT MTU - 3, 509))). An
-     * advertised value above this is malformed; it is clamped down so a buggy advertisement can
-     * never size chunks beyond what the transport carries — the exact silent truncation class the
-     * notification budget exists to prevent.
-     */
-    public static final int K900_BLE_NOTIFY_CAP_CEILING_BYTES = 509;
+    /** Safety margin retained below the BES-advertised notification payload limit. */
+    public static final int K900_CONTROL_FRAME_SAFETY_MARGIN_BYTES = 13;
 
     /** Rendezvous baud shared by every ASG and BES firmware generation. */
     public static final int UART_RENDEZVOUS_BAUD = 460800;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -258,7 +258,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // Initialize every callback dependency before the serial receive thread starts.
         messageParser = new BesMessageParser();
         fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
-        MessageChunker.followLinkState(linkState);
 
         // Create the communication manager
         comManager = new SerialPortBridge(context);
@@ -1382,8 +1381,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
         }
         if (advertised != null && advertised.notifyCap > 0) {
-            // MessageChunker's link-state listener applies this guarantee to both v1 and v2
-            // complete frames without allowing old advertisements to raise the proven ceiling.
+            // Diagnostic contract. ASG control frames use a stricter immutable 240-byte ceiling
+            // for both v1 and v2, so old bearer-specific advertisements cannot make them larger.
             Log.i(TAG, "📏 BES wire_caps advertised notify_cap=" + advertised.notifyCap);
         }
         return advertised;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -258,6 +258,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // Initialize every callback dependency before the serial receive thread starts.
         messageParser = new BesMessageParser();
         fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
+        MessageChunker.followLinkState(linkState);
 
         // Create the communication manager
         comManager = new SerialPortBridge(context);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -411,11 +411,10 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     Log.d(TAG, "📡 📦 JSON DATA BEFORE C-WRAPPING: " + originalData);
 
                     if (BesWireFormat.isBinaryProtocolActive()) {
-                        if (MessageChunker.needsChunking(originalData)) {
-                            return sendBinaryFragmentedJson(originalData);
-                        }
-                        data = BesWireFormat.formatBinaryMessageForTransmission(originalData);
-                        logOutboundWireMetrics(originalData, data, 1);
+                        // Use one exact framing path for both one-frame and fragmented v2
+                        // messages. Every complete frame must fit the same BES notification
+                        // budget; phone-side reassembly does not make an oversized fragment safe.
+                        return sendBinaryFragmentedJson(originalData);
                     } else {
                         String wrappedJson =
                                 BesWireFormat.createTransmissionWrapperJson(originalData);
@@ -1382,8 +1381,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
         }
         if (advertised != null && advertised.notifyCap > 0) {
-            // Diagnostic only. Legacy v1 strings stay at the fixed conservative ceiling;
-            // negotiated capacity is used only by the higher-capacity protocol.
+            // MessageChunker's link-state listener applies this guarantee to both v1 and v2
+            // complete frames without allowing old advertisements to raise the proven ceiling.
             Log.i(TAG, "📏 BES wire_caps advertised notify_cap=" + advertised.notifyCap);
         }
         return advertised;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormat.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormat.java
@@ -39,9 +39,6 @@ public class BesWireFormat {
 
     public static final int BINARY_HEADER_SIZE = 7;
     public static final int LENGTH_CMD_MIN_SIZE = 7; // ## + type + innerLen(2) + $$
-    public static final int MTU_TARGET = 509;
-    public static final int MAX_FRAGMENT_PAYLOAD = 480;
-    public static final int MAX_PACKED_FRAME_SIZE = MTU_TARGET;
     public static final int PROTOCOL_VERSION_V1 = 1;
     public static final int PROTOCOL_VERSION_V2 = 2;
     public static final String HANDSHAKE_PAYLOAD_V2 = "v2";

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
@@ -111,15 +111,10 @@ public final class LinkStateMachine {
         public final int proto;
 
         /**
-         * Max single-notification payload the BES delivers to the phone (wire_caps.notify_cap =
-         * max(253, min(negotiated ATT MTU - 3, 509))). 0 when the firmware predates the
-         * advertisement or the cached value was invalidated.
-         *
-         * <p>Unlike the other caps, notify_cap derives from the PHONE BLE session's negotiated ATT
-         * MTU, so its validity is the intersection of the UART session, the phone BLE session, and
-         * the BES firmware generation: the machine clears it on serial close, on every
-         * phone-presence edge (a new session renegotiates the MTU), and on BES OTA — it re-arms
-         * only from a fresh wire_caps advertisement.
+         * Maximum complete notification payload the BES guarantees across every bearer it may
+         * select. 0 means the firmware did not advertise the capability or the cached value was
+         * invalidated. The value remains phone-session-scoped for compatibility with older BES
+         * firmware that derived it from the current ATT MTU.
          */
         public final int notifyCap;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -10,6 +10,7 @@ import org.json.JSONObject;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -25,24 +26,69 @@ public class MessageChunker {
     private static final int INITIAL_CHUNK_DATA_SIZE = 80;
     private static final int MIN_CHUNK_DATA_SIZE = 4;
 
-    /** Budget for v2 binary fragments — these are reassembled phone-side, so MTU_TARGET holds. */
-    public static final int MAX_PACKED_CHUNK_SIZE = BesWireFormat.MAX_PACKED_FRAME_SIZE;
+    /** Local ceiling for every complete K900 control frame, regardless of wire version. */
+    public static final int MAX_PACKED_CHUNK_SIZE =
+            AsgConstants.K900_CONTROL_MAX_PACKED_FRAME_BYTES;
+
+    private static final int BINARY_FRAME_OVERHEAD =
+            BesWireFormat.LENGTH_CMD_MIN_SIZE + BesWireFormat.BINARY_HEADER_SIZE;
+
+    /**
+     * Session budget for a complete packed frame. An advertised notify_cap may make it smaller,
+     * but never larger than the hardware-proven local ceiling. This makes old BES advertisements
+     * that described only a high-capacity bearer harmless during an ASG-first upgrade.
+     */
+    private static final AtomicInteger PACKED_FRAME_BUDGET =
+            new AtomicInteger(MAX_PACKED_CHUNK_SIZE);
 
     private static final AtomicLong CHUNK_SEQUENCE = new AtomicLong();
 
-    /** Current maximum packed frame size for a v1 STRING ck chunk. */
-    public static int maxPackedStringChunkSize() {
-        return AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES;
+    /** Current maximum size of a complete packed frame for both v1 and v2. */
+    public static int maxPackedFrameSize() {
+        return PACKED_FRAME_BUDGET.get();
     }
 
-    /** Compatibility no-op: {@code notify_cap} cannot raise the legacy v1 ceiling. */
-    public static void setStringChunkBudgetFromNotifyCap(int notifyCap) {}
+    /** Current maximum packed frame size for a v1 STRING ck chunk. */
+    public static int maxPackedStringChunkSize() {
+        return maxPackedFrameSize();
+    }
 
-    /** Compatibility no-op: the legacy v1 budget is always the conservative fixed ceiling. */
-    public static void resetStringChunkBudget() {}
+    /** Current maximum v2 message payload after the 14-byte K900 binary framing overhead. */
+    public static int maxBinaryFragmentPayload() {
+        return Math.max(0, maxPackedFrameSize() - BINARY_FRAME_OVERHEAD);
+    }
 
-    /** Compatibility no-op for old callers; production no longer subscribes to link caps. */
-    public static void followLinkState(LinkStateMachine linkState) {}
+    /**
+     * Apply the BES notification guarantee to the shared v1/v2 frame budget. Keep the proven
+     * 13-byte margin and never allow an advertisement to raise the local 240-byte ceiling.
+     */
+    public static void setFrameBudgetFromNotifyCap(int notifyCap) {
+        if (notifyCap <= 0) {
+            resetFrameBudget();
+            return;
+        }
+        int advertisedBudget =
+                Math.max(0, notifyCap - AsgConstants.K900_CONTROL_FRAME_SAFETY_MARGIN_BYTES);
+        PACKED_FRAME_BUDGET.set(Math.min(MAX_PACKED_CHUNK_SIZE, advertisedBudget));
+    }
+
+    /** Restore the conservative budget when the negotiated capability is no longer valid. */
+    public static void resetFrameBudget() {
+        PACKED_FRAME_BUDGET.set(MAX_PACKED_CHUNK_SIZE);
+    }
+
+    /** Keep the shared frame budget aligned with the negotiated capability lifecycle. */
+    public static void followLinkState(LinkStateMachine linkState) {
+        linkState.addListener(
+                (state, provenCaps, phonePresence) -> {
+                    int notifyCap = linkState.getNegotiatedCaps().notifyCap;
+                    if (notifyCap > 0) {
+                        setFrameBudgetFromNotifyCap(notifyCap);
+                    } else {
+                        resetFrameBudget();
+                    }
+                });
+    }
 
     public static boolean needsChunking(String message) {
         if (message == null) {
@@ -50,10 +96,15 @@ public class MessageChunker {
         }
 
         int messageBytes = message.getBytes(StandardCharsets.UTF_8).length;
-        int threshold =
-                BesWireFormat.isBinaryProtocolActive()
-                        ? BesWireFormat.MAX_FRAGMENT_PAYLOAD
-                        : MESSAGE_SIZE_THRESHOLD_V1;
+        int threshold = MESSAGE_SIZE_THRESHOLD_V1;
+        if (BesWireFormat.isBinaryProtocolActive()) {
+            try {
+                messageBytes = BesWireFormat.buildOutboundPayloadBytes(message).length;
+            } catch (JSONException e) {
+                return true;
+            }
+            threshold = maxBinaryFragmentPayload();
+        }
         boolean needsChunking = messageBytes > threshold;
         if (needsChunking) {
             Log.d(
@@ -117,8 +168,14 @@ public class MessageChunker {
         }
 
         byte[] messageBytes = BesWireFormat.buildOutboundPayloadBytes(originalJson);
-        List<byte[]> payloadChunks =
-                splitUtf8Bytes(messageBytes, BesWireFormat.MAX_FRAGMENT_PAYLOAD);
+        int payloadBudget = maxBinaryFragmentPayload();
+        if (payloadBudget <= 0) {
+            throw new JSONException(
+                    "notify_cap leaves no room for the "
+                            + BINARY_FRAME_OVERHEAD
+                            + "-byte binary frame overhead");
+        }
+        List<byte[]> payloadChunks = splitUtf8Bytes(messageBytes, payloadBudget);
         int totalFragments = payloadChunks.size();
         List<byte[]> frames = new ArrayList<>(totalFragments);
 
@@ -133,12 +190,13 @@ public class MessageChunker {
             byte[] frame =
                     BesWireFormat.packBinaryFragment(
                             flags, msgId, i, totalFragments, payloadChunks.get(i));
-            if (frame == null || frame.length > MAX_PACKED_CHUNK_SIZE) {
+            int frameBudget = maxPackedFrameSize();
+            if (frame == null || frame.length > frameBudget) {
                 throw new JSONException(
                         "Binary fragment "
                                 + i
                                 + " exceeds "
-                                + MAX_PACKED_CHUNK_SIZE
+                                + frameBudget
                                 + " bytes ("
                                 + (frame != null ? frame.length : 0)
                                 + ")");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -10,7 +10,6 @@ import org.json.JSONObject;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -33,19 +32,11 @@ public class MessageChunker {
     private static final int BINARY_FRAME_OVERHEAD =
             BesWireFormat.LENGTH_CMD_MIN_SIZE + BesWireFormat.BINARY_HEADER_SIZE;
 
-    /**
-     * Session budget for a complete packed frame. An advertised notify_cap may make it smaller,
-     * but never larger than the hardware-proven local ceiling. This makes old BES advertisements
-     * that described only a high-capacity bearer harmless during an ASG-first upgrade.
-     */
-    private static final AtomicInteger PACKED_FRAME_BUDGET =
-            new AtomicInteger(MAX_PACKED_CHUNK_SIZE);
-
     private static final AtomicLong CHUNK_SEQUENCE = new AtomicLong();
 
     /** Current maximum size of a complete packed frame for both v1 and v2. */
     public static int maxPackedFrameSize() {
-        return PACKED_FRAME_BUDGET.get();
+        return MAX_PACKED_CHUNK_SIZE;
     }
 
     /** Current maximum packed frame size for a v1 STRING ck chunk. */
@@ -56,38 +47,6 @@ public class MessageChunker {
     /** Current maximum v2 message payload after the 14-byte K900 binary framing overhead. */
     public static int maxBinaryFragmentPayload() {
         return Math.max(0, maxPackedFrameSize() - BINARY_FRAME_OVERHEAD);
-    }
-
-    /**
-     * Apply the BES notification guarantee to the shared v1/v2 frame budget. Keep the proven
-     * 13-byte margin and never allow an advertisement to raise the local 240-byte ceiling.
-     */
-    public static void setFrameBudgetFromNotifyCap(int notifyCap) {
-        if (notifyCap <= 0) {
-            resetFrameBudget();
-            return;
-        }
-        int advertisedBudget =
-                Math.max(0, notifyCap - AsgConstants.K900_CONTROL_FRAME_SAFETY_MARGIN_BYTES);
-        PACKED_FRAME_BUDGET.set(Math.min(MAX_PACKED_CHUNK_SIZE, advertisedBudget));
-    }
-
-    /** Restore the conservative budget when the negotiated capability is no longer valid. */
-    public static void resetFrameBudget() {
-        PACKED_FRAME_BUDGET.set(MAX_PACKED_CHUNK_SIZE);
-    }
-
-    /** Keep the shared frame budget aligned with the negotiated capability lifecycle. */
-    public static void followLinkState(LinkStateMachine linkState) {
-        linkState.addListener(
-                (state, provenCaps, phonePresence) -> {
-                    int notifyCap = linkState.getNegotiatedCaps().notifyCap;
-                    if (notifyCap > 0) {
-                        setFrameBudgetFromNotifyCap(notifyCap);
-                    } else {
-                        resetFrameBudget();
-                    }
-                });
     }
 
     public static boolean needsChunking(String message) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -31,6 +31,8 @@ public class MessageChunker {
 
     private static final int BINARY_FRAME_OVERHEAD =
             BesWireFormat.LENGTH_CMD_MIN_SIZE + BesWireFormat.BINARY_HEADER_SIZE;
+    private static final int MAX_BINARY_FRAGMENT_PAYLOAD =
+            MAX_PACKED_CHUNK_SIZE - BINARY_FRAME_OVERHEAD;
 
     private static final AtomicLong CHUNK_SEQUENCE = new AtomicLong();
 
@@ -46,7 +48,7 @@ public class MessageChunker {
 
     /** Current maximum v2 message payload after the 14-byte K900 binary framing overhead. */
     public static int maxBinaryFragmentPayload() {
-        return Math.max(0, maxPackedFrameSize() - BINARY_FRAME_OVERHEAD);
+        return MAX_BINARY_FRAGMENT_PAYLOAD;
     }
 
     public static boolean needsChunking(String message) {
@@ -56,14 +58,6 @@ public class MessageChunker {
 
         int messageBytes = message.getBytes(StandardCharsets.UTF_8).length;
         int threshold = MESSAGE_SIZE_THRESHOLD_V1;
-        if (BesWireFormat.isBinaryProtocolActive()) {
-            try {
-                messageBytes = BesWireFormat.buildOutboundPayloadBytes(message).length;
-            } catch (JSONException e) {
-                return true;
-            }
-            threshold = maxBinaryFragmentPayload();
-        }
         boolean needsChunking = messageBytes > threshold;
         if (needsChunking) {
             Log.d(
@@ -127,14 +121,7 @@ public class MessageChunker {
         }
 
         byte[] messageBytes = BesWireFormat.buildOutboundPayloadBytes(originalJson);
-        int payloadBudget = maxBinaryFragmentPayload();
-        if (payloadBudget <= 0) {
-            throw new JSONException(
-                    "notify_cap leaves no room for the "
-                            + BINARY_FRAME_OVERHEAD
-                            + "-byte binary frame overhead");
-        }
-        List<byte[]> payloadChunks = splitUtf8Bytes(messageBytes, payloadBudget);
+        List<byte[]> payloadChunks = splitUtf8Bytes(messageBytes, MAX_BINARY_FRAGMENT_PAYLOAD);
         int totalFragments = payloadChunks.size();
         List<byte[]> frames = new ArrayList<>(totalFragments);
 
@@ -149,13 +136,12 @@ public class MessageChunker {
             byte[] frame =
                     BesWireFormat.packBinaryFragment(
                             flags, msgId, i, totalFragments, payloadChunks.get(i));
-            int frameBudget = maxPackedFrameSize();
-            if (frame == null || frame.length > frameBudget) {
+            if (frame == null || frame.length > MAX_PACKED_CHUNK_SIZE) {
                 throw new JSONException(
                         "Binary fragment "
                                 + i
                                 + " exceeds "
-                                + frameBudget
+                                + MAX_PACKED_CHUNK_SIZE
                                 + " bytes ("
                                 + (frame != null ? frame.length : 0)
                                 + ")");

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BinaryMessageChunkerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BinaryMessageChunkerTest.java
@@ -20,14 +20,12 @@ public class BinaryMessageChunkerTest {
     @Before
     public void setUp() {
         BesWireFormat.setBinaryProtocolActive(true);
-        MessageChunker.resetFrameBudget();
     }
 
     @After
     public void tearDown() {
         BesWireFormat.resetBinaryProtocol();
         BesWireFormat.resetFilePackSize();
-        MessageChunker.resetFrameBudget();
     }
 
     @Test
@@ -87,22 +85,6 @@ public class BinaryMessageChunkerTest {
 
         assertThat(MessageChunker.needsChunking(small)).isFalse();
         assertThat(MessageChunker.needsChunking(large)).isTrue();
-    }
-
-    @Test
-    public void notifyCapConstrainsEveryBinaryFrame() throws Exception {
-        MessageChunker.setFrameBudgetFromNotifyCap(200);
-        assertThat(MessageChunker.maxPackedFrameSize()).isEqualTo(187);
-        assertThat(MessageChunker.maxBinaryFragmentPayload()).isEqualTo(173);
-
-        String json =
-                "{\"type\":\"stream_status\",\"d\":\"" + "x".repeat(600) + "\"}";
-        List<byte[]> frames = MessageChunker.createBinaryFragments(json, 123);
-
-        assertThat(frames.size()).isGreaterThan(1);
-        for (byte[] frame : frames) {
-            assertThat(frame.length).isLessThanOrEqualTo(187);
-        }
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BinaryMessageChunkerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BinaryMessageChunkerTest.java
@@ -20,12 +20,14 @@ public class BinaryMessageChunkerTest {
     @Before
     public void setUp() {
         BesWireFormat.setBinaryProtocolActive(true);
+        MessageChunker.resetFrameBudget();
     }
 
     @After
     public void tearDown() {
         BesWireFormat.resetBinaryProtocol();
         BesWireFormat.resetFilePackSize();
+        MessageChunker.resetFrameBudget();
     }
 
     @Test
@@ -34,7 +36,8 @@ public class BinaryMessageChunkerTest {
         List<byte[]> frames = MessageChunker.createBinaryFragments(json, 7);
 
         assertThat(frames).hasSize(1);
-        assertThat(frames.get(0).length).isLessThanOrEqualTo(MessageChunker.MAX_PACKED_CHUNK_SIZE);
+        assertThat(frames.get(0).length)
+                .isLessThanOrEqualTo(MessageChunker.maxPackedFrameSize());
 
         BesWireFormat.BinaryHeader header = BesWireFormat.parseBinaryHeader(frames.get(0));
         assertThat(header.valid).isTrue();
@@ -60,7 +63,8 @@ public class BinaryMessageChunkerTest {
 
         int totalPayload = 0;
         for (int i = 0; i < frames.size(); i++) {
-            assertThat(frames.get(i).length).isLessThanOrEqualTo(MessageChunker.MAX_PACKED_CHUNK_SIZE);
+            assertThat(frames.get(i).length)
+                    .isLessThanOrEqualTo(MessageChunker.maxPackedFrameSize());
             BesWireFormat.BinaryHeader header = BesWireFormat.parseBinaryHeader(frames.get(i));
             assertThat(header.valid).isTrue();
             assertThat(header.msgId).isEqualTo(99);
@@ -74,15 +78,31 @@ public class BinaryMessageChunkerTest {
     }
 
     @Test
-    public void needsChunking_usesHigherThresholdWhenBinaryActive() {
+    public void needsChunking_usesBinaryPayloadBudgetWhenBinaryActive() {
         String small = "{\"type\":\"ping\"}";
         String large =
                 "{\"type\":\"stream_status\",\"d\":\""
-                        + "a".repeat(BesWireFormat.MAX_FRAGMENT_PAYLOAD + 1)
+                        + "a".repeat(MessageChunker.maxBinaryFragmentPayload() + 1)
                         + "\"}";
 
         assertThat(MessageChunker.needsChunking(small)).isFalse();
         assertThat(MessageChunker.needsChunking(large)).isTrue();
+    }
+
+    @Test
+    public void notifyCapConstrainsEveryBinaryFrame() throws Exception {
+        MessageChunker.setFrameBudgetFromNotifyCap(200);
+        assertThat(MessageChunker.maxPackedFrameSize()).isEqualTo(187);
+        assertThat(MessageChunker.maxBinaryFragmentPayload()).isEqualTo(173);
+
+        String json =
+                "{\"type\":\"stream_status\",\"d\":\"" + "x".repeat(600) + "\"}";
+        List<byte[]> frames = MessageChunker.createBinaryFragments(json, 123);
+
+        assertThat(frames.size()).isGreaterThan(1);
+        for (byte[] frame : frames) {
+            assertThat(frame.length).isLessThanOrEqualTo(187);
+        }
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BinaryMessageChunkerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BinaryMessageChunkerTest.java
@@ -76,18 +76,6 @@ public class BinaryMessageChunkerTest {
     }
 
     @Test
-    public void needsChunking_usesBinaryPayloadBudgetWhenBinaryActive() {
-        String small = "{\"type\":\"ping\"}";
-        String large =
-                "{\"type\":\"stream_status\",\"d\":\""
-                        + "a".repeat(MessageChunker.maxBinaryFragmentPayload() + 1)
-                        + "\"}";
-
-        assertThat(MessageChunker.needsChunking(small)).isFalse();
-        assertThat(MessageChunker.needsChunking(large)).isTrue();
-    }
-
-    @Test
     public void buildOutboundPayloadBytes_skipsWrapperForNonCameraMessages() throws Exception {
         String json = "{\"type\":\"photo_status\",\"status\":\"captured\"}";
         byte[] payload = BesWireFormat.buildOutboundPayloadBytes(json);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.mentra.asg_client.service.core.processors.ChunkReassembler;
 import java.util.List;
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,13 +25,6 @@ public class StringChunkBudgetTest {
     public void setUp() {
         // v1 string mode — the post-APK-restart steady state until a BLE reconnect.
         BesWireFormat.resetBinaryProtocol();
-        MessageChunker.resetFrameBudget();
-    }
-
-    @After
-    public void tearDown() {
-        BesWireFormat.resetBinaryProtocol();
-        MessageChunker.resetFrameBudget();
     }
 
     /**
@@ -96,117 +88,13 @@ public class StringChunkBudgetTest {
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
 
-    // ---- Shared v1/v2 envelope: notify_cap may lower but never raise the proven ceiling ----
+    // ---- Shared immutable v1/v2 envelope ----
 
     @Test
-    public void budgetDefaultsToTheConservativeFallback() {
+    public void budgetUsesTheConservativePackedFrameCeiling() {
         assertThat(MessageChunker.maxPackedStringChunkSize())
                 .isEqualTo(com.mentra.asg_client.AsgConstants.K900_CONTROL_MAX_PACKED_FRAME_BYTES)
                 .isEqualTo(240);
-    }
-
-    @Test
-    public void advertisedNotifyCapCannotRaiseTheBudget() {
-        MessageChunker.setFrameBudgetFromNotifyCap(509);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        MessageChunker.setFrameBudgetFromNotifyCap(253);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-    }
-
-    @Test
-    public void smallerNotifyCapLowersTheBudgetWithSafetyMargin() {
-        MessageChunker.setFrameBudgetFromNotifyCap(1000);
-        MessageChunker.setFrameBudgetFromNotifyCap(200);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(187);
-    }
-
-    @Test
-    public void resetRestoresTheFallbackBudget() {
-        MessageChunker.setFrameBudgetFromNotifyCap(509);
-
-        MessageChunker.resetFrameBudget();
-
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-    }
-
-    @Test
-    public void chunksStillFitAndRoundTripAfterLargeAdvertisement() throws Exception {
-        MessageChunker.setFrameBudgetFromNotifyCap(509);
-        assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
-    }
-
-    @Test
-    public void budgetFollowsTheCapsLifecycleThroughTheLinkStateMachine() {
-        LinkStateMachine machine = new LinkStateMachine();
-        MessageChunker.followLinkState(machine);
-
-        machine.serialReady();
-        machine.srSyvrParsed(
-                new LinkStateMachine.BesCaps(
-                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // A discontinuity (baud reopen) keeps the negotiated caps — and the budget with them.
-        machine.streamDiscontinuity();
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // EVERY close path (onSerialClose, failed onSerialOpen, reopen failures) funnels
-        // through the machine's serialClosed transition: caps cleared MUST mean fallback
-        // budget, or a later session against firmware without notify_cap would inherit a
-        // stale oversized budget and silently truncate notifications again.
-        machine.serialClosed();
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // Reconnect to old firmware (sr_syvr without wire_caps): the fallback must hold.
-        machine.serialReady();
-        machine.srSyvrParsed(null);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-    }
-
-    @Test
-    public void budgetFollowsThePhoneSessionLifecycle() {
-        // An old large advertisement cannot raise the proven local envelope.
-        LinkStateMachine machine = new LinkStateMachine();
-        MessageChunker.followLinkState(machine);
-        machine.serialReady();
-        machine.phonePresenceReported(true);
-        machine.srSyvrParsed(
-                new LinkStateMachine.BesCaps(
-                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // Phone disconnects: back to the fallback.
-        machine.phonePresenceReported(false);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // Phone reconnects WITHOUT a fresh advertisement: the fallback must hold.
-        machine.phonePresenceReported(true);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // A smaller fresh guarantee lowers the shared frame budget.
-        machine.srSyvrParsed(
-                new LinkStateMachine.BesCaps(
-                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 200));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(187);
-    }
-
-    @Test
-    public void budgetFallsBackOnBesOta() {
-        // A BES OTA is a firmware-generation boundary AND kills the phone session: the new
-        // firmware may advertise a different notify_cap or none at all.
-        LinkStateMachine machine = new LinkStateMachine();
-        MessageChunker.followLinkState(machine);
-        machine.serialReady();
-        machine.srSyvrParsed(
-                new LinkStateMachine.BesCaps(
-                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
-
-        // onBesOtaApplied drives exactly these two machine transitions.
-        machine.streamDiscontinuity();
-        machine.phonePresenceInvalidated();
-
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+        assertThat(MessageChunker.maxBinaryFragmentPayload()).isEqualTo(226);
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -13,11 +13,10 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
- * Regression test for incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: v1 ck chunks were sized against
- * MTU_TARGET (509) but a v1 string frame must survive the phone leg as a single BLE notification
- * (~253-byte ATT payload). The OTA completion ota_status packed to 256-263-byte chunk frames, every
- * one was truncated on the wire, and the phone failed a successful update. Every packed v1 ck chunk
- * must stay within {@link MessageChunker#MAX_PACKED_STRING_CHUNK_SIZE}.
+ * Regression test for incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: complete K900 frames must survive
+ * the BES-to-phone leg as one BLE notification. The OTA completion ota_status packed to
+ * 256-263-byte v1 chunks, every one was truncated, and the phone failed a successful update. The
+ * same packed-frame ceiling also applies to v2 fragments before phone-side reassembly.
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
@@ -27,13 +26,13 @@ public class StringChunkBudgetTest {
     public void setUp() {
         // v1 string mode — the post-APK-restart steady state until a BLE reconnect.
         BesWireFormat.resetBinaryProtocol();
-        MessageChunker.resetStringChunkBudget();
+        MessageChunker.resetFrameBudget();
     }
 
     @After
     public void tearDown() {
         BesWireFormat.resetBinaryProtocol();
-        MessageChunker.resetStringChunkBudget();
+        MessageChunker.resetFrameBudget();
     }
 
     /**
@@ -97,44 +96,43 @@ public class StringChunkBudgetTest {
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
 
-    // ---- Release A fixed envelope: notify_cap is advisory only ----
+    // ---- Shared v1/v2 envelope: notify_cap may lower but never raise the proven ceiling ----
 
     @Test
     public void budgetDefaultsToTheConservativeFallback() {
         assertThat(MessageChunker.maxPackedStringChunkSize())
-                .isEqualTo(com.mentra.asg_client.AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES)
+                .isEqualTo(com.mentra.asg_client.AsgConstants.K900_CONTROL_MAX_PACKED_FRAME_BYTES)
                 .isEqualTo(240);
     }
 
     @Test
     public void advertisedNotifyCapCannotRaiseTheBudget() {
-        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+        MessageChunker.setFrameBudgetFromNotifyCap(509);
         assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
-        MessageChunker.setStringChunkBudgetFromNotifyCap(253);
+        MessageChunker.setFrameBudgetFromNotifyCap(253);
         assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
     }
 
     @Test
-    public void malformedNotifyCapsCannotChangeTheBudget() {
-        MessageChunker.setStringChunkBudgetFromNotifyCap(1000);
-        MessageChunker.setStringChunkBudgetFromNotifyCap(200);
-        MessageChunker.setStringChunkBudgetFromNotifyCap(-1);
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+    public void smallerNotifyCapLowersTheBudgetWithSafetyMargin() {
+        MessageChunker.setFrameBudgetFromNotifyCap(1000);
+        MessageChunker.setFrameBudgetFromNotifyCap(200);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(187);
     }
 
     @Test
     public void resetRestoresTheFallbackBudget() {
-        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+        MessageChunker.setFrameBudgetFromNotifyCap(509);
 
-        MessageChunker.resetStringChunkBudget();
+        MessageChunker.resetFrameBudget();
 
         assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
     }
 
     @Test
     public void chunksStillFitAndRoundTripAfterLargeAdvertisement() throws Exception {
-        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+        MessageChunker.setFrameBudgetFromNotifyCap(509);
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
 
@@ -168,7 +166,7 @@ public class StringChunkBudgetTest {
 
     @Test
     public void budgetFollowsThePhoneSessionLifecycle() {
-        // Session changes and advertisements must not alter the fixed release-A envelope.
+        // An old large advertisement cannot raise the proven local envelope.
         LinkStateMachine machine = new LinkStateMachine();
         MessageChunker.followLinkState(machine);
         machine.serialReady();
@@ -186,11 +184,11 @@ public class StringChunkBudgetTest {
         machine.phonePresenceReported(true);
         assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
 
-        // A fresh advertisement remains advisory.
+        // A smaller fresh guarantee lowers the shared frame budget.
         machine.srSyvrParsed(
                 new LinkStateMachine.BesCaps(
-                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 260));
-        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 200));
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(187);
     }
 
     @Test


### PR DESCRIPTION
## Why

A complete K900 v2 fragment crosses BES to phone as one BLE notification before phone-side reassembly. The existing ASG code limited v1 chunks to the proven 240-byte envelope but still allowed v2 frames up to 509 bytes, so enabling v2 against the 253-byte minimum bearer could silently lose messages.

## What changed

- use one immutable 240-byte packed-frame ceiling for v1 JSON chunks and v2 binary fragments
- derive the v2 payload size as 226 bytes after 14 bytes of K900 binary framing
- route every v2 control message through the same exact fragmentation path, including single-frame messages
- remove the unused 509-byte control-frame constants and obsolete mutable v1 budget plumbing
- leave negotiated photo and file-transfer payload sizing unchanged

The immutable ceiling is intentional for this safety-critical rollout. New BES advertises notify_cap=253 and rejects anything larger, while ASG remains below that limit. Old BES advertisements cannot raise or corrupt the ASG budget during the ASG-first upgrade. This keeps binary protocol v2 enabled without adding another session-lifecycle state variable.

## Validation

- focused StringChunkBudgetTest and BinaryMessageChunkerTest: pass
- ./scripts/check-android-compile.sh asg: pass
- full GitHub ASG release APK and unit-test workflow is authoritative for the current head
- repository-wide Spotless remains blocked by a pre-existing import-order error in MediaUploadQueueManager.java; none of the touched files are involved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core glasses-to-phone control framing for OTA/status traffic (safety-critical), but the fix is a conservative fixed cap with regression tests and leaves file transfer negotiation untouched.
> 
> **Overview**
> Fixes silent message loss when v2 binary fragments were sized up to **509 bytes** while each complete frame must fit in a single BES→phone BLE notification (~253-byte ATT payload).
> 
> **Unified budget:** Both v1 JSON `ck` chunks and v2 binary fragments now cap at **`K900_CONTROL_MAX_PACKED_FRAME_BYTES` (240)**. v2 fragment payloads are **226 bytes** after 14 bytes of K900 binary framing.
> 
> **Send path:** With binary protocol active, **all** outbound JSON goes through `sendBinaryFragmentedJson` (including messages that previously fit in one oversized frame).
> 
> **Removed:** 509-byte control constants in `BesWireFormat`, `notify_cap`-driven mutable v1 chunk sizing, and related link-state lifecycle hooks. BES `wire_caps.notify_cap` remains **logged only**; negotiated file/photo payload sizing is unchanged.
> 
> Tests assert the shared ceiling and drop notify_cap lifecycle cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108f79bd1643a956bc91e5b07bc5afb40730902d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->