### PR TITLE
Promote BES 26.8.5.0 in live firmware manifest

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.7.30.4",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.30.4.bin",
-    "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c"
+    "version": "26.8.5.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.5.0.bin",
+    "sha256": "141ea18466b2710a1dd039fdb50e1ae818fd1cf45f263e7efa25279810fed44b"
   }
 }


### PR DESCRIPTION
## What changed

- promote the live BES target from `26.7.30.4` to `26.8.5.0`
- copy the URL and SHA-256 exactly from the current CDN `latest.json`
- leave the OTA manifest schema and every MTK patch unchanged

## Provenance

The CDN record was built from merged BES release-B PR Mentra-Community/mentra-live-bes#28:

- BES version: `26.8.5.0`
- source commit: `c9cfd91b3911e10fdbcebed7758e482847df9903`
- built at: `2026-08-05T03:54:57Z`
- artifact size: `1,137,870` bytes
- artifact SHA-256: `141ea18466b2710a1dd039fdb50e1ae818fd1cf45f263e7efa25279810fed44b`
- CDN status: `prerelease: true`

This branch is based on `staging` after MentraOS #3678 merged, preserving the ASG-first/BES-second rollout ordering.

## Validation

- downloaded the CDN artifact and verified its size and SHA-256 against `latest.json`
- compared the local `bes_firmware` record directly with the current CDN record
- `jq empty asg_client/ota_manifests/firmware_live.json`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Live OTA manifest changes directly control which BES binary glasses download and flash; incorrect URL or hash would affect all devices on this channel, though scope is limited to one version field trio with pre-validated checksums.
> 
> **Overview**
> Updates the **live** OTA manifest so devices pull BES **`26.8.5.0`** instead of **`26.7.30.4`**, with the CDN URL and SHA-256 aligned to the current `latest.json` record.
> 
> **MTK patch entries and manifest shape are unchanged**; only the `bes_firmware` block in `firmware_live.json` is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bfadcd1ca4310140522963302a9aebb30b2bca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->