### PR TITLE
Restrict miniapp Wi-Fi ADB API to SYSTEM callers (OS-1627)

### DIFF
--- a/miniapps/example-miniapp/src/ui/pages/tester/GlassesPage.tsx
+++ b/miniapps/example-miniapp/src/ui/pages/tester/GlassesPage.tsx
@@ -45,14 +45,15 @@ export default function GlassesPage() {
 
         <div className="mt-4 rounded-xl border border-border bg-card p-4">
           <div className="mb-2 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Wi-Fi ADB
+            Wi-Fi ADB (SYSTEM-only)
           </div>
-          {!isMentraLive && (
-            <div className="mb-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-[12px] text-amber-500">
-              Wi-Fi ADB is only supported on Mentra Live. Calls still send but other devices will
-              no-op.
-            </div>
-          )}
+          <div className="mb-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-[12px] text-amber-500">
+            Restricted to system miniapps. This example package gets{" "}
+            <code>NOT_PERMITTED</code> unless running as miniapp-dev. Prefer{" "}
+            <code>BluetoothSdk.setWifiAdbState</code> from the Mentra App for
+            debugging.
+            {!isMentraLive && " Mentra Live only — other devices no-op."}
+          </div>
           <p className="mb-3 text-[13px] text-muted-foreground">
             Toggle wireless debugging on the glasses. Off by default for security.
           </p>

--- a/mintlify-docs/app-devs/reference/system-apis.mdx
+++ b/mintlify-docs/app-devs/reference/system-apis.mdx
@@ -1,6 +1,6 @@
 ---
 title: "System Miniapp APIs"
-description: "APIs restricted to system miniapps for discovering, launching, and invoking other miniapps."
+description: "APIs restricted to system miniapps for interop and privileged device controls."
 icon: "shield-halved"
 ---
 
@@ -11,8 +11,9 @@ reference. To make your own miniapp callable, expose actions instead, see
 [Actions](/app-devs/core-concepts/miniapp-interop).
 </Warning>
 
-System miniapps can discover other miniapps, control their lifecycle, and invoke
-the actions those miniapps expose.
+System miniapps can discover other miniapps, control their lifecycle, invoke
+the actions those miniapps expose, and use a small set of privileged device
+controls.
 
 ## Discover and control miniapps
 
@@ -67,3 +68,20 @@ const res = await session.actions.invoke(
 A thrown handler in the target surfaces its own error message to the caller.
 The action descriptor returned by `session.miniapps.list()` includes an optional
 `outputSchema`, which describes the structured result for result-aware callers.
+
+## Privileged device controls
+
+### Wi-Fi ADB (Mentra Live)
+
+`session.glasses.setWifiAdbState` toggles wireless debugging on Mentra Live.
+The preference is persisted on the glasses and reapplied at boot (default
+**off**). Non-system callers get `NOT_PERMITTED`.
+
+```ts
+await session.glasses.setWifiAdbState(true);  // enable
+await session.glasses.setWifiAdbState(false); // disable
+```
+
+| Method | Returns | Notes |
+|---|---|---|
+| `setWifiAdbState(enabled)` | `Promise<void>` | Mentra Live only; other models no-op. SYSTEM-only. |

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -2907,6 +2907,15 @@ class LocalMiniappRuntime {
     payload: Record<string, unknown>,
     requestId?: string,
   ): Promise<void> {
+    // Wi-Fi ADB expands the device attack surface — SYSTEM miniapps only.
+    if (!this.isSystemPackage(packageName)) {
+      this.sendResult(packageName, requestId, false, undefined, {
+        code: MiniappErrorCode.NOT_PERMITTED,
+        message: "setWifiAdbState is restricted to system apps",
+      })
+      return
+    }
+
     if (typeof payload.enabled !== "boolean") {
       this.sendResult(packageName, requestId, false, undefined, {
         code: MiniappErrorCode.INVALID_ARGUMENT,

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -52,6 +52,7 @@ import {phoneVideoCoordinator} from "./PhoneVideoCoordinator"
 import {runSentenceTtsPipeline} from "./SentenceTtsPipeline"
 import {summarizeTranscriptionRoutes, transcriptionDeliveryRoute} from "./TranscriptionRouting"
 import {prepareTtsSentences} from "./TtsTextSanitizer"
+import {handleWifiAdbRequest} from "./WifiAdbRequest"
 import {cloudClientService} from "./CloudClientService"
 import {miniappLauncher} from "./MiniappLauncher"
 import {
@@ -2907,35 +2908,25 @@ class LocalMiniappRuntime {
     payload: Record<string, unknown>,
     requestId?: string,
   ): Promise<void> {
-    // Wi-Fi ADB expands the device attack surface — SYSTEM miniapps only.
-    if (!this.isSystemPackage(packageName)) {
-      this.sendResult(packageName, requestId, false, undefined, {
-        code: MiniappErrorCode.NOT_PERMITTED,
-        message: "setWifiAdbState is restricted to system apps",
-      })
-      return
-    }
+    const result = await handleWifiAdbRequest(packageName, payload, {
+      isSystemPackage: (candidate) => this.isSystemPackage(candidate),
+      setWifiAdbState: async (enabled) => {
+        console.log(`${LOG_TAG}: set_wifi_adb_state enabled=${enabled} from ${packageName}`)
+        try {
+          await BluetoothSdk.setWifiAdbState(enabled)
+        } catch (error) {
+          console.error(`${LOG_TAG}: set_wifi_adb_state error:`, error)
+          throw error
+        }
+      },
+    })
 
-    if (typeof payload.enabled !== "boolean") {
-      this.sendResult(packageName, requestId, false, undefined, {
-        code: MiniappErrorCode.INVALID_ARGUMENT,
-        message: "enabled must be a boolean",
-      })
-      return
-    }
-
-    try {
-      const enabled = payload.enabled
-      console.log(`${LOG_TAG}: set_wifi_adb_state enabled=${enabled} from ${packageName}`)
-      await BluetoothSdk.setWifiAdbState(enabled)
+    if (result.ok) {
       this.sendResult(packageName, requestId, true)
-    } catch (err) {
-      console.error(`${LOG_TAG}: set_wifi_adb_state error:`, err)
-      this.sendResult(packageName, requestId, false, undefined, {
-        code: MiniappErrorCode.INTERNAL,
-        message: err instanceof Error ? err.message : "Wi-Fi ADB error",
-      })
+      return
     }
+
+    this.sendResult(packageName, requestId, false, undefined, result.error)
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/modules/engine/src/services/WifiAdbRequest.ts
+++ b/mobile/modules/engine/src/services/WifiAdbRequest.ts
@@ -1,0 +1,53 @@
+export interface WifiAdbRequestDependencies {
+  isSystemPackage: (packageName: string) => boolean
+  setWifiAdbState: (enabled: boolean) => Promise<void>
+}
+
+export type WifiAdbRequestErrorCode = "NOT_PERMITTED" | "INVALID_ARGUMENT" | "INTERNAL"
+
+export type WifiAdbRequestResult =
+  | {ok: true}
+  | {
+      ok: false
+      error: {code: WifiAdbRequestErrorCode; message: string}
+    }
+
+/** Apply the SYSTEM-only Wi-Fi ADB policy before calling the native SDK. */
+export async function handleWifiAdbRequest(
+  packageName: string,
+  payload: Record<string, unknown>,
+  dependencies: WifiAdbRequestDependencies,
+): Promise<WifiAdbRequestResult> {
+  if (!dependencies.isSystemPackage(packageName)) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_PERMITTED",
+        message: "setWifiAdbState is restricted to system apps",
+      },
+    }
+  }
+
+  if (typeof payload.enabled !== "boolean") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_ARGUMENT",
+        message: "enabled must be a boolean",
+      },
+    }
+  }
+
+  try {
+    await dependencies.setWifiAdbState(payload.enabled)
+    return {ok: true}
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL",
+        message: error instanceof Error ? error.message : "Wi-Fi ADB error",
+      },
+    }
+  }
+}

--- a/mobile/modules/engine/src/services/__tests__/WifiAdbRequest.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/WifiAdbRequest.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, mock, test} from "bun:test"
+
+import {MiniappErrorCode} from "../../../../miniapp/src/protocol"
+import {handleWifiAdbRequest} from "../WifiAdbRequest"
+
+function buildDependencies(allowedPackages: string[], failure?: unknown) {
+  const isSystemPackage = mock((packageName: string) => allowedPackages.includes(packageName))
+  const setWifiAdbState = mock(async (_enabled: boolean) => {
+    if (failure !== undefined) throw failure
+  })
+
+  return {
+    dependencies: {isSystemPackage, setWifiAdbState},
+    isSystemPackage,
+    setWifiAdbState,
+  }
+}
+
+describe("handleWifiAdbRequest", () => {
+  test("rejects a non-system miniapp without calling BluetoothSdk", async () => {
+    const {dependencies, setWifiAdbState} = buildDependencies([])
+
+    const result = await handleWifiAdbRequest("com.example.thirdparty", {enabled: true}, dependencies)
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: MiniappErrorCode.NOT_PERMITTED,
+        message: "setWifiAdbState is restricted to system apps",
+      },
+    })
+    expect(setWifiAdbState).not.toHaveBeenCalled()
+  })
+
+  test.each(["com.mentra.settings", "com.example.miniapp-dev"])(
+    "forwards an allowed SYSTEM/miniapp-dev caller (%s) to BluetoothSdk",
+    async (packageName) => {
+      const {dependencies, setWifiAdbState} = buildDependencies([packageName])
+
+      const result = await handleWifiAdbRequest(packageName, {enabled: false}, dependencies)
+
+      expect(result).toEqual({ok: true})
+      expect(setWifiAdbState).toHaveBeenCalledTimes(1)
+      expect(setWifiAdbState).toHaveBeenCalledWith(false)
+    },
+  )
+
+  test("rejects an invalid enabled value before calling BluetoothSdk", async () => {
+    const {dependencies, setWifiAdbState} = buildDependencies(["com.mentra.settings"])
+
+    const result = await handleWifiAdbRequest("com.mentra.settings", {enabled: "yes"}, dependencies)
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: MiniappErrorCode.INVALID_ARGUMENT,
+        message: "enabled must be a boolean",
+      },
+    })
+    expect(setWifiAdbState).not.toHaveBeenCalled()
+  })
+
+  test("maps BluetoothSdk failures to INTERNAL", async () => {
+    const {dependencies} = buildDependencies(["com.mentra.settings"], new Error("glasses disconnected"))
+
+    const result = await handleWifiAdbRequest("com.mentra.settings", {enabled: true}, dependencies)
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: MiniappErrorCode.INTERNAL,
+        message: "glasses disconnected",
+      },
+    })
+  })
+})

--- a/mobile/modules/miniapp/src/modules/glasses.ts
+++ b/mobile/modules/miniapp/src/modules/glasses.ts
@@ -45,6 +45,9 @@ export class GlassesModule {
   /**
    * Enable or disable Wi-Fi ADB (wireless debugging) on Mentra Live.
    * Persisted on the glasses; boot applies the saved preference (default off).
+   *
+   * SYSTEM-only — rejects with `NOT_PERMITTED` unless this miniapp is a system
+   * app. Third-party miniapps must not expose wireless debugging controls.
    */
   async setWifiAdbState(enabled: boolean): Promise<void> {
     await this.session.sendRequest<void>({

--- a/mobile/modules/miniapp/src/protocol.ts
+++ b/mobile/modules/miniapp/src/protocol.ts
@@ -122,7 +122,10 @@ export enum MiniappRequestType {
   /** Explicitly enable/disable the center-mic loudness gate ("Barrier"). */
   MIC_SET_LOUDNESS_GATE_ENABLED = "miniapp_mic_set_loudness_gate_enabled",
 
-  /** Enable or disable Wi-Fi ADB (wireless debugging) on Mentra Live. */
+  /**
+   * Enable or disable Wi-Fi ADB (wireless debugging) on Mentra Live.
+   * SYSTEM-only — host rejects with NOT_PERMITTED for non-system callers.
+   */
   SET_WIFI_ADB_STATE = "miniapp_set_wifi_adb_state",
 
   /** Share content via the OS share sheet. */
@@ -351,7 +354,10 @@ export enum MiniappErrorCode {
   NOT_CONNECTED = "NOT_CONNECTED",
 
   // ----- Inter-miniapp interop -----
-  /** Caller is not a system app — interop APIs (list/start/stop/invoke) are SYSTEM-only. */
+  /**
+   * Caller is not a system app — SYSTEM-only APIs (interop list/start/stop/invoke,
+   * setWifiAdbState) reject with this code.
+   */
   NOT_PERMITTED = "NOT_PERMITTED",
   /** Target miniapp is not installed. */
   APP_NOT_FOUND = "APP_NOT_FOUND",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#3671](https://github.com/Mentra-Community/MentraOS/pull/3671) / [OS-1627](https://linear.app/mentralabs/issue/OS-1627): gate `session.glasses.setWifiAdbState` so only **SYSTEM** miniapps can enable/disable Mentra Live Wi-Fi ADB.

Feedback was that this Miniapp SDK surface should not be open to arbitrary third-party miniapps (and if kept, must be SYSTEM-only).

### Changes
- **`LocalMiniappRuntime.handleSetWifiAdbState`**: reject non-system callers with `NOT_PERMITTED` before touching BluetoothSdk
- **`@mentra/miniapp`**: document SYSTEM-only on `GlassesModule.setWifiAdbState` + protocol/`NOT_PERMITTED` comments
- **Docs**: add privileged device-control section under System Miniapp APIs
- **Example miniapp tester**: label controls as SYSTEM-only and point Mentra App/`BluetoothSdk` as the preferred debug path

### Unchanged (intentional)
- Glasses default-off + persistence (`asg_client`)
- Phone-native `BluetoothSdk.setWifiAdbState` for Mentra App / Super Mode debugging

### Test plan
- [x] `cd mobile/modules/miniapp && bun test src/protocol.test.ts`
- [ ] Non-system miniapp calling `setWifiAdbState` → `NOT_PERMITTED`
- [ ] System package (e.g. `com.mentra.settings` / miniapp-dev) → still toggles Mentra Live
- [ ] `BluetoothSdk.setWifiAdbState` from Mentra App still works

Refs: OS-1627

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9f6b959-04fc-4658-8766-6b845b78709c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9f6b959-04fc-4658-8766-6b845b78709c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

