### PR TITLE
Harden BES OTA diagnostics and UART recovery

### DIFF
--- a/.github/scripts/validate-asg-ota-manifest.sh
+++ b/.github/scripts/validate-asg-ota-manifest.sh
@@ -11,12 +11,12 @@ if [[ "$check_apk" != "" && "$check_apk" != "--check-apk" ]]; then
 fi
 
 jq -e '
-  def canonical_bes_version:
+  def valid_bes_version:
     if type != "string" then false
     else split(".") as $parts
       | ($parts | length == 4)
         and all($parts[];
-          test("^(0|[1-9][0-9]{0,2})$")
+          test("^[0-9]{1,3}$")
           and (tonumber <= 255))
     end;
 
@@ -30,7 +30,7 @@ jq -e '
     and ($app.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$"))
     and (.mtk_patches | type == "array" and length > 0)
     and ($bes | type == "object")
-    and ($bes.version | canonical_bes_version)
+    and ($bes.version | valid_bes_version)
     and ($bes.url
       | type == "string"
         and test("^https://[^/?#[:space:]]+(?:/[^/?#[:space:]]*)*/[A-Za-z0-9._-]{1,128}$"))

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -1500,6 +1500,13 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             }
         } else if (msg.cmd == BesProtocolConstants.RCMD_SEND_FINISH) {
             if (msg.len == 1 && msg.body != null && msg.body[0] == 1) {
+                Log.i(
+                        TAG,
+                        "BES_OTA_DIAG apply_boundary=before_persist owner="
+                                + activeOwnerSessionId
+                                + " snapshot={"
+                                + stateStore.read().toDiagnosticString()
+                                + "}");
                 BesOtaStateStore.TransitionResult applyPending =
                         stateStore.markApplyPending(activeOwnerSessionId);
                 if (applyPending != BesOtaStateStore.TransitionResult.APPLIED) {
@@ -1509,6 +1516,15 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                     return;
                 }
                 byte[] data = SCmd_OtaApply();
+                Log.i(
+                        TAG,
+                        "BES_OTA_DIAG apply_boundary=before_uart_write owner="
+                                + activeOwnerSessionId
+                                + " persist_result="
+                                + applyPending
+                                + " snapshot={"
+                                + stateStore.read().toDiagnosticString()
+                                + "}");
                 Log.d(
                         TAG,
                         "Sending OtaApply command, data="
@@ -1517,6 +1533,15 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                                         : "null"));
                 armApplyWaitLocked();
                 boolean sent = send(data);
+                Log.i(
+                        TAG,
+                        "BES_OTA_DIAG apply_boundary=after_uart_write owner="
+                                + activeOwnerSessionId
+                                + " write_accepted="
+                                + sent
+                                + " snapshot={"
+                                + stateStore.read().toDiagnosticString()
+                                + "}");
                 if (!sent) {
                     // APPLY_PENDING was committed first. A local write failure is ambiguous, so
                     // retrying 0x92 could apply twice; retain the record and wait for reboot.
@@ -1553,6 +1578,15 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                 cleanup();
             }
         } else if (msg.cmd == BesProtocolConstants.RCMD_APPLY) {
+            Log.i(
+                    TAG,
+                    "BES_OTA_DIAG apply_ack len="
+                            + msg.len
+                            + " accepted="
+                            + (msg.len == 1 && msg.body != null && msg.body[0] == 1)
+                            + " snapshot={"
+                            + stateStore.read().toDiagnosticString()
+                            + "}");
             if (msg.len == 1 && msg.body != null && msg.body[0] == 1) {
                 Log.i(TAG, "BES accepted apply; awaiting reboot and exact version verification");
                 releaseAfterApplyAcknowledgedLocked();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -2,16 +2,15 @@ package com.mentra.asg_client.io.bes;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Process;
+import android.os.SystemClock;
 import android.util.Log;
-
 import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.util.Locale;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Single durable authority for legacy BES OTA admission, apply, verification, and terminal state.
@@ -146,6 +145,13 @@ public final class BesOtaStateStore {
             String currentBootId, boolean framedPathProvenForCurrentSession) {
         synchronized (TRANSITION_LOCK) {
             Snapshot snapshot = readLocked();
+            logDecision(
+                    "prepare_start",
+                    "requested_boot="
+                            + diagnosticValue(canonicalBootId(currentBootId))
+                            + " framed_path="
+                            + framedPathProvenForCurrentSession,
+                    snapshot);
             if (snapshot.isCorrupt()) {
                 return StartDecision.CORRUPT;
             }
@@ -156,7 +162,9 @@ public final class BesOtaStateStore {
                 return StartDecision.ACTIVE;
             }
             if (snapshot.terminalStatus == TerminalStatus.SUCCESS) {
-                return removeLocked() ? StartDecision.ADMIT : StartDecision.PERSISTENCE_FAILURE;
+                return removeLocked("retire_success", snapshot)
+                        ? StartDecision.ADMIT
+                        : StartDecision.PERSISTENCE_FAILURE;
             }
             String boot = canonicalBootId(currentBootId);
             if (boot == null || boot.equals(snapshot.authorizationBootId)) {
@@ -165,7 +173,9 @@ public final class BesOtaStateStore {
             if (!framedPathProvenForCurrentSession) {
                 return StartDecision.PATH_PROOF_REQUIRED;
             }
-            return removeLocked() ? StartDecision.ADMIT : StartDecision.PERSISTENCE_FAILURE;
+            return removeLocked("retire_failure_after_path_proof", snapshot)
+                    ? StartDecision.ADMIT
+                    : StartDecision.PERSISTENCE_FAILURE;
         }
     }
 
@@ -190,7 +200,9 @@ public final class BesOtaStateStore {
             String artifactId,
             String artifactSha256) {
         synchronized (TRANSITION_LOCK) {
-            if (!readLocked().isIdle()) {
+            Snapshot current = readLocked();
+            if (!current.isIdle()) {
+                logDecision("reserve_rejected", "reason=state_not_idle", current);
                 return TransitionResult.REJECTED;
             }
             String owner = canonicalNonempty(ownerSessionId);
@@ -204,6 +216,15 @@ public final class BesOtaStateStore {
                     || identity == null
                     || digest == null
                     || !digest.matches("[0-9a-f]{64}")) {
+                logDecision(
+                        "reserve_rejected",
+                        "reason=invalid_input requested_owner="
+                                + diagnosticValue(owner)
+                                + " requested_boot="
+                                + diagnosticValue(boot)
+                                + " requested_target="
+                                + diagnosticValue(target),
+                        current);
                 return TransitionResult.REJECTED;
             }
             Snapshot reserved =
@@ -218,7 +239,7 @@ public final class BesOtaStateStore {
                             null,
                             null,
                             System.currentTimeMillis());
-            return putLocked(reserved)
+            return putLocked("reserve_authorization", current, reserved)
                     ? TransitionResult.APPLIED
                     : TransitionResult.PERSISTENCE_FAILURE;
         }
@@ -228,10 +249,14 @@ public final class BesOtaStateStore {
         synchronized (TRANSITION_LOCK) {
             Snapshot current = readLocked();
             if (!current.isOwnedActive(State.AUTH_ATTEMPTED, ownerSessionId)) {
+                logDecision(
+                        "mark_apply_rejected",
+                        "requested_owner=" + diagnosticValue(canonicalNonempty(ownerSessionId)),
+                        current);
                 return terminalOrRejected(current);
             }
             Snapshot next = current.withState(State.APPLY_PENDING, null);
-            return putLocked(next)
+            return putLocked("mark_apply_pending", current, next)
                     ? TransitionResult.APPLIED
                     : TransitionResult.PERSISTENCE_FAILURE;
         }
@@ -242,27 +267,31 @@ public final class BesOtaStateStore {
         synchronized (TRANSITION_LOCK) {
             Snapshot current = readLocked();
             if (!current.isValid() || current.state != State.APPLY_PENDING) {
+                logDecision("verification_not_pending", "", current);
                 return VerificationDecision.NOT_PENDING;
             }
             String boot = canonicalBootId(currentBootId);
             if (boot == null) {
+                logDecision("verification_rejected", "reason=invalid_boot", current);
                 return VerificationDecision.PERSISTENCE_FAILURE;
             }
             if (boot.equals(current.authorizationBootId)) {
+                logDecision("verification_wait", "requested_boot=" + boot, current);
                 return VerificationDecision.WAIT_FOR_REBOOT;
             }
             if (current.verificationBootId == null) {
                 Snapshot claimed = current.withVerificationBoot(boot);
-                return putLocked(claimed)
+                return putLocked("claim_verification_boot", current, claimed)
                         ? VerificationDecision.CLAIMED
                         : VerificationDecision.PERSISTENCE_FAILURE;
             }
             if (boot.equals(current.verificationBootId)) {
+                logDecision("verification_resume", "requested_boot=" + boot, current);
                 return VerificationDecision.RESUME;
             }
             Snapshot failed =
                     current.asTerminal(TerminalStatus.FAILURE, "verification_boot_changed");
-            return putLocked(failed)
+            return putLocked("fail_verification_boot_changed", current, failed)
                     ? VerificationDecision.SECOND_BOOT_FAILED
                     : VerificationDecision.PERSISTENCE_FAILURE;
         }
@@ -274,6 +303,15 @@ public final class BesOtaStateStore {
         synchronized (TRANSITION_LOCK) {
             Snapshot current = readLocked();
             if (!current.isOwnedActive(State.APPLY_PENDING, ownerSessionId)) {
+                logDecision(
+                        "version_proof_rejected",
+                        "reason=owner_or_state requested_owner="
+                                + diagnosticValue(canonicalNonempty(ownerSessionId))
+                                + " requested_boot="
+                                + diagnosticValue(canonicalBootId(currentBootId))
+                                + " actual="
+                                + diagnosticValue(canonicalVersion(actualVersion)),
+                        current);
                 return terminalOrRejected(current);
             }
             String boot = canonicalBootId(currentBootId);
@@ -281,6 +319,13 @@ public final class BesOtaStateStore {
             if (boot == null
                     || current.verificationBootId == null
                     || !boot.equals(current.verificationBootId)) {
+                logDecision(
+                        "version_proof_rejected",
+                        "reason=verification_boot requested_boot="
+                                + diagnosticValue(boot)
+                                + " actual="
+                                + diagnosticValue(actual),
+                        current);
                 return TransitionResult.REJECTED;
             }
             boolean matches = current.targetVersion.equals(actual);
@@ -288,7 +333,10 @@ public final class BesOtaStateStore {
                     current.asTerminal(
                             matches ? TerminalStatus.SUCCESS : TerminalStatus.FAILURE,
                             matches ? "verified" : "version_mismatch");
-            return putLocked(terminal)
+            return putLocked(
+                            matches ? "complete_verified" : "fail_version_mismatch",
+                            current,
+                            terminal)
                     ? TransitionResult.APPLIED
                     : TransitionResult.PERSISTENCE_FAILURE;
         }
@@ -299,21 +347,40 @@ public final class BesOtaStateStore {
         synchronized (TRANSITION_LOCK) {
             Snapshot current = readLocked();
             if (current.isCorrupt() || current.isIdle()) {
+                logDecision(
+                        "failure_rejected",
+                        "reason=no_active_state requested_code="
+                                + diagnosticValue(canonicalCode(stableCode)),
+                        current);
                 return TransitionResult.REJECTED;
             }
             if (current.state == State.TERMINAL) {
+                logDecision(
+                        "failure_ignored_terminal",
+                        "requested_owner="
+                                + diagnosticValue(canonicalNonempty(ownerSessionId))
+                                + " requested_code="
+                                + diagnosticValue(canonicalCode(stableCode)),
+                        current);
                 return current.ownerSessionId.equals(canonicalNonempty(ownerSessionId))
                         ? TransitionResult.ALREADY_TERMINAL
                         : TransitionResult.REJECTED;
             }
             if (!current.ownerSessionId.equals(canonicalNonempty(ownerSessionId))) {
+                logDecision(
+                        "failure_rejected",
+                        "reason=owner_mismatch requested_owner="
+                                + diagnosticValue(canonicalNonempty(ownerSessionId))
+                                + " requested_code="
+                                + diagnosticValue(canonicalCode(stableCode)),
+                        current);
                 return TransitionResult.REJECTED;
             }
             String code = canonicalCode(stableCode);
             Snapshot terminal =
                     current.asTerminal(
                             TerminalStatus.FAILURE, code != null ? code : "install_failed");
-            return putLocked(terminal)
+            return putLocked("fail_" + terminal.terminalCode, current, terminal)
                     ? TransitionResult.APPLIED
                     : TransitionResult.PERSISTENCE_FAILURE;
         }
@@ -324,6 +391,7 @@ public final class BesOtaStateStore {
         synchronized (TRANSITION_LOCK) {
             String boot = canonicalBootId(currentBootId);
             Snapshot current = readLocked();
+            logDecision("startup_snapshot", "requested_boot=" + diagnosticValue(boot), current);
             if (current.isCorrupt()) {
                 if (boot == null) {
                     return StartupDecision.PERSISTENCE_FAILURE;
@@ -340,7 +408,7 @@ public final class BesOtaStateStore {
                                 TerminalStatus.FAILURE,
                                 "corrupt_state",
                                 System.currentTimeMillis());
-                return putLocked(repaired)
+                return putLocked("repair_corrupt_startup", current, repaired)
                         ? StartupDecision.QUARANTINED
                         : StartupDecision.PERSISTENCE_FAILURE;
             }
@@ -352,7 +420,7 @@ public final class BesOtaStateStore {
             }
             if (current.state == State.AUTH_ATTEMPTED) {
                 Snapshot failed = current.asTerminal(TerminalStatus.FAILURE, "interrupted");
-                if (!putLocked(failed)) {
+                if (!putLocked("fail_interrupted_on_startup", current, failed)) {
                     return StartupDecision.PERSISTENCE_FAILURE;
                 }
                 return boot.equals(current.authorizationBootId)
@@ -444,34 +512,87 @@ public final class BesOtaStateStore {
         }
     }
 
-    private boolean putLocked(Snapshot snapshot) {
-        boolean committed = storage.put(snapshot.toJson().toString());
+    private boolean putLocked(String operation, Snapshot before, Snapshot snapshot) {
+        String encoded = snapshot.toJson().toString();
+        boolean committed = storage.put(encoded);
+        String readback = storage.get();
+        boolean readbackMatches = encoded.equals(readback);
+        logMutation(operation, before, snapshot, committed, readbackMatches);
         if (!committed) {
             persistenceUncertain = true;
             Log.e(TAG, "BES OTA state commit failed; remaining fail-closed for this process");
-        } else {
-            Log.i(
+        } else if (!readbackMatches) {
+            Log.w(
                     TAG,
-                    "Committed BES OTA state="
-                            + snapshot.state
-                            + " owner="
-                            + snapshot.ownerSessionId
-                            + " target="
-                            + snapshot.targetVersion
-                            + (snapshot.terminalCode != null
-                                    ? " terminal=" + snapshot.terminalCode
-                                    : ""));
+                    diagnosticPrefix(operation)
+                            + " durable state readback differs immediately after successful commit");
         }
         return committed;
     }
 
-    private boolean removeLocked() {
+    private boolean removeLocked(String operation, Snapshot before) {
         boolean committed = storage.remove();
+        boolean readbackRemoved = storage.get() == null;
+        Log.i(
+                TAG,
+                diagnosticPrefix(operation)
+                        + " before={"
+                        + before.toDiagnosticString()
+                        + "} committed="
+                        + committed
+                        + " readback_removed="
+                        + readbackRemoved);
         if (!committed) {
             persistenceUncertain = true;
             Log.e(TAG, "BES OTA state retirement failed; remaining fail-closed");
         }
         return committed;
+    }
+
+    private void logMutation(
+            String operation,
+            Snapshot before,
+            Snapshot after,
+            boolean committed,
+            boolean readbackMatches) {
+        Log.i(
+                TAG,
+                diagnosticPrefix(operation)
+                        + " before={"
+                        + before.toDiagnosticString()
+                        + "} after={"
+                        + after.toDiagnosticString()
+                        + "} committed="
+                        + committed
+                        + " readback_match="
+                        + readbackMatches);
+    }
+
+    private void logDecision(String operation, String details, Snapshot snapshot) {
+        Log.i(
+                TAG,
+                diagnosticPrefix(operation)
+                        + (details == null || details.isEmpty() ? "" : " " + details)
+                        + " snapshot={"
+                        + snapshot.toDiagnosticString()
+                        + "}");
+    }
+
+    private String diagnosticPrefix(String operation) {
+        return "BES_OTA_DIAG op="
+                + operation
+                + " pid="
+                + Process.myPid()
+                + " thread="
+                + Thread.currentThread().getName()
+                + " elapsed_ms="
+                + SystemClock.elapsedRealtime()
+                + " live_boot="
+                + diagnosticValue(currentBootId());
+    }
+
+    private static String diagnosticValue(String value) {
+        return value == null ? "-" : value;
     }
 
     private static TransitionResult terminalOrRejected(Snapshot snapshot) {
@@ -801,6 +922,32 @@ public final class BesOtaStateStore {
 
         public String getTerminalCode() {
             return terminalCode;
+        }
+
+        /** Stable, non-secret summary for correlating OTA transitions across process and boot. */
+        public String toDiagnosticString() {
+            if (isIdle()) {
+                return "state=IDLE";
+            }
+            if (isCorrupt()) {
+                return "state=CORRUPT reason=" + diagnosticValue(corruption);
+            }
+            return "state="
+                    + state
+                    + " owner="
+                    + diagnosticValue(ownerSessionId)
+                    + " auth_boot="
+                    + diagnosticValue(authorizationBootId)
+                    + " verify_boot="
+                    + diagnosticValue(verificationBootId)
+                    + " target="
+                    + diagnosticValue(targetVersion)
+                    + " terminal_status="
+                    + diagnosticValue(terminalStatus == null ? null : terminalStatus.name())
+                    + " terminal_code="
+                    + diagnosticValue(terminalCode)
+                    + " updated_at_ms="
+                    + updatedAtMs;
         }
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -538,6 +538,8 @@ public final class BesOtaStateStore {
                 diagnosticPrefix(operation)
                         + " before={"
                         + before.toDiagnosticString()
+                        + "} after={"
+                        + Snapshot.idle().toDiagnosticString()
                         + "} committed="
                         + committed
                         + " readback_removed="

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1561,6 +1561,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     }
 
     private void reconcileBesOtaVersionProof(String actualVersion) {
+        String canonicalActualVersion = BesOtaStateStore.canonicalVersion(actualVersion);
+        String diagnosticActualVersion =
+                canonicalActualVersion == null ? "invalid" : canonicalActualVersion;
         BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
         String skipReason = null;
         if (!snapshot.isValid()) {
@@ -1575,7 +1578,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.i(
                 TAG,
                 "BES_OTA_DIAG version_proof actual="
-                        + actualVersion
+                        + diagnosticActualVersion
                         + " current_boot="
                         + currentBootId
                         + " disposition="
@@ -1594,7 +1597,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 "BES_OTA_DIAG version_proof_claim result="
                         + verification
                         + " actual="
-                        + actualVersion
+                        + diagnosticActualVersion
                         + " snapshot={"
                         + besOtaStateStore.read().toDiagnosticString()
                         + "}");
@@ -1611,7 +1614,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 "BES_OTA_DIAG version_proof_complete result="
                         + completed
                         + " actual="
-                        + actualVersion
+                        + diagnosticActualVersion
                         + " snapshot={"
                         + besOtaStateStore.read().toDiagnosticString()
                         + "}");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1658,9 +1658,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     /**
      * Compare two dotted version strings numerically, component by component. Missing components
-     * count as 0. Each component is read as its leading numeric prefix so hotfix-suffixed firmware
-     * strings (e.g. "17.26.7.5-fix1") compare as their base version instead of throwing and
-     * silently disabling the transport feature gates.
+     * count as 0. This legacy capability gate reads each component's leading numeric prefix, but it
+     * does not define the BES firmware version format; BES OTA identity remains four numeric bytes.
      *
      * @return negative if a &lt; b, 0 if equal, positive if a &gt; b
      */
@@ -1678,7 +1677,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         return 0;
     }
 
-    /** Numeric prefix of a version component ("5-fix1" -> 5); 0 if there is none. */
+    /** Numeric prefix of a version component; 0 if there is none. */
     private static int leadingInt(String component) {
         String s = component.trim();
         int end = 0;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2,7 +2,6 @@ package com.mentra.asg_client.io.bluetooth.managers;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.BesOtaStateStore;
 import com.mentra.asg_client.io.bes.BesOtaUartListener;
@@ -28,10 +27,6 @@ import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrat
 import com.mentra.asg_client.service.utils.SysProp;
 import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.utils.WakeLockManager;
-
-import org.greenrobot.eventbus.EventBus;
-import org.json.JSONObject;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -44,6 +39,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.greenrobot.eventbus.EventBus;
+import org.json.JSONObject;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -249,7 +246,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         currentBootId = besOtaStateStore.currentBootId();
         BesOtaStateStore.StartupDecision startupDecision =
                 besOtaStateStore.reconcileStartup(currentBootId);
-        Log.i(TAG, "BES OTA startup reconciliation: " + startupDecision);
+        Log.i(
+                TAG,
+                "BES_OTA_DIAG startup_result="
+                        + startupDecision
+                        + " current_boot="
+                        + currentBootId
+                        + " snapshot={"
+                        + besOtaStateStore.read().toDiagnosticString()
+                        + "}");
 
         // Create the notification manager
         notificationManager = new DebugNotificationManager(context);
@@ -1185,6 +1190,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     private void onBesRawOtaModeProvenAfterRestart() {
         BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
+        Log.e(
+                TAG,
+                "BES_OTA_DIAG recovery_result=raw_mode_proven snapshot={"
+                        + snapshot.toDiagnosticString()
+                        + "}");
         if (snapshot.isValid() && snapshot.getState() != BesOtaStateStore.State.TERMINAL) {
             BesOtaStateStore.TransitionResult result =
                     besOtaStateStore.fail(snapshot.getOwnerSessionId(), "raw_mode_after_restart");
@@ -1195,6 +1205,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     private void onBesRecoveryFailed() {
         BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
+        Log.e(
+                TAG,
+                "BES_OTA_DIAG recovery_result=timeout current_boot="
+                        + currentBootId
+                        + " framed_path="
+                        + framedPathProven
+                        + " snapshot={"
+                        + snapshot.toDiagnosticString()
+                        + "}");
         if (snapshot.isValid() && snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
             BesOtaStateStore.TransitionResult result =
                     besOtaStateStore.fail(snapshot.getOwnerSessionId(), "verification_timeout");
@@ -1543,14 +1562,42 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     private void reconcileBesOtaVersionProof(String actualVersion) {
         BesOtaStateStore.Snapshot snapshot = besOtaStateStore.read();
-        if (!snapshot.isValid()
-                || snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
-                || currentBootId == null
-                || currentBootId.equals(snapshot.getAuthorizationBootId())) {
+        String skipReason = null;
+        if (!snapshot.isValid()) {
+            skipReason = "invalid_or_idle_state";
+        } else if (snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING) {
+            skipReason = "state_not_apply_pending";
+        } else if (currentBootId == null) {
+            skipReason = "missing_current_boot";
+        } else if (currentBootId.equals(snapshot.getAuthorizationBootId())) {
+            skipReason = "still_authorization_boot";
+        }
+        Log.i(
+                TAG,
+                "BES_OTA_DIAG version_proof actual="
+                        + actualVersion
+                        + " current_boot="
+                        + currentBootId
+                        + " disposition="
+                        + (skipReason == null ? "candidate" : "ignored")
+                        + (skipReason == null ? "" : " reason=" + skipReason)
+                        + " snapshot={"
+                        + snapshot.toDiagnosticString()
+                        + "}");
+        if (skipReason != null) {
             return;
         }
         BesOtaStateStore.VerificationDecision verification =
                 besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
+        Log.i(
+                TAG,
+                "BES_OTA_DIAG version_proof_claim result="
+                        + verification
+                        + " actual="
+                        + actualVersion
+                        + " snapshot={"
+                        + besOtaStateStore.read().toDiagnosticString()
+                        + "}");
         if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
                 && verification != BesOtaStateStore.VerificationDecision.RESUME) {
             Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
@@ -1559,6 +1606,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         BesOtaStateStore.TransitionResult completed =
                 besOtaStateStore.completeVerified(
                         snapshot.getOwnerSessionId(), currentBootId, actualVersion);
+        Log.i(
+                TAG,
+                "BES_OTA_DIAG version_proof_complete result="
+                        + completed
+                        + " actual="
+                        + actualVersion
+                        + " snapshot={"
+                        + besOtaStateStore.read().toDiagnosticString()
+                        + "}");
         if (completed != BesOtaStateStore.TransitionResult.APPLIED) {
             Log.e(TAG, "Could not commit BES post-apply version proof: " + completed);
             return;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -143,6 +143,8 @@ public final class BesUartTransportCoordinator {
     private static final int[] RECOVERY_BAUDS = {
         AsgConstants.UART_FAST_BAUD, AsgConstants.UART_RENDEZVOUS_BAUD
     };
+    private static final int SAFETY_REOPEN_MAX_ATTEMPTS = 2;
+    private static final long SAFETY_REOPEN_RETRY_DELAY_MS = 200;
 
     private final Object monitor = new Object();
     private final Host host;
@@ -445,11 +447,11 @@ public final class BesUartTransportCoordinator {
             otaRawRouting = true;
             long reopenPhase = ++phaseGeneration;
             Log.w(TAG, "Safety recovery trying alternate UART baud " + alternateBaud);
-            ioLane.submit(() -> performSafetyRecoveryReopen(reopenPhase, alternateBaud));
+            ioLane.submit(() -> performSafetyRecoveryReopen(reopenPhase, alternateBaud, 1));
         }
     }
 
-    private void performSafetyRecoveryReopen(long reopenPhase, int baud) {
+    private void performSafetyRecoveryReopen(long reopenPhase, int baud, int attempt) {
         synchronized (monitor) {
             if (reopenPhase != phaseGeneration || state != State.SAFETY_RECOVERING) {
                 return;
@@ -458,20 +460,49 @@ public final class BesUartTransportCoordinator {
 
         SerialSession opened = replacePhysicalSession(baud);
         boolean closeOpened = false;
+        boolean retry = false;
         synchronized (monitor) {
             if (reopenPhase != phaseGeneration || state != State.SAFETY_RECOVERING) {
                 closeOpened = opened != null;
             } else if (!adoptAndStartSessionLocked(opened)) {
                 closeOpened = opened != null;
-                safetyState.onRecoveryFailed();
-                quarantineCurrentSessionLocked();
+                if (attempt < SAFETY_REOPEN_MAX_ATTEMPTS) {
+                    retry = true;
+                    Log.w(
+                            TAG,
+                            "Safety UART reopen attempt "
+                                    + attempt
+                                    + "/"
+                                    + SAFETY_REOPEN_MAX_ATTEMPTS
+                                    + " failed at "
+                                    + baud
+                                    + "; retrying local descriptor only");
+                } else {
+                    safetyState.onRecoveryFailed();
+                    quarantineCurrentSessionLocked();
+                }
             } else {
                 armSafetyRecoveryProbesLocked();
-                Log.w(TAG, "Safety recovery reopened UART at alternate baud " + baud);
+                Log.w(
+                        TAG,
+                        "Safety recovery reopened UART at alternate baud "
+                                + baud
+                                + " on attempt "
+                                + attempt);
             }
         }
         if (closeOpened) {
             host.closeSession(opened);
+        }
+        if (retry && !executor.isShutdown()) {
+            executor.schedule(
+                    () ->
+                            ioLane.submit(
+                                    () ->
+                                            performSafetyRecoveryReopen(
+                                                    reopenPhase, baud, attempt + 1)),
+                    SAFETY_REOPEN_RETRY_DELAY_MS,
+                    TimeUnit.MILLISECONDS);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -181,6 +181,7 @@ public final class BesUartTransportCoordinator {
     private ScheduledFuture<?> healthTimeout;
     private int safetyRawProbeAttempts;
     private boolean safetyRecoveryListenerReady;
+    private boolean safetyAlternateBaudAttempted;
 
     public BesUartTransportCoordinator(Host host) {
         this(host, () -> SafetyPolicy.NORMAL);
@@ -324,6 +325,7 @@ public final class BesUartTransportCoordinator {
                 state = State.SAFETY_RECOVERING;
                 otaRawRouting = true;
                 safetyRawProbeAttempts = 0;
+                safetyAlternateBaudAttempted = false;
                 phaseGeneration++;
                 if (safetyRecoveryListenerReady) {
                     Log.w(TAG, "Starting raw-first BES OTA recovery probe: " + policy);
@@ -360,6 +362,7 @@ public final class BesUartTransportCoordinator {
             baudTransitionTarget = 0;
             firmwareVersion = "";
             versionProbeDeferred = false;
+            safetyAlternateBaudAttempted = false;
             cancelOutboundDrainLocked();
             state = State.CLOSED;
             operation = Operation.NONE;
@@ -402,28 +405,73 @@ public final class BesUartTransportCoordinator {
             if (phase != phaseGeneration || state != State.SAFETY_RECOVERING) {
                 return;
             }
-            // Raw silence is not proof of framed mode. Release A sends exactly one source-audited
-            // cs_syvr and accepts only its current-session sr_syvr. Physical compatibility remains
-            // a mandatory internal-staging rollout gate before production promotion.
+            // Raw silence is not proof of framed mode. Send exactly one source-audited cs_syvr and
+            // accept only its current-session sr_syvr. A restarted ASG process cannot know whether
+            // BES was left at rendezvous or fast baud, so a timeout advances to the one alternate
+            // physical baud and repeats this raw-first proof before failing closed.
             otaRawRouting = false;
             host.resetParser();
             state = State.DISCOVERING;
             long framedPhase = ++phaseGeneration;
-            scheduleProbeBurstLocked(framedPhase, AsgConstants.UART_RENDEZVOUS_BAUD, 0, 1, 0);
+            scheduleProbeBurstLocked(framedPhase, host.currentBaud(), 0, 1, 0);
             phaseTimeout =
                     executor.schedule(
-                            () -> quarantineSafetyRecoveryIfCurrent(framedPhase),
+                            () -> continueSafetyRecoveryIfCurrent(framedPhase),
                             AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS,
                             TimeUnit.MILLISECONDS);
         }
     }
 
-    private void quarantineSafetyRecoveryIfCurrent(long phase) {
+    private void continueSafetyRecoveryIfCurrent(long phase) {
+        int alternateBaud;
         synchronized (monitor) {
-            if (phase == phaseGeneration && state == State.DISCOVERING) {
+            if (phase != phaseGeneration || state != State.DISCOVERING) {
+                return;
+            }
+            if (safetyAlternateBaudAttempted) {
                 safetyState.onRecoveryFailed();
                 quarantineCurrentSessionLocked();
+                return;
             }
+            safetyAlternateBaudAttempted = true;
+            alternateBaud =
+                    host.currentBaud() == AsgConstants.UART_FAST_BAUD
+                            ? AsgConstants.UART_RENDEZVOUS_BAUD
+                            : AsgConstants.UART_FAST_BAUD;
+            host.invalidateLinkProof();
+            serialSession = null;
+            versionSession = null;
+            state = State.SAFETY_RECOVERING;
+            otaRawRouting = true;
+            long reopenPhase = ++phaseGeneration;
+            Log.w(TAG, "Safety recovery trying alternate UART baud " + alternateBaud);
+            ioLane.submit(() -> performSafetyRecoveryReopen(reopenPhase, alternateBaud));
+        }
+    }
+
+    private void performSafetyRecoveryReopen(long reopenPhase, int baud) {
+        synchronized (monitor) {
+            if (reopenPhase != phaseGeneration || state != State.SAFETY_RECOVERING) {
+                return;
+            }
+        }
+
+        SerialSession opened = replacePhysicalSession(baud);
+        boolean closeOpened = false;
+        synchronized (monitor) {
+            if (reopenPhase != phaseGeneration || state != State.SAFETY_RECOVERING) {
+                closeOpened = opened != null;
+            } else if (!adoptAndStartSessionLocked(opened)) {
+                closeOpened = opened != null;
+                safetyState.onRecoveryFailed();
+                quarantineCurrentSessionLocked();
+            } else {
+                armSafetyRecoveryProbesLocked();
+                Log.w(TAG, "Safety recovery reopened UART at alternate baud " + baud);
+            }
+        }
+        if (closeOpened) {
+            host.closeSession(opened);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
@@ -2,11 +2,9 @@ package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.lhs.serialport.api.SerialManager;
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -15,6 +13,9 @@ import java.io.OutputStream;
 /** Manager for serial communication with the BES2700 Bluetooth module in K900 devices. */
 public class SerialPortBridge {
     private static final String TAG = "SerialPortBridge";
+
+    /** Maximum time to wait for a closed descriptor's reader to terminate. */
+    private static final long READER_STOP_TIMEOUT_MS = 1000;
 
     // Serial port configuration - matches the K900 SDK
     private static final String COM_PATH = "/dev/ttyS1";
@@ -39,6 +40,11 @@ public class SerialPortBridge {
     private volatile boolean mbRequestFast = false;
     private long nextSessionId = 0;
     private volatile SerialSession currentSession;
+    private final SerialDriver serialDriver;
+    private final long readerStopTimeoutMs;
+
+    /** True only when no native descriptor from the previous session can be reused by a reader. */
+    private boolean lastCloseSafe = true;
 
     /** Baud rate the port is currently open at (DEFAULT_BAUDRATE until a reopen succeeds). */
     private volatile int mCurrentBaud = DEFAULT_BAUDRATE;
@@ -49,7 +55,13 @@ public class SerialPortBridge {
      * @param context The application context
      */
     public SerialPortBridge(Context context) {
+        this(context, new LhsSerialDriver(), READER_STOP_TIMEOUT_MS);
+    }
+
+    SerialPortBridge(Context context, SerialDriver serialDriver, long readerStopTimeoutMs) {
         mContext = context;
+        this.serialDriver = serialDriver;
+        this.readerStopTimeoutMs = readerStopTimeoutMs;
     }
 
     /**
@@ -68,20 +80,22 @@ public class SerialPortBridge {
      */
     public synchronized boolean start() {
         if (mbStart) return true;
-        if (mRecvThread != null) {
-            closeCurrentPort();
+        if (!prepareForOpen()) {
+            Log.e(TAG, "Refusing to start serial port while the previous reader is alive");
+            return false;
         }
 
-        boolean bSucc = SerialManager.getInstance().openSerial(COM_PATH, COM_BAUDRATE);
+        boolean bSucc = serialDriver.open(COM_PATH, COM_BAUDRATE);
         Log.d(TAG, "openSerial dev=" + COM_PATH + ", bSucc=" + bSucc);
 
         if (mListener != null) mListener.onSerialOpen(bSucc, 0, COM_PATH, "");
 
         if (bSucc) {
             mbStart = true;
+            lastCloseSafe = false;
             mCurrentBaud = COM_BAUDRATE;
-            mIS = SerialManager.getInstance().getInputStream(COM_PATH);
-            mOS = SerialManager.getInstance().getOutputStream(COM_PATH);
+            mIS = serialDriver.getInputStream(COM_PATH);
+            mOS = serialDriver.getOutputStream(COM_PATH);
 
             SerialSession session = newSession(COM_BAUDRATE);
             currentSession = session;
@@ -149,8 +163,15 @@ public class SerialPortBridge {
                         + mCurrentBaud
                         + ")");
 
-        if (mbStart || mRecvThread != null) {
-            closeCurrentPort();
+        if (!prepareForOpen()) {
+            Log.e(
+                    BAUD_TAG,
+                    "Refusing to open "
+                            + COM_PATH
+                            + " at "
+                            + baud
+                            + " while the previous reader is alive");
+            return null;
         }
 
         if (!openDriverAtBaud(baud)) {
@@ -159,9 +180,10 @@ public class SerialPortBridge {
         }
 
         mCurrentBaud = baud;
-        mIS = SerialManager.getInstance().getInputStream(COM_PATH);
-        mOS = SerialManager.getInstance().getOutputStream(COM_PATH);
+        mIS = serialDriver.getInputStream(COM_PATH);
+        mOS = serialDriver.getOutputStream(COM_PATH);
         mbStart = true;
+        lastCloseSafe = false;
 
         SerialSession session = newSession(baud);
         currentSession = session;
@@ -199,8 +221,24 @@ public class SerialPortBridge {
         return new SerialSession(++nextSessionId, COM_PATH, baud);
     }
 
-    /** Close the descriptor and retire its reader before another stream is published. */
-    private void closeCurrentPort() {
+    /** Ensure no prior descriptor or reader remains before opening a new physical session. */
+    private boolean prepareForOpen() {
+        if (!mbStart && mRecvThread == null && lastCloseSafe) {
+            return true;
+        }
+        return closeCurrentPort();
+    }
+
+    /**
+     * Close the descriptor, then wait for its reader to terminate before allowing another open.
+     *
+     * <p>{@code liblhsserial} indexes streams by path. Reopening {@code /dev/ttyS1} while an old
+     * {@link InputStream#read(byte[])} is still blocked can attach that old reader to the new
+     * native descriptor. Interrupting a Java thread is not sufficient to unblock that native read.
+     * The replacement must therefore fail closed unless descriptor close plus interruption actually
+     * terminates the reader.
+     */
+    private boolean closeCurrentPort() {
         RecvThread oldThread = mRecvThread;
         if (oldThread != null) {
             oldThread.setStop();
@@ -214,25 +252,56 @@ public class SerialPortBridge {
         mIS = null;
         mOS = null;
 
+        boolean driverClosed = true;
         try {
-            SerialManager.getInstance().closeSerial(COM_PATH);
+            serialDriver.close(COM_PATH);
         } catch (Exception e) {
+            driverClosed = false;
             Log.e(BAUD_TAG, "Error closing serial port", e);
         }
 
-        // The session retirement above waits for an already-entered listener callback. The old
-        // reader therefore cannot cross the descriptor replacement, and stop prevents another
-        // completed native read from being delivered or another read from starting.
+        boolean readerStopped = true;
         if (oldThread != null) {
             oldThread.interrupt();
+            if (Thread.currentThread() == oldThread) {
+                readerStopped = false;
+                Log.e(BAUD_TAG, "Serial reader attempted to replace its own descriptor");
+            } else {
+                try {
+                    oldThread.join(readerStopTimeoutMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    readerStopped = false;
+                    Log.e(BAUD_TAG, "Interrupted while waiting for serial reader to stop", e);
+                }
+                if (oldThread.isAlive()) {
+                    readerStopped = false;
+                    Log.e(
+                            BAUD_TAG,
+                            "Serial reader did not exit within "
+                                    + readerStopTimeoutMs
+                                    + "ms; replacement is blocked for "
+                                    + oldThread.session);
+                }
+            }
         }
-        mRecvThread = null;
+
+        if (readerStopped) {
+            mRecvThread = null;
+        } else {
+            // Retain ownership of the live reader so every later open attempt must close and wait
+            // again. Never lose the only handle to a thread that can consume the next descriptor.
+            mRecvThread = oldThread;
+        }
+
+        lastCloseSafe = driverClosed && readerStopped;
+        return lastCloseSafe;
     }
 
     /** Open COM_PATH at the given baud, catching any exception. */
     private boolean openDriverAtBaud(int baud) {
         try {
-            boolean bSucc = SerialManager.getInstance().openSerial(COM_PATH, baud);
+            boolean bSucc = serialDriver.open(COM_PATH, baud);
             Log.d(BAUD_TAG, "openSerial dev=" + COM_PATH + " baud=" + baud + " bSucc=" + bSucc);
             return bSucc;
         } catch (Exception | LinkageError e) {
@@ -357,6 +426,8 @@ public class SerialPortBridge {
         public void run() {
             int readSize;
 
+            Log.i(BAUD_TAG, "Serial reader started for " + session);
+
             while (!mbStop) {
                 if (input != null) {
                     try {
@@ -394,7 +465,39 @@ public class SerialPortBridge {
                 }
             }
 
-            Log.d(TAG, "RecvThread exiting");
+            Log.i(BAUD_TAG, "Serial reader exited for " + session);
+        }
+    }
+
+    interface SerialDriver {
+        boolean open(String path, int baud);
+
+        InputStream getInputStream(String path);
+
+        OutputStream getOutputStream(String path);
+
+        void close(String path);
+    }
+
+    private static final class LhsSerialDriver implements SerialDriver {
+        @Override
+        public boolean open(String path, int baud) {
+            return SerialManager.getInstance().openSerial(path, baud);
+        }
+
+        @Override
+        public InputStream getInputStream(String path) {
+            return SerialManager.getInstance().getInputStream(path);
+        }
+
+        @Override
+        public OutputStream getOutputStream(String path) {
+            return SerialManager.getInstance().getOutputStream(path);
+        }
+
+        @Override
+        public void close(String path) {
+            SerialManager.getInstance().closeSerial(path);
         }
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -291,9 +291,17 @@ public class OtaHelper {
     public boolean sendAuthoritativeBesStatusToPhone() {
         JSONObject status = getAuthoritativeBesStatus();
         if (status == null) {
+            Log.i(TAG, "BES_OTA_DIAG phone_projection=absent");
             return false;
         }
-        if (phoneConnectionProvider != null && isPhoneConnected()) {
+        boolean connected = phoneConnectionProvider != null && isPhoneConnected();
+        Log.i(
+                TAG,
+                "BES_OTA_DIAG phone_projection=durable connected="
+                        + connected
+                        + " status="
+                        + status);
+        if (connected) {
             phoneConnectionProvider.sendOtaStatus(status);
         }
         return true;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
@@ -58,15 +58,15 @@ public final class BesFirmwareArtifactValidator {
             assertProduct(raw, AsgConstants.BES_OTA_PRODUCT);
             String targetVersion = requiredString(metadata, "version");
             String canonicalTarget = BesOtaStateStore.canonicalVersion(targetVersion);
-            if (canonicalTarget == null || !canonicalTarget.equals(targetVersion)) {
+            if (canonicalTarget == null) {
                 throw new ValidationException(
-                        "BES target version must be canonical major.minor.patch.build");
+                        "BES target version must contain four numeric byte components");
             }
             return new ValidatedBesArtifact(
                     artifact,
                     artifactId,
                     compressedSha256,
-                    targetVersion,
+                    canonicalTarget,
                     compressedSize,
                     raw.length);
         } catch (ValidationException e) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -169,16 +169,21 @@ public class BesOtaStateStoreTest {
 
         assertThat(store.prepareForNewSession(BOOT_B, false))
                 .isEqualTo(StartDecision.PATH_PROOF_REQUIRED);
+        ShadowLog.clear();
         assertThat(store.prepareForNewSession(BOOT_B, true)).isEqualTo(StartDecision.ADMIT);
         assertThat(store.read().isIdle()).isTrue();
+        assertThat(logsContain("op=retire_failure_after_path_proof", "after={state=IDLE}"))
+                .isTrue();
     }
 
     @Test
     public void successfulTerminalCanRetireWithoutAnotherBoot() {
         completeSuccessfully();
 
+        ShadowLog.clear();
         assertThat(store.prepareForNewSession(BOOT_B, false)).isEqualTo(StartDecision.ADMIT);
         assertThat(store.read().isIdle()).isTrue();
+        assertThat(logsContain("op=retire_success", "after={state=IDLE}")).isTrue();
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -10,13 +10,13 @@ import com.mentra.asg_client.io.bes.BesOtaStateStore.TerminalStatus;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.TransitionResult;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.UartPolicy;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.VerificationDecision;
-
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
@@ -269,6 +269,26 @@ public class BesOtaStateStoreTest {
     }
 
     @Test
+    public void successfulCommitWithStaleImmediateReadbackIsDiagnosed() {
+        reserve();
+        ShadowLog.clear();
+        storage.dropNextSuccessfulPut = true;
+
+        assertThat(store.markApplyPending(OWNER)).isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getState()).isEqualTo(State.AUTH_ATTEMPTED);
+        assertThat(logsContain("op=mark_apply_pending", "readback_match=false")).isTrue();
+    }
+
+    @Test
+    public void diagnosticStateSummaryOmitsArtifactIdentityAndDigest() {
+        reserve();
+
+        String summary = store.read().toDiagnosticString();
+        assertThat(summary).contains("state=AUTH_ATTEMPTED", "target=" + TARGET);
+        assertThat(summary).doesNotContain(ARTIFACT, SHA);
+    }
+
+    @Test
     public void versionCanonicalizationIsExactAndBounded() {
         assertThat(BesOtaStateStore.canonicalVersion("026.007.030.004")).isEqualTo("26.7.30.4");
         assertThat(BesOtaStateStore.canonicalVersion("26.7.30")).isNull();
@@ -293,10 +313,20 @@ public class BesOtaStateStoreTest {
                 .isEqualTo(TransitionResult.APPLIED);
     }
 
+    private static boolean logsContain(String first, String second) {
+        for (ShadowLog.LogItem item : ShadowLog.getLogsForTag("BesOtaStateStore")) {
+            if (item.msg.contains(first) && item.msg.contains(second)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static final class FakeStorage implements BesOtaStateStore.Storage {
         String raw;
         boolean failNextPut;
         boolean failNextRemove;
+        boolean dropNextSuccessfulPut;
 
         @Override
         public String get() {
@@ -308,6 +338,10 @@ public class BesOtaStateStoreTest {
             if (failNextPut) {
                 failNextPut = false;
                 return false;
+            }
+            if (dropNextSuccessfulPut) {
+                dropNextSuccessfulPut = false;
+                return true;
             }
             raw = value;
             return true;

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -444,20 +444,49 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
+    public void durableRecovery_processRestartFindsBesAtFastBaud() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
+        coordinator.onSerialReady(host.session);
+        coordinator.startSafetyRecovery();
+
+        awaitControlCommandCount("cs_syvr", 2, 12_000);
+
+        assertThat(host.openAttempts).containsExactly(AsgConstants.UART_FAST_BAUD);
+        assertThat(host.currentBaud()).isEqualTo(AsgConstants.UART_FAST_BAUD);
+        assertThat(host.rawWrites).hasSize(6);
+        assertThat(countControlCommands("cs_syvr")).isEqualTo(2);
+        assertThat(
+                        coordinator.onSystemVersion(
+                                "26.8.5.0",
+                                coordinator.getSerialSession(),
+                                () ->
+                                        safety.policy =
+                                                BesUartTransportCoordinator.SafetyPolicy.NORMAL))
+                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+        assertThat(safety.recoveryFailed).isFalse();
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.READY_FAST);
+    }
+
+    @Test
     public void durableRecovery_totalSilenceFailsClosed() throws Exception {
         safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
         coordinator.onSerialReady(host.session);
         coordinator.startSafetyRecovery();
 
         long deadline =
-                System.currentTimeMillis() + AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS + 5_000;
+                System.currentTimeMillis()
+                        + 2L * AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS
+                        + 9_000;
         while (System.currentTimeMillis() < deadline && !safety.recoveryFailed) {
             Thread.sleep(10);
         }
 
         assertThat(safety.recoveryFailed).isTrue();
         assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.QUARANTINED);
-        assertThat(countControlCommands("cs_syvr")).isEqualTo(1);
+        assertThat(host.openAttempts).containsExactly(AsgConstants.UART_FAST_BAUD);
+        assertThat(host.rawWrites).hasSize(6);
+        assertThat(countControlCommands("cs_syvr")).isEqualTo(2);
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -501,12 +501,7 @@ public class BesUartTransportCoordinatorTest {
         coordinator.onSerialReady(host.session);
         coordinator.startSafetyRecovery();
 
-        long deadline = System.currentTimeMillis() + 10_000;
-        while (System.currentTimeMillis() < deadline && !safety.recoveryFailed) {
-            Thread.sleep(10);
-        }
-
-        assertThat(safety.recoveryFailed).isTrue();
+        awaitRecoveryFailed(15_000);
         assertThat(host.openAttempts)
                 .containsExactly(AsgConstants.UART_FAST_BAUD, AsgConstants.UART_FAST_BAUD);
         assertThat(host.rawWrites).hasSize(3);
@@ -520,15 +515,7 @@ public class BesUartTransportCoordinatorTest {
         coordinator.onSerialReady(host.session);
         coordinator.startSafetyRecovery();
 
-        long deadline =
-                System.currentTimeMillis()
-                        + 2L * AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS
-                        + 9_000;
-        while (System.currentTimeMillis() < deadline && !safety.recoveryFailed) {
-            Thread.sleep(10);
-        }
-
-        assertThat(safety.recoveryFailed).isTrue();
+        awaitRecoveryFailed(2L * AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS + 9_000);
         assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.QUARANTINED);
         assertThat(host.openAttempts).containsExactly(AsgConstants.UART_FAST_BAUD);
         assertThat(host.rawWrites).hasSize(6);
@@ -932,6 +919,14 @@ public class BesUartTransportCoordinatorTest {
             Thread.sleep(10);
         }
         assertThat(countOpenAttempts(baud)).isGreaterThanOrEqualTo(expected);
+    }
+
+    private void awaitRecoveryFailed(long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline && !safety.recoveryFailed) {
+            Thread.sleep(10);
+        }
+        assertThat(safety.recoveryFailed).isTrue();
     }
 
     private long countControlCommands(String command) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -469,6 +469,52 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
+    public void durableRecovery_transientAlternateReopenFailureRetriesLocally() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
+        host.openFailuresRemaining = 1;
+        coordinator.onSerialReady(host.session);
+        coordinator.startSafetyRecovery();
+
+        awaitControlCommandCount("cs_syvr", 2, 12_000);
+
+        assertThat(host.openAttempts)
+                .containsExactly(AsgConstants.UART_FAST_BAUD, AsgConstants.UART_FAST_BAUD);
+        assertThat(host.currentBaud()).isEqualTo(AsgConstants.UART_FAST_BAUD);
+        assertThat(host.rawWrites).hasSize(6);
+        assertThat(
+                        coordinator.onSystemVersion(
+                                "26.8.5.0",
+                                coordinator.getSerialSession(),
+                                () ->
+                                        safety.policy =
+                                                BesUartTransportCoordinator.SafetyPolicy.NORMAL))
+                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+        assertThat(safety.recoveryFailed).isFalse();
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.READY_FAST);
+    }
+
+    @Test
+    public void durableRecovery_repeatedAlternateReopenFailureFailsClosed() throws Exception {
+        safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
+        host.openFailuresRemaining = 2;
+        coordinator.onSerialReady(host.session);
+        coordinator.startSafetyRecovery();
+
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline && !safety.recoveryFailed) {
+            Thread.sleep(10);
+        }
+
+        assertThat(safety.recoveryFailed).isTrue();
+        assertThat(host.openAttempts)
+                .containsExactly(AsgConstants.UART_FAST_BAUD, AsgConstants.UART_FAST_BAUD);
+        assertThat(host.rawWrites).hasSize(3);
+        assertThat(countControlCommands("cs_syvr")).isEqualTo(1);
+        assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.QUARANTINED);
+    }
+
+    @Test
     public void durableRecovery_totalSilenceFailsClosed() throws Exception {
         safety.policy = BesUartTransportCoordinator.SafetyPolicy.VERSION_PROBE_ONLY;
         coordinator.onSerialReady(host.session);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeSessionTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeSessionTest.java
@@ -3,20 +3,25 @@ package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.app.Application;
-
 import androidx.test.core.app.ApplicationProvider;
-
 import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
-
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import java.io.ByteArrayInputStream;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(application = Application.class, sdk = 33)
@@ -101,5 +106,145 @@ public class SerialPortBridgeSessionTest {
         assertThat(received.await(200, TimeUnit.MILLISECONDS)).isFalse();
         reader.setStop();
         reader.interrupt();
+    }
+
+    @Test
+    public void openAtBaud_waitsForClosedReaderBeforeOpeningReplacement() throws Exception {
+        BlockingInputStream firstInput = new BlockingInputStream(true);
+        FakeSerialDriver driver =
+                new FakeSerialDriver(firstInput, new ByteArrayInputStream(new byte[0]));
+        SerialPortBridge bridge =
+                new SerialPortBridge(
+                        ApplicationProvider.getApplicationContext(), driver, 200 /* timeoutMs */);
+
+        assertThat(bridge.start()).isTrue();
+        assertThat(firstInput.awaitRead()).isTrue();
+        SerialSession firstSession = bridge.getCurrentSession();
+
+        SerialSession replacement = bridge.openAtBaud(921600);
+
+        assertThat(replacement).isNotNull();
+        assertThat(firstInput.awaitReadExit()).isTrue();
+        assertThat(firstSession.isActive()).isFalse();
+        assertThat(bridge.getCurrentSession()).isSameAs(replacement);
+        assertThat(driver.openBauds).containsExactly(SerialPortBridge.DEFAULT_BAUDRATE, 921600);
+
+        assertThat(bridge.startReader(replacement)).isTrue();
+        bridge.stop();
+    }
+
+    @Test
+    public void openAtBaud_refusesReplacementWhileClosedReaderIsStillAlive() throws Exception {
+        BlockingInputStream stuckInput = new BlockingInputStream(false);
+        FakeSerialDriver driver =
+                new FakeSerialDriver(stuckInput, new ByteArrayInputStream(new byte[0]));
+        SerialPortBridge bridge =
+                new SerialPortBridge(
+                        ApplicationProvider.getApplicationContext(), driver, 25 /* timeoutMs */);
+
+        assertThat(bridge.start()).isTrue();
+        assertThat(stuckInput.awaitRead()).isTrue();
+        SerialSession firstSession = bridge.getCurrentSession();
+
+        assertThat(bridge.openAtBaud(921600)).isNull();
+
+        assertThat(firstSession.isActive()).isFalse();
+        assertThat(bridge.isOpen()).isFalse();
+        assertThat(bridge.getCurrentSession()).isNull();
+        assertThat(driver.openBauds).containsExactly(SerialPortBridge.DEFAULT_BAUDRATE);
+
+        // Once the native read really exits, the retained reader handle permits a safe retry.
+        stuckInput.release();
+        SerialSession replacement = bridge.openAtBaud(921600);
+        assertThat(replacement).isNotNull();
+        assertThat(driver.openBauds).containsExactly(SerialPortBridge.DEFAULT_BAUDRATE, 921600);
+        bridge.closeSession(replacement);
+    }
+
+    private static final class FakeSerialDriver implements SerialPortBridge.SerialDriver {
+        private final Queue<InputStream> inputs;
+        private InputStream activeInput;
+        final List<Integer> openBauds = new ArrayList<>();
+
+        FakeSerialDriver(InputStream... inputs) {
+            this.inputs = new ArrayDeque<>(Arrays.asList(inputs));
+        }
+
+        @Override
+        public boolean open(String path, int baud) {
+            openBauds.add(baud);
+            activeInput = inputs.remove();
+            return true;
+        }
+
+        @Override
+        public InputStream getInputStream(String path) {
+            return activeInput;
+        }
+
+        @Override
+        public OutputStream getOutputStream(String path) {
+            return new ByteArrayOutputStream();
+        }
+
+        @Override
+        public void close(String path) {
+            try {
+                activeInput.close();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    /** A native-read stand-in that may either obey or ignore descriptor close and interruption. */
+    private static final class BlockingInputStream extends InputStream {
+        private final boolean closeReleases;
+        private final CountDownLatch readEntered = new CountDownLatch(1);
+        private final CountDownLatch readExited = new CountDownLatch(1);
+        private boolean released;
+
+        BlockingInputStream(boolean closeReleases) {
+            this.closeReleases = closeReleases;
+        }
+
+        @Override
+        public int read() {
+            readEntered.countDown();
+            try {
+                synchronized (this) {
+                    while (!released) {
+                        try {
+                            wait();
+                        } catch (InterruptedException ignored) {
+                            // Model a native read that Java interruption alone cannot unblock.
+                        }
+                    }
+                }
+                return -1;
+            } finally {
+                readExited.countDown();
+            }
+        }
+
+        @Override
+        public void close() {
+            if (closeReleases) {
+                release();
+            }
+        }
+
+        synchronized void release() {
+            released = true;
+            notifyAll();
+        }
+
+        boolean awaitRead() throws InterruptedException {
+            return readEntered.await(1, TimeUnit.SECONDS);
+        }
+
+        boolean awaitReadExit() throws InterruptedException {
+            return readExited.await(1, TimeUnit.SECONDS);
+        }
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeSessionTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeSessionTest.java
@@ -155,6 +155,7 @@ public class SerialPortBridgeSessionTest {
 
         // Once the native read really exits, the retained reader handle permits a safe retry.
         stuckInput.release();
+        assertThat(stuckInput.awaitReadExit()).isTrue();
         SerialSession replacement = bridge.openAtBaud(921600);
         assertThat(replacement).isNotNull();
         assertThat(driver.openBauds).containsExactly(SerialPortBridge.DEFAULT_BAUDRATE, 921600);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -1,5 +1,6 @@
 package com.mentra.asg_client.io.ota.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mentra.asg_client.AsgConstants;
@@ -165,16 +166,27 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
-    public void nonCanonicalTargetVersionFailsBeforeAuthorization() throws Exception {
+    public void zeroPaddedTargetVersionIsNormalizedForVerification() throws Exception {
         TestArtifact artifact = createArtifact();
         artifact.metadata.put("version", "017.26.7.24");
+
+        BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
+                BesFirmwareArtifactValidator.validate(artifact.file, artifact.metadata);
+
+        assertThat(validated.getTargetVersion()).isEqualTo("17.26.7.24");
+    }
+
+    @Test
+    public void nonNumericTargetVersionFailsBeforeAuthorization() throws Exception {
+        TestArtifact artifact = createArtifact();
+        artifact.metadata.put("version", "17.26.7.24-fix1");
 
         assertThatThrownBy(
                         () ->
                                 BesFirmwareArtifactValidator.validate(
                                         artifact.file, artifact.metadata))
                 .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
-                .hasMessageContaining("canonical");
+                .hasMessageContaining("four numeric byte components");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add structured `BES_OTA_DIAG` records for every durable BES OTA mutation and handoff boundary
- enforce exclusive ownership of `/dev/ttyS1`: a replacement descriptor is never opened until the prior reader has exited
- retain a live reader handle and fail the transition closed when native close plus interruption cannot terminate it
- add deterministic tests for both successful reader teardown and an uninterruptible native read

## Hardware finding and design rationale

On connected glasses, BES traffic continued arriving at 460800 baud, but `Thread-2` consumed it through retired `SerialSession{id=1}`. Every frame was rejected as stale, so BES button events never reached the battery-announcement or camera handlers.

`liblhsserial` exposes streams by device path. Closing and immediately reopening `/dev/ttyS1` while the previous native `InputStream.read()` remains blocked can let that old reader consume bytes from the replacement descriptor. A session token prevents stale callbacks from corrupting state, but it cannot enforce physical descriptor ownership.

`SerialPortBridge` now owns that invariant:

1. retire the current session
2. close the native descriptor
3. interrupt and join its reader
4. refuse the replacement if the reader remains alive
5. only then open and prepare the new session

The coordinator still publishes the prepared session before starting its reader, preserving first-byte routing correctness. This is transport lifecycle hardening, not an OTA-specific delay or retry.

## Diagnostic coverage

The structured diagnostics trace durable state commits/readback, apply handoff and acknowledgement, boot reconciliation, version-proof admission/completion, recovery outcomes, and authoritative status projection to the phone. Firmware artifact identity and SHA remain omitted.

## Validation

- `./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.SerialPortBridgeSessionTest --tests com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.SerialSessionTest --tests com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesUartTransportCoordinatorTest`
- `./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.bes.BesOtaStateStoreTest`
- `./scripts/check-android-compile.sh asg`
- focused Spotless formatting on changed Java files; full-project Spotless remains blocked by the pre-existing import layout in `MediaUploadQueueManager.java`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core K900 UART open/close and post-restart BES OTA recovery paths where mis-behavior can drop all BES input; logging-only paths are lower risk but the transport and durable-state transitions are safety-critical.
> 
> **Overview**
> Fixes a class of K900 bugs where reopening `/dev/ttyS1` while a blocked native read was still alive could let a **retired serial reader consume the new descriptor**, so BES traffic never reached the active session. **`SerialPortBridge`** now closes the driver, joins the reader (with timeout), and **refuses a replacement open** until teardown succeeds; injectable **`SerialDriver`** and new session tests cover the happy path and stuck-reader fail-closed behavior.
> 
> **Durable BES OTA safety recovery** after a process restart no longer assumes BES is at rendezvous baud: **`BesUartTransportCoordinator`** probes the current baud, then **one alternate** (fast vs rendezvous), each with the same raw-first → single **`cs_syvr`** proof; repeated reopen failures or silence at both bauds still **quarantines**.
> 
> **`BES_OTA_DIAG`** logging is added across **`BesOtaStateStore`** (mutations with immediate readback check), apply/UART boundaries in **`BesOtaManager`**, startup/recovery/version-proof in **`K900BluetoothManager`**, and phone status projection. **`Snapshot.toDiagnosticString()`** omits artifact identity/SHA.
> 
> **BES firmware version rules** align: manifest validation allows 1–3 digit components (still ≤255); artifacts **normalize zero-padded** four-byte versions and reject non-numeric suffixes; validated targets store the canonical form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4770fbfb7a926265ab627f88461b367eb9e213ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Process-restart recovery

A process restart does not reset BES, so ASG cannot assume BES returned to 460800: the previous process may have negotiated 1152000. Durable OTA safety recovery now probes at most two physical candidates (the current baud, then the one alternate supported baud). Each candidate remains raw-first: three bounded `0x99` protocol probes must be silent before ASG sends exactly one framed `cs_syvr`. Only a current-session `sr_syvr` can restore normal routing; a raw OTA response or silence at both bauds still quarantines fail-closed.

## On-device validation

Installed release-signed `50364715-dev` (APK SHA-256 `3ec9d005d2a46cf7ac327dcedbb25ddfb81f5798d0265bdbe438a5860d2baa19`) over the preserved hardware failure state: BES remained at 1152000 while the restarted ASG process had quarantined after probing 460800.

Observed without rebooting the glasses:

1. bounded raw-first recovery and one framed timeout at 460800
2. session 1 reader exited before the descriptor changed
3. session 2 opened at 1152000 and ran bounded raw-first recovery
4. `sr_syvr` arrived and the coordinator entered `READY_FAST`
5. zero retired-session data drops
6. power-button traffic reached ASG and announced `battery/100.mp3`
7. action-button traffic produced `/storage/emulated/0/asg_media/com.mentra.asg_client.camera/IMG_20260805_182655_899_631/base.jpg` (4032x3024, 3,077,689 bytes)
