### PR TITLE
Resolve native display placeholders before dispatch

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -948,15 +948,20 @@ class DeviceManager {
 
         when (currentViewState.layoutType) {
             "text_wall" -> {
-                sgc?.sendTextWall(currentViewState.text)
+                sgc?.sendTextWall(parsePlaceholders(currentViewState.text))
             }
 
             "double_text_wall" -> {
-                sgc?.sendDoubleTextWall(currentViewState.topText, currentViewState.bottomText)
+                sgc?.sendDoubleTextWall(
+                    parsePlaceholders(currentViewState.topText),
+                    parsePlaceholders(currentViewState.bottomText)
+                )
             }
 
             "reference_card" -> {
-                sgc?.sendTextWall("${currentViewState.title}\n\n${currentViewState.text}")
+                val title = parsePlaceholders(currentViewState.title)
+                val text = parsePlaceholders(currentViewState.text)
+                sgc?.sendTextWall("$title\n\n$text")
             }
 
             "bitmap_view" -> {
@@ -973,7 +978,7 @@ class DeviceManager {
 
             "positioned_text" -> {
                 sgc?.sendPositionedText(
-                    currentViewState.text,
+                    parsePlaceholders(currentViewState.text),
                     currentViewState.bmpX ?: 0,
                     currentViewState.bmpY ?: 0,
                     currentViewState.bmpWidth ?: 576,

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -999,6 +999,8 @@ class DeviceManager {
     }
 
     private fun parsePlaceholders(text: String): String {
+        if (!text.contains('$')) return text
+
         val dateFormatter = SimpleDateFormat("M/dd, h:mm", Locale.getDefault())
         val formattedDate = dateFormatter.format(Date())
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -704,14 +704,16 @@ struct ViewState {
             let layoutType = currentViewState.layoutType
             switch layoutType {
             case "text_wall":
-                let text = currentViewState.text
+                let text = parsePlaceholders(currentViewState.text)
                 await sgc?.sendTextWall(text)
             case "double_text_wall":
-                let topText = currentViewState.topText
-                let bottomText = currentViewState.bottomText
+                let topText = parsePlaceholders(currentViewState.topText)
+                let bottomText = parsePlaceholders(currentViewState.bottomText)
                 await sgc?.sendDoubleTextWall(topText, bottomText)
             case "reference_card":
-                await sgc?.sendTextWall(currentViewState.title + "\n\n" + currentViewState.text)
+                let title = parsePlaceholders(currentViewState.title)
+                let text = parsePlaceholders(currentViewState.text)
+                await sgc?.sendTextWall(title + "\n\n" + text)
             case "bitmap_view":
                 // Bridge.log("MAN: Processing bitmap_view layout")
                 guard let data = currentViewState.data else {
@@ -727,11 +729,12 @@ struct ViewState {
                     height: currentViewState.bmpHeight
                 )
             case "positioned_text":
+                let text = parsePlaceholders(currentViewState.text)
                 Bridge.log(
-                    "MAN: positioned_text -> text='\(currentViewState.text)' rect=\(currentViewState.bmpX ?? 0),\(currentViewState.bmpY ?? 0) \(currentViewState.bmpWidth ?? 576)x\(currentViewState.bmpHeight ?? 288)"
+                    "MAN: positioned_text -> text='\(text)' rect=\(currentViewState.bmpX ?? 0),\(currentViewState.bmpY ?? 0) \(currentViewState.bmpWidth ?? 576)x\(currentViewState.bmpHeight ?? 288)"
                 )
                 await sgc?.sendPositionedText(
-                    currentViewState.text,
+                    text,
                     x: currentViewState.bmpX ?? 0,
                     y: currentViewState.bmpY ?? 0,
                     width: currentViewState.bmpWidth ?? 576,

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -756,6 +756,8 @@ struct ViewState {
     }
 
     func parsePlaceholders(_ text: String) -> String {
+        guard text.contains("$") else { return text }
+
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "M/dd, h:mm"
         let formattedDate = dateFormatter.string(from: Date())


### PR DESCRIPTION
## Summary

- resolve dashboard placeholders immediately before native text dispatch on iOS
- keep Android behavior in parity so its built-in dashboard cannot expose raw tokens either
- avoid placeholder-formatting work for already-resolved text

## Root cause

The built-in G1 dashboard is initialized with `$TIME12$`, `$DATE$`, `$GBATT$`, and `$CONNECTION_STATUS$`, but placeholder replacement only ran while ingesting cloud display events. The fallback dashboard bypassed that path, so `sendCurrentState()` sent its tokens verbatim.

## User impact

The built-in G1 dashboard now shows resolved time/date/battery/connection values instead of template tokens, including on iOS as reported in `rep_01KZ9GX720H2JRNZW2Q75043G0`.

## Validation

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `xcodebuild -scheme MentraBluetoothSDK -destination 'generic/platform=iOS Simulator' -derivedDataPath ../../../../.context/DerivedData/bluetooth-sdk CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Slack report: https://mentra-labs.slack.com/archives/C0A8015JBPT/p1785952378969229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-string handling in DeviceManager with no auth or data-model changes; main risk is incorrect substitution on edge-case strings containing `$`.
> 
> **Overview**
> Fixes the **built-in G1 dashboard** showing raw tokens like `$TIME12$` and `$GBATT$` by running **`parsePlaceholders` in `sendCurrentState()`** right before native text is sent to the glasses on **iOS and Android**.
> 
> That path replays stored `viewStates` (including the fallback dashboard template) and previously sent strings unchanged; cloud **`displayEvent`** ingestion already substituted placeholders, so only the native replay path was affected.
> 
> **`text_wall`**, **`double_text_wall`**, **`reference_card`**, and **`positioned_text`** now resolve time, date, battery, and connection tokens at dispatch time. Both platforms also **skip placeholder formatting when the string has no `$`**, avoiding extra `DateFormatter` work on plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b1aeb9e49d58c9695920b1f0d905298e0c1154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->