### PR TITLE
Probe idle UART before recovery

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -180,6 +180,10 @@ public final class BesUartTransportCoordinator {
     private boolean versionProbeDeferred = false;
     private boolean outboundDrainPending = false;
     private long outboundDrainGeneration = 0;
+    // A state-machine phase can remain unchanged across many READY_FAST health-timer rearms.
+    // Give every arm its own identity so a callback that already started before cancel(false)
+    // cannot clear a replacement timer or recover a link that a newer valid frame just proved.
+    private long healthTimerGeneration = 0;
 
     private ScheduledFuture<?> phaseTimeout;
     private ScheduledFuture<?> healthTimeout;
@@ -1469,16 +1473,20 @@ public final class BesUartTransportCoordinator {
         cancelHealthTimeoutLocked();
         if (state == State.READY_FAST && !executor.isShutdown()) {
             long phase = phaseGeneration;
+            long healthTimer = ++healthTimerGeneration;
             healthTimeout =
                     executor.schedule(
-                            () -> onHealthTimeout(phase),
+                            () -> onHealthTimeout(phase, healthTimer),
                             idleHealthProbeMs,
                             TimeUnit.MILLISECONDS);
         }
     }
 
-    private void onHealthTimeout(long phase) {
+    private void onHealthTimeout(long phase, long healthTimer) {
         synchronized (monitor) {
+            if (healthTimer != healthTimerGeneration) {
+                return;
+            }
             healthTimeout = null;
             if (phase != phaseGeneration || state != State.READY_FAST) {
                 return;
@@ -1489,17 +1497,21 @@ public final class BesUartTransportCoordinator {
             }
             int baud = host.currentBaud();
             scheduleProbeBurstLocked(phase, baud, 0, 1, 0);
+            long healthProbeTimer = ++healthTimerGeneration;
             healthTimeout =
                     executor.schedule(
-                            () -> onHealthProbeTimeout(phase),
+                            () -> onHealthProbeTimeout(phase, healthProbeTimer),
                             healthProbeTimeoutMs,
                             TimeUnit.MILLISECONDS);
             Log.d(TAG, "Probing idle fast UART session at " + baud);
         }
     }
 
-    private void onHealthProbeTimeout(long phase) {
+    private void onHealthProbeTimeout(long phase, long healthTimer) {
         synchronized (monitor) {
+            if (healthTimer != healthTimerGeneration) {
+                return;
+            }
             healthTimeout = null;
             if (phase != phaseGeneration || state != State.READY_FAST) {
                 return;
@@ -1588,6 +1600,7 @@ public final class BesUartTransportCoordinator {
     }
 
     private void cancelHealthTimeoutLocked() {
+        healthTimerGeneration++;
         if (healthTimeout != null) {
             healthTimeout.cancel(false);
             healthTimeout = null;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinator.java
@@ -147,6 +147,8 @@ public final class BesUartTransportCoordinator {
     private final Object monitor = new Object();
     private final Host host;
     private final SafetyState safetyState;
+    private final long idleHealthProbeMs;
+    private final long healthProbeTimeoutMs;
     private final BesUartIoLane ioLane = new BesUartIoLane();
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private final ArrayDeque<FutureTask<Boolean>> deferredNormalWrites = new ArrayDeque<>();
@@ -188,14 +190,28 @@ public final class BesUartTransportCoordinator {
     }
 
     public BesUartTransportCoordinator(Host host, SafetyState safetyState) {
+        this(
+                host,
+                safetyState,
+                AsgConstants.UART_HIGH_BAUD_IDLE_PROBE_MS,
+                AsgConstants.UART_BAUD_PROBE_TIMEOUT_MS);
+    }
+
+    BesUartTransportCoordinator(
+            Host host, SafetyState safetyState, long idleHealthProbeMs, long healthProbeTimeoutMs) {
         if (host == null) {
             throw new IllegalArgumentException("host is required");
         }
         if (safetyState == null) {
             throw new IllegalArgumentException("safetyState is required");
         }
+        if (idleHealthProbeMs <= 0 || healthProbeTimeoutMs <= 0) {
+            throw new IllegalArgumentException("health probe timings must be positive");
+        }
         this.host = host;
         this.safetyState = safetyState;
+        this.idleHealthProbeMs = idleHealthProbeMs;
+        this.healthProbeTimeoutMs = healthProbeTimeoutMs;
     }
 
     public State getState() {
@@ -1425,7 +1441,7 @@ public final class BesUartTransportCoordinator {
             healthTimeout =
                     executor.schedule(
                             () -> onHealthTimeout(phase),
-                            AsgConstants.UART_HIGH_BAUD_IDLE_PROBE_MS,
+                            idleHealthProbeMs,
                             TimeUnit.MILLISECONDS);
         }
     }
@@ -1440,7 +1456,28 @@ public final class BesUartTransportCoordinator {
                 scheduleHealthCheckLocked();
                 return;
             }
-            startRecoveryLocked("idle_health_probe");
+            int baud = host.currentBaud();
+            scheduleProbeBurstLocked(phase, baud, 0, 1, 0);
+            healthTimeout =
+                    executor.schedule(
+                            () -> onHealthProbeTimeout(phase),
+                            healthProbeTimeoutMs,
+                            TimeUnit.MILLISECONDS);
+            Log.d(TAG, "Probing idle fast UART session at " + baud);
+        }
+    }
+
+    private void onHealthProbeTimeout(long phase) {
+        synchronized (monitor) {
+            healthTimeout = null;
+            if (phase != phaseGeneration || state != State.READY_FAST) {
+                return;
+            }
+            if (operation != Operation.NONE) {
+                scheduleHealthCheckLocked();
+                return;
+            }
+            startRecoveryLocked("idle_health_probe_timeout");
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/interfaces/IHardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/interfaces/IHardwareManager.java
@@ -161,16 +161,27 @@ public interface IHardwareManager {
     // ============================================
 
     /**
-     * Get the current battery level. On K900 devices, this may briefly query BES if the cache is
-     * stale (>2 min). On standard Android devices, uses BatteryManager API directly.
+     * Get the current battery level without waiting for external hardware. K900 implementations
+     * may trigger an asynchronous cache refresh when stale. Standard Android devices use
+     * BatteryManager directly.
      *
      * @return Battery level percentage (0-100), or -1 if unknown
      */
     int getBatteryLevel();
 
     /**
-     * Get the current charging status. On K900 devices, this may briefly query BES if the cache is
-     * stale (>2 min). On standard Android devices, uses BatteryManager API directly.
+     * Actively refresh and return the battery level. Implementations that query external hardware
+     * may block, so callers must use a worker thread. Implementations without an external battery
+     * source fall back to {@link #getBatteryLevel()}.
+     */
+    default int queryBatteryLevel() {
+        return getBatteryLevel();
+    }
+
+    /**
+     * Get the current charging status without waiting for external hardware. K900 implementations
+     * may trigger an asynchronous cache refresh when stale. Standard Android devices use
+     * BatteryManager directly.
      *
      * @return true if charging, false if not charging or unknown
      */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/interfaces/IHardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/interfaces/IHardwareManager.java
@@ -161,16 +161,16 @@ public interface IHardwareManager {
     // ============================================
 
     /**
-     * Get the current battery level. On K900 devices, this may query BES if cache is stale (>2
-     * min), with 50ms timeout. On standard Android devices, uses BatteryManager API directly.
+     * Get the current battery level. On K900 devices, this may briefly query BES if the cache is
+     * stale (>2 min). On standard Android devices, uses BatteryManager API directly.
      *
      * @return Battery level percentage (0-100), or -1 if unknown
      */
     int getBatteryLevel();
 
     /**
-     * Get the current charging status. On K900 devices, this may query BES if cache is stale (>2
-     * min), with 50ms timeout. On standard Android devices, uses BatteryManager API directly.
+     * Get the current charging status. On K900 devices, this may briefly query BES if the cache is
+     * stale (>2 min). On standard Android devices, uses BatteryManager API directly.
      *
      * @return true if charging, false if not charging or unknown
      */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
@@ -30,6 +30,7 @@ public class K900HardwareManager extends BaseHardwareManager {
 
     // Battery cache settings
     private static final long BATTERY_CACHE_DURATION_MS = 2 * 60 * 1000; // 2 minutes
+    private static final long BATTERY_REFRESH_RETRY_MS = 1000;
     private static final long BATTERY_QUERY_SEND_TIMEOUT_MS = 1000;
     private static final long BATTERY_QUERY_TIMEOUT_MS = 250;
 
@@ -42,6 +43,8 @@ public class K900HardwareManager extends BaseHardwareManager {
     private int cachedBatteryLevel = -1;
     private boolean cachedChargingStatus = false;
     private long lastBatteryQueryTime = 0;
+    private long lastBatteryRefreshRequestTime = 0;
+    private boolean batteryRefreshQueued = false;
     private CountDownLatch batteryResponseLatch;
     private final Object batteryLock = new Object();
     private final Object batteryQueryLock = new Object();
@@ -402,6 +405,22 @@ public class K900HardwareManager extends BaseHardwareManager {
 
     @Override
     public int getBatteryLevel() {
+        int batteryLevel;
+        boolean refresh;
+        synchronized (batteryLock) {
+            batteryLevel = cachedBatteryLevel;
+            refresh = !isBatteryCacheFreshLocked();
+        }
+        if (refresh) {
+            requestBatteryRefresh();
+        } else {
+            Log.d(TAG, "🔋 Returning cached battery level: " + batteryLevel + "%");
+        }
+        return batteryLevel;
+    }
+
+    @Override
+    public int queryBatteryLevel() {
         synchronized (batteryQueryLock) {
             synchronized (batteryLock) {
                 if (isBatteryCacheFreshLocked()) {
@@ -409,7 +428,6 @@ public class K900HardwareManager extends BaseHardwareManager {
                     return cachedBatteryLevel;
                 }
             }
-
             if (!queryBatteryFromBes()) {
                 Log.w(TAG, "🔋 Battery query failed; returning the last cached value");
             }
@@ -421,26 +439,81 @@ public class K900HardwareManager extends BaseHardwareManager {
 
     @Override
     public boolean getChargingStatus() {
-        synchronized (batteryQueryLock) {
-            synchronized (batteryLock) {
-                if (isBatteryCacheFreshLocked()) {
-                    Log.d(TAG, "🔋 Returning cached charging status: " + cachedChargingStatus);
-                    return cachedChargingStatus;
-                }
-            }
-
-            if (!queryBatteryFromBes()) {
-                Log.w(TAG, "🔋 Battery query failed; returning the last cached charging status");
-            }
-            synchronized (batteryLock) {
-                return cachedChargingStatus;
-            }
+        boolean charging;
+        boolean refresh;
+        synchronized (batteryLock) {
+            charging = cachedChargingStatus;
+            refresh = !isBatteryCacheFreshLocked();
         }
+        if (refresh) {
+            requestBatteryRefresh();
+        } else {
+            Log.d(TAG, "🔋 Returning cached charging status: " + charging);
+        }
+        return charging;
     }
 
     private boolean isBatteryCacheFreshLocked() {
         return cachedBatteryLevel >= 0
                 && (System.currentTimeMillis() - lastBatteryQueryTime) < BATTERY_CACHE_DURATION_MS;
+    }
+
+    /** Queue at most one best-effort refresh without blocking a getter caller. */
+    private void requestBatteryRefresh() {
+        if (bluetoothManager == null || !bluetoothManager.isConnected()) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        synchronized (batteryLock) {
+            if (isBatteryCacheFreshLocked()
+                    || batteryRefreshQueued
+                    || batteryResponseLatch != null
+                    || (now - lastBatteryRefreshRequestTime) < BATTERY_REFRESH_RETRY_MS) {
+                return;
+            }
+            batteryRefreshQueued = true;
+            lastBatteryRefreshRequestTime = now;
+        }
+
+        byte[] command;
+        try {
+            command = buildBatteryQueryCommand();
+        } catch (JSONException e) {
+            Log.e(TAG, "🔋 Error building asynchronous battery query command", e);
+            finishBatteryRefresh(false);
+            return;
+        }
+
+        boolean accepted =
+                bluetoothManager.sendMessage(
+                        command,
+                        success -> {
+                            finishBatteryRefresh(success);
+                            if (!success) {
+                                Log.w(TAG, "🔋 Asynchronous battery refresh send failed");
+                            }
+                        });
+        if (!accepted) {
+            finishBatteryRefresh(false);
+        }
+    }
+
+    private void finishBatteryRefresh(boolean sent) {
+        synchronized (batteryLock) {
+            batteryRefreshQueued = false;
+            if (!sent) {
+                lastBatteryRefreshRequestTime = 0;
+            }
+        }
+    }
+
+    private static byte[] buildBatteryQueryCommand() throws JSONException {
+        JSONObject k900Command = new JSONObject();
+        k900Command.put("C", "mh_batv");
+        k900Command.put("V", 1);
+        k900Command.put("B", "");
+        return k900Command.toString().getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -463,20 +536,15 @@ public class K900HardwareManager extends BaseHardwareManager {
                 batteryResponseLatch = responseLatch;
             }
 
-            // Build K900 protocol command for battery query
-            JSONObject k900Command = new JSONObject();
-            k900Command.put("C", "mh_batv");
-            k900Command.put("V", 1);
-            k900Command.put("B", "");
-
-            String commandStr = k900Command.toString();
+            byte[] command = buildBatteryQueryCommand();
+            String commandStr = new String(command, StandardCharsets.UTF_8);
             Log.d(TAG, "🔋 Querying battery from BES: " + commandStr);
 
             // sendMessage queues work. Wait for its completion callback before starting the BES
             // response budget so unrelated outbound traffic cannot consume that entire budget.
             boolean accepted =
                     bluetoothManager.sendMessage(
-                            commandStr.getBytes(StandardCharsets.UTF_8),
+                            command,
                             success -> {
                                 sendSucceeded.set(success);
                                 sendLatch.countDown();
@@ -544,6 +612,7 @@ public class K900HardwareManager extends BaseHardwareManager {
             cachedBatteryLevel = batteryLevel;
             cachedChargingStatus = batteryVoltage > 3900;
             lastBatteryQueryTime = System.currentTimeMillis();
+            batteryRefreshQueued = false;
 
             Log.d(
                     TAG,

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
@@ -29,7 +29,7 @@ public class K900HardwareManager extends BaseHardwareManager {
 
     // Battery cache settings
     private static final long BATTERY_CACHE_DURATION_MS = 2 * 60 * 1000; // 2 minutes
-    private static final long BATTERY_QUERY_TIMEOUT_MS = 50; // 50ms timeout
+    private static final long BATTERY_QUERY_TIMEOUT_MS = 250;
 
     private K900LedController ledController;
     private K900RgbLedController rgbLedController;
@@ -42,6 +42,7 @@ public class K900HardwareManager extends BaseHardwareManager {
     private long lastBatteryQueryTime = 0;
     private CountDownLatch batteryResponseLatch;
     private final Object batteryLock = new Object();
+    private final Object batteryQueryLock = new Object();
 
     /**
      * Create a new K900HardwareManager
@@ -399,56 +400,50 @@ public class K900HardwareManager extends BaseHardwareManager {
 
     @Override
     public int getBatteryLevel() {
-        synchronized (batteryLock) {
-            long now = System.currentTimeMillis();
-
-            // Return cached value if still fresh
-            if (cachedBatteryLevel >= 0
-                    && (now - lastBatteryQueryTime) < BATTERY_CACHE_DURATION_MS) {
-                Log.d(TAG, "🔋 Returning cached battery level: " + cachedBatteryLevel + "%");
-                return cachedBatteryLevel;
+        synchronized (batteryQueryLock) {
+            synchronized (batteryLock) {
+                if (isBatteryCacheFreshLocked()) {
+                    Log.d(TAG, "🔋 Returning cached battery level: " + cachedBatteryLevel + "%");
+                    return cachedBatteryLevel;
+                }
             }
 
-            // Query BES for fresh battery status
             if (!queryBatteryFromBes()) {
-                Log.w(
-                        TAG,
-                        "🔋 Battery query failed, returning cached value: " + cachedBatteryLevel);
+                Log.w(TAG, "🔋 Battery query failed; returning the last cached value");
+            }
+            synchronized (batteryLock) {
                 return cachedBatteryLevel;
             }
-
-            return cachedBatteryLevel;
         }
     }
 
     @Override
     public boolean getChargingStatus() {
-        synchronized (batteryLock) {
-            long now = System.currentTimeMillis();
-
-            // Return cached value if still fresh
-            if (cachedBatteryLevel >= 0
-                    && (now - lastBatteryQueryTime) < BATTERY_CACHE_DURATION_MS) {
-                Log.d(TAG, "🔋 Returning cached charging status: " + cachedChargingStatus);
-                return cachedChargingStatus;
+        synchronized (batteryQueryLock) {
+            synchronized (batteryLock) {
+                if (isBatteryCacheFreshLocked()) {
+                    Log.d(TAG, "🔋 Returning cached charging status: " + cachedChargingStatus);
+                    return cachedChargingStatus;
+                }
             }
 
-            // Query BES for fresh battery status
             if (!queryBatteryFromBes()) {
-                Log.w(
-                        TAG,
-                        "🔋 Battery query failed, returning cached charging status: "
-                                + cachedChargingStatus);
+                Log.w(TAG, "🔋 Battery query failed; returning the last cached charging status");
+            }
+            synchronized (batteryLock) {
                 return cachedChargingStatus;
             }
-
-            return cachedChargingStatus;
         }
     }
 
+    private boolean isBatteryCacheFreshLocked() {
+        return cachedBatteryLevel >= 0
+                && (System.currentTimeMillis() - lastBatteryQueryTime) < BATTERY_CACHE_DURATION_MS;
+    }
+
     /**
-     * Query battery status from BES chipset. Sends mh_batv command and waits up to 50ms for hm_batv
-     * response.
+     * Query battery status from BES chipset. The caller must not be the UART reader: that reader
+     * has to remain free to deliver the matching hm_batv response.
      *
      * @return true if query succeeded and cache was updated, false otherwise
      */
@@ -458,9 +453,11 @@ public class K900HardwareManager extends BaseHardwareManager {
             return false;
         }
 
+        CountDownLatch responseLatch = new CountDownLatch(1);
         try {
-            // Create latch for waiting on response
-            batteryResponseLatch = new CountDownLatch(1);
+            synchronized (batteryLock) {
+                batteryResponseLatch = responseLatch;
+            }
 
             // Build K900 protocol command for battery query
             JSONObject k900Command = new JSONObject();
@@ -480,8 +477,7 @@ public class K900HardwareManager extends BaseHardwareManager {
             }
 
             // Wait for response with timeout
-            boolean received =
-                    batteryResponseLatch.await(BATTERY_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            boolean received = responseLatch.await(BATTERY_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
             if (received) {
                 Log.d(TAG, "🔋 Battery query response received within timeout");
                 return true;
@@ -497,6 +493,12 @@ public class K900HardwareManager extends BaseHardwareManager {
             Log.e(TAG, "🔋 Battery query interrupted", e);
             Thread.currentThread().interrupt();
             return false;
+        } finally {
+            synchronized (batteryLock) {
+                if (batteryResponseLatch == responseLatch) {
+                    batteryResponseLatch = null;
+                }
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
@@ -19,6 +19,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Implementation of IHardwareManager for K900 devices. Uses K900-specific hardware APIs including
@@ -29,6 +30,7 @@ public class K900HardwareManager extends BaseHardwareManager {
 
     // Battery cache settings
     private static final long BATTERY_CACHE_DURATION_MS = 2 * 60 * 1000; // 2 minutes
+    private static final long BATTERY_QUERY_SEND_TIMEOUT_MS = 1000;
     private static final long BATTERY_QUERY_TIMEOUT_MS = 250;
 
     private K900LedController ledController;
@@ -454,6 +456,8 @@ public class K900HardwareManager extends BaseHardwareManager {
         }
 
         CountDownLatch responseLatch = new CountDownLatch(1);
+        CountDownLatch sendLatch = new CountDownLatch(1);
+        AtomicBoolean sendSucceeded = new AtomicBoolean(false);
         try {
             synchronized (batteryLock) {
                 batteryResponseLatch = responseLatch;
@@ -468,10 +472,28 @@ public class K900HardwareManager extends BaseHardwareManager {
             String commandStr = k900Command.toString();
             Log.d(TAG, "🔋 Querying battery from BES: " + commandStr);
 
-            // Send command to BES
-            boolean sent =
-                    bluetoothManager.sendMessage(commandStr.getBytes(StandardCharsets.UTF_8));
-            if (!sent) {
+            // sendMessage queues work. Wait for its completion callback before starting the BES
+            // response budget so unrelated outbound traffic cannot consume that entire budget.
+            boolean accepted =
+                    bluetoothManager.sendMessage(
+                            commandStr.getBytes(StandardCharsets.UTF_8),
+                            success -> {
+                                sendSucceeded.set(success);
+                                sendLatch.countDown();
+                            });
+            if (!accepted) {
+                Log.e(TAG, "🔋 Failed to queue battery query command");
+                return false;
+            }
+            if (!sendLatch.await(BATTERY_QUERY_SEND_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                Log.w(
+                        TAG,
+                        "🔋 Battery query send timed out after "
+                                + BATTERY_QUERY_SEND_TIMEOUT_MS
+                                + "ms");
+                return false;
+            }
+            if (!sendSucceeded.get()) {
                 Log.e(TAG, "🔋 Failed to send battery query command");
                 return false;
             }
@@ -530,6 +552,9 @@ public class K900HardwareManager extends BaseHardwareManager {
                             + "%, charging="
                             + cachedChargingStatus);
 
+            // hm_batv has no request ID. Every reply is therefore a valid battery state sample;
+            // a delayed reply may satisfy the current serialized reader rather than being
+            // discarded using correlation information the protocol does not provide.
             if (batteryResponseLatch != null) {
                 batteryResponseLatch.countDown();
             }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
@@ -44,11 +44,13 @@ import com.mentra.asg_client.service.system.managers.StateManager;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /** Wires core service components (replaces the former {@link ServiceContainer}). */
 public final class ServiceInitializer {
 
     private static final String TAG = "ServiceInitializer";
+    private static final long BATTERY_ANNOUNCEMENT_SHUTDOWN_TIMEOUT_MS = 1000;
 
     private final IServiceLifecycle lifecycleManager;
     private final ICommunicationManager communicationManager;
@@ -152,6 +154,15 @@ public final class ServiceInitializer {
     public void cleanup() {
         Log.d(TAG, "Cleaning up service graph");
         batteryAnnouncementExecutor.shutdownNow();
+        try {
+            if (!batteryAnnouncementExecutor.awaitTermination(
+                    BATTERY_ANNOUNCEMENT_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                Log.w(TAG, "Battery announcement worker did not stop before service teardown");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.w(TAG, "Interrupted while stopping battery announcement worker");
+        }
         streamingManager.cleanup();
         lifecycleManager.cleanup();
         Log.d(TAG, "Service graph cleanup completed");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
@@ -42,6 +42,8 @@ import com.mentra.asg_client.service.system.managers.ConfigurationManager;
 import com.mentra.asg_client.service.system.managers.ServiceLifecycleManager;
 import com.mentra.asg_client.service.system.managers.StateManager;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /** Wires core service components (replaces the former {@link ServiceContainer}). */
 public final class ServiceInitializer {
@@ -57,6 +59,7 @@ public final class ServiceInitializer {
     private final CommandProcessor commandProcessor;
     private final AsgNotificationManager notificationManager;
     private final IResponseBuilder responseBuilder;
+    private final ExecutorService batteryAnnouncementExecutor;
 
     public ServiceInitializer(
             @NonNull AsgClientService service,
@@ -84,6 +87,9 @@ public final class ServiceInitializer {
         serviceManager.setStateManager(this.stateManager);
 
         this.streamingManager = new MediaManager(context, serviceManager);
+        this.batteryAnnouncementExecutor =
+                Executors.newSingleThreadExecutor(
+                        runnable -> new Thread(runnable, "battery-announcement"));
 
         RgbLedCommandHandler rgbLedHandler =
                 new RgbLedCommandHandler(serviceManager, hardwareManager);
@@ -100,7 +106,11 @@ public final class ServiceInitializer {
         peripheralBus.subscribe(
                 new BatteryEventSubscriber(hardwareManager, stateManager, serviceManager));
         peripheralBus.subscribe(
-                new ButtonEventSubscriber(serviceManager, hardwareManager, stateManager));
+                new ButtonEventSubscriber(
+                        serviceManager,
+                        hardwareManager,
+                        stateManager,
+                        batteryAnnouncementExecutor));
         peripheralBus.subscribe(new ShutdownEventSubscriber(serviceManager, context));
         peripheralBus.subscribe(new FactoryResetEventSubscriber(serviceManager, context, otaHelper));
         peripheralBus.subscribe(new BesVersionEventSubscriber(serviceManager));
@@ -141,6 +151,7 @@ public final class ServiceInitializer {
 
     public void cleanup() {
         Log.d(TAG, "Cleaning up service graph");
+        batteryAnnouncementExecutor.shutdownNow();
         streamingManager.cleanup();
         lifecycleManager.cleanup();
         Log.d(TAG, "Service graph cleanup completed");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
@@ -64,8 +64,8 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
                 handleConfigurableButtonPress(true); // true = long press
                 break;
             case POWER_SHORT_PRESS:
-                // UART callbacks are synchronous. A cold battery read sends mh_batv and waits for
-                // hm_batv, so it must run away from the one reader that delivers that response.
+                // UART callbacks are synchronous. The explicit cold battery query sends mh_batv
+                // and waits for hm_batv, so it must run away from the reader that delivers it.
                 try {
                     batteryAnnouncementExecutor.execute(this::handlePowerButtonShortPress);
                 } catch (RejectedExecutionException e) {
@@ -280,7 +280,7 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
         }
 
         // Use hardwareManager to get battery level - this will query BES if cache is stale
-        int batteryLevel = hardwareManager.getBatteryLevel();
+        int batteryLevel = hardwareManager.queryBatteryLevel();
         if (Thread.currentThread().isInterrupted()) {
             Log.d(TAG, "Battery announcement cancelled after battery query");
             return;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
@@ -252,6 +252,11 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
     private void handlePowerButtonShortPress() {
         Log.d(TAG, "🔘 Key event - power button short press");
 
+        if (Thread.currentThread().isInterrupted()) {
+            Log.d(TAG, "Battery announcement cancelled during service shutdown");
+            return;
+        }
+
         if (!hardwareManager.supportsAudioPlayback()) {
             Log.w(TAG, "⚠️ Hardware does not support audio playback");
             return;
@@ -276,6 +281,10 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
 
         // Use hardwareManager to get battery level - this will query BES if cache is stale
         int batteryLevel = hardwareManager.getBatteryLevel();
+        if (Thread.currentThread().isInterrupted()) {
+            Log.d(TAG, "Battery announcement cancelled after battery query");
+            return;
+        }
         if (batteryLevel >= 0) {
             String asset = AudioAssets.getBatteryLevelAsset(batteryLevel);
             Log.i(TAG, "🔋 Announcing battery level: " + batteryLevel + "% -> " + asset);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
@@ -17,6 +17,8 @@ import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
 import com.mentra.asg_client.settings.VideoSettings;
 import com.mentra.asg_client.utils.WakeLockManager;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -33,14 +35,17 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
     private final AsgClientServiceManager serviceManager;
     private final IHardwareManager hardwareManager;
     private final IStateManager stateManager;
+    private final Executor batteryAnnouncementExecutor;
 
     public ButtonEventSubscriber(
             AsgClientServiceManager serviceManager,
             IHardwareManager hardwareManager,
-            IStateManager stateManager) {
+            IStateManager stateManager,
+            Executor batteryAnnouncementExecutor) {
         this.serviceManager = serviceManager;
         this.hardwareManager = hardwareManager;
         this.stateManager = stateManager;
+        this.batteryAnnouncementExecutor = batteryAnnouncementExecutor;
     }
 
     @Override
@@ -59,7 +64,13 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
                 handleConfigurableButtonPress(true); // true = long press
                 break;
             case POWER_SHORT_PRESS:
-                handlePowerButtonShortPress();
+                // UART callbacks are synchronous. A cold battery read sends mh_batv and waits for
+                // hm_batv, so it must run away from the one reader that delivers that response.
+                try {
+                    batteryAnnouncementExecutor.execute(this::handlePowerButtonShortPress);
+                } catch (RejectedExecutionException e) {
+                    Log.w(TAG, "Battery announcement ignored during service shutdown");
+                }
                 break;
             default:
                 break;

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -677,6 +677,42 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
+    public void validFrameRearm_rejectsAlreadyRunningHealthProbeTimeout() throws Exception {
+        replaceCoordinatorWithHealthTimings(200, 50);
+        establishFastLink();
+        host.controlCommands.clear();
+        host.openAttempts.clear();
+
+        awaitControlCommandCount("cs_syvr", 1, 500);
+        SerialSession session = coordinator.getSerialSession();
+
+        assertThat(
+                        coordinator.runForCurrentSerialSession(
+                                session,
+                                () -> {
+                                    try {
+                                        // Let the probe timeout start and block on the coordinator
+                                        // monitor. onValidFrame is reentrant here, so it can rearm
+                                        // health before that already-running callback gets the
+                                        // lock.
+                                        Thread.sleep(100);
+                                    } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                        throw new AssertionError(e);
+                                    }
+                                    coordinator.onValidFrame(session);
+                                }))
+                .isTrue();
+
+        // The stale callback runs first on the single scheduled executor. The newly armed idle
+        // timer is still 200 ms away, leaving this assertion specific to the stale callback.
+        Thread.sleep(50);
+        assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.READY_FAST);
+        assertThat(host.openAttempts).isEmpty();
+        assertThat(coordinator.getSerialSession()).isSameAs(session);
+    }
+
+    @Test
     public void idleFastLink_silenceStartsPhysicalRecoveryAfterProbe() throws Exception {
         replaceCoordinatorWithHealthTimings(20, 50);
         establishFastLink();

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -628,6 +628,36 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
+    public void idleFastLink_probesCurrentSessionWithoutReopening() throws Exception {
+        replaceCoordinatorWithHealthTimings(200, 100);
+        establishFastLink();
+        host.controlCommands.clear();
+        host.openAttempts.clear();
+
+        awaitControlCommandCount("cs_syvr", 1, 500);
+
+        assertThat(host.openAttempts).isEmpty();
+        assertThat(systemVersion("17.26.7.23"))
+                .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+        Thread.sleep(150);
+        assertThat(host.openAttempts).isEmpty();
+    }
+
+    @Test
+    public void idleFastLink_silenceStartsPhysicalRecoveryAfterProbe() throws Exception {
+        replaceCoordinatorWithHealthTimings(20, 50);
+        establishFastLink();
+        host.controlCommands.clear();
+        host.openAttempts.clear();
+
+        awaitControlCommandCount("cs_syvr", 1, 500);
+        assertThat(host.openAttempts).isEmpty();
+
+        awaitOpenAttemptCount(AsgConstants.UART_FAST_BAUD, 1);
+        assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.RECOVERING);
+    }
+
+    @Test
     public void validFrame_provesBaudWithoutCancellingVersionDiscovery() throws Exception {
         coordinator.onSerialReady(host.session);
 
@@ -907,6 +937,11 @@ public class BesUartTransportCoordinatorTest {
 
     private BesUartTransportCoordinator.SystemVersionResult systemVersion(String version) {
         return coordinator.onSystemVersion(version, coordinator.getSerialSession(), null);
+    }
+
+    private void replaceCoordinatorWithHealthTimings(long idleMs, long timeoutMs) {
+        coordinator.shutdown();
+        coordinator = new BesUartTransportCoordinator(host, safety, idleMs, timeoutMs);
     }
 
     private static final class FakeHost implements BesUartTransportCoordinator.Host {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import android.app.Application;
 import com.mentra.asg_client.AsgConstants;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Queue;
@@ -13,7 +14,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -678,12 +681,22 @@ public class BesUartTransportCoordinatorTest {
 
     @Test
     public void validFrameRearm_rejectsAlreadyRunningHealthProbeTimeout() throws Exception {
-        replaceCoordinatorWithHealthTimings(200, 50);
+        replaceCoordinatorWithHealthTimings(500, 500);
         establishFastLink();
         host.controlCommands.clear();
         host.openAttempts.clear();
 
-        awaitControlCommandCount("cs_syvr", 1, 500);
+        ScheduledExecutorService healthExecutor = coordinatorExecutor();
+        AtomicReference<Thread> healthWorker = new AtomicReference<>();
+        CountDownLatch healthWorkerCaptured = new CountDownLatch(1);
+        healthExecutor.execute(
+                () -> {
+                    healthWorker.set(Thread.currentThread());
+                    healthWorkerCaptured.countDown();
+                });
+        assertThat(healthWorkerCaptured.await(1, TimeUnit.SECONDS)).isTrue();
+
+        awaitControlCommandCount("cs_syvr", 1, 1_000);
         SerialSession session = coordinator.getSerialSession();
 
         assertThat(
@@ -691,11 +704,18 @@ public class BesUartTransportCoordinatorTest {
                                 session,
                                 () -> {
                                     try {
-                                        // Let the probe timeout start and block on the coordinator
-                                        // monitor. onValidFrame is reentrant here, so it can rearm
-                                        // health before that already-running callback gets the
-                                        // lock.
-                                        Thread.sleep(100);
+                                        // Wait until the already-running probe timeout is blocked
+                                        // on this monitor. onValidFrame is reentrant here, so it
+                                        // deterministically rearms health before that callback can
+                                        // inspect its token.
+                                        long deadline = System.currentTimeMillis() + 2_000;
+                                        while (System.currentTimeMillis() < deadline
+                                                && healthWorker.get().getState()
+                                                        != Thread.State.BLOCKED) {
+                                            Thread.sleep(1);
+                                        }
+                                        assertThat(healthWorker.get().getState())
+                                                .isEqualTo(Thread.State.BLOCKED);
                                     } catch (InterruptedException e) {
                                         Thread.currentThread().interrupt();
                                         throw new AssertionError(e);
@@ -704,9 +724,11 @@ public class BesUartTransportCoordinatorTest {
                                 }))
                 .isTrue();
 
-        // The stale callback runs first on the single scheduled executor. The newly armed idle
-        // timer is still 200 ms away, leaving this assertion specific to the stale callback.
-        Thread.sleep(50);
+        // A FIFO barrier on the same single-thread executor proves that the stale callback has
+        // returned. The newly armed idle timer is still in the future.
+        CountDownLatch staleCallbackDrained = new CountDownLatch(1);
+        healthExecutor.execute(staleCallbackDrained::countDown);
+        assertThat(staleCallbackDrained.await(1, TimeUnit.SECONDS)).isTrue();
         assertThat(coordinator.getState()).isEqualTo(BesUartTransportCoordinator.State.READY_FAST);
         assertThat(host.openAttempts).isEmpty();
         assertThat(coordinator.getSerialSession()).isSameAs(session);
@@ -1019,6 +1041,12 @@ public class BesUartTransportCoordinatorTest {
     private void replaceCoordinatorWithHealthTimings(long idleMs, long timeoutMs) {
         coordinator.shutdown();
         coordinator = new BesUartTransportCoordinator(host, safety, idleMs, timeoutMs);
+    }
+
+    private ScheduledExecutorService coordinatorExecutor() throws Exception {
+        Field field = BesUartTransportCoordinator.class.getDeclaredField("executor");
+        field.setAccessible(true);
+        return (ScheduledExecutorService) field.get(coordinator);
     }
 
     private static final class FakeHost implements BesUartTransportCoordinator.Host {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManagerBatteryTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManagerBatteryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Application;
+import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
@@ -29,21 +30,80 @@ public class K900HardwareManagerBatteryTest {
         when(transport.isConnected()).thenReturn(true);
         doAnswer(
                         invocation -> {
+                            IBluetoothManager.SendMessageCallback callback =
+                                    invocation.getArgument(1);
                             Thread thread =
                                     new Thread(
-                                            () -> manager.notifyBatteryReading(82, 4100),
+                                            () -> {
+                                                callback.onSendComplete(true);
+                                                manager.notifyBatteryReading(82, 4100);
+                                            },
                                             "test-battery-response");
                             responseThread.set(thread);
                             thread.start();
                             return true;
                         })
                 .when(transport)
-                .sendMessage(any(byte[].class));
+                .sendMessage(
+                        any(byte[].class), any(IBluetoothManager.SendMessageCallback.class));
         manager.setTransport(transport);
 
-        assertThat(manager.getBatteryLevel()).isEqualTo(82);
-        responseThread.get().join(1_000);
-        assertThat(responseThread.get().isAlive()).isFalse();
-        verify(transport).sendMessage(any(byte[].class));
+        try {
+            assertThat(manager.getBatteryLevel()).isEqualTo(82);
+            verify(transport)
+                    .sendMessage(
+                            any(byte[].class),
+                            any(IBluetoothManager.SendMessageCallback.class));
+        } finally {
+            Thread thread = responseThread.get();
+            if (thread != null) {
+                thread.join(1_000);
+                assertThat(thread.isAlive()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    public void queuedSendDelay_preservesFullBatteryResponseBudget() throws Exception {
+        K900HardwareManager manager =
+                new K900HardwareManager(RuntimeEnvironment.getApplication());
+        K900BluetoothManager transport = mock(K900BluetoothManager.class);
+        AtomicReference<Thread> responseThread = new AtomicReference<>();
+        when(transport.isConnected()).thenReturn(true);
+        doAnswer(
+                        invocation -> {
+                            IBluetoothManager.SendMessageCallback callback =
+                                    invocation.getArgument(1);
+                            Thread thread =
+                                    new Thread(
+                                            () -> {
+                                                try {
+                                                    Thread.sleep(300);
+                                                    callback.onSendComplete(true);
+                                                    Thread.sleep(100);
+                                                    manager.notifyBatteryReading(64, 4000);
+                                                } catch (InterruptedException e) {
+                                                    Thread.currentThread().interrupt();
+                                                }
+                                            },
+                                            "test-delayed-battery-response");
+                            responseThread.set(thread);
+                            thread.start();
+                            return true;
+                        })
+                .when(transport)
+                .sendMessage(
+                        any(byte[].class), any(IBluetoothManager.SendMessageCallback.class));
+        manager.setTransport(transport);
+
+        try {
+            assertThat(manager.getBatteryLevel()).isEqualTo(64);
+        } finally {
+            Thread thread = responseThread.get();
+            if (thread != null) {
+                thread.join(1_000);
+                assertThat(thread.isAlive()).isFalse();
+            }
+        }
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManagerBatteryTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManagerBatteryTest.java
@@ -49,7 +49,7 @@ public class K900HardwareManagerBatteryTest {
         manager.setTransport(transport);
 
         try {
-            assertThat(manager.getBatteryLevel()).isEqualTo(82);
+            assertThat(manager.queryBatteryLevel()).isEqualTo(82);
             verify(transport)
                     .sendMessage(
                             any(byte[].class),
@@ -97,7 +97,7 @@ public class K900HardwareManagerBatteryTest {
         manager.setTransport(transport);
 
         try {
-            assertThat(manager.getBatteryLevel()).isEqualTo(64);
+            assertThat(manager.queryBatteryLevel()).isEqualTo(64);
         } finally {
             Thread thread = responseThread.get();
             if (thread != null) {
@@ -105,5 +105,22 @@ public class K900HardwareManagerBatteryTest {
                 assertThat(thread.isAlive()).isFalse();
             }
         }
+    }
+
+    @Test
+    public void coldCachedGetter_queuesRefreshWithoutWaitingForSendCompletion() {
+        K900HardwareManager manager =
+                new K900HardwareManager(RuntimeEnvironment.getApplication());
+        K900BluetoothManager transport = mock(K900BluetoothManager.class);
+        when(transport.isConnected()).thenReturn(true);
+        when(transport.sendMessage(
+                        any(byte[].class), any(IBluetoothManager.SendMessageCallback.class)))
+                .thenReturn(true);
+        manager.setTransport(transport);
+
+        assertThat(manager.getBatteryLevel()).isEqualTo(-1);
+        verify(transport)
+                .sendMessage(
+                        any(byte[].class), any(IBluetoothManager.SendMessageCallback.class));
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManagerBatteryTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManagerBatteryTest.java
@@ -1,0 +1,49 @@
+package com.mentra.asg_client.io.hardware.managers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Application;
+import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(application = Application.class, sdk = 33)
+public class K900HardwareManagerBatteryTest {
+
+    @Test
+    public void coldCache_allowsUartReaderToDeliverBatteryResponse() throws Exception {
+        K900HardwareManager manager =
+                new K900HardwareManager(RuntimeEnvironment.getApplication());
+        K900BluetoothManager transport = mock(K900BluetoothManager.class);
+        AtomicReference<Thread> responseThread = new AtomicReference<>();
+        when(transport.isConnected()).thenReturn(true);
+        doAnswer(
+                        invocation -> {
+                            Thread thread =
+                                    new Thread(
+                                            () -> manager.notifyBatteryReading(82, 4100),
+                                            "test-battery-response");
+                            responseThread.set(thread);
+                            thread.start();
+                            return true;
+                        })
+                .when(transport)
+                .sendMessage(any(byte[].class));
+        manager.setTransport(transport);
+
+        assertThat(manager.getBatteryLevel()).isEqualTo(82);
+        responseThread.get().join(1_000);
+        assertThat(responseThread.get().isAlive()).isFalse();
+        verify(transport).sendMessage(any(byte[].class));
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
@@ -82,11 +82,11 @@ public class ButtonEventSubscriberTest {
     @Test
     public void powerPress_releasesUartCallbackBeforeQueryingBattery() {
         when(hardwareManager.supportsAudioPlayback()).thenReturn(true);
-        when(hardwareManager.getBatteryLevel()).thenReturn(100);
+        when(hardwareManager.queryBatteryLevel()).thenReturn(100);
 
         powerShortPress();
 
-        verify(hardwareManager, never()).getBatteryLevel();
+        verify(hardwareManager, never()).queryBatteryLevel();
         assertThat(batteryTasks).hasSize(1);
 
         batteryTasks.remove().run();
@@ -96,7 +96,7 @@ public class ButtonEventSubscriberTest {
     @Test
     public void interruptedBatteryQuery_doesNotStartAudioDuringShutdown() {
         when(hardwareManager.supportsAudioPlayback()).thenReturn(true);
-        when(hardwareManager.getBatteryLevel())
+        when(hardwareManager.queryBatteryLevel())
                 .thenAnswer(
                         invocation -> {
                             Thread.currentThread().interrupt();

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
@@ -1,5 +1,6 @@
 package com.mentra.asg_client.service.core.handlers.subscribers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -7,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.mentra.asg_client.audio.AudioAssets;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine;
@@ -16,6 +18,8 @@ import com.mentra.asg_client.io.peripheral.events.ButtonEvent;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
 import com.mentra.asg_client.settings.AsgSettings;
+import java.util.ArrayDeque;
+import java.util.Queue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +39,8 @@ public class ButtonEventSubscriberTest {
     private MediaCaptureService captureService;
     private K900BluetoothManager bluetoothManager;
     private LinkStateMachine linkState;
+    private IHardwareManager hardwareManager;
+    private Queue<Runnable> batteryTasks;
     private ButtonEventSubscriber subscriber;
 
     @Before
@@ -42,6 +48,8 @@ public class ButtonEventSubscriberTest {
         serviceManager = mock(AsgClientServiceManager.class);
         captureService = mock(MediaCaptureService.class);
         bluetoothManager = mock(K900BluetoothManager.class);
+        hardwareManager = mock(IHardwareManager.class);
+        batteryTasks = new ArrayDeque<>();
         AsgSettings asgSettings = mock(AsgSettings.class);
         linkState = new LinkStateMachine();
 
@@ -57,11 +65,32 @@ public class ButtonEventSubscriberTest {
 
         subscriber =
                 new ButtonEventSubscriber(
-                        serviceManager, mock(IHardwareManager.class), mock(IStateManager.class));
+                        serviceManager,
+                        hardwareManager,
+                        mock(IStateManager.class),
+                        batteryTasks::add);
     }
 
     private void shortPress() {
         subscriber.onMcuEvent(new ButtonEvent(ButtonEvent.Type.CAMERA_SHORT_PRESS));
+    }
+
+    private void powerShortPress() {
+        subscriber.onMcuEvent(new ButtonEvent(ButtonEvent.Type.POWER_SHORT_PRESS));
+    }
+
+    @Test
+    public void powerPress_releasesUartCallbackBeforeQueryingBattery() {
+        when(hardwareManager.supportsAudioPlayback()).thenReturn(true);
+        when(hardwareManager.getBatteryLevel()).thenReturn(100);
+
+        powerShortPress();
+
+        verify(hardwareManager, never()).getBatteryLevel();
+        assertThat(batteryTasks).hasSize(1);
+
+        batteryTasks.remove().run();
+        verify(hardwareManager).playAudioAsset(AudioAssets.getBatteryLevelAsset(100));
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
@@ -94,6 +94,25 @@ public class ButtonEventSubscriberTest {
     }
 
     @Test
+    public void interruptedBatteryQuery_doesNotStartAudioDuringShutdown() {
+        when(hardwareManager.supportsAudioPlayback()).thenReturn(true);
+        when(hardwareManager.getBatteryLevel())
+                .thenAnswer(
+                        invocation -> {
+                            Thread.currentThread().interrupt();
+                            return 100;
+                        });
+
+        powerShortPress();
+        try {
+            batteryTasks.remove().run();
+            verify(hardwareManager, never()).playAudioAsset(anyString());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     public void phonePresent_skipsLocalCapture() {
         linkState.serialReady();
         linkState.phonePresenceReported(true);


### PR DESCRIPTION
## Stack

Depends on #3681. Review this PR against `codex/bes-ota-durable-diagnostics`; only the two hardware follow-ups are in this diff.

## Summary

- probe an idle fast UART session in place before entering physical descriptor/baud recovery
- keep the existing fail-safe recovery scan when that current-session proof times out
- move power-button battery queries off the synchronous UART callback
- let `hm_batv` update the battery cache and release the waiting query without lock inversion
- serialize cold battery queries and bound their wait to 250 ms

## Root causes

`UART_HIGH_BAUD_IDLE_PROBE_MS` previously entered `startRecoveryLocked()` directly. Despite being named an idle probe, every quiet healthy fast link closed and reopened `/dev/ttyS1`. The coordinator now sends one `cs_syvr` on the owned session. Any valid reply rearms the idle timer; only silence reaches the existing recovery path.

Power-button handling ran synchronously on the UART reader. A cold `getBatteryLevel()` sent `mh_batv` and waited for `hm_batv` while both occupying the only thread that could parse the response and holding the cache lock needed by the response handler. The first press therefore timed out structurally. The service now owns a single battery-announcement executor, while the hardware manager uses separate query serialization and response/cache locking.

## Validation

- focused coordinator, serial-reader, battery-manager, and button-subscriber unit tests
- `./scripts/check-android-compile.sh asg`
- release APK build and production-signature path
- focused Spotless formatting on all changed Java files

### Hardware

Installed release-signed `50365704-dev` (SHA-256 `e9ef5657f31f02871cca23af6512cc232ed36d76717cf1babe6a8d307f66222e`) over the connected Mentra Live.

- #3681 startup recovery reached UART session 2 at 1152000
- the subsequent idle `cs_syvr`/`sr_syvr` exchange stayed on session 2: no reader exit, replacement descriptor, or retired-session warning
- one cold-cache power press arrived on UART reader thread 6188
- battery work ran on thread 6236, `hm_batv` returned on reader thread 6188, and `battery/100.mp3` started 63 ms after the key event

Full local capture: `/Users/philippe/dev/MentraOS/pr3681-followups-hardware-20260805.log` (SHA-256 `c223e2ef923508b585c47a4701871da56821719b02bbeba0527003d765c16f5f`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches UART link recovery and synchronous BES battery I/O on the hot reader path; behavior is covered by new unit tests and validated on hardware, but regressions could affect link stability or battery announcements.
> 
> **Overview**
> **UART idle health** no longer jumps straight into physical recovery when a fast link goes quiet. After the idle timer fires, the coordinator sends an in-session `cs_syvr` probe and only runs the existing recovery path if that probe times out; valid frames rearm the timer. **`healthTimerGeneration`** invalidates stale scheduled callbacks after cancel/rearm so an old probe timeout cannot recover a link that fresh traffic already proved.
> 
> **K900 battery** splits **non-blocking getters** (`getBatteryLevel` / charging: return cache, queue at most one async `mh_batv` refresh) from **`queryBatteryLevel()`**, which blocks on a worker with serialized queries, send-completion before the response window, and a 250 ms cap. **`IHardwareManager`** documents this and adds the default `queryBatteryLevel()`.
> 
> **Power-button battery announce** runs on a dedicated executor from **`ServiceInitializer`** so the UART reader is free to deliver `hm_batv`; announcement uses **`queryBatteryLevel()`** and bails on interrupt during shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821da6418c91a8ab6bb3db8323b2606038a213f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->