### PR TITLE
Recover completed BES updates after reboot

### DIFF
--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -1201,6 +1201,8 @@ export interface OtaUpdateInfo {
   updates: string[] // ["apk", "mtk", "bes"]
   totalSize: number
   cacheReady?: boolean
+  /** Exact BES target selected from the OTA manifest, when a BES step is pending. */
+  besVersion?: string
   /** True when the APK step installs an older build than the glasses currently run (exact-pin manifests only). */
   isDowngrade?: boolean
 }

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -25,6 +25,7 @@ import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk/internal"
 import GlobalEventEmitter from "../utils/GlobalEventEmitter"
 import {isGlassesConnected, useGlassesStore} from "../stores/glasses"
 import {resolveOtaManifestUrl} from "./otaManifestUrl"
+import {compareVersions} from "./OtaUpdateCheckService"
 import {deriveDisplayState, type DisplayState} from "./otaDisplayState"
 import {
   BES_CONTINUE_LOCKOUT_MS,
@@ -326,11 +327,14 @@ class OtaInstallCoordinator {
       this.clearPerStepTimers()
       this.clearLegacyApkSettleTimer()
       this.clearMtkSimulationTimers()
+      this.clearContinueLockoutTimer()
       this.retryCount = 0
       this.hasFirstActivity = false
       this.hasReceivedAck = false
+      this.resetBesRestartAttempt()
       this.setSawReconnectEdge(false)
       this.setErrorMsg("")
+      this.setContinueButtonDisabled(false)
       this.setApkCompletedViaBuildIncrease(false)
       this.setLegacyApkSettleHold(false)
       this.setMtkSimulatedPercent(null)
@@ -392,7 +396,10 @@ class OtaInstallCoordinator {
         versionChangeSession: this.versionChangeSession,
       }),
       errorMsg: this.errorMsg,
-      continueButtonDisabled: this.continueButtonDisabled,
+      // A timed post-restart lockout may expire while version_info is still
+      // missing or mismatched. Verification is a stronger gate: the user must
+      // not clear the session until the installed BES target is confirmed.
+      continueButtonDisabled: this.continueButtonDisabled || this.besRestartRecovery === "awaiting",
       connected,
       // Copies: the snapshot must not hand callers mutable references into the store.
       otaStatus: otaStatus ? {...otaStatus} : null,
@@ -456,9 +463,7 @@ class OtaInstallCoordinator {
     this.apkExpectedInSession = false
     this.apkCompletedViaBuildIncrease = false
     this.protocolProfile = null
-    this.besRestartExpected = false
-    this.besRestartDisconnectObserved = false
-    this.besRestartRecovery = null
+    this.resetBesRestartAttempt()
     this.besTargetVersion = null
     this.versionChangeSession = false
     this.versionChangeTarget = null
@@ -481,6 +486,13 @@ class OtaInstallCoordinator {
     this.lastDisplayState = null
     this.lastStallSig = ""
     this.reactQueued = false
+  }
+
+  /** Reset only the reboot lifecycle that belongs to one install attempt. */
+  private resetBesRestartAttempt(): void {
+    this.besRestartExpected = false
+    this.besRestartDisconnectObserved = false
+    this.besRestartRecovery = null
   }
 
   /** Notify snapshot subscribers of a coordinator-internal state change. */
@@ -1103,7 +1115,7 @@ class OtaInstallCoordinator {
     if (!this.besRestartDisconnectObserved || this.besRestartRecovery !== "awaiting") return
     const current = currentVersion.trim()
     if (this.besTargetVersion) {
-      if (current !== this.besTargetVersion) return
+      if (compareVersions(current, this.besTargetVersion) !== 0) return
       console.log(
         `[OTA_PROGRESS] BES restart verified by version_info (${current}) — completing despite stale OTA progress`,
       )

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -29,6 +29,8 @@ import {compareVersions} from "./OtaUpdateCheckService"
 import {deriveDisplayState, type DisplayState} from "./otaDisplayState"
 import {
   BES_CONTINUE_LOCKOUT_MS,
+  BES_VERSION_VERIFY_INTERVAL_MS,
+  BES_VERSION_VERIFY_MAX_ATTEMPTS,
   DOWNLOAD_STUCK_TIMEOUT_MS,
   GLOBAL_OTA_TIMEOUT_MS,
   LEGACY_APK_COMPLETION_SETTLE_MS,
@@ -209,6 +211,8 @@ class OtaInstallCoordinator {
   private progressTimeout: ReturnType<typeof setTimeout> | null = null
   private pingInterval: ReturnType<typeof setInterval> | null = null
   private queryReplyTimeout: ReturnType<typeof setTimeout> | null = null
+  private besVersionVerificationTimer: ReturnType<typeof setTimeout> | null = null
+  private besVersionVerificationAttempts = 0
   private continueLockoutTimer: ReturnType<typeof setTimeout> | null = null
   private legacyApkSettleTimer: ReturnType<typeof setTimeout> | null = null
   private mtkStallDetectTimer: ReturnType<typeof setTimeout> | null = null
@@ -490,6 +494,7 @@ class OtaInstallCoordinator {
 
   /** Reset only the reboot lifecycle that belongs to one install attempt. */
   private resetBesRestartAttempt(): void {
+    this.clearBesVersionVerificationTimer()
     this.besRestartExpected = false
     this.besRestartDisconnectObserved = false
     this.besRestartRecovery = null
@@ -944,9 +949,7 @@ class OtaInstallCoordinator {
     if (this.besRestartDisconnectObserved) {
       console.log(`[OTA_PROGRESS] ${label}: BES reboot reconnect observed — no ota_query_status`)
       if (this.besRestartRecovery === "awaiting") {
-        void BluetoothSdk.requestVersionInfo().catch((error) => {
-          console.warn("[OTA_PROGRESS] BES reconnect version request failed", error)
-        })
+        this.startBesVersionVerification()
       }
       return true
     }
@@ -1128,6 +1131,45 @@ class OtaInstallCoordinator {
     this.setErrorMsg("")
     this.besRestartRecovery = "complete"
     this.emitInternalChange()
+  }
+
+  /**
+   * Ask for fresh version_info immediately after the BES reboot, then every five
+   * seconds for at most one minute. A resolved request only confirms delivery;
+   * reconciliation still waits for the store to receive the target BES version.
+   */
+  private startBesVersionVerification(): void {
+    if (this.errorMsg || this.besRestartRecovery !== "awaiting" || this.besVersionVerificationTimer) return
+    this.besVersionVerificationAttempts = 0
+    this.runBesVersionVerificationAttempt()
+  }
+
+  private runBesVersionVerificationAttempt(): void {
+    if (this.besRestartRecovery !== "awaiting") {
+      this.clearBesVersionVerificationTimer()
+      return
+    }
+
+    if (this.besVersionVerificationAttempts >= BES_VERSION_VERIFY_MAX_ATTEMPTS) {
+      console.log(
+        `[OTA_PROGRESS] BES version still unverified after ${BES_VERSION_VERIFY_MAX_ATTEMPTS} attempts, failing`,
+      )
+      this.clearBesVersionVerificationTimer()
+      this.setErrorMsg(OtaProgressMessages.besVersionVerificationFailed)
+      return
+    }
+
+    this.besVersionVerificationAttempts += 1
+    if (isGlassesConnected(useGlassesStore.getState().connection)) {
+      void BluetoothSdk.requestVersionInfo().catch((error) => {
+        console.warn("[OTA_PROGRESS] BES reconnect version request failed; retrying", error)
+      })
+    }
+
+    this.besVersionVerificationTimer = setTimeout(() => {
+      this.besVersionVerificationTimer = null
+      this.runBesVersionVerificationAttempt()
+    }, BES_VERSION_VERIFY_INTERVAL_MS)
   }
 
   /**
@@ -1460,6 +1502,14 @@ class OtaInstallCoordinator {
     }
   }
 
+  private clearBesVersionVerificationTimer(): void {
+    if (this.besVersionVerificationTimer) {
+      clearTimeout(this.besVersionVerificationTimer)
+      this.besVersionVerificationTimer = null
+    }
+    this.besVersionVerificationAttempts = 0
+  }
+
   private clearContinueLockoutTimer(): void {
     if (this.continueLockoutTimer) {
       clearTimeout(this.continueLockoutTimer)
@@ -1497,6 +1547,7 @@ class OtaInstallCoordinator {
     this.clearStuckTimeout()
     this.clearProgressTimeout()
     this.clearQueryReplyTimeout()
+    this.clearBesVersionVerificationTimer()
   }
 
   private clearAllOtaTimers(): void {

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -53,6 +53,8 @@ import {
   RETRY_INTERVAL_MS,
   isLegacyShapedOtaSession,
   isLegacyShapedOtaStatus,
+  selectOtaProtocolProfile,
+  type OtaProtocolProfile,
 } from "./otaInstallPolicy"
 
 function isTerminalForWatchdog(d: DisplayState): boolean {
@@ -167,6 +169,18 @@ class OtaInstallCoordinator {
   private apkExpectedInSession = false
   // Latched when the legacy build-number completion fires; projected as "complete".
   private apkCompletedViaBuildIncrease = false
+  // The split routes selected legacy/unified behavior before navigation. Keep
+  // that choice sticky while an APK step upgrades ASG mid-flow.
+  private protocolProfile: OtaProtocolProfile | null = null
+
+  // BES reboot recovery. Old ASG/BES combinations can reboot after reporting
+  // install 100% without ever delivering a terminal ota_status. Preserve the
+  // observed install -> disconnect -> reconnect lifecycle independently of the
+  // stale status left in the store.
+  private besRestartExpected = false
+  private besRestartDisconnectObserved = false
+  private besRestartRecovery: "awaiting" | "complete" | null = null
+  private besTargetVersion: string | null = null
 
   // Downgrade detour (version-change mode). Captured at attach from the selected
   // update: the pinned target is a LOWER build, executed by the recovery worker via
@@ -240,7 +254,14 @@ class OtaInstallCoordinator {
     if (this.attached) return
     this.attached = true
     this.resetSessionState()
-    const selected = useGlassesStore.getState().otaUpdateAvailable
+    const initialState = useGlassesStore.getState()
+    this.protocolProfile = selectOtaProtocolProfile(
+      initialState.otaStatus,
+      initialState.otaProgress,
+      initialState.buildNumber,
+    )
+    const selected = initialState.otaUpdateAvailable
+    this.besTargetVersion = selected?.besVersion?.trim() || null
     if (selected?.isDowngrade && typeof selected.versionCode === "number" && selected.versionCode > 0) {
       this.versionChangeSession = true
       this.versionChangeTarget = selected.versionCode
@@ -366,6 +387,7 @@ class OtaInstallCoordinator {
         sawReconnectEdge: this.sawReconnectEdge,
         legacyApkSettleHold: this.legacyApkSettleHold,
         apkCompletedViaBuildIncrease: this.apkCompletedViaBuildIncrease,
+        besRestartRecovery: this.besRestartRecovery,
         versionChangeConverged: this.versionChangeConverged,
         versionChangeSession: this.versionChangeSession,
       }),
@@ -433,6 +455,11 @@ class OtaInstallCoordinator {
     this.initialBuildNumber = null
     this.apkExpectedInSession = false
     this.apkCompletedViaBuildIncrease = false
+    this.protocolProfile = null
+    this.besRestartExpected = false
+    this.besRestartDisconnectObserved = false
+    this.besRestartRecovery = null
+    this.besTargetVersion = null
     this.versionChangeSession = false
     this.versionChangeTarget = null
     this.versionChangeInstallStarted = false
@@ -505,14 +532,21 @@ class OtaInstallCoordinator {
     this.emitInternalChange()
   }
 
-  /**
-   * Legacy-session shape (WP 8C): event shape wins once events exist; before any event
-   * only the session-start build number can tell (falls back to the live build number
-   * until it is captured). Old builds get the LEGACY_* padded policy durations.
-   */
+  /** Legacy/unified policy is selected once, matching the old sticky route choice. */
   private isLegacySessionShapeNow(): boolean {
+    if (this.protocolProfile) return this.protocolProfile === "legacy"
     const state = useGlassesStore.getState()
-    return isLegacyShapedOtaSession(state.otaStatus, state.otaProgress, this.initialBuildNumber || state.buildNumber)
+    const selected = selectOtaProtocolProfile(
+      state.otaStatus,
+      state.otaProgress,
+      this.initialBuildNumber || state.buildNumber,
+    )
+    if (selected) {
+      this.protocolProfile = selected
+      console.log(`[OTA_PROGRESS] protocol profile selected: ${selected}`)
+      return selected === "legacy"
+    }
+    return isLegacyShapedOtaSession(state.otaStatus, state.otaProgress, state.buildNumber)
   }
 
   private react(): void {
@@ -565,6 +599,21 @@ class OtaInstallCoordinator {
 
     const legacySession = this.isLegacySessionShapeNow()
 
+    if (this.isBesRestartExpected(otaStatus, otaProgress)) {
+      this.besRestartExpected = true
+    }
+
+    // Port the legacy route's actual reboot invariant before deriving display
+    // state, so reconnecting with stale BES in_progress@100 never renders updating.
+    if (connectedChanged && !connected && this.besRestartExpected && this.besRestartRecovery === null) {
+      this.besRestartDisconnectObserved = true
+      this.besRestartRecovery = "awaiting"
+      console.log("[OTA_PROGRESS] BES restart disconnect observed — awaiting reconnect verification")
+    }
+    if (this.besRestartRecovery === "awaiting" && connected) {
+      this.reconcileBesRestart(state.besFirmwareVersion, legacySession)
+    }
+
     // Derived UI state — the glasses data IS the source of truth.
     const displayState = deriveDisplayState({
       otaStatus,
@@ -574,6 +623,7 @@ class OtaInstallCoordinator {
       sawReconnectEdge: this.sawReconnectEdge,
       legacyApkSettleHold: this.legacyApkSettleHold,
       apkCompletedViaBuildIncrease: this.apkCompletedViaBuildIncrease,
+      besRestartRecovery: this.besRestartRecovery,
       versionChangeConverged: this.versionChangeConverged,
       versionChangeSession: this.versionChangeSession,
     })
@@ -879,6 +929,16 @@ class OtaInstallCoordinator {
     this.clearQueryReplyTimeout()
     this.setSawReconnectEdge(true)
 
+    if (this.besRestartDisconnectObserved) {
+      console.log(`[OTA_PROGRESS] ${label}: BES reboot reconnect observed — no ota_query_status`)
+      if (this.besRestartRecovery === "awaiting") {
+        void BluetoothSdk.requestVersionInfo().catch((error) => {
+          console.warn("[OTA_PROGRESS] BES reconnect version request failed", error)
+        })
+      }
+      return true
+    }
+
     // Legacy apk settle window (WP 8C): the glasses restarting into the new build is
     // the EXPECTED reconnect here — the legacy screen took no action on it. Skip the
     // query/fallback; the settle timer (or the build-number increase) completes.
@@ -1018,6 +1078,46 @@ class OtaInstallCoordinator {
     }
   }
 
+  private isBesRestartExpected(otaStatus: OtaStatus | null, otaProgress: OtaProgress | null): boolean {
+    const statusReadyToRestart =
+      otaStatus?.stepType === "bes" &&
+      otaStatus.phase === "install" &&
+      (otaStatus.status === "step_complete" ||
+        otaStatus.status === "complete" ||
+        otaStatus.stepPercent >= 100 ||
+        otaStatus.overallPercent >= 100)
+    const progressReadyToRestart =
+      otaProgress?.currentUpdate === "bes" &&
+      otaProgress.stage === "install" &&
+      (otaProgress.status === "FINISHED" || otaProgress.progress >= 100)
+    return statusReadyToRestart || progressReadyToRestart
+  }
+
+  /**
+   * Complete a phone-observed BES reboot when fresh version_info matches the
+   * manifest target. Frozen legacy manifests did not always expose that target
+   * through the mobile read model, so truly legacy flows retain the old route's
+   * disconnect/reconnect completion fallback.
+   */
+  private reconcileBesRestart(currentVersion: string, legacySession: boolean): void {
+    if (!this.besRestartDisconnectObserved || this.besRestartRecovery !== "awaiting") return
+    const current = currentVersion.trim()
+    if (this.besTargetVersion) {
+      if (current !== this.besTargetVersion) return
+      console.log(
+        `[OTA_PROGRESS] BES restart verified by version_info (${current}) — completing despite stale OTA progress`,
+      )
+    } else if (legacySession) {
+      console.log("[OTA_PROGRESS] legacy BES restart reconnected without target metadata — completing by reboot edge")
+    } else {
+      return
+    }
+    this.clearPerStepTimers()
+    this.setErrorMsg("")
+    this.besRestartRecovery = "complete"
+    this.emitInternalChange()
+  }
+
   /**
    * Legacy MTK install stall simulation (WP 8C-e), ported verbatim: the MTK system
    * install typically stalls around 49-50%. Every real event restarts stall detection;
@@ -1093,6 +1193,7 @@ class OtaInstallCoordinator {
       sawReconnectEdge: this.sawReconnectEdge,
       legacyApkSettleHold: this.legacyApkSettleHold,
       apkCompletedViaBuildIncrease: this.apkCompletedViaBuildIncrease,
+      besRestartRecovery: this.besRestartRecovery,
       versionChangeConverged: this.versionChangeConverged,
       versionChangeSession: this.versionChangeSession,
     })
@@ -1287,11 +1388,7 @@ class OtaInstallCoordinator {
       // whatever legacy-shaped status/progress sits in the store is a pre-query
       // leftover, not a reply — a NEW legacy event would have cleared this timer
       // through the reaction pass. Only a unified reply suppresses the fallback.
-      const legacySession = isLegacyShapedOtaSession(
-        state.otaStatus,
-        state.otaProgress,
-        this.initialBuildNumber || state.buildNumber,
-      )
+      const legacySession = this.isLegacySessionShapeNow()
       if (!legacySession && hasRecoveringOtaReply(state.otaStatus, state.otaProgress)) return
       // Don't fire if we've left the active phase (e.g. user backed out, error overlay).
       if (isTerminalForWatchdog(this.computeDisplayStateNow())) return

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -512,6 +512,7 @@ export async function checkCurrentGlassesForUpdate(
         versionName: result.latestVersionInfo?.versionName || "",
         updates: filteredUpdates,
         totalSize: 0,
+        ...(filteredUpdates.includes("bes") && result.besVersion ? {besVersion: result.besVersion} : {}),
         isDowngrade: isApkDowngrade,
       }
     : null

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -259,7 +259,7 @@ export function checkBesUpdate(besFirmware: BesFirmware | undefined, currentVers
   return compareVersions(besFirmware.version, currentVersion) > 0
 }
 
-function compareVersions(version1: string, version2: string): number {
+export function compareVersions(version1: string, version2: string): number {
   if (version1.includes(".") && version2.includes(".")) {
     const parts1 = version1.split(".")
     const parts2 = version2.split(".")

--- a/mobile/modules/engine/src/services/otaDisplayState.ts
+++ b/mobile/modules/engine/src/services/otaDisplayState.ts
@@ -18,19 +18,21 @@ export type DisplayState = "starting" | "updating" | "complete" | "failed" | "di
  *
  * Priority-ordered rules (first match wins):
  *   1. errorMsg !== ""                                          -> "failed"
- *   2. BES terminal + connected + sawReconnectEdge             -> "complete"
- *   3. BES terminal (any connection state)                     -> "restarting"
+ *   2. BES reboot recovery verified                             -> "complete"
+ *   3. BES reboot recovery awaiting verification               -> "restarting"
+ *   4. BES terminal + connected + sawReconnectEdge             -> "complete"
+ *   5. BES terminal (any connection state)                     -> "restarting"
  *      (legacy-shaped BES "complete" counts only in install phase)
- *   4. apkCompletedViaBuildIncrease (legacy build-number port) -> "complete"
- *   5. otaStatus.status === "failed"                           -> "failed"
- *   6. otaStatus.status === "complete" (non-BES)               -> "complete"
+ *   6. apkCompletedViaBuildIncrease (legacy build-number port) -> "complete"
+ *   7. otaStatus.status === "failed"                           -> "failed"
+ *   8. otaStatus.status === "complete" (non-BES)               -> "complete"
  *      (unless legacy-shaped download-complete or held apk settle -> in flight)
- *   7. !connected + legacy in-flight complete (held apk)       -> "updating"
- *   8. !connected + APK step_complete with totalSteps > 1      -> "starting"   (expected reboot)
- *   9. !connected + BES in flight                              -> "restarting" (defensive)
- *   10. !connected                                             -> "disconnected"
- *   11. connected + in_progress | step_complete | legacy in-flight complete -> "updating"
- *   12. fallback                                               -> "starting"
+ *   9. !connected + legacy in-flight complete (held apk)       -> "updating"
+ *   10. !connected + APK step_complete with totalSteps > 1     -> "starting"   (expected reboot)
+ *   11. !connected + BES in flight                             -> "restarting" (defensive)
+ *   12. !connected                                             -> "disconnected"
+ *   13. connected + in_progress | step_complete | legacy in-flight complete -> "updating"
+ *   14. fallback                                               -> "starting"
  */
 export function deriveDisplayState(args: {
   otaStatus: OtaStatus | null
@@ -42,6 +44,8 @@ export function deriveDisplayState(args: {
   legacyApkSettleHold?: boolean
   /** Legacy APK completion detected by build-number increase (WP 8C). */
   apkCompletedViaBuildIncrease?: boolean
+  /** Phone-observed BES disconnect/reconnect recovery, independent of stale OTA progress. */
+  besRestartRecovery?: "awaiting" | "complete" | null
   /** Downgrade detour: the reconnected glasses reported exactly the pinned target version. */
   versionChangeConverged?: boolean
   /** True for the whole downgrade (version-change) session. */
@@ -55,6 +59,7 @@ export function deriveDisplayState(args: {
     sawReconnectEdge,
     legacyApkSettleHold,
     apkCompletedViaBuildIncrease,
+    besRestartRecovery,
     versionChangeConverged,
     versionChangeSession,
   } = args
@@ -66,6 +71,12 @@ export function deriveDisplayState(args: {
   // a LOWER build so no build-number increase fires). Outranks the stale install
   // status still sitting in the store from before the handoff.
   if (versionChangeConverged) return "complete"
+
+  // A BES reboot destroys or strands the glasses-side OTA session on older
+  // clients. Once the phone observed that reboot, stale pre-reboot progress must
+  // not move the UI from restarting back to updating.
+  if (besRestartRecovery === "complete") return "complete"
+  if (besRestartRecovery === "awaiting") return "restarting"
 
   // In a version-change session, convergence (above) is the ONLY completion for the ASG
   // downgrade. A bare non-firmware "complete" before convergence — the glasses refusing

--- a/mobile/modules/engine/src/services/otaInstallPolicy.ts
+++ b/mobile/modules/engine/src/services/otaInstallPolicy.ts
@@ -69,6 +69,8 @@ export const LEGACY_MTK_STALL_ZONE_MAX_PERCENT = 55
 export const LEGACY_MTK_SIM_FLOOR_PERCENT = 51
 export const LEGACY_MTK_SIM_CAP_PERCENT = 60
 
+export type OtaProtocolProfile = "legacy" | "unified"
+
 /**
  * Legacy-shaped ota_status: old (< 37) ASG builds send `ota_progress`, which the SDK
  * (Android MentraLive.kt / iOS MentraLive.swift) maps to a unified ota_status with
@@ -94,6 +96,26 @@ export function isLegacyShapedOtaSession(
   if (otaProgress) return true
   const build = Number.parseInt(buildNumber ?? "", 10)
   return Number.isFinite(build) && build > 0 && build < MINIMUM_OTA_STATUS_BUILD
+}
+
+/**
+ * Select the compatibility profile once at install-screen attach. The old split
+ * routes made this decision from the pre-update build and kept it for the whole
+ * mounted flow, even when an APK step restarted into a newer ASG build. Returning
+ * null leaves the coordinator undecided until the first meaningful OTA event.
+ */
+export function selectOtaProtocolProfile(
+  otaStatus: OtaStatus | null,
+  otaProgress: OtaProgress | null,
+  buildNumber: string | null | undefined,
+): OtaProtocolProfile | null {
+  const build = Number.parseInt(buildNumber ?? "", 10)
+  if (Number.isFinite(build) && build > 0) {
+    return build < MINIMUM_OTA_STATUS_BUILD ? "legacy" : "unified"
+  }
+  if (otaStatus) return isLegacyShapedOtaStatus(otaStatus) ? "legacy" : "unified"
+  if (otaProgress) return "legacy"
+  return null
 }
 
 export const OtaProgressMessages = {

--- a/mobile/modules/engine/src/services/otaInstallPolicy.ts
+++ b/mobile/modules/engine/src/services/otaInstallPolicy.ts
@@ -31,6 +31,10 @@ export const PING_INTERVAL_MS = 10_000
 export const QUERY_REPLY_TIMEOUT_MS = 6000
 /** 15s lockout on the Continue button after a BES restart, to prevent an accidental tap. */
 export const BES_CONTINUE_LOCKOUT_MS = 15_000
+/** Retry version_info while confirming the BES firmware that booted after OTA. */
+export const BES_VERSION_VERIFY_INTERVAL_MS = 5000
+/** One minute total: an immediate request plus eleven fixed-interval retries. */
+export const BES_VERSION_VERIFY_MAX_ATTEMPTS = 12
 
 // --- Legacy old-build (< MINIMUM_OTA_STATUS_BUILD) OTA policy (WP 8C) ---
 //
@@ -123,4 +127,5 @@ export const OtaProgressMessages = {
   stalledOrStuck: "Update may have failed. Ensure glasses have internet access and try again.",
   globalTimeout: "Update took too long. Please try again.",
   sendOtaStartFailed: "Failed to communicate with glasses.",
+  besVersionVerificationFailed: "Glasses restarted, but the updated firmware could not be verified. Please try again.",
 } as const

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -111,6 +111,7 @@ beforeEach(() => {
   useGlassesStore.getState().reset()
   bluetoothSdkMock.startOtaUpdate.mockClear()
   bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+  bluetoothSdkMock.requestVersionInfo.mockClear()
   bluetoothSdkMock.updateGlasses.mockClear()
   bluetoothSdkMock.ping.mockClear()
 })
@@ -638,6 +639,131 @@ describe("OtaInstallCoordinator legacy query-status fallback (WP 8C-b)", () => {
 
     await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS * 2)
     expect(bluetoothSdkMock.startOtaUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe("OtaInstallCoordinator BES reboot recovery", () => {
+  function seedBesUpdate(besVersion?: string) {
+    useGlassesStore.getState().setOtaUpdateAvailable({
+      available: true,
+      versionCode: 39,
+      versionName: "39.0",
+      updates: ["apk", "bes"],
+      totalSize: 0,
+      ...(besVersion ? {besVersion} : {}),
+    })
+  }
+
+  function emitUnifiedBesAt100() {
+    useGlassesStore.getState().setOtaStatus(
+      inProgressStatus({
+        sessionId: "modern-after-apk",
+        totalSteps: 2,
+        currentStep: 2,
+        stepType: "bes",
+        phase: "install",
+        stepPercent: 100,
+        overallPercent: 100,
+      }),
+    )
+  }
+
+  it("keeps the day-one legacy policy sticky after ASG upgrades and completes the BES reboot edge", () => {
+    setLegacyGlassesConnected("27")
+    seedBesUpdate()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+
+    // The same mounted flow has now upgraded ASG and receives unified-shaped
+    // events. The old split route would still be progress-legacy.tsx.
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "39"})
+    emitUnifiedBesAt100()
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
+    setGlassesConnected()
+
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+    expect(bluetoothSdkMock.sendOtaQueryStatus).not.toHaveBeenCalled()
+    expect(bluetoothSdkMock.requestVersionInfo).not.toHaveBeenCalled()
+  })
+
+  it("holds stale BES 100% in restarting until version_info matches the manifest target", () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      buildNumber: "39",
+      besFirmwareVersion: "17.26.1.1",
+    })
+    seedBesUpdate("17.26.7.9")
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    emitUnifiedBesAt100()
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
+    expect(bluetoothSdkMock.sendOtaQueryStatus).not.toHaveBeenCalled()
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(1)
+
+    useGlassesStore.getState().setGlassesInfo({besFirmwareVersion: "17.26.7.9"})
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+  })
+
+  it("completes immediately when the target BES version arrived before the reconnect edge", () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      buildNumber: "39",
+      besFirmwareVersion: "17.26.1.1",
+    })
+    seedBesUpdate("17.26.7.9")
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    emitUnifiedBesAt100()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    useGlassesStore.getState().setGlassesInfo({besFirmwareVersion: "17.26.7.9"})
+    setGlassesConnected()
+
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+
+    // Later link noise on the completed screen cannot reopen recovery or issue
+    // another version request.
+    bluetoothSdkMock.requestVersionInfo.mockClear()
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+    expect(bluetoothSdkMock.requestVersionInfo).not.toHaveBeenCalled()
+  })
+
+  it("does not treat an early BES-install link drop as the expected reboot", () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      buildNumber: "39",
+      besFirmwareVersion: "17.26.1.1",
+    })
+    seedBesUpdate("17.26.7.9")
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(
+      inProgressStatus({
+        sessionId: "bes-before-reboot",
+        stepType: "bes",
+        phase: "install",
+        stepPercent: 50,
+        overallPercent: 50,
+      }),
+    )
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("updating")
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+    expect(bluetoothSdkMock.requestVersionInfo).not.toHaveBeenCalled()
   })
 })
 

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -689,13 +689,15 @@ describe("OtaInstallCoordinator BES reboot recovery", () => {
     expect(bluetoothSdkMock.requestVersionInfo).not.toHaveBeenCalled()
   })
 
-  it("holds stale BES 100% in restarting until version_info matches the manifest target", () => {
+  it("holds stale BES 100% and Continue until a semantically equivalent target version arrives", async () => {
     useGlassesStore.getState().setGlassesInfo({
       connection: {state: "connected", fullyBooted: true},
       buildNumber: "39",
       besFirmwareVersion: "17.26.1.1",
     })
-    seedBesUpdate("17.26.7.9")
+    // The production manifest pads components, while version_info from the
+    // real glasses does not: 17.26.07.09 and 17.26.7.9 are the same release.
+    seedBesUpdate("17.26.07.09")
     otaInstallCoordinator.attach()
     GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
     emitUnifiedBesAt100()
@@ -705,11 +707,47 @@ describe("OtaInstallCoordinator BES reboot recovery", () => {
     setGlassesConnected()
 
     expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
+    expect(otaInstallCoordinator.snapshot().continueButtonDisabled).toBe(true)
     expect(bluetoothSdkMock.sendOtaQueryStatus).not.toHaveBeenCalled()
     expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(1)
 
+    // The ordinary post-restart lockout expiring must not let the user clear a
+    // session whose target version is still unverified.
+    await jest.advanceTimersByTimeAsync(BES_CONTINUE_LOCKOUT_MS * 2)
+    expect(otaInstallCoordinator.snapshot().continueButtonDisabled).toBe(true)
+
     useGlassesStore.getState().setGlassesInfo({besFirmwareVersion: "17.26.7.9"})
     expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+    expect(otaInstallCoordinator.snapshot().continueButtonDisabled).toBe(false)
+  })
+
+  it("retry clears stale BES reboot latches before a new install attempt", async () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      buildNumber: "39",
+      besFirmwareVersion: "17.26.1.1",
+    })
+    seedBesUpdate("17.26.07.09")
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    emitUnifiedBesAt100()
+
+    // Fail before the expected reboot edge, then begin a new attempt.
+    await jest.advanceTimersByTimeAsync(PROGRESS_TIMEOUT_MS)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
+    otaInstallCoordinator.retry()
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
+
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+    bluetoothSdkMock.requestVersionInfo.mockClear()
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+
+    // This link edge happened before the retried attempt reached BES 100%, so
+    // it follows ordinary reconnect arbitration instead of BES verification.
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+    expect(bluetoothSdkMock.requestVersionInfo).not.toHaveBeenCalled()
   })
 
   it("completes immediately when the target BES version arrived before the reconnect edge", () => {

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -13,6 +13,8 @@ import type {OtaStatus} from "@mentra/bluetooth-sdk-internal"
 import {otaInstallCoordinator} from "../../modules/engine/src/services/OtaInstallCoordinator"
 import {
   BES_CONTINUE_LOCKOUT_MS,
+  BES_VERSION_VERIFY_INTERVAL_MS,
+  BES_VERSION_VERIFY_MAX_ATTEMPTS,
   DOWNLOAD_STUCK_TIMEOUT_MS,
   GLOBAL_OTA_TIMEOUT_MS,
   LEGACY_APK_COMPLETION_SETTLE_MS,
@@ -668,6 +670,20 @@ describe("OtaInstallCoordinator BES reboot recovery", () => {
     )
   }
 
+  function enterBesVersionVerification() {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      buildNumber: "39",
+      besFirmwareVersion: "17.26.1.1",
+    })
+    seedBesUpdate("17.26.7.9")
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    emitUnifiedBesAt100()
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+  }
+
   it("keeps the day-one legacy policy sticky after ASG upgrades and completes the BES reboot edge", () => {
     setLegacyGlassesConnected("27")
     seedBesUpdate()
@@ -719,6 +735,55 @@ describe("OtaInstallCoordinator BES reboot recovery", () => {
     useGlassesStore.getState().setGlassesInfo({besFirmwareVersion: "17.26.7.9"})
     expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
     expect(otaInstallCoordinator.snapshot().continueButtonDisabled).toBe(false)
+  })
+
+  it("retries a rejected version request every five seconds and stops after the target arrives", async () => {
+    bluetoothSdkMock.requestVersionInfo.mockRejectedValueOnce(new Error("transient BLE failure"))
+    enterBesVersionVerification()
+
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(1)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
+
+    await jest.advanceTimersByTimeAsync(BES_VERSION_VERIFY_INTERVAL_MS)
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(2)
+
+    useGlassesStore.getState().setGlassesInfo({besFirmwareVersion: "17.26.7.9"})
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+
+    await jest.advanceTimersByTimeAsync(BES_VERSION_VERIFY_INTERVAL_MS * BES_VERSION_VERIFY_MAX_ATTEMPTS)
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(2)
+  })
+
+  it("fails with Retry after one minute without a matching version and clears the retry loop", async () => {
+    enterBesVersionVerification()
+
+    await jest.advanceTimersByTimeAsync(BES_VERSION_VERIFY_INTERVAL_MS * BES_VERSION_VERIFY_MAX_ATTEMPTS)
+
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(BES_VERSION_VERIFY_MAX_ATTEMPTS)
+    expect(otaInstallCoordinator.snapshot()).toMatchObject({
+      displayState: "failed",
+      errorMsg: OtaProgressMessages.besVersionVerificationFailed,
+    })
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+    await jest.advanceTimersByTimeAsync(BES_VERSION_VERIFY_INTERVAL_MS)
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(BES_VERSION_VERIFY_MAX_ATTEMPTS)
+
+    otaInstallCoordinator.retry()
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
+    await jest.advanceTimersByTimeAsync(BES_VERSION_VERIFY_INTERVAL_MS * 2)
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(BES_VERSION_VERIFY_MAX_ATTEMPTS)
+  })
+
+  it("clears pending BES version retries when the coordinator detaches", async () => {
+    enterBesVersionVerification()
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(1)
+
+    otaInstallCoordinator.detach()
+    await jest.advanceTimersByTimeAsync(BES_VERSION_VERIFY_INTERVAL_MS * BES_VERSION_VERIFY_MAX_ATTEMPTS)
+
+    expect(bluetoothSdkMock.requestVersionInfo).toHaveBeenCalledTimes(1)
   })
 
   it("retry clears stale BES reboot latches before a new install attempt", async () => {

--- a/mobile/src/__tests__/otaUpdateCheckService.test.ts
+++ b/mobile/src/__tests__/otaUpdateCheckService.test.ts
@@ -271,6 +271,7 @@ describe("OtaUpdateCheckService", () => {
         versionCode: 11,
         versionName: "11",
         updates: ["apk", "mtk", "bes"],
+        besVersion: "17.26.1.15",
       }),
     )
   })

--- a/mobile/src/app/ota/__tests__/deriveOtaDisplayState.test.ts
+++ b/mobile/src/app/ota/__tests__/deriveOtaDisplayState.test.ts
@@ -135,6 +135,16 @@ describe("deriveDisplayState", () => {
       {errorMsg: "boom", otaStatus: besComplete, connected: true, sawReconnectEdge: true},
       "failed",
     ],
+    [
+      "BES reboot verification stays restarting despite stale in-progress status",
+      {otaStatus: besInProgress, besRestartRecovery: "awaiting"},
+      "restarting",
+    ],
+    [
+      "BES reboot verification completes despite stale in-progress status",
+      {otaStatus: besInProgress, besRestartRecovery: "complete"},
+      "complete",
+    ],
     ["Rule 2: BES step_complete + edge -> complete", {otaStatus: besStepComplete, sawReconnectEdge: true}, "complete"],
     ["Rule 2: BES complete (1-step) + edge -> complete", {otaStatus: besComplete, sawReconnectEdge: true}, "complete"],
     ["Rule 3: BES terminal, no edge -> restarting", {otaStatus: besStepComplete}, "restarting"],


### PR DESCRIPTION
## Summary

- Keep the OTA progress UI as one React screen while selecting a sticky `legacy` or `unified` coordinator policy at flow attach.
- Preserve the old legacy route's BES reboot invariant: once BES install reaches 100%, an observed disconnect/reconnect cannot be overwritten by stale pre-reboot progress.
- Carry the manifest's expected BES version into the install session and complete only after post-reboot `version_info` matches it. Frozen legacy flows without target metadata retain the historical disconnect/reconnect fallback.
- Keep early BES-install link drops on the normal query/resume path, and share all behavior between iOS and Android through the engine coordinator.

## Root cause

Before the progress routes were merged, `check-for-updates.tsx` selected `progress-legacy.tsx` once for builds below 37. That component remained mounted after an APK step upgraded ASG and completed BES locally after an observed restart disconnect/reconnect.

The merged coordinator instead allowed the latest OTA event shape to change the compatibility policy. After BES reboot, the store still contained the pre-reboot `in_progress` state at 100%, so reconnect derived `updating` again and eventually fired the progress timeout despite the firmware having installed successfully.

## Device evidence

Captured from `iphone-syslog-ota-verification-20260805-123944.txt` during the staging iPhone + Mentra Live validation:

```text
1497760: Aug  5 12:47:03.910102 Mentra[17008] <Info>: BLE_TRACE direction=glasses_to_phone layer=sdk_ble_event source=processJsonObject(_:)(MentraBluetoothSDK/MentraLive.swift:2416) type=version_info_3 payload={"type":"version_info_3","bt_mac_address":"","bes_fw_version":"17.26.7.9","mtk_fw_version":"MentraLive_20260709"}
1500500: Aug  5 12:47:04.548495 Mentra(React)[17008] <Info>: '[OTA_PROGRESS] displayState restarting -> updating', '{"connected":true,"sawReconnectEdge":false,"errorMsg":null,"otaStatus":{"stepType":"bes","phase":"install","status":"in_progress","step":"2/2","pct":100},"otaProgress":{"currentUpdate":"bes","stage":"install","status":"PROGRESS","progress":100}}'
1500510: Aug  5 12:47:04.549036 Mentra(React)[17008] <Info>: [OTA_PROGRESS] connect-edge: false->true, flipping sawReconnectEdge=true
1500536: Aug  5 12:47:04.550195 Mentra(React)[17008] <Info>: [OTA_PROGRESS] connect-edge: reconnected, sending ota_query_status
1501155: Aug  5 12:47:04.605477 Mentra(React)[17008] <Info>: 'CORE:', 'LIVE: Sending data to glasses: {"mId":74,"type":"ota_query_status","timestamp":1785959224553}'
1505133: Aug  5 12:47:08.108642 Mentra[17008] <Info>: BLE_TRACE direction=glasses_to_phone layer=sdk_ble_event source=processJsonObject(_:)(MentraBluetoothSDK/MentraLive.swift:2416) type=msg_ack payload={"type":"msg_ack","mId":74,"timestamp":1785959224952}
```

The glasses reported the installed target BES version before the mobile UI moved from `restarting` back to stale `updating`. The query received a delivery ACK for message 74 but no fresh `ota_status`, leaving the stale 100% state in control.

## Validation

- `bun run test -- --runInBand --silent src/__tests__/otaInstallCoordinator.test.ts src/app/ota/__tests__/deriveOtaDisplayState.test.ts src/__tests__/otaUpdateCheckService.test.ts src/app/ota/__tests__/progress.test.tsx` — 134 tests passed.
- `bun run compile` — passed.
- `git diff --check` — passed.

Regression coverage includes:

- day-one build 27 upgrading to ASG 39 before the BES reboot;
- stale unified BES `in_progress` at 100% after reconnect;
- BES target version arriving before and after the reconnect edge;
- legacy fallback without target metadata;
- an early BES disconnect at 50% staying on the normal query/resume path;
- later link noise not reopening a completed recovery;
- zero-padded manifest BES versions matching unpadded `version_info`;
- Continue remaining disabled while BES target verification is pending;
- Retry clearing stale BES reboot-attempt latches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core OTA install completion and reconnect arbitration in `OtaInstallCoordinator`; behavior is heavily tested but mistakes could mark success too early or block legitimate retries.
> 
> **Overview**
> **Fixes BES firmware updates that actually succeeded but the progress UI treated as stuck or failed** because stale `in_progress` at 100% came back after reconnect and `ota_query_status` never refreshed session state.
> 
> The install coordinator now **locks `legacy` vs `unified` OTA behavior at attach** (matching the old split routes when an APK step upgrades ASG mid-flow), and adds a **phone-observed BES reboot path**: after BES install hits 100%, disconnect/reconnect is tracked separately from store OTA status. On reconnect it **skips `ota_query_status`**, polls **`version_info`**, and marks complete only when **`besFirmwareVersion` matches the manifest `besVersion`** (with semantic version compare); legacy sessions without target metadata still complete on the historical reboot edge. **Continue stays disabled** until verification finishes or times out (~1 minute).
> 
> `OtaUpdateInfo` and the update check now **surface `besVersion` from the manifest** when a BES step is pending. `deriveDisplayState` **prioritizes `besRestartRecovery`** so stale progress cannot flip the UI from `restarting` back to `updating`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7044fe3ddc4c17c0ad3558020f2d4e94c58429a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->