### PR TITLE
Restore validated ADB BES updates

### DIFF
--- a/asg_client/app/src/main/AndroidManifest.xml
+++ b/asg_client/app/src/main/AndroidManifest.xml
@@ -162,7 +162,8 @@
         <receiver
             android:name="com.mentra.asg_client.receiver.DebugBesOtaReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:permission="android.permission.DUMP">
             <intent-filter>
                 <action android:name="com.mentra.DEBUG_BES_OTA" />
             </intent-filter>

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -156,6 +156,19 @@ public class AsgConstants {
     /** Mentra Live BES build target required in the decompressed image payload. */
     public static final String BES_OTA_PRODUCT = "best1502x_ibrt_bpone";
 
+    /** Prefix for hash-addressed ADB-only artifacts, separate from phone-owned BES OTA data. */
+    public static final String DEBUG_BES_OTA_ARTIFACT_PREFIX =
+            "/storage/emulated/0/asg/debug_bes_";
+
+    /** Debug BES intent extra carrying the exact post-reboot firmware version. */
+    public static final String DEBUG_BES_OTA_TARGET_VERSION_EXTRA = "target_version";
+
+    /** Debug BES intent extra carrying the staged artifact SHA-256. */
+    public static final String DEBUG_BES_OTA_SHA256_EXTRA = "sha256";
+
+    /** Debug BES intent extra carrying a stable identifier for durable state. */
+    public static final String DEBUG_BES_OTA_ARTIFACT_ID_EXTRA = "artifact_id";
+
     /**
      * Exclusive decompressed destination limit in the deployed ota_copy bootloader:
      * NEW_IMAGE_FLASH_OFFSET (0x200000) - OTA_CODE_OFFSET (0x20000). Images at or above this size

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -128,6 +128,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     public boolean isBesOtaInProgress() {
         BesOtaStateStore.Snapshot snapshot = stateStore.read();
         return isBesOtaInProgress
+                || snapshot.isCorrupt()
                 || (snapshot.isValid() && snapshot.getState() != BesOtaStateStore.State.TERMINAL);
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -458,8 +458,6 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                                                 if (authorizationReserved) {
                                                     k900BluetoothManager.setLiveBesOtaOwner(
                                                             activeOwnerSessionId);
-                                                    deleteEphemeralArtifactLocked(
-                                                            "after durable reservation");
                                                 } else {
                                                     Log.e(
                                                             TAG,
@@ -706,6 +704,9 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         }
         isWaitingForAuthorization = false;
         transportLease = null;
+        // SetStartInfo and SetConfig reopen the source file while negotiating the transfer.
+        // BES has now accepted apply, so no remaining protocol command needs those bytes on disk.
+        deleteEphemeralArtifactLocked("after BES accepted apply");
         bInit = false;
         fileData = null;
         sentPos = 0;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -458,6 +458,8 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                                                 if (authorizationReserved) {
                                                     k900BluetoothManager.setLiveBesOtaOwner(
                                                             activeOwnerSessionId);
+                                                    deleteEphemeralArtifactLocked(
+                                                            "after durable reservation");
                                                 } else {
                                                     Log.e(
                                                             TAG,
@@ -795,9 +797,21 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     }
 
     private void clearRunIdentityLocked() {
+        deleteEphemeralArtifactLocked("while clearing BES run identity");
         authorizationReserved = false;
         activeOwnerSessionId = "";
         activeArtifact = null;
+    }
+
+    private void deleteEphemeralArtifactLocked(String reason) {
+        if (activeArtifact != null && !activeArtifact.deleteSourceIfEphemeral()) {
+            Log.w(
+                    TAG,
+                    "Could not delete ephemeral BES artifact "
+                            + activeArtifact.getFile()
+                            + " "
+                            + reason);
+        }
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -3160,6 +3160,19 @@ public class OtaHelper {
         boolean deleteRefusedArtifact = false;
         boolean started = false;
         try {
+            IBesOtaController manager = getOtaController();
+            if (manager == null) {
+                Log.e(TAG, "DEBUG BES install blocked - BES OTA controller is unavailable");
+                return false;
+            }
+            if (manager.isBesOtaInProgress()) {
+                Log.e(TAG, "DEBUG BES install blocked - BES transaction already active");
+                return false;
+            }
+
+            // Shared admission plus an inactive manager proves that this request's path is not
+            // owned by a live BES transaction. Every refusal below may safely delete it.
+            deleteRefusedArtifact = true;
             if (isUpdating) {
                 Log.e(TAG, "DEBUG BES install blocked - APK update in progress");
                 return false;
@@ -3173,19 +3186,6 @@ public class OtaHelper {
                 return false;
             }
 
-            IBesOtaController manager = getOtaController();
-            if (manager == null) {
-                Log.e(TAG, "DEBUG BES install blocked - BES OTA controller is unavailable");
-                return false;
-            }
-            if (manager.isBesOtaInProgress()) {
-                Log.e(TAG, "DEBUG BES install blocked - BES transaction already active");
-                return false;
-            }
-
-            // From this point the shared admission permit and inactive manager prove that no
-            // transaction owns this path. A refusal may therefore clean up only this request.
-            deleteRefusedArtifact = true;
             ValidatedBesArtifact artifact =
                     BesFirmwareArtifactValidator.validateLocal(
                             firmwareFile, artifactId, expectedSha256, targetVersion);
@@ -3209,6 +3209,10 @@ public class OtaHelper {
                 Log.e(TAG, "DEBUG BES install was refused by the BES OTA manager");
             } else {
                 deleteRefusedArtifact = false;
+                // The manager now owns this validated artifact. No sibling debug artifact belongs
+                // to the admitted transaction, so interrupted-run leftovers can be removed without
+                // endangering the active source.
+                pruneAbandonedDebugBesArtifacts(firmwareFile);
             }
             return started;
         } catch (BesFirmwareArtifactValidator.ValidationException e) {
@@ -3225,6 +3229,33 @@ public class OtaHelper {
     private void deleteRefusedDebugBesArtifact(File artifact) {
         if (artifact != null && artifact.exists() && !artifact.delete()) {
             Log.w(TAG, "Could not delete refused debug BES artifact " + artifact);
+        }
+    }
+
+    private void pruneAbandonedDebugBesArtifacts(File currentArtifact) {
+        if (currentArtifact == null) {
+            return;
+        }
+        File parent = currentArtifact.getParentFile();
+        if (parent == null || !parent.isDirectory()) {
+            return;
+        }
+        String debugPrefix = new File(AsgConstants.DEBUG_BES_OTA_ARTIFACT_PREFIX).getName();
+        String currentPath = currentArtifact.getAbsolutePath();
+        File[] abandonedArtifacts =
+                parent.listFiles(
+                        (directory, name) ->
+                                name.startsWith(debugPrefix) && name.endsWith(".bin"));
+        if (abandonedArtifacts == null) {
+            return;
+        }
+        for (File abandonedArtifact : abandonedArtifacts) {
+            if (abandonedArtifact.getAbsolutePath().equals(currentPath)) {
+                continue;
+            }
+            if (!abandonedArtifact.delete()) {
+                Log.w(TAG, "Could not delete abandoned debug BES artifact " + abandonedArtifact);
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -41,8 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
-import java.util.concurrent.locks.ReentrantLock;
 
 import com.mentra.asg_client.io.ota.session.OtaSessionManager;
 import com.mentra.asg_client.io.ota.utils.DowngradeGate;
@@ -82,7 +82,10 @@ public class OtaHelper {
         void sendOtaStatus(JSONObject status);
     }
     private static final String TAG = OtaConstants.TAG;
-    private static final ReentrantLock versionCheckLock = new ReentrantLock();
+    // A permit, rather than a ReentrantLock, lets the phone command thread reserve OTA admission
+    // synchronously and hand ownership to its worker. This closes the acknowledged-but-dropped
+    // window without changing the existing single-worker pipeline.
+    private static final Semaphore otaAdmissionPermit = new Semaphore(1);
     private static volatile boolean isUpdating = false;  // Tracks download/install in progress
 
     // Downgrade handoff verdict plumbing: the watchdog must be cancellable because recovery
@@ -464,35 +467,65 @@ public class OtaHelper {
 
         // Immediately acknowledge receipt so the phone cancels its retry timer.
         sendOtaStartAck();
-
-        IBesOtaController besController = getOtaController();
-        if (besController != null && !besController.prepareForNewOtaSession()) {
-            Log.w(TAG, "BES durable state blocks a new OTA session");
-            sendAuthoritativeBesStatusToPhone();
-            return;
-        }
-
-        // If OTA already in progress, do not start a parallel pipeline. The phone
-        // will receive the current status and can keep retrying/querying normally.
-        if (versionCheckLock.isLocked()) {
-            Log.i(TAG, "📱 OTA already in progress - acknowledging ota_start and sending current status");
+        String resolvedVersionJsonUrl = requireVersionJsonUrl(requestedVersionJsonUrl);
+        if (resolvedVersionJsonUrl == null) {
+            Log.e(TAG, "Refusing phone OTA start without a manifest URL");
             sendOtaStatus();
             return;
         }
 
-        // Acquire wakelock to prevent CPU sleep during OTA download/install
-        WakeLockManager.acquireCpu(context, WakeLockManager.WakeOwner.MTK_OTA, OTA_WAKELOCK_TIMEOUT_MS);
-        Log.i(TAG, "📱 OTA wakelock acquired for " + (OTA_WAKELOCK_TIMEOUT_MS / 1000) + " seconds");
+        // Reserve admission before arming phone state or the wake lease. Semaphore ownership can
+        // cross threads, so the worker can release the reservation when the pipeline finishes.
+        if (!otaAdmissionPermit.tryAcquire()) {
+            Log.i(
+                    TAG,
+                    "📱 OTA already in progress - acknowledging ota_start and sending current"
+                            + " status");
+            sendOtaStatus();
+            return;
+        }
 
-        isPhoneInitiatedOta = true;
+        boolean handedToWorker = false;
+        try {
+            if (isUpdating || isMtkOtaInProgress || isBesOtaInProgress()) {
+                Log.i(TAG, "📱 OTA install already active - sending current status");
+                sendOtaStatus();
+                return;
+            }
 
-        // Reset progress tracking
-        lastProgressSentTime = 0;
-        lastProgressSentPercent = 0;
+            IBesOtaController besController = getOtaController();
+            if (besController != null && !besController.prepareForNewOtaSession()) {
+                Log.w(TAG, "BES durable state blocks a new OTA session");
+                sendAuthoritativeBesStatusToPhone();
+                return;
+            }
 
-        Log.i(TAG, "📱 Phone-initiated OTA: starting version check (download STARTED deferred)");
+            // Acquire wakelock to prevent CPU sleep during OTA download/install
+            WakeLockManager.acquireCpu(
+                    context, WakeLockManager.WakeOwner.MTK_OTA, OTA_WAKELOCK_TIMEOUT_MS);
+            Log.i(
+                    TAG,
+                    "📱 OTA wakelock acquired for "
+                            + (OTA_WAKELOCK_TIMEOUT_MS / 1000)
+                            + " seconds");
 
-        startVersionCheckWithUrl(context, requestedVersionJsonUrl);
+            isPhoneInitiatedOta = true;
+
+            // Reset progress tracking
+            lastProgressSentTime = 0;
+            lastProgressSentPercent = 0;
+
+            Log.i(
+                    TAG,
+                    "📱 Phone-initiated OTA: starting version check (download STARTED deferred)");
+
+            startVersionCheckWithReservedAdmission(context, resolvedVersionJsonUrl);
+            handedToWorker = true;
+        } finally {
+            if (!handedToWorker) {
+                otaAdmissionPermit.release();
+            }
+        }
     }
 
     private String requireVersionJsonUrl(String versionJsonUrl) {
@@ -509,14 +542,26 @@ public class OtaHelper {
      * @param versionJsonUrl URL to fetch the version JSON from (http, https)
      */
     public void startVersionCheckWithUrl(Context context, String versionJsonUrl) {
+        startVersionCheckWithUrl(context, versionJsonUrl, false);
+    }
+
+    private void startVersionCheckWithReservedAdmission(Context context, String versionJsonUrl) {
+        startVersionCheckWithUrl(context, versionJsonUrl, true);
+    }
+
+    private void startVersionCheckWithUrl(
+            Context context, String versionJsonUrl, boolean admissionReserved) {
         String resolvedVersionJsonUrl = requireVersionJsonUrl(versionJsonUrl);
         if (resolvedVersionJsonUrl == null) {
             Log.e(TAG, "Refusing OTA version check without a manifest URL");
+            if (admissionReserved) {
+                otaAdmissionPermit.release();
+            }
             return;
         }
         Log.d(TAG, "Check OTA update method init");
         Log.i(TAG, "OTA check trigger -> phoneInitiated=" + isPhoneInitiatedOta
-                + ", lockHeld=" + versionCheckLock.isLocked()
+                + ", admissionHeld=" + (otaAdmissionPermit.availablePermits() == 0)
                 + ", isUpdating=" + isUpdating
                 + ", mtkInProgress=" + isMtkOtaInProgress
                 + ", besInProgress=" + isBesOtaInProgress()
@@ -528,12 +573,12 @@ public class OtaHelper {
         // }
 
         new Thread(() -> {
-            // Try to acquire lock - if already held, another check is in progress
-            if (!versionCheckLock.tryLock()) {
+            // Phone ota_start can reserve admission before dispatch. Other callers acquire here.
+            if (!admissionReserved && !otaAdmissionPermit.tryAcquire()) {
                 Log.d(TAG, "Version check already in progress, skipping this request");
                 return;
             }
-            Log.d(TAG, "Version check lock acquired");
+            Log.d(TAG, "OTA admission permit acquired");
 
             // Store the URL under the lock so a concurrent caller can't overwrite it
             // before this check finishes.
@@ -542,7 +587,12 @@ public class OtaHelper {
             // Check if update is in progress (separate from version check)
             if (isUpdating) {
                 Log.d(TAG, "Update already in progress, skipping version check");
-                versionCheckLock.unlock();
+                if (admissionReserved) {
+                    isPhoneInitiatedOta = false;
+                    WakeLockManager.release(WakeLockManager.WakeOwner.MTK_OTA);
+                    sendOtaStatus();
+                }
+                otaAdmissionPermit.release();
                 return;
             }
 
@@ -604,9 +654,14 @@ public class OtaHelper {
                 }
             } finally {
                 isPhoneInitiatedOta = false;
-                versionCheckLock.unlock();
-                Log.d(TAG, "Version check thread finished (reachedSuccessLog=" + otaCheckReachedSuccessLog[0]
-                        + ", lastStage=" + stage[0] + "), lock released, ready for next check");
+                otaAdmissionPermit.release();
+                Log.d(
+                        TAG,
+                        "Version check thread finished (reachedSuccessLog="
+                                + otaCheckReachedSuccessLog[0]
+                                + ", lastStage="
+                                + stage[0]
+                                + "), admission released, ready for next check");
             }
         }).start();
     }
@@ -3097,11 +3152,13 @@ public class OtaHelper {
             String targetVersion,
             String expectedSha256,
             String artifactId) {
-        if (!versionCheckLock.tryLock()) {
+        if (!otaAdmissionPermit.tryAcquire()) {
             Log.e(TAG, "DEBUG BES install blocked - phone OTA admission is active");
             return false;
         }
 
+        boolean deleteRefusedArtifact = false;
+        boolean started = false;
         try {
             if (isUpdating) {
                 Log.e(TAG, "DEBUG BES install blocked - APK update in progress");
@@ -3126,7 +3183,9 @@ public class OtaHelper {
                 return false;
             }
 
-            pruneStaleDebugBesArtifacts(firmwareFile);
+            // From this point the shared admission permit and inactive manager prove that no
+            // transaction owns this path. A refusal may therefore clean up only this request.
+            deleteRefusedArtifact = true;
             ValidatedBesArtifact artifact =
                     BesFirmwareArtifactValidator.validateLocal(
                             firmwareFile, artifactId, expectedSha256, targetVersion);
@@ -3145,41 +3204,27 @@ public class OtaHelper {
                             + artifact.getTargetVersion()
                             + " owner="
                             + ownerSessionId);
-            boolean started = manager.startFirmwareUpdate(artifact, ownerSessionId);
+            started = manager.startFirmwareUpdate(artifact, ownerSessionId);
             if (!started) {
                 Log.e(TAG, "DEBUG BES install was refused by the BES OTA manager");
+            } else {
+                deleteRefusedArtifact = false;
             }
             return started;
         } catch (BesFirmwareArtifactValidator.ValidationException e) {
             Log.e(TAG, "DEBUG BES artifact validation failed: " + e.getMessage(), e);
             return false;
         } finally {
-            versionCheckLock.unlock();
+            if (deleteRefusedArtifact && !started) {
+                deleteRefusedDebugBesArtifact(firmwareFile);
+            }
+            otaAdmissionPermit.release();
         }
     }
 
-    /** Remove abandoned hash-addressed debug artifacts while preserving this request's bytes. */
-    private void pruneStaleDebugBesArtifacts(File currentArtifact) {
-        File prefix = new File(AsgConstants.DEBUG_BES_OTA_ARTIFACT_PREFIX);
-        File parent = prefix.getParentFile();
-        if (parent == null || !parent.isDirectory()) {
-            return;
-        }
-        String currentPath = currentArtifact == null ? "" : currentArtifact.getAbsolutePath();
-        File[] staleArtifacts =
-                parent.listFiles(
-                        (directory, name) ->
-                                name.startsWith(prefix.getName()) && name.endsWith(".bin"));
-        if (staleArtifacts == null) {
-            return;
-        }
-        for (File staleArtifact : staleArtifacts) {
-            if (staleArtifact.getAbsolutePath().equals(currentPath)) {
-                continue;
-            }
-            if (!staleArtifact.delete()) {
-                Log.w(TAG, "Could not delete stale debug BES artifact " + staleArtifact);
-            }
+    private void deleteRefusedDebugBesArtifact(File artifact) {
+        if (artifact != null && artifact.exists() && !artifact.delete()) {
+            Log.w(TAG, "Could not delete refused debug BES artifact " + artifact);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -519,10 +519,12 @@ public class OtaHelper {
                     TAG,
                     "📱 Phone-initiated OTA: starting version check (download STARTED deferred)");
 
-            startVersionCheckWithReservedAdmission(context, resolvedVersionJsonUrl);
+            startVersionCheckWithReservedAdmission(context, resolvedVersionJsonUrl, true);
             handedToWorker = true;
         } finally {
             if (!handedToWorker) {
+                isPhoneInitiatedOta = false;
+                WakeLockManager.release(WakeLockManager.WakeOwner.MTK_OTA);
                 otaAdmissionPermit.release();
             }
         }
@@ -540,25 +542,42 @@ public class OtaHelper {
      * Used by DebugApkOtaReceiver to test OTA with a local/custom URL.
      * @param context Application context
      * @param versionJsonUrl URL to fetch the version JSON from (http, https)
+     * @return true when admission was reserved and the worker was dispatched
      */
-    public void startVersionCheckWithUrl(Context context, String versionJsonUrl) {
-        startVersionCheckWithUrl(context, versionJsonUrl, false);
-    }
-
-    private void startVersionCheckWithReservedAdmission(Context context, String versionJsonUrl) {
-        startVersionCheckWithUrl(context, versionJsonUrl, true);
-    }
-
-    private void startVersionCheckWithUrl(
-            Context context, String versionJsonUrl, boolean admissionReserved) {
+    public boolean startVersionCheckWithUrl(Context context, String versionJsonUrl) {
         String resolvedVersionJsonUrl = requireVersionJsonUrl(versionJsonUrl);
         if (resolvedVersionJsonUrl == null) {
             Log.e(TAG, "Refusing OTA version check without a manifest URL");
-            if (admissionReserved) {
-                otaAdmissionPermit.release();
-            }
-            return;
+            return false;
         }
+        if (!otaAdmissionPermit.tryAcquire()) {
+            Log.w(TAG, "Version check admission is busy; refusing before worker dispatch");
+            return false;
+        }
+        if (isUpdating || isMtkOtaInProgress || isBesOtaInProgress()) {
+            Log.w(TAG, "Version check admission blocked by an active OTA install");
+            otaAdmissionPermit.release();
+            return false;
+        }
+
+        isPhoneInitiatedOta = true;
+        try {
+            startVersionCheckWithReservedAdmission(context, resolvedVersionJsonUrl, false);
+            return true;
+        } catch (RuntimeException dispatchFailure) {
+            Log.e(TAG, "Could not dispatch admitted OTA version check", dispatchFailure);
+            isPhoneInitiatedOta = false;
+            otaAdmissionPermit.release();
+            return false;
+        } catch (Error fatalDispatchFailure) {
+            isPhoneInitiatedOta = false;
+            otaAdmissionPermit.release();
+            throw fatalDispatchFailure;
+        }
+    }
+
+    private void startVersionCheckWithReservedAdmission(
+            Context context, String resolvedVersionJsonUrl, boolean releaseWakeOnAdmissionAbort) {
         Log.d(TAG, "Check OTA update method init");
         Log.i(TAG, "OTA check trigger -> phoneInitiated=" + isPhoneInitiatedOta
                 + ", admissionHeld=" + (otaAdmissionPermit.availablePermits() == 0)
@@ -573,25 +592,20 @@ public class OtaHelper {
         // }
 
         new Thread(() -> {
-            // Phone ota_start can reserve admission before dispatch. Other callers acquire here.
-            if (!admissionReserved && !otaAdmissionPermit.tryAcquire()) {
-                Log.d(TAG, "Version check already in progress, skipping this request");
-                return;
-            }
             Log.d(TAG, "OTA admission permit acquired");
 
-            // Store the URL under the lock so a concurrent caller can't overwrite it
+            // Store the URL under admission so a concurrent caller can't overwrite it
             // before this check finishes.
             lastVersionJsonUrl = resolvedVersionJsonUrl;
 
             // Check if update is in progress (separate from version check)
             if (isUpdating) {
                 Log.d(TAG, "Update already in progress, skipping version check");
-                if (admissionReserved) {
-                    isPhoneInitiatedOta = false;
+                isPhoneInitiatedOta = false;
+                if (releaseWakeOnAdmissionAbort) {
                     WakeLockManager.release(WakeLockManager.WakeOwner.MTK_OTA);
-                    sendOtaStatus();
                 }
+                sendOtaStatus();
                 otaAdmissionPermit.release();
                 return;
             }
@@ -2920,9 +2934,8 @@ public class OtaHelper {
         Log.i(TAG, "continueSessionAfterStepComplete: auto-advancing from step "
                 + currentIndex + " to step " + nextStep + " type=" + nextType);
 
-        // Advance the session record so the phone sees the new current step immediately.
+        // Advance the durable session before dispatch so the admitted worker sees the next step.
         sessionManager.advanceStep(nextStep, "download");
-        sendOtaStatus();
 
         // Kick off the next step's download/install cycle. Sessions always carry the
         // phone-supplied manifest URL; a session without one is unrecoverable by design
@@ -2933,8 +2946,14 @@ public class OtaHelper {
             sendOtaStatus();
             return false;
         }
-        setPhoneInitiatedOta(true);
-        startVersionCheckWithUrl(context, versionJsonUrl);
+        if (!startVersionCheckWithUrl(context, versionJsonUrl)) {
+            Log.e(TAG, "Next OTA step lost admission before worker dispatch");
+            sessionManager.setFailed("OTA admission busy before next step");
+            sendOtaStatus();
+            // The active session handled the failure; suppress the caller's legacy completion path.
+            return true;
+        }
+        sendOtaStatus();
         return true;
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -3097,30 +3097,36 @@ public class OtaHelper {
             String targetVersion,
             String expectedSha256,
             String artifactId) {
-        if (isUpdating) {
-            Log.e(TAG, "DEBUG BES install blocked - APK update in progress");
-            return false;
-        }
-        if (isMtkOtaInProgress) {
-            Log.e(TAG, "DEBUG BES install blocked - MTK update in progress");
-            return false;
-        }
-        if (!isBatterySufficientForUpdates()) {
-            Log.e(TAG, "DEBUG BES install blocked - battery is insufficient");
-            return false;
-        }
-
-        IBesOtaController manager = getOtaController();
-        if (manager == null) {
-            Log.e(TAG, "DEBUG BES install blocked - BES OTA controller is unavailable");
-            return false;
-        }
-        if (manager.isBesOtaInProgress()) {
-            Log.e(TAG, "DEBUG BES install blocked - BES transaction already active");
+        if (!versionCheckLock.tryLock()) {
+            Log.e(TAG, "DEBUG BES install blocked - phone OTA admission is active");
             return false;
         }
 
         try {
+            if (isUpdating) {
+                Log.e(TAG, "DEBUG BES install blocked - APK update in progress");
+                return false;
+            }
+            if (isMtkOtaInProgress) {
+                Log.e(TAG, "DEBUG BES install blocked - MTK update in progress");
+                return false;
+            }
+            if (!isBatterySufficientForUpdates()) {
+                Log.e(TAG, "DEBUG BES install blocked - battery is insufficient");
+                return false;
+            }
+
+            IBesOtaController manager = getOtaController();
+            if (manager == null) {
+                Log.e(TAG, "DEBUG BES install blocked - BES OTA controller is unavailable");
+                return false;
+            }
+            if (manager.isBesOtaInProgress()) {
+                Log.e(TAG, "DEBUG BES install blocked - BES transaction already active");
+                return false;
+            }
+
+            pruneStaleDebugBesArtifacts(firmwareFile);
             ValidatedBesArtifact artifact =
                     BesFirmwareArtifactValidator.validateLocal(
                             firmwareFile, artifactId, expectedSha256, targetVersion);
@@ -3147,6 +3153,33 @@ public class OtaHelper {
         } catch (BesFirmwareArtifactValidator.ValidationException e) {
             Log.e(TAG, "DEBUG BES artifact validation failed: " + e.getMessage(), e);
             return false;
+        } finally {
+            versionCheckLock.unlock();
+        }
+    }
+
+    /** Remove abandoned hash-addressed debug artifacts while preserving this request's bytes. */
+    private void pruneStaleDebugBesArtifacts(File currentArtifact) {
+        File prefix = new File(AsgConstants.DEBUG_BES_OTA_ARTIFACT_PREFIX);
+        File parent = prefix.getParentFile();
+        if (parent == null || !parent.isDirectory()) {
+            return;
+        }
+        String currentPath = currentArtifact == null ? "" : currentArtifact.getAbsolutePath();
+        File[] staleArtifacts =
+                parent.listFiles(
+                        (directory, name) ->
+                                name.startsWith(prefix.getName()) && name.endsWith(".bin"));
+        if (staleArtifacts == null) {
+            return;
+        }
+        for (File staleArtifact : staleArtifacts) {
+            if (staleArtifact.getAbsolutePath().equals(currentPath)) {
+                continue;
+            }
+            if (!staleArtifact.delete()) {
+                Log.w(TAG, "Could not delete stale debug BES artifact " + staleArtifact);
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -3079,6 +3079,78 @@ public class OtaHelper {
     // ========== DEBUG METHODS ==========
 
     /**
+     * Start an explicit ADB-requested BES version change through the release-A safety boundary.
+     *
+     * <p>Unlike the retired raw-file entry point, this validates the release container and
+     * immutable identity, observes APK/MTK/BES mutual exclusion, and assigns a durable owner before
+     * the manager can reserve {@code mh_ota}. Direction is intentionally not compared: selecting an
+     * older target is the supported internal downgrade use case for this privileged debug path.
+     *
+     * @param firmwareFile locally staged release-packaged BES OTA container
+     * @param targetVersion exact four-component version expected after the BES reboot
+     * @param expectedSha256 SHA-256 of the staged container
+     * @param artifactId stable artifact identifier stored with the durable transaction
+     * @return true when the validated transaction was accepted by the BES OTA manager
+     */
+    public boolean startValidatedDebugBesFirmware(
+            File firmwareFile,
+            String targetVersion,
+            String expectedSha256,
+            String artifactId) {
+        if (isUpdating) {
+            Log.e(TAG, "DEBUG BES install blocked - APK update in progress");
+            return false;
+        }
+        if (isMtkOtaInProgress) {
+            Log.e(TAG, "DEBUG BES install blocked - MTK update in progress");
+            return false;
+        }
+        if (!isBatterySufficientForUpdates()) {
+            Log.e(TAG, "DEBUG BES install blocked - battery is insufficient");
+            return false;
+        }
+
+        IBesOtaController manager = getOtaController();
+        if (manager == null) {
+            Log.e(TAG, "DEBUG BES install blocked - BES OTA controller is unavailable");
+            return false;
+        }
+        if (manager.isBesOtaInProgress()) {
+            Log.e(TAG, "DEBUG BES install blocked - BES transaction already active");
+            return false;
+        }
+
+        try {
+            ValidatedBesArtifact artifact =
+                    BesFirmwareArtifactValidator.validateLocal(
+                            firmwareFile, artifactId, expectedSha256, targetVersion);
+            if (!manager.prepareForNewOtaSession()) {
+                Log.e(TAG, "DEBUG BES install blocked - durable state refused a new session");
+                return false;
+            }
+
+            String ownerSessionId =
+                    "adb-bes-" + java.util.UUID.randomUUID().toString().replace("-", "");
+            Log.w(
+                    TAG,
+                    "DEBUG: starting validated BES version change artifact="
+                            + artifact.getArtifactId()
+                            + " target="
+                            + artifact.getTargetVersion()
+                            + " owner="
+                            + ownerSessionId);
+            boolean started = manager.startFirmwareUpdate(artifact, ownerSessionId);
+            if (!started) {
+                Log.e(TAG, "DEBUG BES install was refused by the BES OTA manager");
+            }
+            return started;
+        } catch (BesFirmwareArtifactValidator.ValidationException e) {
+            Log.e(TAG, "DEBUG BES artifact validation failed: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
      * DEBUG: Force install MTK firmware from local zip file without any checks
      * Skips version checking, downloading, and mutual exclusion
      * Use for testing only!

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -507,8 +507,12 @@ public class OtaService extends Service {
                 return;
             }
 
-            otaHelper.setPhoneInitiatedOta(true);
-            otaHelper.startVersionCheckWithUrl(this, versionJsonUrl);
+            if (!otaHelper.startVersionCheckWithUrl(this, versionJsonUrl)) {
+                Log.e(TAG, "OTA admission busy - failing resumed session before worker dispatch");
+                sessionManager.consumePendingApkStatus();
+                sessionManager.setFailed("OTA admission busy after APK restart");
+                otaHelper.sendCompletionToPhone(sessionManager);
+            }
         } catch (Exception e) {
             Log.e(TAG, "Error resuming OTA from session", e);
             sessionManager.setFailed("Resume error: " + e.getMessage());

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
@@ -40,40 +40,72 @@ public final class BesFirmwareArtifactValidator {
     public static ValidatedBesArtifact validate(File artifact, JSONObject metadata)
             throws ValidationException {
         try {
-            if (artifact == null || !artifact.isFile()) {
-                throw new ValidationException("BES OTA artifact is missing");
-            }
             if (metadata == null) {
                 throw new ValidationException("BES OTA release metadata is missing");
             }
 
             String artifactId = artifactIdFromUrl(metadata);
-            long compressedSize = artifact.length();
-
-            byte[] container = readArtifact(artifact);
             String compressedSha256 = requiredSha256(metadata, "sha256");
-            assertSha256(container, compressedSha256, "compressed");
-
-            byte[] raw = unpackAndValidateContainer(container);
-            assertProduct(raw, AsgConstants.BES_OTA_PRODUCT);
             String targetVersion = requiredString(metadata, "version");
-            String canonicalTarget = BesOtaStateStore.canonicalVersion(targetVersion);
-            if (canonicalTarget == null) {
-                throw new ValidationException(
-                        "BES target version must contain four numeric byte components");
-            }
-            return new ValidatedBesArtifact(
-                    artifact,
-                    artifactId,
-                    compressedSha256,
-                    canonicalTarget,
-                    compressedSize,
-                    raw.length);
+            return validateKnownIdentity(
+                    artifact, artifactId, compressedSha256, targetVersion);
         } catch (ValidationException e) {
             throw e;
         } catch (Exception e) {
             throw new ValidationException("Invalid BES OTA artifact: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Validate an ADB-staged release container with explicit immutable identity metadata.
+     *
+     * <p>This performs the same byte, digest, product, size, and target validation as the
+     * phone-owned manifest path. It exists so the privileged debug receiver can exercise the
+     * production BES state machine without inventing an HTTPS URL for a local artifact.
+     */
+    public static ValidatedBesArtifact validateLocal(
+            File artifact, String artifactId, String expectedSha256, String targetVersion)
+            throws ValidationException {
+        try {
+            String canonicalArtifactId = artifactId == null ? "" : artifactId.trim();
+            if (!canonicalArtifactId.matches("[A-Za-z0-9._-]{1,128}")) {
+                throw new ValidationException("BES OTA artifact has an invalid identifier");
+            }
+            String canonicalSha256 = canonicalSha256(expectedSha256);
+            return validateKnownIdentity(
+                    artifact, canonicalArtifactId, canonicalSha256, targetVersion);
+        } catch (ValidationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ValidationException("Invalid BES OTA artifact: " + e.getMessage(), e);
+        }
+    }
+
+    private static ValidatedBesArtifact validateKnownIdentity(
+            File artifact, String artifactId, String compressedSha256, String targetVersion)
+            throws Exception {
+        if (artifact == null || !artifact.isFile()) {
+            throw new ValidationException("BES OTA artifact is missing");
+        }
+
+        long compressedSize = artifact.length();
+        byte[] container = readArtifact(artifact);
+        assertSha256(container, compressedSha256, "compressed");
+
+        byte[] raw = unpackAndValidateContainer(container);
+        assertProduct(raw, AsgConstants.BES_OTA_PRODUCT);
+        String canonicalTarget = BesOtaStateStore.canonicalVersion(targetVersion);
+        if (canonicalTarget == null) {
+            throw new ValidationException(
+                    "BES target version must contain four numeric byte components");
+        }
+        return new ValidatedBesArtifact(
+                artifact,
+                artifactId,
+                compressedSha256,
+                canonicalTarget,
+                compressedSize,
+                raw.length);
     }
 
     private static byte[] readArtifact(File artifact) throws IOException, ValidationException {
@@ -221,9 +253,18 @@ public final class BesFirmwareArtifactValidator {
 
     private static String requiredSha256(JSONObject metadata, String key)
             throws ValidationException {
-        String value = requiredString(metadata, key).toLowerCase(Locale.US);
+        String value = requiredString(metadata, key);
+        value = value.trim().toLowerCase(Locale.US);
         if (!value.matches("[0-9a-f]{64}")) {
             throw new ValidationException("Invalid BES OTA SHA-256 metadata: " + key);
+        }
+        return value;
+    }
+
+    private static String canonicalSha256(String value) throws ValidationException {
+        value = value == null ? "" : value.trim().toLowerCase(Locale.US);
+        if (!value.matches("[0-9a-f]{64}")) {
+            throw new ValidationException("Invalid BES OTA SHA-256 metadata");
         }
         return value;
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidator.java
@@ -48,7 +48,7 @@ public final class BesFirmwareArtifactValidator {
             String compressedSha256 = requiredSha256(metadata, "sha256");
             String targetVersion = requiredString(metadata, "version");
             return validateKnownIdentity(
-                    artifact, artifactId, compressedSha256, targetVersion);
+                    artifact, artifactId, compressedSha256, targetVersion, false);
         } catch (ValidationException e) {
             throw e;
         } catch (Exception e) {
@@ -71,9 +71,9 @@ public final class BesFirmwareArtifactValidator {
             if (!canonicalArtifactId.matches("[A-Za-z0-9._-]{1,128}")) {
                 throw new ValidationException("BES OTA artifact has an invalid identifier");
             }
-            String canonicalSha256 = canonicalSha256(expectedSha256);
+            String canonicalSha256 = normalizeSha256(expectedSha256, null);
             return validateKnownIdentity(
-                    artifact, canonicalArtifactId, canonicalSha256, targetVersion);
+                    artifact, canonicalArtifactId, canonicalSha256, targetVersion, true);
         } catch (ValidationException e) {
             throw e;
         } catch (Exception e) {
@@ -82,7 +82,11 @@ public final class BesFirmwareArtifactValidator {
     }
 
     private static ValidatedBesArtifact validateKnownIdentity(
-            File artifact, String artifactId, String compressedSha256, String targetVersion)
+            File artifact,
+            String artifactId,
+            String compressedSha256,
+            String targetVersion,
+            boolean ephemeralSource)
             throws Exception {
         if (artifact == null || !artifact.isFile()) {
             throw new ValidationException("BES OTA artifact is missing");
@@ -105,7 +109,8 @@ public final class BesFirmwareArtifactValidator {
                 compressedSha256,
                 canonicalTarget,
                 compressedSize,
-                raw.length);
+                raw.length,
+                ephemeralSource);
     }
 
     private static byte[] readArtifact(File artifact) throws IOException, ValidationException {
@@ -253,18 +258,14 @@ public final class BesFirmwareArtifactValidator {
 
     private static String requiredSha256(JSONObject metadata, String key)
             throws ValidationException {
-        String value = requiredString(metadata, key);
-        value = value.trim().toLowerCase(Locale.US);
-        if (!value.matches("[0-9a-f]{64}")) {
-            throw new ValidationException("Invalid BES OTA SHA-256 metadata: " + key);
-        }
-        return value;
+        return normalizeSha256(requiredString(metadata, key), key);
     }
 
-    private static String canonicalSha256(String value) throws ValidationException {
+    private static String normalizeSha256(String value, String key) throws ValidationException {
         value = value == null ? "" : value.trim().toLowerCase(Locale.US);
         if (!value.matches("[0-9a-f]{64}")) {
-            throw new ValidationException("Invalid BES OTA SHA-256 metadata");
+            throw new ValidationException(
+                    "Invalid BES OTA SHA-256 metadata" + (key == null ? "" : ": " + key));
         }
         return value;
     }
@@ -323,6 +324,7 @@ public final class BesFirmwareArtifactValidator {
         private final String targetVersion;
         private final long compressedSize;
         private final long decompressedSize;
+        private final boolean ephemeralSource;
 
         private ValidatedBesArtifact(
                 File file,
@@ -330,13 +332,15 @@ public final class BesFirmwareArtifactValidator {
                 String compressedSha256,
                 String targetVersion,
                 long compressedSize,
-                long decompressedSize) {
+                long decompressedSize,
+                boolean ephemeralSource) {
             this.file = file;
             this.artifactId = artifactId;
             this.compressedSha256 = compressedSha256;
             this.targetVersion = targetVersion;
             this.compressedSize = compressedSize;
             this.decompressedSize = decompressedSize;
+            this.ephemeralSource = ephemeralSource;
         }
 
         /** Close the validation-to-use race before authorization is reserved. */
@@ -375,6 +379,11 @@ public final class BesFirmwareArtifactValidator {
 
         public long getDecompressedSize() {
             return decompressedSize;
+        }
+
+        /** Delete ADB-staged bytes while preserving artifacts owned by the phone manifest. */
+        public boolean deleteSourceIfEphemeral() {
+            return !ephemeralSource || !file.exists() || file.delete();
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugApkOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugApkOtaReceiver.java
@@ -54,8 +54,10 @@ public class DebugApkOtaReceiver extends BroadcastReceiver {
         }
 
         Log.i(TAG, "🚀 Starting APK OTA check with custom URL...");
-        helper.setPhoneInitiatedOta(true);
-        helper.startVersionCheckWithUrl(context, url);
-        Log.i(TAG, "✅ APK OTA check triggered - monitor logcat for progress");
+        if (helper.startVersionCheckWithUrl(context, url)) {
+            Log.i(TAG, "✅ APK OTA check triggered - monitor logcat for progress");
+        } else {
+            Log.e(TAG, "❌ APK OTA check refused because OTA admission is busy");
+        }
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
@@ -4,13 +4,20 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.di.hilt.AsgClientEntryPoint;
+import com.mentra.asg_client.io.ota.helpers.OtaHelper;
+import dagger.hilt.android.EntryPointAccessors;
+import java.io.File;
+import java.util.Locale;
 
 /**
- * Compatibility receiver that rejects the retired direct BES OTA adb entry point.
+ * Privileged receiver for testing validated BES firmware version changes through ADB.
  *
- * <p>Direct installs cannot prove immutable release metadata or durable session ownership. Use a
- * phone-driven staging manifest so development tests exercise the production admission gate. The
- * old action remains registered only so existing scripts fail loudly.
+ * <p>The manifest requires {@code android.permission.DUMP}, which is available to ADB shell but not
+ * ordinary applications. The caller supplies immutable identity metadata for the staged release
+ * container; {@link OtaHelper} then uses the same validator and durable BES manager as the
+ * phone-owned flow. This path intentionally permits explicit internal downgrades.
  */
 public class DebugBesOtaReceiver extends BroadcastReceiver {
     private static final String TAG = "DebugBesOtaReceiver";
@@ -26,8 +33,63 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
         Log.w(TAG, "⚠️ DEBUG BES OTA TRIGGERED VIA ADB ⚠️");
         Log.w(TAG, "========================================");
 
-        // Raw-path starts bypass release metadata, artifact identity, and durable session
-        // ownership. Use the phone-driven staging OTA flow so the same safety gate is exercised.
-        Log.e(TAG, "❌ Direct BES OTA broadcast is disabled; use a validated staging manifest");
+        String targetVersion =
+                intent.getStringExtra(AsgConstants.DEBUG_BES_OTA_TARGET_VERSION_EXTRA);
+        String expectedSha256 = intent.getStringExtra(AsgConstants.DEBUG_BES_OTA_SHA256_EXTRA);
+        String artifactId = intent.getStringExtra(AsgConstants.DEBUG_BES_OTA_ARTIFACT_ID_EXTRA);
+        if (isBlank(targetVersion) || isBlank(expectedSha256) || isBlank(artifactId)) {
+            Log.e(
+                    TAG,
+                    "❌ Missing required target_version, sha256, or artifact_id intent extra;"
+                            + " use scripts/test-bes-ota.sh");
+            return;
+        }
+        String normalizedSha256 = expectedSha256.trim().toLowerCase(Locale.US);
+        if (!normalizedSha256.matches("[0-9a-f]{64}")) {
+            Log.e(TAG, "❌ Invalid sha256 intent extra; use scripts/test-bes-ota.sh");
+            return;
+        }
+
+        Context applicationContext = context.getApplicationContext();
+        PendingResult pendingResult = goAsync();
+        new Thread(
+                        () -> {
+                            try {
+                                OtaHelper helper =
+                                        EntryPointAccessors.fromApplication(
+                                                        applicationContext,
+                                                        AsgClientEntryPoint.class)
+                                                .otaHelper();
+                                File artifact =
+                                        new File(
+                                                AsgConstants.DEBUG_BES_OTA_ARTIFACT_PREFIX
+                                                        + normalizedSha256
+                                                        + ".bin");
+                                boolean started =
+                                        helper.startValidatedDebugBesFirmware(
+                                                artifact,
+                                                targetVersion,
+                                                normalizedSha256,
+                                                artifactId);
+                                if (started) {
+                                    Log.i(
+                                            TAG,
+                                            "✅ Validated BES OTA started; monitor durable state"
+                                                    + " through reboot");
+                                } else {
+                                    Log.e(TAG, "❌ Validated BES OTA was refused");
+                                }
+                            } catch (Exception e) {
+                                Log.e(TAG, "❌ Debug BES OTA dispatch failed", e);
+                            } finally {
+                                pendingResult.finish();
+                            }
+                        },
+                        "debug-bes-ota")
+                .start();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
@@ -54,18 +54,19 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
         PendingResult pendingResult = goAsync();
         new Thread(
                         () -> {
+                            File artifact =
+                                    new File(
+                                            AsgConstants.DEBUG_BES_OTA_ARTIFACT_PREFIX
+                                                    + normalizedSha256
+                                                    + ".bin");
+                            boolean started = false;
                             try {
                                 OtaHelper helper =
                                         EntryPointAccessors.fromApplication(
                                                         applicationContext,
                                                         AsgClientEntryPoint.class)
                                                 .otaHelper();
-                                File artifact =
-                                        new File(
-                                                AsgConstants.DEBUG_BES_OTA_ARTIFACT_PREFIX
-                                                        + normalizedSha256
-                                                        + ".bin");
-                                boolean started =
+                                started =
                                         helper.startValidatedDebugBesFirmware(
                                                 artifact,
                                                 targetVersion,
@@ -82,6 +83,9 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
                             } catch (Exception e) {
                                 Log.e(TAG, "❌ Debug BES OTA dispatch failed", e);
                             } finally {
+                                if (!started && artifact.exists() && !artifact.delete()) {
+                                    Log.w(TAG, "Could not delete refused debug BES artifact " + artifact);
+                                }
                                 pendingResult.finish();
                             }
                         },

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugBesOtaReceiver.java
@@ -83,9 +83,6 @@ public class DebugBesOtaReceiver extends BroadcastReceiver {
                             } catch (Exception e) {
                                 Log.e(TAG, "❌ Debug BES OTA dispatch failed", e);
                             } finally {
-                                if (!started && artifact.exists() && !artifact.delete()) {
-                                    Log.w(TAG, "Could not delete refused debug BES artifact " + artifact);
-                                }
                                 pendingResult.finish();
                             }
                         },

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugOtaReceiverSupport.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugOtaReceiverSupport.java
@@ -50,8 +50,10 @@ final class DebugOtaReceiverSupport {
         }
 
         Log.i(tag, "🚀 Starting " + flowLabel + " with custom OTA URL...");
-        helper.setPhoneInitiatedOta(true);
-        helper.startVersionCheckWithUrl(context, url);
-        Log.i(tag, "✅ " + flowLabel + " trigger dispatched - monitor logcat for progress");
+        if (helper.startVersionCheckWithUrl(context, url)) {
+            Log.i(tag, "✅ " + flowLabel + " trigger dispatched - monitor logcat for progress");
+        } else {
+            Log.e(tag, "❌ " + flowLabel + " trigger refused because OTA admission is busy");
+        }
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaManagerArtifactLifetimeTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaManagerArtifactLifetimeTest.java
@@ -45,8 +45,7 @@ public class BesOtaManagerArtifactLifetimeTest {
                 new BesOtaManager(null, null, ApplicationProvider.getApplicationContext());
         ValidatedBesArtifact artifact = mock(ValidatedBesArtifact.class);
         when(artifact.getFile()).thenReturn(source);
-        when(artifact.deleteSourceIfEphemeral())
-                .thenAnswer(invocation -> !source.exists() || source.delete());
+        when(artifact.deleteSourceIfEphemeral()).thenReturn(true);
         setField(manager, "activeArtifact", artifact);
 
         assertThat(manager.init(source.getAbsolutePath())).isTrue();
@@ -58,7 +57,6 @@ public class BesOtaManagerArtifactLifetimeTest {
         invokeNoArgs(manager, "releaseAfterApplyAcknowledgedLocked");
 
         verify(artifact).deleteSourceIfEphemeral();
-        assertThat(source).doesNotExist();
     }
 
     private static void setField(Object target, String name, Object value) throws Exception {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaManagerArtifactLifetimeTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaManagerArtifactLifetimeTest.java
@@ -1,0 +1,75 @@
+package com.mentra.asg_client.io.bes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Application;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(application = Application.class, sdk = 33)
+public class BesOtaManagerArtifactLifetimeTest {
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void ephemeralArtifactSurvivesMetadataCommandsAndDeletesAfterApplyAck()
+            throws Exception {
+        File source = temporaryFolder.newFile("debug_bes.bin");
+        byte[] bytes = new byte[512];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) (i * 31);
+        }
+        try (FileOutputStream output = new FileOutputStream(source)) {
+            output.write(bytes);
+        }
+
+        BesOtaManager manager =
+                new BesOtaManager(null, null, ApplicationProvider.getApplicationContext());
+        ValidatedBesArtifact artifact = mock(ValidatedBesArtifact.class);
+        when(artifact.getFile()).thenReturn(source);
+        when(artifact.deleteSourceIfEphemeral())
+                .thenAnswer(invocation -> !source.exists() || source.delete());
+        setField(manager, "activeArtifact", artifact);
+
+        assertThat(manager.init(source.getAbsolutePath())).isTrue();
+        assertThat(manager.SCmd_SetStartInfo()).isNotNull();
+        assertThat(manager.SCmd_SetConfig(false, null, null, null, null)).isNotNull();
+        assertThat(source).exists();
+        verify(artifact, never()).deleteSourceIfEphemeral();
+
+        invokeNoArgs(manager, "releaseAfterApplyAcknowledgedLocked");
+
+        verify(artifact).deleteSourceIfEphemeral();
+        assertThat(source).doesNotExist();
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static void invokeNoArgs(Object target, String name) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(name);
+        method.setAccessible(true);
+        method.invoke(target);
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaManagerVersionTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaManagerVersionTest.java
@@ -26,12 +26,14 @@ import org.robolectric.annotation.Config;
 @Config(sdk = 33)
 public class BesOtaManagerVersionTest {
 
+    private Context context;
     private IBesOtaController controller;
     private boolean previousInProgressFlag;
 
     @Before
     public void setUp() {
-        Context context = ApplicationProvider.getApplicationContext();
+        context = ApplicationProvider.getApplicationContext();
+        context.getSharedPreferences("bes_ota_state", Context.MODE_PRIVATE).edit().clear().commit();
         controller = new BesOtaManager(null, mock(K900BluetoothManager.class), context);
         previousInProgressFlag = BesOtaManager.isBesOtaInProgress;
     }
@@ -40,6 +42,7 @@ public class BesOtaManagerVersionTest {
     public void tearDown() {
         // The in-progress flag is static — restore it so state never leaks across tests.
         BesOtaManager.isBesOtaInProgress = previousInProgressFlag;
+        context.getSharedPreferences("bes_ota_state", Context.MODE_PRIVATE).edit().clear().commit();
     }
 
     @Test
@@ -102,6 +105,17 @@ public class BesOtaManagerVersionTest {
         assertThat(controller.isBesOtaInProgress()).isFalse();
 
         BesOtaManager.isBesOtaInProgress = true;
+        assertThat(controller.isBesOtaInProgress()).isTrue();
+    }
+
+    @Test
+    public void isBesOtaInProgress_blocksAdmissionWhenDurableStateIsCorrupt() {
+        BesOtaManager.isBesOtaInProgress = false;
+        context.getSharedPreferences("bes_ota_state", Context.MODE_PRIVATE)
+                .edit()
+                .putString("record", "")
+                .commit();
+
         assertThat(controller.isBesOtaInProgress()).isTrue();
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -257,8 +257,7 @@ public class OtaHelperBesGuardTest {
                 mock(OtaHelper.PhoneConnectionProvider.class);
         when(provider.isPhoneConnected()).thenReturn(true);
         helper.setPhoneConnectionProvider(provider);
-        reset(provider);
-        when(provider.isPhoneConnected()).thenReturn(true);
+        clearInvocations(provider);
         helper.setPhoneInitiatedOta(false);
         WakeLockManager.release(WakeLockManager.WakeOwner.MTK_OTA);
         PowerManager.WakeLock previousWakeLock = ShadowPowerManager.getLatestWakeLock();
@@ -276,6 +275,41 @@ public class OtaHelperBesGuardTest {
         verify(controller, never()).prepareForNewOtaSession();
         assertThat(phoneInitiatedOta()).isFalse();
         assertThat(ShadowPowerManager.getLatestWakeLock()).isSameAs(previousWakeLock);
+    }
+
+    @Test
+    public void continuedPhoneSessionFailsDurablyWhenDebugOwnsAdmissionPermit()
+            throws Exception {
+        StubRegistry registry = new StubRegistry();
+        registry.setInstance(mock(IBesOtaController.class));
+        OtaHelper helper = newHelper(registry);
+        OtaHelper.PhoneConnectionProvider provider =
+                mock(OtaHelper.PhoneConnectionProvider.class);
+        when(provider.isPhoneConnected()).thenReturn(true);
+        helper.setPhoneConnectionProvider(provider);
+        clearInvocations(provider);
+        assertThat(
+                        helper.getSessionManager()
+                                .createSession(
+                                        new String[] {"mtk", "bes"},
+                                        "https://updates.example.invalid/version.json"))
+                .isTrue();
+
+        Semaphore permit = admissionPermit();
+        assertThat(permit.tryAcquire()).isTrue();
+        boolean handled;
+        try {
+            handled = helper.continueSessionAfterStepComplete(
+                    ApplicationProvider.getApplicationContext());
+        } finally {
+            permit.release();
+        }
+
+        assertThat(handled).isTrue();
+        assertThat(helper.getSessionManager().getStatus()).isEqualTo("failed");
+        assertThat(helper.getSessionManager().getCurrentStepIndex()).isEqualTo(1);
+        assertThat(phoneInitiatedOta()).isFalse();
+        verify(provider).sendOtaStatus(any(JSONObject.class));
     }
 
     private static Semaphore admissionPermit() throws Exception {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
@@ -2,25 +2,31 @@ package com.mentra.asg_client.io.ota.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import android.os.PowerManager;
 import androidx.test.core.app.ApplicationProvider;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
+import com.mentra.asg_client.utils.WakeLockManager;
 import java.io.File;
 import java.lang.reflect.Field;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.Semaphore;
+import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPowerManager;
 
 /**
  * Focused guard-path tests for {@link OtaHelper} verifying null-safe {@link IBesOtaRegistry}
@@ -31,6 +37,7 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
 public class OtaHelperBesGuardTest {
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     /** Simple registry stub whose controller can be swapped per test. */
     private static final class StubRegistry implements IBesOtaRegistry {
@@ -55,10 +62,14 @@ public class OtaHelperBesGuardTest {
     private OtaHelper otaHelper;
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (otaHelper != null) {
             otaHelper.cleanup();
         }
+        Semaphore permit = admissionPermit();
+        permit.drainPermits();
+        permit.release();
+        WakeLockManager.release(WakeLockManager.WakeOwner.MTK_OTA);
     }
 
     private OtaHelper newHelper(StubRegistry registry) {
@@ -123,48 +134,31 @@ public class OtaHelperBesGuardTest {
     }
 
     @Test
-    public void debugBesInstallDoesNotSupersedeActiveTransaction() {
+    public void debugBesInstallDoesNotSupersedeActiveTransaction() throws Exception {
         StubRegistry registry = new StubRegistry();
         IBesOtaController controller = mock(IBesOtaController.class);
         when(controller.isBesOtaInProgress()).thenReturn(true);
         registry.setInstance(controller);
         OtaHelper helper = newHelper(registry);
+        File activeArtifact = temporaryFolder.newFile("debug_bes_same_sha.bin");
 
         assertThat(
                         helper.startValidatedDebugBesFirmware(
-                                new File("missing.bin"), "17.26.7.9", "0".repeat(64), "adb.bin"))
+                                activeArtifact, "17.26.7.9", "0".repeat(64), "adb.bin"))
                 .isFalse();
         verify(controller, never()).prepareForNewOtaSession();
+        assertThat(activeArtifact).exists();
     }
 
     @Test
-    public void debugBesInstallIsRejectedWhilePhoneOtaOwnsAdmissionLock() throws Exception {
+    public void debugBesInstallIsRejectedWhilePhoneOtaOwnsAdmissionPermit() throws Exception {
         StubRegistry registry = new StubRegistry();
         IBesOtaController controller = mock(IBesOtaController.class);
         registry.setInstance(controller);
         OtaHelper helper = newHelper(registry);
 
-        Field field = OtaHelper.class.getDeclaredField("versionCheckLock");
-        field.setAccessible(true);
-        ReentrantLock admissionLock = (ReentrantLock) field.get(null);
-        CountDownLatch lockHeld = new CountDownLatch(1);
-        CountDownLatch releaseLock = new CountDownLatch(1);
-        Thread phoneOta =
-                new Thread(
-                        () -> {
-                            admissionLock.lock();
-                            try {
-                                lockHeld.countDown();
-                                releaseLock.await(5, TimeUnit.SECONDS);
-                            } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                            } finally {
-                                admissionLock.unlock();
-                            }
-                        },
-                        "phone-ota-admission-test");
-        phoneOta.start();
-        assertThat(lockHeld.await(5, TimeUnit.SECONDS)).isTrue();
+        Semaphore permit = admissionPermit();
+        assertThat(permit.tryAcquire()).isTrue();
 
         try {
             assertThat(
@@ -177,9 +171,53 @@ public class OtaHelperBesGuardTest {
             verify(controller, never()).isBesOtaInProgress();
             verify(controller, never()).prepareForNewOtaSession();
         } finally {
-            releaseLock.countDown();
-            phoneOta.join(5000);
+            permit.release();
         }
-        assertThat(phoneOta.isAlive()).isFalse();
+    }
+
+    @Test
+    public void phoneOtaRefusesBeforeStateAndWakeLeaseWhenDebugOwnsAdmissionPermit()
+            throws Exception {
+        StubRegistry registry = new StubRegistry();
+        IBesOtaController controller = mock(IBesOtaController.class);
+        when(controller.getAuthoritativeStatus())
+                .thenReturn(new JSONObject().put("status", "installing"));
+        registry.setInstance(controller);
+        OtaHelper helper = newHelper(registry);
+        OtaHelper.PhoneConnectionProvider provider =
+                mock(OtaHelper.PhoneConnectionProvider.class);
+        when(provider.isPhoneConnected()).thenReturn(true);
+        helper.setPhoneConnectionProvider(provider);
+        reset(provider);
+        when(provider.isPhoneConnected()).thenReturn(true);
+        helper.setPhoneInitiatedOta(false);
+        WakeLockManager.release(WakeLockManager.WakeOwner.MTK_OTA);
+        PowerManager.WakeLock previousWakeLock = ShadowPowerManager.getLatestWakeLock();
+
+        Semaphore permit = admissionPermit();
+        assertThat(permit.tryAcquire()).isTrue();
+        try {
+            helper.startOtaFromPhone("https://updates.example.invalid/version.json");
+        } finally {
+            permit.release();
+        }
+
+        verify(provider).sendOtaMessage(any(JSONObject.class));
+        verify(provider).sendOtaStatus(any(JSONObject.class));
+        verify(controller, never()).prepareForNewOtaSession();
+        assertThat(phoneInitiatedOta()).isFalse();
+        assertThat(ShadowPowerManager.getLatestWakeLock()).isSameAs(previousWakeLock);
+    }
+
+    private static Semaphore admissionPermit() throws Exception {
+        Field field = OtaHelper.class.getDeclaredField("otaAdmissionPermit");
+        field.setAccessible(true);
+        return (Semaphore) field.get(null);
+    }
+
+    private static boolean phoneInitiatedOta() throws Exception {
+        Field field = OtaHelper.class.getDeclaredField("isPhoneInitiatedOta");
+        field.setAccessible(true);
+        return field.getBoolean(null);
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
@@ -12,6 +12,10 @@ import androidx.test.core.app.ApplicationProvider;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,5 +135,51 @@ public class OtaHelperBesGuardTest {
                                 new File("missing.bin"), "17.26.7.9", "0".repeat(64), "adb.bin"))
                 .isFalse();
         verify(controller, never()).prepareForNewOtaSession();
+    }
+
+    @Test
+    public void debugBesInstallIsRejectedWhilePhoneOtaOwnsAdmissionLock() throws Exception {
+        StubRegistry registry = new StubRegistry();
+        IBesOtaController controller = mock(IBesOtaController.class);
+        registry.setInstance(controller);
+        OtaHelper helper = newHelper(registry);
+
+        Field field = OtaHelper.class.getDeclaredField("versionCheckLock");
+        field.setAccessible(true);
+        ReentrantLock admissionLock = (ReentrantLock) field.get(null);
+        CountDownLatch lockHeld = new CountDownLatch(1);
+        CountDownLatch releaseLock = new CountDownLatch(1);
+        Thread phoneOta =
+                new Thread(
+                        () -> {
+                            admissionLock.lock();
+                            try {
+                                lockHeld.countDown();
+                                releaseLock.await(5, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            } finally {
+                                admissionLock.unlock();
+                            }
+                        },
+                        "phone-ota-admission-test");
+        phoneOta.start();
+        assertThat(lockHeld.await(5, TimeUnit.SECONDS)).isTrue();
+
+        try {
+            assertThat(
+                            helper.startValidatedDebugBesFirmware(
+                                    new File("missing.bin"),
+                                    "17.26.7.9",
+                                    "0".repeat(64),
+                                    "adb.bin"))
+                    .isFalse();
+            verify(controller, never()).isBesOtaInProgress();
+            verify(controller, never()).prepareForNewOtaSession();
+        } finally {
+            releaseLock.countDown();
+            phoneOta.join(5000);
+        }
+        assertThat(phoneOta.isAlive()).isFalse();
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
@@ -3,12 +3,15 @@ package com.mentra.asg_client.io.ota.helpers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
+import java.io.File;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -103,5 +106,30 @@ public class OtaHelperBesGuardTest {
         IBesOtaRegistry registry = new StubRegistry();
 
         assertThat(registry.getInstance()).isNull();
+    }
+
+    @Test
+    public void debugBesInstallWithoutControllerFailsClosed() {
+        OtaHelper helper = newHelper(new StubRegistry());
+
+        assertThat(
+                        helper.startValidatedDebugBesFirmware(
+                                new File("missing.bin"), "17.26.7.9", "0".repeat(64), "adb.bin"))
+                .isFalse();
+    }
+
+    @Test
+    public void debugBesInstallDoesNotSupersedeActiveTransaction() {
+        StubRegistry registry = new StubRegistry();
+        IBesOtaController controller = mock(IBesOtaController.class);
+        when(controller.isBesOtaInProgress()).thenReturn(true);
+        registry.setInstance(controller);
+        OtaHelper helper = newHelper(registry);
+
+        assertThat(
+                        helper.startValidatedDebugBesFirmware(
+                                new File("missing.bin"), "17.26.7.9", "0".repeat(64), "adb.bin"))
+                .isFalse();
+        verify(controller, never()).prepareForNewOtaSession();
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperBesGuardTest.java
@@ -3,7 +3,9 @@ package com.mentra.asg_client.io.ota.helpers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -12,8 +14,11 @@ import static org.mockito.Mockito.when;
 import android.content.Context;
 import android.os.PowerManager;
 import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.events.BatteryStatusEvent;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator;
+import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
 import com.mentra.asg_client.utils.WakeLockManager;
 import java.io.File;
 import java.lang.reflect.Field;
@@ -24,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowPowerManager;
@@ -148,6 +154,69 @@ public class OtaHelperBesGuardTest {
                 .isFalse();
         verify(controller, never()).prepareForNewOtaSession();
         assertThat(activeArtifact).exists();
+    }
+
+    @Test
+    public void debugBesEarlyRefusalDeletesArtifactProvenUnowned() throws Exception {
+        StubRegistry registry = new StubRegistry();
+        IBesOtaController controller = mock(IBesOtaController.class);
+        when(controller.isBesOtaInProgress()).thenReturn(false);
+        registry.setInstance(controller);
+        OtaHelper helper = newHelper(registry);
+        helper.onBatteryStatusEvent(new BatteryStatusEvent(1, false, System.currentTimeMillis()));
+        File refusedArtifact = temporaryFolder.newFile("debug_bes_low_battery.bin");
+
+        assertThat(
+                        helper.startValidatedDebugBesFirmware(
+                                refusedArtifact,
+                                "17.26.7.9",
+                                "0".repeat(64),
+                                "adb-low-battery.bin"))
+                .isFalse();
+
+        verify(controller, never()).prepareForNewOtaSession();
+        assertThat(refusedArtifact).doesNotExist();
+    }
+
+    @Test
+    public void admittedDebugBesInstallPrunesOnlyAbandonedSiblingArtifacts() throws Exception {
+        StubRegistry registry = new StubRegistry();
+        IBesOtaController controller = mock(IBesOtaController.class);
+        when(controller.isBesOtaInProgress()).thenReturn(false);
+        when(controller.prepareForNewOtaSession()).thenReturn(true);
+        when(controller.startFirmwareUpdate(any(), anyString())).thenReturn(true);
+        registry.setInstance(controller);
+        OtaHelper helper = newHelper(registry);
+        File currentArtifact = temporaryFolder.newFile("debug_bes_current.bin");
+        File abandonedArtifact = temporaryFolder.newFile("debug_bes_abandoned.bin");
+        File unrelatedArtifact = temporaryFolder.newFile("keep_this.bin");
+        ValidatedBesArtifact validatedArtifact = mock(ValidatedBesArtifact.class);
+
+        try (MockedStatic<BesFirmwareArtifactValidator> validator =
+                mockStatic(BesFirmwareArtifactValidator.class)) {
+            validator.when(
+                            () ->
+                                    BesFirmwareArtifactValidator.validateLocal(
+                                            currentArtifact,
+                                            "adb-current.bin",
+                                            "0".repeat(64),
+                                            "17.26.7.9"))
+                    .thenReturn(validatedArtifact);
+
+            assertThat(
+                            helper.startValidatedDebugBesFirmware(
+                                    currentArtifact,
+                                    "17.26.7.9",
+                                    "0".repeat(64),
+                                    "adb-current.bin"))
+                    .isTrue();
+        }
+
+        assertThat(currentArtifact).exists();
+        assertThat(abandonedArtifact).doesNotExist();
+        assertThat(unrelatedArtifact).exists();
+        verify(controller).prepareForNewOtaSession();
+        verify(controller).startFirmwareUpdate(any(), anyString());
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -50,7 +50,7 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
-    public void localArtifactIsDeletedAfterDurableReservation() throws Exception {
+    public void localArtifactSupportsEphemeralCleanup() throws Exception {
         TestArtifact artifact = createArtifact();
         BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
                 BesFirmwareArtifactValidator.validateLocal(
@@ -64,7 +64,7 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
-    public void manifestArtifactRemainsAfterReservationCleanupHook() throws Exception {
+    public void manifestArtifactIgnoresEphemeralCleanup() throws Exception {
         TestArtifact artifact = createArtifact();
         BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
                 BesFirmwareArtifactValidator.validate(artifact.file, artifact.metadata);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -50,6 +50,30 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
+    public void localArtifactIsDeletedAfterDurableReservation() throws Exception {
+        TestArtifact artifact = createArtifact();
+        BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
+                BesFirmwareArtifactValidator.validateLocal(
+                        artifact.file,
+                        "adb-17.26.7.24.bin",
+                        artifact.metadata.getString("sha256"),
+                        "17.26.7.24");
+
+        assertThat(validated.deleteSourceIfEphemeral()).isTrue();
+        assertThat(artifact.file).doesNotExist();
+    }
+
+    @Test
+    public void manifestArtifactRemainsAfterReservationCleanupHook() throws Exception {
+        TestArtifact artifact = createArtifact();
+        BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
+                BesFirmwareArtifactValidator.validate(artifact.file, artifact.metadata);
+
+        assertThat(validated.deleteSourceIfEphemeral()).isTrue();
+        assertThat(artifact.file).exists();
+    }
+
+    @Test
     public void localArtifactRejectsUnsafeIdentity() throws Exception {
         TestArtifact artifact = createArtifact();
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/BesFirmwareArtifactValidatorTest.java
@@ -35,6 +35,51 @@ public class BesFirmwareArtifactValidatorTest {
     }
 
     @Test
+    public void localReleasePackagedArtifactWithExplicitIdentityPasses() throws Exception {
+        TestArtifact artifact = createArtifact();
+
+        BesFirmwareArtifactValidator.ValidatedBesArtifact validated =
+                BesFirmwareArtifactValidator.validateLocal(
+                        artifact.file,
+                        "adb-17.26.7.24.bin",
+                        artifact.metadata.getString("sha256"),
+                        "17.26.7.24");
+
+        assertThat(validated.getArtifactId()).isEqualTo("adb-17.26.7.24.bin");
+        assertThat(validated.getTargetVersion()).isEqualTo("17.26.7.24");
+    }
+
+    @Test
+    public void localArtifactRejectsUnsafeIdentity() throws Exception {
+        TestArtifact artifact = createArtifact();
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validateLocal(
+                                        artifact.file,
+                                        "../../update_ota.bin",
+                                        artifact.metadata.getString("sha256"),
+                                        "17.26.7.24"))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("identifier");
+    }
+
+    @Test
+    public void localArtifactRejectsIncorrectDigest() throws Exception {
+        TestArtifact artifact = createArtifact();
+
+        assertThatThrownBy(
+                        () ->
+                                BesFirmwareArtifactValidator.validateLocal(
+                                        artifact.file,
+                                        "adb-17.26.7.24.bin",
+                                        "0".repeat(64),
+                                        "17.26.7.24"))
+                .isInstanceOf(BesFirmwareArtifactValidator.ValidationException.class)
+                .hasMessageContaining("SHA-256 mismatch");
+    }
+
+    @Test
     public void externalReleaseArtifactCanBeValidated() throws Exception {
         String artifactPath = System.getenv("BES_RELEASE_ARTIFACT");
         String version = System.getenv("BES_RELEASE_VERSION");

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -141,8 +141,26 @@ Stored under `/storage/emulated/0/asg/`:
 
 ## Internal staging test
 
-Do not use `scripts/test-bes-ota.sh`: its direct ADB broadcast entry point is intentionally disabled
-and it bypasses the phone-owned session contract this flow needs to exercise.
+The ADB script is available for explicit internal BES upgrades and downgrades. It does not exercise
+the phone UI, but it does use the release artifact validator, durable transaction owner, UART
+quarantine, reboot reconciliation, and exact-version proof used by the production path. The
+receiver requires Android's privileged `DUMP` permission, so ordinary apps cannot trigger it.
+
+Use only release-packaged `update_ota.bin`, never raw BES build output, and state the exact version
+the glasses must report after reboot:
+
+```bash
+ANDROID_SERIAL=0123456789ABCDEF \
+  ./scripts/test-bes-ota.sh /path/to/update_ota.bin 17.26.7.9
+```
+
+The script computes and verifies the local/device SHA-256 before sending the protected intent.
+Selecting an older target is allowed for bench recovery and compatibility testing. A wrong target
+does not create false success: durable reconciliation fails unless post-reboot `sr_syvr` reports the
+exact supplied version.
+
+Use the phone-driven procedure below for release qualification because it additionally exercises
+the immutable manifest pin, Mentra App progress UI, and BLE reconnect behavior.
 
 1. Land the candidate ASG and `firmware_live.json` on `staging` so the staging
    workflow publishes one combined, immutable-per-run manifest and embeds its URL in that run's

--- a/asg_client/scripts/test-bes-ota.sh
+++ b/asg_client/scripts/test-bes-ota.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
 #
 # Test BES firmware OTA update
-# Usage: ./scripts/test-bes-ota.sh [path-to-update_ota.bin]
+# Usage: ./scripts/test-bes-ota.sh <path-to-update_ota.bin> <target-version>
 #
-# If no path is provided, uses update_ota.bin in the same directory as this script.
+# The artifact must be the release-packaged OTA container, never raw BES build output.
+# Set ANDROID_SERIAL when more than one Android device may be attached.
 #
 
-set -e
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEFAULT_FIRMWARE="$SCRIPT_DIR/update_ota.bin"
+FIRMWARE_PATH="${1:-}"
+TARGET_VERSION="${2:-}"
 
-if [ -z "$1" ]; then
-    if [ -f "$DEFAULT_FIRMWARE" ]; then
-        FIRMWARE_PATH="$DEFAULT_FIRMWARE"
-        echo "Using default firmware: $FIRMWARE_PATH"
-    else
-        echo "Usage: ./scripts/test-bes-ota.sh [path-to-update_ota.bin]"
-        echo "Or place the release-packaged update_ota.bin next to this script."
-        exit 1
-    fi
-else
-    FIRMWARE_PATH="$1"
+if [ -z "$FIRMWARE_PATH" ] || [ -z "$TARGET_VERSION" ]; then
+    echo "Usage: ./scripts/test-bes-ota.sh <path-to-update_ota.bin> <target-version>"
+    echo "Example: ANDROID_SERIAL=0123456789ABCDEF $0 ./update_ota.bin 17.26.7.9"
+    exit 1
 fi
 
 if [ ! -f "$FIRMWARE_PATH" ]; then
@@ -29,29 +23,52 @@ if [ ! -f "$FIRMWARE_PATH" ]; then
     exit 1
 fi
 
-if [ "$(basename "$FIRMWARE_PATH")" != "update_ota.bin" ]; then
-    echo "❌ Refusing non-OTA payload: $FIRMWARE_PATH"
-    echo "Use the release-packaged update_ota.bin, never raw BES build output."
+if ! [[ "$TARGET_VERSION" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+    echo "❌ Target version must have four numeric components: $TARGET_VERSION"
     exit 1
 fi
+
+ADB=(adb)
+if [ -n "${ANDROID_SERIAL:-}" ]; then
+    ADB+=( -s "$ANDROID_SERIAL" )
+fi
+
+"${ADB[@]}" get-state >/dev/null
+
+FIRMWARE_SHA256="$(shasum -a 256 "$FIRMWARE_PATH" | awk '{print $1}')"
+ARTIFACT_ID="adb-${FIRMWARE_SHA256}.bin"
+REMOTE_PATH="/storage/emulated/0/asg/debug_bes_${FIRMWARE_SHA256}.bin"
 
 echo "=========================================="
 echo "🔧 BES OTA Test"
 echo "=========================================="
 echo "Firmware: $FIRMWARE_PATH"
+echo "Target: $TARGET_VERSION"
 echo "Size: $(ls -lh "$FIRMWARE_PATH" | awk '{print $5}')"
-echo "SHA-256: $(shasum -a 256 "$FIRMWARE_PATH" | awk '{print $1}')"
+echo "SHA-256: $FIRMWARE_SHA256"
 echo ""
 
 echo "📤 Pushing firmware to glasses..."
-adb push "$FIRMWARE_PATH" /storage/emulated/0/asg/bes_firmware.bin
+"${ADB[@]}" push "$FIRMWARE_PATH" "$REMOTE_PATH"
+
+REMOTE_SHA256="$("${ADB[@]}" shell sha256sum "$REMOTE_PATH" | awk '{print $1}' | tr -d '\r')"
+if [ "$REMOTE_SHA256" != "$FIRMWARE_SHA256" ]; then
+    echo "❌ Device SHA-256 mismatch after push"
+    "${ADB[@]}" shell rm -f "$REMOTE_PATH"
+    exit 1
+fi
 
 echo ""
 echo "🚀 Triggering BES OTA..."
-adb logcat -c
-adb shell am broadcast -a com.mentra.DEBUG_BES_OTA -n com.mentra.asg_client/.receiver.DebugBesOtaReceiver
+"${ADB[@]}" logcat -c
+"${ADB[@]}" shell am broadcast \
+    -a com.mentra.DEBUG_BES_OTA \
+    --es target_version "$TARGET_VERSION" \
+    --es sha256 "$FIRMWARE_SHA256" \
+    --es artifact_id "$ARTIFACT_ID" \
+    -n com.mentra.asg_client/.receiver.DebugBesOtaReceiver
 
 echo ""
 echo "📋 Monitoring logs (Ctrl+C to exit)..."
 echo "=========================================="
-adb logcat | grep --line-buffered -E "(BES-UART|BesOta|DebugBesOta|mh_ota|hm_ota|sr_syvr|cs_baud)"
+"${ADB[@]}" logcat | grep --line-buffered -E "(BES-UART|BES_OTA_DIAG|BesOta|DebugBesOta|mh_ota|hm_ota|sr_syvr|cs_baud)"

--- a/asg_client/scripts/test-bes-ota.sh
+++ b/asg_client/scripts/test-bes-ota.sh
@@ -27,6 +27,13 @@ if ! [[ "$TARGET_VERSION" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
     echo "❌ Target version must have four numeric components: $TARGET_VERSION"
     exit 1
 fi
+IFS=. read -r -a VERSION_COMPONENTS <<< "$TARGET_VERSION"
+for component in "${VERSION_COMPONENTS[@]}"; do
+    if ((10#$component > 255)); then
+        echo "❌ Target version components must be in the 0-255 range: $TARGET_VERSION"
+        exit 1
+    fi
+done
 
 ADB=(adb)
 if [ -n "${ANDROID_SERIAL:-}" ]; then
@@ -35,7 +42,14 @@ fi
 
 "${ADB[@]}" get-state >/dev/null
 
-FIRMWARE_SHA256="$(shasum -a 256 "$FIRMWARE_PATH" | awk '{print $1}')"
+if command -v shasum >/dev/null 2>&1; then
+    FIRMWARE_SHA256="$(shasum -a 256 "$FIRMWARE_PATH" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+    FIRMWARE_SHA256="$(sha256sum "$FIRMWARE_PATH" | awk '{print $1}')"
+else
+    echo "❌ No SHA-256 tool found (need shasum or sha256sum)"
+    exit 1
+fi
 ARTIFACT_ID="adb-${FIRMWARE_SHA256}.bin"
 REMOTE_PATH="/storage/emulated/0/asg/debug_bes_${FIRMWARE_SHA256}.bin"
 


### PR DESCRIPTION
## Summary

- restore `asg_client/scripts/test-bes-ota.sh` for explicit internal BES upgrades and downgrades
- keep the release-A safety boundary: validate SHA-256, packaged-container structure/CRC, product, size, and exact target version before UART authorization
- route the ADB request through the durable BES transaction manager with APK/MTK/BES mutual exclusion and a durable owner session
- serialize ADB BES admission with every phone OTA pipeline entry through a transferable permit; initial starts, APK resumes, and MTK-to-BES continuation all reserve synchronously before worker dispatch
- fail and report an existing durable phone session if a resumed/continued step cannot obtain admission, rather than leaving the UI on a step with no worker
- treat corrupt or blank durable BES state as admission-blocking, consistent with UART quarantine
- restrict the exported receiver to callers holding `android.permission.DUMP` and stage artifacts under hash-addressed paths
- retain admitted artifacts through protocol setup and delete them after apply acknowledgement or failure cleanup
- delete a refused request only after proving its path unowned, preserve active same-hash bytes, and prune abandoned siblings only after the manager accepts the validated current artifact
- support both `shasum` and `sha256sum`, reject version components outside `0..255`, and share SHA-256 normalization between phone and ADB validation
- document that phone-driven OTA remains the release-qualification flow

## Why

The prior raw-file receiver was correctly disabled because it bypassed immutable artifact identity, release-container validation, and durable transaction ownership. That also removed the bench recovery workflow used by `test-bes-ota.sh`. This restores that workflow without restoring the bypass. Explicit downgrade direction is allowed only on this ADB-shell path; success still requires the exact supplied version to be proven after reboot.

Phone and ADB admission now share a semaphore rather than a thread-owned lock. Every non-initial version-check dispatch reserves admission synchronously and returns an admission result; the worker never competes for the permit after durable/UI state has moved. Initial phone starts transfer their existing reservation to the worker. APK resume and MTK-to-BES continuation fail and report their existing session immediately if ADB owns admission. The APK -> MTK -> BES worker pipeline and update ordering are unchanged.

Corrupt durable BES state is treated as admission-blocking rather than inactive. This matches the state store's existing fail-closed UART quarantine and prevents cleanup while ownership is uncertain.

ADB-staged bytes are revalidated immediately before durable authorization is reserved. The protocol's `SetStartInfo` and `SetConfig` commands still reopen the source file, so the manager retains it through transfer negotiation and deletes it only after BES accepts apply. Failure cleanup also deletes it. A refused duplicate never deletes a shared hash-addressed path owned by an active transaction. Once the manager accepts a validated ADB artifact, the helper removes only sibling `debug_bes_*.bin` leftovers from interrupted bench runs; it never prunes before validation or while admission is refused.

## Validation

- `./gradlew app:testDebugUnitTest`
  - full ASG unit suite passed
  - covers both initial admission directions: phone owns the gate versus ADB, and ADB owns the gate versus phone
  - covers ADB ownership during MTK-to-BES continuation and verifies the durable session fails/reports without falling into the legacy completion path
  - verifies corrupt durable BES state blocks admission
  - proves active same-SHA ownership preserves the staged source
  - proves a manager-inactive early refusal deletes only its current artifact
  - proves an accepted request keeps its current source, prunes abandoned debug siblings, and leaves unrelated files untouched
  - proves the staged source survives `SetStartInfo` and `SetConfig`, and that the manager invokes ephemeral cleanup after apply acknowledgement
  - covers production deletion policy for ADB-local artifacts and retention of phone-manifest artifacts
- `./scripts/check-android-compile.sh asg`
- `bash -n asg_client/scripts/test-bes-ota.sh`
- out-of-range script smoke test: `256.0.0.0` is rejected before ADB access
- `git diff --check`

## Local tooling note

The unscoped `:app:spotlessJavaCheck` task is blocked in this worktree by an existing non-contiguous import error in `MediaUploadQueueManager.java`, outside this diff. The modified Java sources compile and the full ASG unit suite passes.

> [!WARNING]
> Do not merge until the restored ADB BES path has been verified on hardware.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes mutual exclusion and lifecycle for BES firmware updates and durable OTA state; regressions could block installs, race phone vs ADB starts, or delete staging bytes at the wrong time.
> 
> **Overview**
> Restores **bench BES firmware testing via ADB** without bringing back the old raw-file bypass. `DebugBesOtaReceiver` again accepts `com.mentra.DEBUG_BES_OTA`, but only with **`android.permission.DUMP`**, hash-addressed staging under `debug_bes_*`, and intent extras for **target version, SHA-256, and artifact id**. `OtaHelper.startValidatedDebugBesFirmware` runs the same **release-container validator** and **durable BES manager** as phone OTA, with APK/MTK/BES exclusion and optional **internal downgrades** when the stated post-reboot version is proven.
> 
> **Phone vs ADB admission** is reworked: `versionCheckLock` becomes a **`Semaphore`** so `ota_start` can **reserve admission on the command thread** before arming session state or the MTK wake lease, then hand the permit to the worker. Debug BES and phone pipelines share that gate; busy callers get authoritative status or a durable session failure instead of overlapping work. Session resume and multi-step auto-advance use the new `startVersionCheckWithUrl` boolean contract.
> 
> **Artifact lifecycle**: validated ADB artifacts are **ephemeral**—kept through `SetStartInfo`/`SetConfig`, then deleted after BES accepts apply or on cleanup; refused unowned staging files are removed, and sibling `debug_bes_*.bin` leftovers are pruned only after the manager accepts the current artifact. **`isBesOtaInProgress`** now treats **corrupt durable BES state** as blocking new sessions.
> 
> Docs and **`scripts/test-bes-ota.sh`** are updated for the two-argument flow (artifact + target version), device SHA verification, and protected broadcast extras.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e5185c9add859b880315c217da999a7faff3f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->