### PR TITLE
Recover BES OTA success after hard reboot

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -342,6 +342,56 @@ public final class BesOtaStateStore {
         }
     }
 
+    /**
+     * Resolve an authorization record recovered on a later Linux boot.
+     *
+     * <p>An abrupt MTK reboot can restore the last filesystem-persisted record even when a newer
+     * SharedPreferences value was committed and read back before BES apply. In that case the
+     * durable record is still {@link State#AUTH_ATTEMPTED}, so only a fresh, source-audited framed
+     * version reply from the later boot may decide whether the target was installed.
+     */
+    public TransitionResult completeRecoveredAfterRestart(
+            String ownerSessionId, String currentBootId, String actualVersion) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            String owner = canonicalNonempty(ownerSessionId);
+            String boot = canonicalBootId(currentBootId);
+            String actual = canonicalVersion(actualVersion);
+            if (!current.isOwnedActive(State.AUTH_ATTEMPTED, owner)
+                    || boot == null
+                    || boot.equals(current.authorizationBootId)) {
+                logDecision(
+                        "recovered_version_proof_rejected",
+                        "reason=owner_state_or_boot requested_owner="
+                                + diagnosticValue(owner)
+                                + " requested_boot="
+                                + diagnosticValue(boot)
+                                + " actual="
+                                + diagnosticValue(actual),
+                        current);
+                return terminalOrRejected(current);
+            }
+            boolean matches = current.targetVersion.equals(actual);
+            Snapshot terminal =
+                    current.withVerificationBoot(boot)
+                            .asTerminal(
+                                    matches ? TerminalStatus.SUCCESS : TerminalStatus.FAILURE,
+                                    matches
+                                            ? "verified"
+                                            : (actual == null
+                                                    ? "invalid_version_proof"
+                                                    : "version_mismatch"));
+            return putLocked(
+                            matches
+                                    ? "complete_recovered_after_restart"
+                                    : "fail_recovered_" + terminal.terminalCode,
+                            current,
+                            terminal)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
     /** Monotonic owner-checked failure transition. Failure never erases authorization history. */
     public TransitionResult fail(String ownerSessionId, String stableCode) {
         synchronized (TRANSITION_LOCK) {
@@ -419,13 +469,17 @@ public final class BesOtaStateStore {
                 return StartupDecision.QUARANTINED;
             }
             if (current.state == State.AUTH_ATTEMPTED) {
+                if (!boot.equals(current.authorizationBootId)) {
+                    // A hard reboot can expose an older, otherwise valid filesystem record. Keep
+                    // the target and owner active until raw OTA mode, a fresh framed version
+                    // reply, or the bounded recovery timeout resolves the hardware state.
+                    return StartupDecision.RECOVERY_PROBE_ONLY;
+                }
                 Snapshot failed = current.asTerminal(TerminalStatus.FAILURE, "interrupted");
                 if (!putLocked("fail_interrupted_on_startup", current, failed)) {
                     return StartupDecision.PERSISTENCE_FAILURE;
                 }
-                return boot.equals(current.authorizationBootId)
-                        ? StartupDecision.QUARANTINED
-                        : StartupDecision.RECOVERY_PROBE_ONLY;
+                return StartupDecision.QUARANTINED;
             }
             if (current.state == State.APPLY_PENDING) {
                 if (boot.equals(current.authorizationBootId)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1214,11 +1214,17 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + " snapshot={"
                         + snapshot.toDiagnosticString()
                         + "}");
-        if (snapshot.isValid() && snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
+        if (snapshot.isValid()
+                && (snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING
+                        || snapshot.getState() == BesOtaStateStore.State.AUTH_ATTEMPTED)) {
+            String timeoutCode =
+                    snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING
+                            ? "verification_timeout"
+                            : "recovery_timeout";
             BesOtaStateStore.TransitionResult result =
-                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), "verification_timeout");
-            Log.e(TAG, "BES post-apply recovery timed out: " + result);
-            EventBus.getDefault().post(BesOtaProgressEvent.createFailed("verification_timeout"));
+                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), timeoutCode);
+            Log.e(TAG, "BES OTA restart recovery timed out: " + result);
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed(timeoutCode));
         }
     }
 
@@ -1568,8 +1574,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         String skipReason = null;
         if (!snapshot.isValid()) {
             skipReason = "invalid_or_idle_state";
-        } else if (snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING) {
-            skipReason = "state_not_apply_pending";
+        } else if (snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
+                && snapshot.getState() != BesOtaStateStore.State.AUTH_ATTEMPTED) {
+            skipReason = "state_not_recoverable";
         } else if (currentBootId == null) {
             skipReason = "missing_current_boot";
         } else if (currentBootId.equals(snapshot.getAuthorizationBootId())) {
@@ -1590,25 +1597,32 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (skipReason != null) {
             return;
         }
-        BesOtaStateStore.VerificationDecision verification =
-                besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
-        Log.i(
-                TAG,
-                "BES_OTA_DIAG version_proof_claim result="
-                        + verification
-                        + " actual="
-                        + diagnosticActualVersion
-                        + " snapshot={"
-                        + besOtaStateStore.read().toDiagnosticString()
-                        + "}");
-        if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
-                && verification != BesOtaStateStore.VerificationDecision.RESUME) {
-            Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
-            return;
+        BesOtaStateStore.TransitionResult completed;
+        if (snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
+            BesOtaStateStore.VerificationDecision verification =
+                    besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
+            Log.i(
+                    TAG,
+                    "BES_OTA_DIAG version_proof_claim result="
+                            + verification
+                            + " actual="
+                            + diagnosticActualVersion
+                            + " snapshot={"
+                            + besOtaStateStore.read().toDiagnosticString()
+                            + "}");
+            if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
+                    && verification != BesOtaStateStore.VerificationDecision.RESUME) {
+                Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
+                return;
+            }
+            completed =
+                    besOtaStateStore.completeVerified(
+                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
+        } else {
+            completed =
+                    besOtaStateStore.completeRecoveredAfterRestart(
+                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
         }
-        BesOtaStateStore.TransitionResult completed =
-                besOtaStateStore.completeVerified(
-                        snapshot.getOwnerSessionId(), currentBootId, actualVersion);
         Log.i(
                 TAG,
                 "BES_OTA_DIAG version_proof_complete result="
@@ -1627,13 +1641,16 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "BES target version verified after reboot: " + actualVersion);
             EventBus.getDefault().post(BesOtaProgressEvent.createFinished());
         } else {
+            String failureCode = terminal.getTerminalCode();
             Log.e(
                     TAG,
-                    "BES version mismatch after reboot expected="
+                    "BES version proof failed after reboot code="
+                            + failureCode
+                            + " expected="
                             + terminal.getTargetVersion()
                             + " actual="
                             + actualVersion);
-            EventBus.getDefault().post(BesOtaProgressEvent.createFailed("version_mismatch"));
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed(failureCode));
         }
     }
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -209,8 +209,54 @@ public class BesOtaStateStoreTest {
         reserve();
 
         assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.RECOVERY_PROBE_ONLY);
+        assertThat(store.read().getState()).isEqualTo(State.AUTH_ATTEMPTED);
         assertThat(store.uartPolicy(BOOT_B, false, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+        assertThat(store.uartPolicy(BOOT_B, true, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+    }
+
+    @Test
+    public void exactVersionResolvesLaterBootAuthorizationAsSuccess() {
+        reserve();
+        assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.RECOVERY_PROBE_ONLY);
+
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getState()).isEqualTo(State.TERMINAL);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+        assertThat(store.read().getTerminalCode()).isEqualTo("verified");
+        assertThat(store.read().getVerificationBootId()).isEqualTo(BOOT_B);
         assertThat(store.uartPolicy(BOOT_B, true, null)).isEqualTo(UartPolicy.NORMAL);
+    }
+
+    @Test
+    public void differentVersionResolvesLaterBootAuthorizationAsFailure() {
+        reserve();
+
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_B, "26.7.30.3"))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("version_mismatch");
+    }
+
+    @Test
+    public void invalidVersionProofResolvesLaterBootAuthorizationAsFailure() {
+        reserve();
+
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_B, "unknown"))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("invalid_version_proof");
+    }
+
+    @Test
+    public void recoveredVersionProofRequiresOwnerAndLaterBoot() {
+        reserve();
+
+        assertThat(store.completeRecoveredAfterRestart(OTHER_OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_A, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.read().getState()).isEqualTo(State.AUTH_ATTEMPTED);
     }
 
     @Test

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -201,6 +201,11 @@ version name after the fact.
 - **Stuck in OTA mode** — a persisted nonterminal BES session deliberately owns/quarantines UART
   until raw-versus-framed recovery resolves. A raw `0x9a` proves BES is still in OTA mode; only the
   exact fresh `sr_syvr` requested by the audited framed probe can prove normal mode.
+- **Hard reboot after apply** — Android filesystem persistence can expose the earlier authorization
+  record even when apply was committed and acknowledged immediately before power loss. On a later
+  Linux boot, ASG keeps that record quarantined while bounded raw-first recovery runs: raw `0x9a`
+  fails the update, an exact target `sr_syvr` completes it, and a mismatch or timeout fails it. A
+  process restart in the original Linux boot remains an immediate failure.
 
 ## Logcat tags
 


### PR DESCRIPTION
## Summary

- keep a later-boot `AUTH_ATTEMPTED` BES OTA record quarantined until bounded raw-first recovery resolves the hardware state
- accept only the exact target version from the fresh, source-audited `sr_syvr` as recovered success
- fail recovered sessions on raw OTA mode, version mismatch/invalid proof, or timeout while preserving the existing same-boot fail-closed behavior
- document the hard-reboot recovery contract and cover the new transitions with unit tests

## Root cause

The successful BES apply path committed and immediately read back `APPLY_PENDING`, then received the accepted apply acknowledgement:

```text
08-07 23:02:29.444  1329  2261 I BesOtaStateStore: BES_OTA_DIAG op=mark_apply_pending pid=1329 thread=Thread-5 elapsed_ms=1028990 live_boot=3a788755-b1f1-4116-ac3c-09f9c025272c before={state=AUTH_ATTEMPTED owner=adb-bes-28584d79780949e0a756f5d130bde3b0 auth_boot=3a788755-b1f1-4116-ac3c-09f9c025272c verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786143697630} after={state=APPLY_PENDING owner=adb-bes-28584d79780949e0a756f5d130bde3b0 auth_boot=3a788755-b1f1-4116-ac3c-09f9c025272c verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786143749435} committed=true readback_match=true
08-07 23:02:30.051  1329  2261 I BesOtaManager: BES_OTA_DIAG apply_ack len=1 accepted=true snapshot={state=APPLY_PENDING owner=adb-bes-28584d79780949e0a756f5d130bde3b0 auth_boot=3a788755-b1f1-4116-ac3c-09f9c025272c verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786143749435}
```

After the hard MTK reboot, filesystem persistence exposed the earlier valid `AUTH_ATTEMPTED` record. Startup immediately converted that ambiguity to `interrupted`, projected failure to the phone, and then ignored the exact installed version:

```text
08-07 23:03:34.086  1331  1331 I ASGClientOTA: BES_OTA_DIAG phone_projection=durable connected=true status={"type":"ota_status","sid":"adb-bes-28584d79780949e0a756f5d130bde3b0","st":"bes","phase":"install","status":"failed","err":"install_failed"}
08-07 23:03:34.192  1331  1523 I K900BluetoothManager: BES_OTA_DIAG version_proof actual=26.8.6.0 current_boot=e67e6f46-cb27-446e-aada-7505b97df123 disposition=ignored reason=state_not_apply_pending snapshot={state=TERMINAL owner=adb-bes-28584d79780949e0a756f5d130bde3b0 auth_boot=3a788755-b1f1-4116-ac3c-09f9c025272c verify_boot=- target=26.8.6.0 terminal_status=FAILURE terminal_code=interrupted updated_at_ms=1786143808752}
```

This made the Mentra App show `100%` followed by `Update Failed` even though BES had installed `26.8.6.0` successfully.

## Fixed hardware evidence

The candidate ASG was installed on Mentra Live, BES was factory-restored to `26.8.5.0`, and the release-packaged `26.8.6.0` `update_ota.bin` was applied twice. Both cycles reproduced the stale `AUTH_ATTEMPTED` record after reboot and completed successfully. The second cycle recorded:

```text
08-07 23:22:34.065  1308  1308 I BesOtaStateStore: BES_OTA_DIAG op=startup_snapshot pid=1308 thread=main elapsed_ms=21611 live_boot=3ceb2fa9-a6a1-4430-b795-cedcb5937294 requested_boot=3ceb2fa9-a6a1-4430-b795-cedcb5937294 snapshot={state=AUTH_ATTEMPTED owner=adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0 auth_boot=3624a132-0445-458f-825d-30ef4cf7b138 verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786144843359}
08-07 23:22:34.069  1308  1308 I K900BluetoothManager: BES_OTA_DIAG startup_result=RECOVERY_PROBE_ONLY current_boot=3ceb2fa9-a6a1-4430-b795-cedcb5937294 snapshot={state=AUTH_ATTEMPTED owner=adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0 auth_boot=3624a132-0445-458f-825d-30ef4cf7b138 verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786144843359}
08-07 23:22:39.282  1308  1308 I ASGClientOTA: BES_OTA_DIAG phone_projection=durable connected=true status={"type":"ota_status","sid":"adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0","st":"bes","phase":"install","status":"in_progress","op":0}
08-07 23:22:39.398  1308  1427 I K900BluetoothManager: BES_OTA_DIAG version_proof actual=26.8.6.0 current_boot=3ceb2fa9-a6a1-4430-b795-cedcb5937294 disposition=candidate snapshot={state=AUTH_ATTEMPTED owner=adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0 auth_boot=3624a132-0445-458f-825d-30ef4cf7b138 verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786144843359}
08-07 23:22:39.408  1308  1427 I BesOtaStateStore: BES_OTA_DIAG op=complete_recovered_after_restart pid=1308 thread=Thread-2 elapsed_ms=26954 live_boot=3ceb2fa9-a6a1-4430-b795-cedcb5937294 before={state=AUTH_ATTEMPTED owner=adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0 auth_boot=3624a132-0445-458f-825d-30ef4cf7b138 verify_boot=- target=26.8.6.0 terminal_status=- terminal_code=- updated_at_ms=1786144843359} after={state=TERMINAL owner=adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0 auth_boot=3624a132-0445-458f-825d-30ef4cf7b138 verify_boot=3ceb2fa9-a6a1-4430-b795-cedcb5937294 target=26.8.6.0 terminal_status=SUCCESS terminal_code=verified updated_at_ms=1786144959400} committed=true readback_match=true
08-07 23:22:39.416  1308  1308 I ASGClientOTA: BES_OTA_DIAG phone_projection=durable connected=false status={"type":"ota_status","sid":"adb-bes-f60bc5f9a15b4014b2dea7e37bf8a9f0","st":"bes","phase":"install","status":"complete","op":100}
```

Hardware identity and artifact:

- candidate ASG: `50554764-dev`
- BES: `26.8.5.0` -> `26.8.6.0`
- MTK: `MentraLive_20260709`
- Bluetooth MAC: `CC:E7:DE:E0:02:3B`
- release `update_ota.bin`: 1,137,871 bytes, SHA-256 `a803477db2ca244bd8d5d1afc4149c50c14e6c5bc8bd2463c00168bcaa783bac`
- Wi-Fi ADB remained recoverable across both hard reboots

## Validation

- `./gradlew :app:testDebugUnitTest --tests 'com.mentra.asg_client.io.bes.*' --tests 'com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesUartTransportCoordinatorTest'`
- `./scripts/check-android-compile.sh asg`
- `./gradlew :app:assembleRelease`
- `git diff --check`
- two physical Mentra Live OTA cycles from BES `26.8.5.0` to `26.8.6.0`

Local `spotlessCheck` could not provide a scoped result because Spotless does not detect the linked-worktree `.git` file, disables its ratchet, and then fails on the pre-existing import layout in `MediaUploadQueueManager.java`. No unrelated formatting was changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BES OTA durable state and phone-visible outcomes around reboot boundaries; behavior is guarded by owner/boot checks and tests but affects firmware update success reporting.
> 
> **Overview**
> Fixes false **Update Failed** on the phone when BES actually installed the target firmware but a hard MTK reboot left durable OTA state at **`AUTH_ATTEMPTED`** instead of **`APPLY_PENDING`**.
> 
> **`BesOtaStateStore`** no longer marks **`AUTH_ATTEMPTED`** as **`interrupted`** on startup when the current Linux boot differs from the authorization boot; it returns **`RECOVERY_PROBE_ONLY`** and keeps the session active. A new **`completeRecoveredAfterRestart`** path terminates the session from a later boot using only an owner-checked, framed **`sr_syvr`** version (success, mismatch, or invalid proof). Same-boot process restart still fails closed with **`interrupted`**.
> 
> **`K900BluetoothManager`** extends version-proof reconciliation and recovery timeout handling to **`AUTH_ATTEMPTED`** as well as **`APPLY_PENDING`**, routing recovered boots through **`completeRecoveredAfterRestart`** and surfacing the store’s terminal failure codes to the UI. Docs and unit tests cover the hard-reboot contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf9fea7b9b960d151088abac0dfd87e3ce02c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->