### PR TITLE
Chain Mentra Live OTA updates automatically

### DIFF
--- a/mobile/src/__tests__/otaAutoChain.test.ts
+++ b/mobile/src/__tests__/otaAutoChain.test.ts
@@ -2,9 +2,12 @@ import type {OtaCheckCurrentGlassesResult} from "@mentra/engine"
 
 import {
   beginOtaAutoChain,
+  clearOtaAutoChainReconnectWait,
   isOtaAutoChainActive,
   MAX_OTA_AUTO_CHAIN_PASSES,
+  OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS,
   otaAutoChainFingerprint,
+  otaAutoChainReconnectWaitRemaining,
   stopOtaAutoChain,
   tryAdvanceOtaAutoChain,
 } from "@/services/otaAutoChain"
@@ -86,4 +89,21 @@ it("bounds the number of automatic passes", () => {
 
   expect(tryAdvanceOtaAutoChain("one-too-many", false)).toEqual({advance: false, reason: "max_passes"})
   expect(isOtaAutoChainActive()).toBe(false)
+})
+
+it("bounds a reboot reconnect wait without extending it on subsequent renders", () => {
+  beginOtaAutoChain("pass-1", false)
+
+  expect(otaAutoChainReconnectWaitRemaining(1_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS)
+  expect(otaAutoChainReconnectWaitRemaining(2_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS - 1_000)
+  expect(otaAutoChainReconnectWaitRemaining(1_000 + OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS)).toBe(0)
+})
+
+it("starts a fresh bounded wait after a successful reconnect", () => {
+  beginOtaAutoChain("pass-1", false)
+  expect(otaAutoChainReconnectWaitRemaining(1_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS)
+
+  clearOtaAutoChainReconnectWait()
+
+  expect(otaAutoChainReconnectWaitRemaining(10_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS)
 })

--- a/mobile/src/__tests__/otaAutoChain.test.ts
+++ b/mobile/src/__tests__/otaAutoChain.test.ts
@@ -1,0 +1,89 @@
+import type {OtaCheckCurrentGlassesResult} from "@mentra/engine"
+
+import {
+  beginOtaAutoChain,
+  isOtaAutoChainActive,
+  MAX_OTA_AUTO_CHAIN_PASSES,
+  otaAutoChainFingerprint,
+  stopOtaAutoChain,
+  tryAdvanceOtaAutoChain,
+} from "@/services/otaAutoChain"
+
+function result(overrides: Partial<OtaCheckCurrentGlassesResult> = {}): OtaCheckCurrentGlassesResult {
+  return {
+    hasCheckCompleted: true,
+    updateAvailable: true,
+    latestVersionInfo: {
+      versionCode: 37,
+      versionName: "37.0",
+      downloadUrl: "https://example.com/asg.apk",
+      apkSize: 1,
+      sha256: "abc",
+      releaseNotes: "",
+    },
+    updates: ["apk"],
+    mtkPatch: null,
+    besVersion: null,
+    isApkDowngrade: false,
+    manifestBody: '{"version":37}',
+    updateInfo: {
+      available: true,
+      versionCode: 37,
+      versionName: "37.0",
+      updates: ["apk"],
+      totalSize: 0,
+    },
+    isRequired: true,
+    manifestUrl: "https://example.com/legacy.json",
+    buildNumber: "1",
+    mtkFirmwareVersion: "MentraLive_20260113",
+    besFirmwareVersion: "17.26.01.13",
+    ...overrides,
+  }
+}
+
+afterEach(() => stopOtaAutoChain())
+
+it("advances through distinct update offers after the user approves the first pass", () => {
+  const first = otaAutoChainFingerprint(result())
+  const second = otaAutoChainFingerprint(result({buildNumber: "37", updates: ["mtk", "bes"]}))
+
+  beginOtaAutoChain(first, false)
+
+  expect(tryAdvanceOtaAutoChain(second, false)).toEqual({advance: true, passCount: 2})
+  expect(isOtaAutoChainActive()).toBe(true)
+})
+
+it("stops instead of reinstalling the same offer twice", () => {
+  const fingerprint = otaAutoChainFingerprint(result())
+  beginOtaAutoChain(fingerprint, false)
+
+  expect(tryAdvanceOtaAutoChain(fingerprint, false)).toEqual({advance: false, reason: "duplicate"})
+  expect(isOtaAutoChainActive()).toBe(false)
+})
+
+it("requires separate approval when an upgrade chain encounters a downgrade", () => {
+  beginOtaAutoChain(otaAutoChainFingerprint(result()), false)
+
+  expect(tryAdvanceOtaAutoChain("downgrade", true)).toEqual({
+    advance: false,
+    reason: "downgrade_not_approved",
+  })
+  expect(isOtaAutoChainActive()).toBe(false)
+})
+
+it("allows subsequent downgrade passes when the user approved a downgrade initially", () => {
+  beginOtaAutoChain("firmware-first-downgrade", true)
+
+  expect(tryAdvanceOtaAutoChain("downgrade-handoff", true)).toEqual({advance: true, passCount: 2})
+})
+
+it("bounds the number of automatic passes", () => {
+  beginOtaAutoChain("pass-1", false)
+  for (let pass = 2; pass <= MAX_OTA_AUTO_CHAIN_PASSES; pass += 1) {
+    expect(tryAdvanceOtaAutoChain(`pass-${pass}`, false).advance).toBe(true)
+  }
+
+  expect(tryAdvanceOtaAutoChain("one-too-many", false)).toEqual({advance: false, reason: "max_passes"})
+  expect(isOtaAutoChainActive()).toBe(false)
+})

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -346,6 +346,30 @@ describe("progress.tsx display states", () => {
     expect(getByText("Retry")).toBeDefined()
   })
 
+  it("stops automatic chaining when leaving a failed pass to change WiFi", () => {
+    setGlassesConnected()
+    beginOtaAutoChain("initial-offer", false)
+    const {getByText} = render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "apk",
+        phase: "download",
+        stepPercent: 0,
+        overallPercent: 0,
+        status: "failed",
+        error: "no_internet",
+      })
+    })
+
+    fireEvent.press(getByText("Change WiFi"))
+
+    expect(isOtaAutoChainActive()).toBe(false)
+  })
+
   it("requires a glasses restart for the existing generic BES install failure", () => {
     setGlassesConnected()
     const {getByText, queryByText} = render(<OtaProgressScreen />)

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -258,6 +258,48 @@ describe("progress.tsx display states", () => {
     }
   })
 
+  it("reschedules chained navigation when a reboot starts during the success delay", async () => {
+    setGlassesConnected()
+    beginOtaAutoChain("initial-offer", false)
+    const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
+    try {
+      render(<OtaProgressScreen />)
+      act(() => {
+        useGlassesStore.getState().setOtaStatus({
+          sessionId: "s1",
+          totalSteps: 1,
+          currentStep: 1,
+          stepType: "apk",
+          phase: "install",
+          stepPercent: 100,
+          overallPercent: 100,
+          status: "complete",
+        })
+      })
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300)
+      })
+      act(() => {
+        setGlassesDisconnected()
+      })
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(750)
+      })
+      expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
+
+      act(() => {
+        setGlassesConnected()
+      })
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(750)
+      })
+      expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
+    } finally {
+      replaceSpy.mockRestore()
+    }
+  })
+
   it("stops automatic chaining when Continue bypasses BES reboot verification", () => {
     setGlassesConnected()
     beginOtaAutoChain("initial-offer", false)

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -10,7 +10,7 @@ import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 import OtaProgressScreen from "@/app/ota/progress"
 import {MINIMUM_OTA_STATUS_BUILD, OtaProgressMessages} from "@mentra/engine"
 import {BES_INSTALL_RESTART_MESSAGE} from "@/utils/otaErrorMapping"
-import {beginOtaAutoChain, stopOtaAutoChain} from "@/services/otaAutoChain"
+import {beginOtaAutoChain, isOtaAutoChainActive, stopOtaAutoChain} from "@/services/otaAutoChain"
 
 const mockReplace = jest.fn()
 
@@ -254,6 +254,29 @@ describe("progress.tsx display states", () => {
     })
     expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
     replaceSpy.mockRestore()
+  })
+
+  it("stops automatic chaining when Continue bypasses BES reboot verification", () => {
+    setGlassesConnected()
+    beginOtaAutoChain("initial-offer", false)
+    const {getByText} = render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "bes",
+        phase: "install",
+        stepPercent: 100,
+        overallPercent: 100,
+        status: "step_complete",
+      })
+    })
+
+    fireEvent.press(getByText("Continue"))
+
+    expect(isOtaAutoChainActive()).toBe(false)
   })
 
   it("transitions to failed on failed ota_status with error", () => {

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -10,6 +10,7 @@ import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 import OtaProgressScreen from "@/app/ota/progress"
 import {MINIMUM_OTA_STATUS_BUILD, OtaProgressMessages} from "@mentra/engine"
 import {BES_INSTALL_RESTART_MESSAGE} from "@/utils/otaErrorMapping"
+import {beginOtaAutoChain, stopOtaAutoChain} from "@/services/otaAutoChain"
 
 const mockReplace = jest.fn()
 
@@ -87,9 +88,11 @@ beforeEach(() => {
   mockReplace.mockClear()
   BluetoothSdk.sendOtaQueryStatus.mockClear()
   BluetoothSdk.startOtaUpdate.mockClear()
+  stopOtaAutoChain()
 })
 
 afterEach(() => {
+  stopOtaAutoChain()
   jest.useRealTimers()
 })
 
@@ -189,6 +192,33 @@ describe("progress.tsx display states", () => {
 
     expect(getByText("Update complete!")).toBeDefined()
     expect(getByText("Done")).toBeDefined()
+  })
+
+  it("automatically returns to update checking after a chained pass completes", async () => {
+    setGlassesConnected()
+    beginOtaAutoChain("initial-offer", false)
+    const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
+    render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "apk",
+        phase: "install",
+        stepPercent: 100,
+        overallPercent: 100,
+        status: "complete",
+      })
+    })
+
+    expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(750)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
+    replaceSpy.mockRestore()
   })
 
   it("transitions to failed on failed ota_status with error", () => {

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -198,62 +198,64 @@ describe("progress.tsx display states", () => {
     setGlassesConnected()
     beginOtaAutoChain("initial-offer", false)
     const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
-    render(<OtaProgressScreen />)
+    try {
+      render(<OtaProgressScreen />)
 
-    act(() => {
-      useGlassesStore.getState().setOtaStatus({
-        sessionId: "s1",
-        totalSteps: 1,
-        currentStep: 1,
-        stepType: "apk",
-        phase: "install",
-        stepPercent: 100,
-        overallPercent: 100,
-        status: "complete",
+      act(() => {
+        useGlassesStore.getState().setOtaStatus({
+          sessionId: "s1",
+          totalSteps: 1,
+          currentStep: 1,
+          stepType: "apk",
+          phase: "install",
+          stepPercent: 100,
+          overallPercent: 100,
+          status: "complete",
+        })
       })
-    })
 
-    expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
-    await act(async () => {
-      await jest.advanceTimersByTimeAsync(750)
-    })
-    expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
-    replaceSpy.mockRestore()
+      expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(750)
+      })
+      expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
+    } finally {
+      replaceSpy.mockRestore()
+    }
   })
 
   it("waits for a rebooting chained pass to reconnect before checking again", async () => {
-    setGlassesConnected()
+    setGlassesDisconnected()
     beginOtaAutoChain("initial-offer", false)
+    useGlassesStore.getState().setOtaStatus({
+      sessionId: "s1",
+      totalSteps: 1,
+      currentStep: 1,
+      stepType: "apk",
+      phase: "install",
+      stepPercent: 100,
+      overallPercent: 100,
+      status: "complete",
+    })
     const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
-    render(<OtaProgressScreen />)
+    try {
+      render(<OtaProgressScreen />)
 
-    act(() => {
-      useGlassesStore.getState().setOtaStatus({
-        sessionId: "s1",
-        totalSteps: 1,
-        currentStep: 1,
-        stepType: "apk",
-        phase: "install",
-        stepPercent: 100,
-        overallPercent: 100,
-        status: "complete",
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(750)
       })
-      setGlassesDisconnected()
-    })
+      expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
 
-    await act(async () => {
-      await jest.advanceTimersByTimeAsync(750)
-    })
-    expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
-
-    act(() => {
-      setGlassesConnected()
-    })
-    await act(async () => {
-      await jest.advanceTimersByTimeAsync(750)
-    })
-    expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
-    replaceSpy.mockRestore()
+      act(() => {
+        setGlassesConnected()
+      })
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(750)
+      })
+      expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
+    } finally {
+      replaceSpy.mockRestore()
+    }
   })
 
   it("stops automatic chaining when Continue bypasses BES reboot verification", () => {

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -221,6 +221,41 @@ describe("progress.tsx display states", () => {
     replaceSpy.mockRestore()
   })
 
+  it("waits for a rebooting chained pass to reconnect before checking again", async () => {
+    setGlassesConnected()
+    beginOtaAutoChain("initial-offer", false)
+    const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
+    render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "apk",
+        phase: "install",
+        stepPercent: 100,
+        overallPercent: 100,
+        status: "complete",
+      })
+      setGlassesDisconnected()
+    })
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(750)
+    })
+    expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
+
+    act(() => {
+      setGlassesConnected()
+    })
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(750)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith("/ota/check-for-updates")
+    replaceSpy.mockRestore()
+  })
+
   it("transitions to failed on failed ota_status with error", () => {
     setGlassesConnected()
     const {getByText} = render(<OtaProgressScreen />)

--- a/mobile/src/app/ota/check-for-updates.tsx
+++ b/mobile/src/app/ota/check-for-updates.tsx
@@ -10,6 +10,13 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {translate} from "@/i18n/translate"
 import {useNavigationStore} from "@/stores/navigation"
+import {
+  beginOtaAutoChain,
+  isOtaAutoChainActive,
+  otaAutoChainFingerprint,
+  stopOtaAutoChain,
+  tryAdvanceOtaAutoChain,
+} from "@/services/otaAutoChain"
 import {getNextOnboardingRoute} from "@/utils/onboarding/getNextOnboardingRoute"
 
 type CheckState = "checking" | "update_available" | "no_update" | "dev_build" | "error"
@@ -33,6 +40,7 @@ export default function OtaCheckForUpdatesScreen() {
   const [isDowngradeUpdate, setIsDowngradeUpdate] = useState(false)
   /** Distinguishes retryable network trouble from a dead pin (remedy: update the app). */
   const [errorKind, setErrorKind] = useState<"network" | "pin_unavailable">("network")
+  const [updateFingerprint, setUpdateFingerprint] = useState<string | null>(null)
   const [checkKey, setCheckKey] = useState(0)
   /** Incremented each effect run so stale async performCheck exits before mutating state. */
   const performCheckGenerationRef = useRef(0)
@@ -41,6 +49,26 @@ export default function OtaCheckForUpdatesScreen() {
   const checkCompletedRef = useRef(false)
 
   focusEffectPreventBack()
+
+  const navigateToProgress = useCallback(() => {
+    const otaProgressBefore = engine.ota.snapshot().legacyProgress
+    console.log(
+      "OTA_TRACK: navigate_to_progress",
+      JSON.stringify({
+        from: "check-for-updates",
+        action: "clear_otaProgress_then_replace",
+        otaProgressBefore: otaProgressBefore
+          ? {
+              currentUpdate: otaProgressBefore.currentUpdate,
+              status: otaProgressBefore.status,
+              stage: otaProgressBefore.stage,
+            }
+          : null,
+      }),
+    )
+    engine.ota.clearProgress()
+    replace("/ota/progress")
+  }, [replace])
 
   // Re-run OTA check when screen gains focus (for iterative updates: APK → MTK → BES)
   useFocusEffect(
@@ -72,6 +100,14 @@ export default function OtaCheckForUpdatesScreen() {
       if (!glassesConnected) {
         if (checkStartedRef.current) {
           console.log("OTA: Glasses disconnected after OTA check started - setting error state")
+          stopOtaAutoChain()
+          checkCompletedRef.current = true
+          setCheckState("error")
+          return
+        }
+        if (isOtaAutoChainActive()) {
+          console.log("OTA: Glasses disconnected during automatic update chain - stopping chain")
+          stopOtaAutoChain()
           checkCompletedRef.current = true
           setCheckState("error")
           return
@@ -109,12 +145,20 @@ export default function OtaCheckForUpdatesScreen() {
 
         if (result.skippedReason === "disconnected") {
           console.log("OTA: Check skipped after glasses disconnected - setting error state")
+          stopOtaAutoChain()
           checkCompletedRef.current = true
           setCheckState("error")
           return
         }
 
         if (result.skippedReason === "missing_build") {
+          if (isOtaAutoChainActive()) {
+            console.log("OTA: Missing build metadata during automatic update chain - stopping chain")
+            stopOtaAutoChain()
+            checkCompletedRef.current = true
+            setCheckState("error")
+            return
+          }
           console.log("OTA: Check skipped (missing_build) - proceeding to next step")
           checkCompletedRef.current = true
           handleContinue()
@@ -125,6 +169,7 @@ export default function OtaCheckForUpdatesScreen() {
           // Locally built mobile apps are exempt from OTA. Shown as its own state — NOT
           // "up to date", which would be an unverified claim.
           console.log("OTA: Check skipped (dev_build) - mobile app is a development build")
+          stopOtaAutoChain()
           checkCompletedRef.current = true
           engine.ota.clearUpdateAvailable()
           setCheckState("dev_build")
@@ -133,6 +178,7 @@ export default function OtaCheckForUpdatesScreen() {
 
         if (!result.hasCheckCompleted) {
           console.log(`📱 OTA check did not complete (${result.checkFailureReason ?? "network"}) - setting error state`)
+          stopOtaAutoChain()
           checkCompletedRef.current = true
           setErrorKind(result.checkFailureReason === "pin_unavailable" ? "pin_unavailable" : "network")
           setCheckState("error")
@@ -144,9 +190,28 @@ export default function OtaCheckForUpdatesScreen() {
           checkCompletedRef.current = true
           setIsUpdateRequired(result.isRequired)
           setIsDowngradeUpdate(result.updateInfo.isDowngrade === true)
+          const fingerprint = otaAutoChainFingerprint(result)
+          setUpdateFingerprint(fingerprint)
+
+          if (isOtaAutoChainActive()) {
+            if (!engine.ota.snapshot().wifiConnected) {
+              console.log("OTA: Automatic update chain paused because glasses WiFi is disconnected")
+              stopOtaAutoChain()
+            } else {
+              const admission = tryAdvanceOtaAutoChain(fingerprint, result.updateInfo.isDowngrade === true)
+              if (admission.advance) {
+                console.log(`OTA: Automatically starting chained update pass ${admission.passCount}`)
+                navigateToProgress()
+                return
+              }
+              console.warn(`OTA: Automatic update chain stopped (${admission.reason})`)
+            }
+          }
+
           setCheckState("update_available")
         } else {
           console.log("📱 No updates available - setting no_update state")
+          stopOtaAutoChain()
           checkCompletedRef.current = true
           engine.ota.clearUpdateAvailable()
           setCheckState("no_update")
@@ -163,6 +228,7 @@ export default function OtaCheckForUpdatesScreen() {
         if (cancelled || myGen !== performCheckGenerationRef.current) {
           return
         }
+        stopOtaAutoChain()
         checkCompletedRef.current = true
         setCheckState("error")
       }
@@ -175,10 +241,11 @@ export default function OtaCheckForUpdatesScreen() {
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkKey, currentBuildNumber, mtkFirmwareVersion, besFirmwareVersion, glassesConnected])
+  }, [checkKey, currentBuildNumber, mtkFirmwareVersion, besFirmwareVersion, glassesConnected, navigateToProgress])
 
   // Navigate to next step based on onboarding status
   const handleContinue = () => {
+    stopOtaAutoChain()
     const nextRoute = getNextOnboardingRoute({
       includeMentraLive: true,
       onboardingLiveCompleted,
@@ -211,25 +278,12 @@ export default function OtaCheckForUpdatesScreen() {
       push("/wifi/scan")
       return
     }
-    const otaProgressBefore = engine.ota.snapshot().legacyProgress
-    console.log(
-      "OTA_TRACK: navigate_to_progress",
-      JSON.stringify({
-        from: "check-for-updates",
-        action: "clear_otaProgress_then_replace",
-        otaProgressBefore: otaProgressBefore
-          ? {
-              currentUpdate: otaProgressBefore.currentUpdate,
-              status: otaProgressBefore.status,
-              stage: otaProgressBefore.stage,
-            }
-          : null,
-      }),
-    )
-    engine.ota.clearProgress()
-    // One unified progress route: old-build (< MINIMUM_OTA_STATUS_BUILD)
-    // compatibility now lives inside the island install coordinator (WP 8C/8D).
-    replace("/ota/progress")
+    if (updateFingerprint) {
+      beginOtaAutoChain(updateFingerprint, isDowngradeUpdate)
+    }
+    // One unified progress route: old-build compatibility lives inside the
+    // engine install coordinator. The chain remains armed across successful passes.
+    navigateToProgress()
   }
 
   const renderContent = () => {

--- a/mobile/src/app/ota/check-for-updates.tsx
+++ b/mobile/src/app/ota/check-for-updates.tsx
@@ -12,7 +12,9 @@ import {translate} from "@/i18n/translate"
 import {useNavigationStore} from "@/stores/navigation"
 import {
   beginOtaAutoChain,
+  clearOtaAutoChainReconnectWait,
   isOtaAutoChainActive,
+  otaAutoChainReconnectWaitRemaining,
   otaAutoChainFingerprint,
   stopOtaAutoChain,
   tryAdvanceOtaAutoChain,
@@ -91,6 +93,7 @@ export default function OtaCheckForUpdatesScreen() {
 
     const myGen = ++performCheckGenerationRef.current
     let cancelled = false
+    let reconnectTimeout: ReturnType<typeof setTimeout> | null = null
 
     const performCheck = async () => {
       if (checkCompletedRef.current) {
@@ -98,15 +101,23 @@ export default function OtaCheckForUpdatesScreen() {
       }
 
       if (!glassesConnected) {
-        if (checkStartedRef.current) {
-          console.log("OTA: Glasses disconnected after OTA check started - setting error state")
-          stopOtaAutoChain()
-          checkCompletedRef.current = true
-          setCheckState("error")
+        if (isOtaAutoChainActive()) {
+          const remainingMs = otaAutoChainReconnectWaitRemaining()
+          if (remainingMs === null) return
+
+          console.log(`OTA: Waiting up to ${remainingMs}ms for glasses to reconnect between chained passes`)
+          reconnectTimeout = setTimeout(() => {
+            if (cancelled || myGen !== performCheckGenerationRef.current || engine.ota.snapshot().connected) return
+
+            console.log("OTA: Timed out waiting for glasses to reconnect during automatic update chain")
+            stopOtaAutoChain()
+            checkCompletedRef.current = true
+            setCheckState("error")
+          }, remainingMs)
           return
         }
-        if (isOtaAutoChainActive()) {
-          console.log("OTA: Glasses disconnected during automatic update chain - stopping chain")
+        if (checkStartedRef.current) {
+          console.log("OTA: Glasses disconnected after OTA check started - setting error state")
           stopOtaAutoChain()
           checkCompletedRef.current = true
           setCheckState("error")
@@ -118,6 +129,7 @@ export default function OtaCheckForUpdatesScreen() {
         return
       }
 
+      clearOtaAutoChainReconnectWait()
       checkStartedRef.current = true
       const startTime = Date.now()
 
@@ -239,6 +251,7 @@ export default function OtaCheckForUpdatesScreen() {
     // Cleanup timeouts on unmount or when dependencies change
     return () => {
       cancelled = true
+      if (reconnectTimeout) clearTimeout(reconnectTimeout)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkKey, currentBuildNumber, mtkFirmwareVersion, besFirmwareVersion, glassesConnected, navigateToProgress])

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -78,8 +78,9 @@ export default function OtaProgressScreen() {
   useEffect(() => {
     if (displayState !== "complete" || !connected || !isOtaAutoChainActive() || autoChainAdvancedRef.current) return
 
-    autoChainAdvancedRef.current = true
     const timeout = setTimeout(() => {
+      if (!isOtaAutoChainActive()) return
+      autoChainAdvancedRef.current = true
       engine.ota.installSession.finish()
       replace("/ota/check-for-updates")
     }, AUTO_CHAIN_COMPLETE_DELAY_MS)

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -106,6 +106,7 @@ export default function OtaProgressScreen() {
   }
 
   const handleChangeWifi = useCallback(() => {
+    stopOtaAutoChain()
     push("/wifi/scan")
   }, [push])
 

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -73,10 +73,10 @@ export default function OtaProgressScreen() {
   }, [])
 
   // A verified completion is the safe boundary between manifest generations.
-  // Keep the success state visible briefly, then re-enter the existing checker;
-  // it either starts the next admitted pass or presents the final up-to-date UI.
+  // Wait through any final reboot, keep success visible briefly, then re-enter
+  // the checker; it either starts the next pass or presents the final state.
   useEffect(() => {
-    if (displayState !== "complete" || !isOtaAutoChainActive() || autoChainAdvancedRef.current) return
+    if (displayState !== "complete" || !connected || !isOtaAutoChainActive() || autoChainAdvancedRef.current) return
 
     autoChainAdvancedRef.current = true
     const timeout = setTimeout(() => {
@@ -85,7 +85,7 @@ export default function OtaProgressScreen() {
     }, AUTO_CHAIN_COMPLETE_DELAY_MS)
 
     return () => clearTimeout(timeout)
-  }, [displayState, replace])
+  }, [connected, displayState, replace])
 
   const handleContinue = () => {
     engine.ota.installSession.finish()

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -1,5 +1,5 @@
 import {engine, SETTINGS, useSetting} from "@mentra/engine"
-import {useCallback, useEffect} from "react"
+import {useCallback, useEffect, useRef} from "react"
 import {View, ActivityIndicator} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
@@ -15,6 +15,9 @@ import {
   shouldShowChangeWifiForOtaDownloadFailure,
 } from "@/utils/otaErrorMapping"
 import {useNavigationStore} from "@/stores/navigation"
+import {isOtaAutoChainActive, stopOtaAutoChain} from "@/services/otaAutoChain"
+
+const AUTO_CHAIN_COMPLETE_DELAY_MS = 750
 
 /**
  * Pure renderer over the island OTA install state machine
@@ -39,6 +42,7 @@ export default function OtaProgressScreen() {
     versionChangeConverged,
     versionChangePhase,
   } = install
+  const autoChainAdvancedRef = useRef(false)
 
   focusEffectPreventBack()
 
@@ -68,6 +72,21 @@ export default function OtaProgressScreen() {
     }
   }, [])
 
+  // A verified completion is the safe boundary between manifest generations.
+  // Keep the success state visible briefly, then re-enter the existing checker;
+  // it either starts the next admitted pass or presents the final up-to-date UI.
+  useEffect(() => {
+    if (displayState !== "complete" || !isOtaAutoChainActive() || autoChainAdvancedRef.current) return
+
+    autoChainAdvancedRef.current = true
+    const timeout = setTimeout(() => {
+      engine.ota.installSession.finish()
+      replace("/ota/check-for-updates")
+    }, AUTO_CHAIN_COMPLETE_DELAY_MS)
+
+    return () => clearTimeout(timeout)
+  }, [displayState, replace])
+
   const handleContinue = () => {
     engine.ota.installSession.finish()
     replace("/ota/check-for-updates")
@@ -87,9 +106,15 @@ export default function OtaProgressScreen() {
   }, [push])
 
   const handleSkipSuper = useCallback(() => {
+    stopOtaAutoChain()
     engine.ota.installSession.discard()
     replace("/ota/check-for-updates")
   }, [replace])
+
+  const handleFailureDone = () => {
+    stopOtaAutoChain()
+    handleDone()
+  }
 
   const renderContent = () => {
     // Downgrade detour: the recovery worker owns the transaction while ASG is being
@@ -143,10 +168,10 @@ export default function OtaProgressScreen() {
       const isApkOnlyInstalling = otaStatus?.stepType === "apk" && otaStatus?.phase === "install" && totalSteps === 1
 
       const rawPercent = isDownload
-        ? otaStatus?.stepPercent ?? 0
+        ? (otaStatus?.stepPercent ?? 0)
         : totalSteps >= 2
-        ? otaStatus?.overallPercent ?? 0
-        : otaStatus?.stepPercent ?? 0
+          ? (otaStatus?.overallPercent ?? 0)
+          : (otaStatus?.stepPercent ?? 0)
       // Legacy (< 37) MTK install stall simulation (WP 8C-e): the coordinator projects a
       // display-only percent while the MTK system install goes quiet; render whichever is
       // further along. Null for unified sessions and outside legacy MTK installs.
@@ -279,9 +304,9 @@ export default function OtaProgressScreen() {
           </View>
           <View className="gap-3">
             {requiresGlassesReboot ? (
-              <Button preset="primary" text="Done" flexContainer onPress={handleDone} />
+              <Button preset="primary" text="Done" flexContainer onPress={handleFailureDone} />
             ) : (
-            <Button preset="primary" text="Retry" flexContainer onPress={handleRetry} />
+              <Button preset="primary" text="Retry" flexContainer onPress={handleRetry} />
             )}
             {showChangeWifi ? (
               <Button preset="secondary" text="Change WiFi" flexContainer onPress={handleChangeWifi} />

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -88,6 +88,9 @@ export default function OtaProgressScreen() {
   }, [connected, displayState, replace])
 
   const handleContinue = () => {
+    // This is the explicit BES recovery escape hatch shown before reboot
+    // verification completes. Returning early must not preserve automation.
+    stopOtaAutoChain()
     engine.ota.installSession.finish()
     replace("/ota/check-for-updates")
   }

--- a/mobile/src/services/otaAutoChain.ts
+++ b/mobile/src/services/otaAutoChain.ts
@@ -64,7 +64,7 @@ export function stopOtaAutoChain(): void {
  * Start (or continue) the bounded wait for glasses that are rebooting between
  * passes. Re-renders must not extend the original deadline indefinitely.
  */
-export function otaAutoChainReconnectWaitRemaining(now = Date.now()): number | null {
+export function otaAutoChainReconnectWaitRemaining(now = performance.now()): number | null {
   if (!session) return null
 
   session.reconnectDeadline ??= now + OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS

--- a/mobile/src/services/otaAutoChain.ts
+++ b/mobile/src/services/otaAutoChain.ts
@@ -1,10 +1,12 @@
 import type {OtaCheckCurrentGlassesResult} from "@mentra/engine"
 
 export const MAX_OTA_AUTO_CHAIN_PASSES = 8
+export const OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS = 120_000
 
 type OtaAutoChainSession = {
   approvedDowngrade: boolean
   passCount: number
+  reconnectDeadline: number | null
   seenFingerprints: Set<string>
 }
 
@@ -44,6 +46,7 @@ export function beginOtaAutoChain(initialFingerprint: string, approvedDowngrade:
   session = {
     approvedDowngrade,
     passCount: 1,
+    reconnectDeadline: null,
     seenFingerprints: new Set([initialFingerprint]),
   }
 }
@@ -55,6 +58,22 @@ export function isOtaAutoChainActive(): boolean {
 /** End the current chain. Safe to call when no chain is active. */
 export function stopOtaAutoChain(): void {
   session = null
+}
+
+/**
+ * Start (or continue) the bounded wait for glasses that are rebooting between
+ * passes. Re-renders must not extend the original deadline indefinitely.
+ */
+export function otaAutoChainReconnectWaitRemaining(now = Date.now()): number | null {
+  if (!session) return null
+
+  session.reconnectDeadline ??= now + OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS
+  return Math.max(0, session.reconnectDeadline - now)
+}
+
+/** A successful reconnect allows a future pass to establish a fresh wait. */
+export function clearOtaAutoChainReconnectWait(): void {
+  if (session) session.reconnectDeadline = null
 }
 
 /**

--- a/mobile/src/services/otaAutoChain.ts
+++ b/mobile/src/services/otaAutoChain.ts
@@ -1,0 +1,87 @@
+import type {OtaCheckCurrentGlassesResult} from "@mentra/engine"
+
+export const MAX_OTA_AUTO_CHAIN_PASSES = 8
+
+type OtaAutoChainSession = {
+  approvedDowngrade: boolean
+  passCount: number
+  seenFingerprints: Set<string>
+}
+
+export type OtaAutoChainAdvanceResult =
+  | {advance: true; passCount: number}
+  | {advance: false; reason: "inactive" | "duplicate" | "max_passes" | "downgrade_not_approved"}
+
+let session: OtaAutoChainSession | null = null
+
+/**
+ * Identify the exact update offer that produced one OTA pass. Including the
+ * observed versions and manifest body lets a changed manifest advance while a
+ * stale post-install version_info response is rejected as a duplicate.
+ */
+export function otaAutoChainFingerprint(result: OtaCheckCurrentGlassesResult): string {
+  return JSON.stringify({
+    manifestUrl: result.manifestUrl ?? "",
+    manifestBody: result.manifestBody ?? "",
+    buildNumber: result.buildNumber ?? "",
+    mtkFirmwareVersion: result.mtkFirmwareVersion ?? "",
+    besFirmwareVersion: result.besFirmwareVersion ?? "",
+    updates: result.updates,
+    targetBuildNumber: result.updateInfo?.versionCode ?? result.latestVersionInfo?.versionCode ?? 0,
+    targetBesVersion: result.besVersion ?? "",
+    mtkPatch: result.mtkPatch
+      ? {
+          startFirmware: result.mtkPatch.start_firmware,
+          endFirmware: result.mtkPatch.end_firmware,
+          url: result.mtkPatch.url,
+        }
+      : null,
+  })
+}
+
+/** Start a chain after the user explicitly approves its first update pass. */
+export function beginOtaAutoChain(initialFingerprint: string, approvedDowngrade: boolean): void {
+  session = {
+    approvedDowngrade,
+    passCount: 1,
+    seenFingerprints: new Set([initialFingerprint]),
+  }
+}
+
+export function isOtaAutoChainActive(): boolean {
+  return session !== null
+}
+
+/** End the current chain. Safe to call when no chain is active. */
+export function stopOtaAutoChain(): void {
+  session = null
+}
+
+/**
+ * Admit the next pass of an active chain. Repeated offers, unexpectedly
+ * destructive downgrades, and runaway chains fail closed and end automation.
+ */
+export function tryAdvanceOtaAutoChain(fingerprint: string, isDowngrade: boolean): OtaAutoChainAdvanceResult {
+  if (!session) {
+    return {advance: false, reason: "inactive"}
+  }
+
+  if (isDowngrade && !session.approvedDowngrade) {
+    stopOtaAutoChain()
+    return {advance: false, reason: "downgrade_not_approved"}
+  }
+
+  if (session.seenFingerprints.has(fingerprint)) {
+    stopOtaAutoChain()
+    return {advance: false, reason: "duplicate"}
+  }
+
+  if (session.passCount >= MAX_OTA_AUTO_CHAIN_PASSES) {
+    stopOtaAutoChain()
+    return {advance: false, reason: "max_passes"}
+  }
+
+  session.seenFingerprints.add(fingerprint)
+  session.passCount += 1
+  return {advance: true, passCount: session.passCount}
+}


### PR DESCRIPTION
## Summary

- automatically recheck for another Mentra Live update after each verified OTA pass completes
- automatically start distinct follow-up offers across historical manifest handoffs
- stop safely on duplicate offers, unexpected downgrades, missing prerequisites, errors, or the eight-pass limit
- preserve the existing final up-to-date screen and manual fallback behavior

## Root cause

Each manifest-scoped install was treated as the end of the user flow, even when that install moved an older unit onto a new manifest URL with another required update. Users therefore had to press Continue and Update repeatedly through the bootstrap chain.

## Validation

- `cd mobile && bun run compile`
- `cd mobile && bun run test -- --runInBand src/__tests__/otaAutoChain.test.ts src/__tests__/otaUpdateCheckService.test.ts src/__tests__/otaInstallCoordinator.test.ts src/__tests__/otaService.test.ts src/app/ota/__tests__/deriveOtaDisplayState.test.ts src/app/ota/__tests__/progress.test.tsx src/effects/__tests__/OtaUpdateChecker.test.ts` (7 suites, 178 tests)
- `cd mobile && bunx eslint src/services/otaAutoChain.ts src/app/ota/check-for-updates.tsx src/app/ota/progress.tsx src/__tests__/otaAutoChain.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches firmware OTA navigation and install boundaries; safeguards limit runaway installs and unexpected downgrades, but mis-fingerprinting or reconnect timing could still affect update UX on legacy devices.
> 
> **Overview**
> Adds **`otaAutoChain`** session state so one **Update Now** approval can drive multiple manifest-scoped OTA passes (APK → MTK → BES) without repeated taps.
> 
> After each verified install, **`progress`** waits for reconnect if needed, then navigates back to **`check-for-updates`**, which either auto-starts the next distinct offer or shows the normal final UI. Chaining **stops** on duplicate offers, unapproved downgrades, WiFi/check errors, user escape hatches (Continue, Change WiFi, skip), or an **8-pass** cap, with a **120s** bounded reconnect wait between passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d8443a3d9a2ce2d62d554e84dc2439e42c1a9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->