### PR TITLE
Staging -> dev

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -342,6 +342,56 @@ public final class BesOtaStateStore {
         }
     }
 
+    /**
+     * Resolve an authorization record recovered on a later Linux boot.
+     *
+     * <p>An abrupt MTK reboot can restore the last filesystem-persisted record even when a newer
+     * SharedPreferences value was committed and read back before BES apply. In that case the
+     * durable record is still {@link State#AUTH_ATTEMPTED}, so only a fresh, source-audited framed
+     * version reply from the later boot may decide whether the target was installed.
+     */
+    public TransitionResult completeRecoveredAfterRestart(
+            String ownerSessionId, String currentBootId, String actualVersion) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            String owner = canonicalNonempty(ownerSessionId);
+            String boot = canonicalBootId(currentBootId);
+            String actual = canonicalVersion(actualVersion);
+            if (!current.isOwnedActive(State.AUTH_ATTEMPTED, owner)
+                    || boot == null
+                    || boot.equals(current.authorizationBootId)) {
+                logDecision(
+                        "recovered_version_proof_rejected",
+                        "reason=owner_state_or_boot requested_owner="
+                                + diagnosticValue(owner)
+                                + " requested_boot="
+                                + diagnosticValue(boot)
+                                + " actual="
+                                + diagnosticValue(actual),
+                        current);
+                return terminalOrRejected(current);
+            }
+            boolean matches = current.targetVersion.equals(actual);
+            Snapshot terminal =
+                    current.withVerificationBoot(boot)
+                            .asTerminal(
+                                    matches ? TerminalStatus.SUCCESS : TerminalStatus.FAILURE,
+                                    matches
+                                            ? "verified"
+                                            : (actual == null
+                                                    ? "invalid_version_proof"
+                                                    : "version_mismatch"));
+            return putLocked(
+                            matches
+                                    ? "complete_recovered_after_restart"
+                                    : "fail_recovered_" + terminal.terminalCode,
+                            current,
+                            terminal)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
     /** Monotonic owner-checked failure transition. Failure never erases authorization history. */
     public TransitionResult fail(String ownerSessionId, String stableCode) {
         synchronized (TRANSITION_LOCK) {
@@ -419,13 +469,17 @@ public final class BesOtaStateStore {
                 return StartupDecision.QUARANTINED;
             }
             if (current.state == State.AUTH_ATTEMPTED) {
+                if (!boot.equals(current.authorizationBootId)) {
+                    // A hard reboot can expose an older, otherwise valid filesystem record. Keep
+                    // the target and owner active until raw OTA mode, a fresh framed version
+                    // reply, or the bounded recovery timeout resolves the hardware state.
+                    return StartupDecision.RECOVERY_PROBE_ONLY;
+                }
                 Snapshot failed = current.asTerminal(TerminalStatus.FAILURE, "interrupted");
                 if (!putLocked("fail_interrupted_on_startup", current, failed)) {
                     return StartupDecision.PERSISTENCE_FAILURE;
                 }
-                return boot.equals(current.authorizationBootId)
-                        ? StartupDecision.QUARANTINED
-                        : StartupDecision.RECOVERY_PROBE_ONLY;
+                return StartupDecision.QUARANTINED;
             }
             if (current.state == State.APPLY_PENDING) {
                 if (boot.equals(current.authorizationBootId)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1214,11 +1214,17 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + " snapshot={"
                         + snapshot.toDiagnosticString()
                         + "}");
-        if (snapshot.isValid() && snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
+        if (snapshot.isValid()
+                && (snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING
+                        || snapshot.getState() == BesOtaStateStore.State.AUTH_ATTEMPTED)) {
+            String timeoutCode =
+                    snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING
+                            ? "verification_timeout"
+                            : "recovery_timeout";
             BesOtaStateStore.TransitionResult result =
-                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), "verification_timeout");
-            Log.e(TAG, "BES post-apply recovery timed out: " + result);
-            EventBus.getDefault().post(BesOtaProgressEvent.createFailed("verification_timeout"));
+                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), timeoutCode);
+            Log.e(TAG, "BES OTA restart recovery timed out: " + result);
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed(timeoutCode));
         }
     }
 
@@ -1568,8 +1574,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         String skipReason = null;
         if (!snapshot.isValid()) {
             skipReason = "invalid_or_idle_state";
-        } else if (snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING) {
-            skipReason = "state_not_apply_pending";
+        } else if (snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
+                && snapshot.getState() != BesOtaStateStore.State.AUTH_ATTEMPTED) {
+            skipReason = "state_not_recoverable";
         } else if (currentBootId == null) {
             skipReason = "missing_current_boot";
         } else if (currentBootId.equals(snapshot.getAuthorizationBootId())) {
@@ -1590,25 +1597,32 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (skipReason != null) {
             return;
         }
-        BesOtaStateStore.VerificationDecision verification =
-                besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
-        Log.i(
-                TAG,
-                "BES_OTA_DIAG version_proof_claim result="
-                        + verification
-                        + " actual="
-                        + diagnosticActualVersion
-                        + " snapshot={"
-                        + besOtaStateStore.read().toDiagnosticString()
-                        + "}");
-        if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
-                && verification != BesOtaStateStore.VerificationDecision.RESUME) {
-            Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
-            return;
+        BesOtaStateStore.TransitionResult completed;
+        if (snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
+            BesOtaStateStore.VerificationDecision verification =
+                    besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
+            Log.i(
+                    TAG,
+                    "BES_OTA_DIAG version_proof_claim result="
+                            + verification
+                            + " actual="
+                            + diagnosticActualVersion
+                            + " snapshot={"
+                            + besOtaStateStore.read().toDiagnosticString()
+                            + "}");
+            if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
+                    && verification != BesOtaStateStore.VerificationDecision.RESUME) {
+                Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
+                return;
+            }
+            completed =
+                    besOtaStateStore.completeVerified(
+                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
+        } else {
+            completed =
+                    besOtaStateStore.completeRecoveredAfterRestart(
+                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
         }
-        BesOtaStateStore.TransitionResult completed =
-                besOtaStateStore.completeVerified(
-                        snapshot.getOwnerSessionId(), currentBootId, actualVersion);
         Log.i(
                 TAG,
                 "BES_OTA_DIAG version_proof_complete result="
@@ -1627,13 +1641,16 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "BES target version verified after reboot: " + actualVersion);
             EventBus.getDefault().post(BesOtaProgressEvent.createFinished());
         } else {
+            String failureCode = terminal.getTerminalCode();
             Log.e(
                     TAG,
-                    "BES version mismatch after reboot expected="
+                    "BES version proof failed after reboot code="
+                            + failureCode
+                            + " expected="
                             + terminal.getTargetVersion()
                             + " actual="
                             + actualVersion);
-            EventBus.getDefault().post(BesOtaProgressEvent.createFailed("version_mismatch"));
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed(failureCode));
         }
     }
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -209,8 +209,54 @@ public class BesOtaStateStoreTest {
         reserve();
 
         assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.RECOVERY_PROBE_ONLY);
+        assertThat(store.read().getState()).isEqualTo(State.AUTH_ATTEMPTED);
         assertThat(store.uartPolicy(BOOT_B, false, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+        assertThat(store.uartPolicy(BOOT_B, true, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+    }
+
+    @Test
+    public void exactVersionResolvesLaterBootAuthorizationAsSuccess() {
+        reserve();
+        assertThat(store.reconcileStartup(BOOT_B)).isEqualTo(StartupDecision.RECOVERY_PROBE_ONLY);
+
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getState()).isEqualTo(State.TERMINAL);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+        assertThat(store.read().getTerminalCode()).isEqualTo("verified");
+        assertThat(store.read().getVerificationBootId()).isEqualTo(BOOT_B);
         assertThat(store.uartPolicy(BOOT_B, true, null)).isEqualTo(UartPolicy.NORMAL);
+    }
+
+    @Test
+    public void differentVersionResolvesLaterBootAuthorizationAsFailure() {
+        reserve();
+
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_B, "26.7.30.3"))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("version_mismatch");
+    }
+
+    @Test
+    public void invalidVersionProofResolvesLaterBootAuthorizationAsFailure() {
+        reserve();
+
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_B, "unknown"))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("invalid_version_proof");
+    }
+
+    @Test
+    public void recoveredVersionProofRequiresOwnerAndLaterBoot() {
+        reserve();
+
+        assertThat(store.completeRecoveredAfterRestart(OTHER_OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.completeRecoveredAfterRestart(OWNER, BOOT_A, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.read().getState()).isEqualTo(State.AUTH_ATTEMPTED);
     }
 
     @Test

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -201,6 +201,11 @@ version name after the fact.
 - **Stuck in OTA mode** — a persisted nonterminal BES session deliberately owns/quarantines UART
   until raw-versus-framed recovery resolves. A raw `0x9a` proves BES is still in OTA mode; only the
   exact fresh `sr_syvr` requested by the audited framed probe can prove normal mode.
+- **Hard reboot after apply** — Android filesystem persistence can expose the earlier authorization
+  record even when apply was committed and acknowledged immediately before power loss. On a later
+  Linux boot, ASG keeps that record quarantined while bounded raw-first recovery runs: raw `0x9a`
+  fails the update, an exact target `sr_syvr` completes it, and a mismatch or timeout fails it. A
+  process restart in the original Linux boot remains an immediate failure.
 
 ## Logcat tags
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes durable BES OTA state transitions and UART quarantine at boot; incorrect logic could mis-report success/failure or block UART, but behavior is covered by new unit tests and matches an existing post-apply verification pattern.
> 
> **Overview**
> Fixes **false BES OTA failures** when a hard reboot leaves durable state at `AUTH_ATTEMPTED` on a **new Linux boot** (e.g. filesystem rolls back to an older persisted record after apply was committed in-process).
> 
> **`BesOtaStateStore`:** On startup, a later boot with `AUTH_ATTEMPTED` now returns **`RECOVERY_PROBE_ONLY`** instead of terminal `interrupted`. Adds **`completeRecoveredAfterRestart`** so a framed `sr_syvr` on that boot can end the session as success (`verified`), `version_mismatch`, or `invalid_version_proof`, with owner and boot checks.
> 
> **`K900BluetoothManager`:** Version reconciliation runs for **`AUTH_ATTEMPTED`** as well as `APPLY_PENDING`; recovery timeout applies to both (`recovery_timeout` vs `verification_timeout`). Phone failure events use the store’s **terminal code** instead of a fixed `version_mismatch`.
> 
> Tests and **`bes-ota.md`** document the hard-reboot recovery matrix (raw OTA mode vs exact target version vs timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec03eaa089f15cb2bba2238ec39ed9020060b57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->