### PR TITLE
Prepare Bluetooth SDK 0.1.21-dev.5 release

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.8.6.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.6.0.bin",
-    "sha256": "a803477db2ca244bd8d5d1afc4149c50c14e6c5bc8bd2463c00168bcaa783bac"
+    "version": "26.8.8.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.8.0.bin",
+    "sha256": "aaf2da4d6868c375564ddfdff71fd919b26f5d8da8f11b12898e4cc3d94527b9"
   }
 }

--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.4")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.5")
 }
 ```
 

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -453,7 +453,7 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.4` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.5` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 

--- a/mintlify-docs/mentra-live/examples.mdx
+++ b/mintlify-docs/mentra-live/examples.mdx
@@ -6,7 +6,7 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
-The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.4` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.5` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.4`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.5`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.4"
+  from: "0.1.21-beta.5"
 )
 ```
 

--- a/mintlify-docs/mentra-live/overview.mdx
+++ b/mintlify-docs/mentra-live/overview.mdx
@@ -27,7 +27,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
-- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.4`.
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.5`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
@@ -35,7 +35,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.4` must use the matching Mentra Live `0.1.21-beta.4` software release.
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.5` must use the matching Mentra Live `0.1.21-beta.5` software release.
 </Warning>
 
 <CardGroup cols={2}>

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -11,7 +11,7 @@ Use a physical phone for Bluetooth testing. Simulators and emulators are useful 
 </Warning>
 
 <Warning>
-This quickstart uses Bluetooth SDK `0.1.21-beta.4`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.4` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+This quickstart uses Bluetooth SDK `0.1.21-beta.5`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.5` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
 </Warning>
 
 ## Step 1: Install The SDK
@@ -20,7 +20,7 @@ This quickstart uses Bluetooth SDK `0.1.21-beta.4`. Before testing SDK features,
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.4
+bun add @mentra/bluetooth-sdk@0.1.21-beta.5
 bunx expo install expo-build-properties
 ```
 
@@ -95,7 +95,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.4")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.5")
 }
 ```
 
@@ -112,14 +112,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.21-beta.4`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.21-beta.5`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.4"
+  from: "0.1.21-beta.5"
 )
 ```
 

--- a/mintlify-docs/mentra-live/react-native-expo.mdx
+++ b/mintlify-docs/mentra-live/react-native-expo.mdx
@@ -11,13 +11,13 @@ Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the
 </Warning>
 
 <Warning>
-SDK `0.1.21-beta.4` requires the matching Mentra Live `0.1.21-beta.4` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+SDK `0.1.21-beta.5` requires the matching Mentra Live `0.1.21-beta.5` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
 </Warning>
 
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.4
+bun add @mentra/bluetooth-sdk@0.1.21-beta.5
 bunx expo install expo-build-properties
 ```
 

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -10,12 +10,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-beta.4` | Mentra Live software `0.1.21-beta.4` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.4` | Mentra Live software `0.1.21-beta.4` |
-| iOS `MentraBluetoothSDK` version `0.1.21-beta.4` | Mentra Live software `0.1.21-beta.4` |
+| React Native `@mentra/bluetooth-sdk@0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| iOS `MentraBluetoothSDK` version `0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.4`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.4` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.5`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.5` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -28,7 +28,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-beta.4`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.4/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `0.1.21-beta.5`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.5/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -60,7 +60,7 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 6. Wait until the app reports that the update is complete. The glasses may restart during installation.
 7. Reconnect and run **Check OTA** again to confirm that no update remains.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.4`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.5`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
@@ -68,7 +68,7 @@ Use this path when the software currently installed on Mentra Live cannot run th
 
 All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
 
-For the latest `0.1.21-beta.4` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.4-`.
+For the latest `0.1.21-beta.5` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.5-`.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -80,13 +80,13 @@ Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.4-build>.apk"
+  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.5-build>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-beta.4` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.4` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `0.1.21-beta.5` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.5` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App

--- a/mintlify-docs/mentra-live/troubleshooting.mdx
+++ b/mintlify-docs/mentra-live/troubleshooting.mdx
@@ -62,7 +62,7 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 
 Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
 
-If your app uses SDK `0.1.21-beta.4`, [install the matching Mentra Live `0.1.21-beta.4` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+If your app uses SDK `0.1.21-beta.5`, [install the matching Mentra Live `0.1.21-beta.5` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
 
 ## Optional Local Stream Preview Does Not Show Video
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -244,7 +244,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.4",
+      "version": "0.1.21-dev.5",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.21-dev.4",
+  "version": "0.1.21-dev.5",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -263,7 +263,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.4",
+      "version": "0.1.21-dev.5",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",


### PR DESCRIPTION
## Summary

- bump the Bluetooth SDK source package and Bun lockfiles to `0.1.21-dev.5`
- promote public Mentra Live documentation to the matching `0.1.21-beta.5` release
- update the live OTA manifest to verified BES firmware `26.8.8.0`
- prepare the release automation to publish the BES OTA hard-reboot recovery landed after `dev.4` in #3695

## Firmware verification

- URL: `https://firmwarecdn.mentraglass.com/bes_firmware_26.8.8.0.bin`
- Size: `1,137,871` bytes
- SHA-256: `aaf2da4d6868c375564ddfdff71fd919b26f5d8da8f11b12898e4cc3d94527b9`
- CDN tag: `main-26.8.8.0-91dc7076`
- CDN commit: `91dc7076eb0d10e12b7d1bff4f4017caf3cbeab7`

The downloaded binary size and SHA-256 matched the current CDN manifest.

## Validation

- `bun install --frozen-lockfile` in `mobile` and `sdk` (sequentially)
- `CI=1 bun run build` in `mobile/modules/bluetooth-sdk`
- iOS SDK version prepack injection and postpack restoration
- `npm pack --dry-run --ignore-scripts --json`
- Bluetooth SDK release detector for the `dev` pull-request path
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `./gradlew :app:testDebugUnitTest --tests 'com.mentra.asg_client.io.bes.BesOtaStateStoreTest'`
- `jq empty docs.json`
- `bunx --bun mint export` (56 pages)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the live BES OTA entry affects glasses firmware updates in the field; incorrect URL or hash would break or mis-deliver updates, though the PR describes verified CDN metadata. No application runtime code changes beyond versioning and documentation.
> 
> **Overview**
> Prepares **Bluetooth SDK `0.1.21-dev.5`** for release by bumping `@mentra/bluetooth-sdk` in `mobile/modules/bluetooth-sdk/package.json` and refreshing **`mobile`** and **`sdk`** Bun lockfiles.
> 
> Updates the live OTA manifest **`firmware_live.json`** so **`bes_firmware`** points at **BES `26.8.8.0`** (new CDN URL and SHA-256) instead of `26.8.6.0`; MTK patch entries are unchanged.
> 
> Aligns **Mentra Live** Mintlify docs across Android, iOS, React Native, quickstart, overview, examples, API reference, software-update, and troubleshooting so the documented matching release is **`0.1.21-beta.5`** (install snippets, version warnings, starter-kit APK links, and ADB bootstrap examples).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a08a252cda2707f95f67eff63d352c48337854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->