### PR TITLE
Keep the App WebSocket open for non-fatal errors

### DIFF
--- a/cloud/packages/cloud/src/services/session/handlers/app-message-handler.test.ts
+++ b/cloud/packages/cloud/src/services/session/handlers/app-message-handler.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Logger } from "pino";
 
-import { AppErrorCode, sendError } from "./app-message-handler";
+import { AppErrorCode, sendError, streamErrorCode } from "./app-message-handler";
 import type { IWebSocket } from "../../websocket/types";
 
 function makeSocket() {
@@ -55,4 +55,25 @@ describe("sendError", () => {
 
     expect(closed).toEqual([{ code: 1011, reason: "Internal server error" }]);
   });
+});
+
+describe("streamErrorCode", () => {
+  // Managed and unmanaged streams both tag WiFi failures this way. Reporting
+  // them as INTERNAL_ERROR would close the socket, which is the bug above.
+  test("classifies a tagged WiFi failure as non-fatal", () => {
+    const e = Object.assign(new Error("must be connected to WiFi"), { code: "WIFI_NOT_CONNECTED" });
+
+    expect(streamErrorCode(e)).toBe(AppErrorCode.WIFI_NOT_CONNECTED);
+  });
+
+  test("classifies the legacy no_wifi_connection message as non-fatal", () => {
+    expect(streamErrorCode(new Error("no_wifi_connection"))).toBe(AppErrorCode.WIFI_NOT_CONNECTED);
+  });
+
+  test.each([new Error("rtmp handshake failed"), Object.assign(new Error("nope"), { code: "SOMETHING_ELSE" }), null])(
+    "classifies everything else as INTERNAL_ERROR (%s)",
+    (e) => {
+      expect(streamErrorCode(e)).toBe(AppErrorCode.INTERNAL_ERROR);
+    },
+  );
 });

--- a/cloud/packages/cloud/src/services/session/handlers/app-message-handler.test.ts
+++ b/cloud/packages/cloud/src/services/session/handlers/app-message-handler.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+
+import { AppErrorCode, sendError } from "./app-message-handler";
+import type { IWebSocket } from "../../websocket/types";
+
+function makeSocket() {
+  const sent: string[] = [];
+  const closed: { code?: number; reason?: string }[] = [];
+
+  const ws: IWebSocket = {
+    readyState: 1,
+    send: (data) => sent.push(String(data)),
+    close: (code, reason) => closed.push({ code, reason }),
+  };
+
+  return { ws, sent, closed };
+}
+
+const logger = { debug: () => {}, error: () => {} } as unknown as Logger;
+
+const fatalCodes = Object.values(AppErrorCode).filter((code) => code !== AppErrorCode.WIFI_NOT_CONNECTED);
+
+describe("sendError", () => {
+  // A missing WiFi connection blocks one stream request, not the session.
+  test("leaves the socket open for a non-fatal code", () => {
+    const { ws, sent, closed } = makeSocket();
+
+    sendError(ws, AppErrorCode.WIFI_NOT_CONNECTED, "Glasses must be on WiFi to stream", logger);
+
+    expect(JSON.parse(sent[0]).code).toBe(AppErrorCode.WIFI_NOT_CONNECTED);
+    expect(closed).toEqual([]);
+  });
+
+  test.each(fatalCodes)("closes the socket for %s", (code) => {
+    const { ws, sent, closed } = makeSocket();
+
+    sendError(ws, code, "something went wrong", logger);
+
+    expect(JSON.parse(sent[0]).code).toBe(code);
+    expect(closed).toEqual([{ code: 1008, reason: "something went wrong" }]);
+  });
+
+  test("closes with 1011 when the payload cannot be sent", () => {
+    const closed: { code?: number; reason?: string }[] = [];
+    const ws: IWebSocket = {
+      readyState: 1,
+      send: () => {
+        throw new Error("socket already gone");
+      },
+      close: (code, reason) => closed.push({ code, reason }),
+    };
+
+    sendError(ws, AppErrorCode.WIFI_NOT_CONNECTED, "Glasses must be on WiFi to stream", logger);
+
+    expect(closed).toEqual([{ code: 1011, reason: "Internal server error" }]);
+  });
+});

--- a/cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts
+++ b/cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts
@@ -68,6 +68,21 @@ export enum AppErrorCode {
 // Errors about one request rather than the connection. Reported to the App without closing the socket.
 const NON_FATAL_ERROR_CODES: ReadonlySet<AppErrorCode> = new Set([AppErrorCode.WIFI_NOT_CONNECTED]);
 
+/**
+ * Map a thrown streaming error to the code sent to the App.
+ *
+ * The streaming extensions tag WiFi failures from ConnectionValidator with
+ * `.code = WIFI_NOT_CONNECTED`. Reporting those as INTERNAL_ERROR would close
+ * the socket, so every stream handler must classify through here.
+ */
+export function streamErrorCode(e: unknown): AppErrorCode {
+  const message = (e as Error)?.message;
+  const code = (e as { code?: string })?.code;
+  return code === AppErrorCode.WIFI_NOT_CONNECTED || message === "no_wifi_connection"
+    ? AppErrorCode.WIFI_NOT_CONNECTED
+    : AppErrorCode.INTERNAL_ERROR;
+}
+
 // Debouncing for subscription changes to prevent rapid stream recreation
 const subscriptionChangeTimers = new Map<string, NodeJS.Timeout>();
 const SUBSCRIPTION_DEBOUNCE_MS = 500;
@@ -453,16 +468,7 @@ async function handleStreamRequest(
   } catch (e) {
     logger.error({ e, packageName: message.packageName }, "Error starting stream");
 
-    const errorMessage = (e as Error).message || "Failed to start stream.";
-    const errorCode = (e as any).code;
-    const isWifiError = errorCode === "WIFI_NOT_CONNECTED" || errorMessage === "no_wifi_connection";
-
-    sendError(
-      appWebsocket,
-      isWifiError ? AppErrorCode.WIFI_NOT_CONNECTED : AppErrorCode.INTERNAL_ERROR,
-      errorMessage,
-      logger,
-    );
+    sendError(appWebsocket, streamErrorCode(e), (e as Error).message || "Failed to start stream.", logger);
   }
 }
 
@@ -637,12 +643,7 @@ async function handleManagedStreamRequest(
     logger.info({ streamId, packageName: message.packageName }, "Managed stream request processed");
   } catch (e) {
     logger.error({ e, packageName: message.packageName }, "Error starting managed stream");
-    sendError(
-      appWebsocket,
-      AppErrorCode.INTERNAL_ERROR,
-      (e as Error).message || "Failed to start managed stream",
-      logger,
-    );
+    sendError(appWebsocket, streamErrorCode(e), (e as Error).message || "Failed to start managed stream", logger);
   }
 }
 
@@ -660,12 +661,7 @@ async function handleManagedStreamStop(
     logger.info({ packageName: message.packageName }, "Managed stream stop processed");
   } catch (e) {
     logger.error({ e, packageName: message.packageName }, "Error stopping managed stream");
-    sendError(
-      appWebsocket,
-      AppErrorCode.INTERNAL_ERROR,
-      (e as Error).message || "Failed to stop managed stream",
-      logger,
-    );
+    sendError(appWebsocket, streamErrorCode(e), (e as Error).message || "Failed to stop managed stream", logger);
   }
 }
 

--- a/cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts
+++ b/cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts
@@ -65,6 +65,9 @@ export enum AppErrorCode {
   WIFI_NOT_CONNECTED = "WIFI_NOT_CONNECTED",
 }
 
+// Errors about one request rather than the connection. Reported to the App without closing the socket.
+const NON_FATAL_ERROR_CODES: ReadonlySet<AppErrorCode> = new Set([AppErrorCode.WIFI_NOT_CONNECTED]);
+
 // Debouncing for subscription changes to prevent rapid stream recreation
 const subscriptionChangeTimers = new Map<string, NodeJS.Timeout>();
 const SUBSCRIPTION_DEBOUNCE_MS = 500;
@@ -805,7 +808,7 @@ async function checkCameraPermission(packageName: string, userSession: UserSessi
 /**
  * Send an error response to the App client
  */
-function sendError(ws: IWebSocket, code: AppErrorCode, message: string, logger: Logger): void {
+export function sendError(ws: IWebSocket, code: AppErrorCode, message: string, logger: Logger): void {
   try {
     const errorResponse = {
       type: CloudToAppMessageType.CONNECTION_ERROR,
@@ -814,6 +817,12 @@ function sendError(ws: IWebSocket, code: AppErrorCode, message: string, logger: 
       timestamp: new Date(),
     };
     ws.send(JSON.stringify(errorResponse));
+
+    if (NON_FATAL_ERROR_CODES.has(code)) {
+      return;
+    }
+
+    // The SDK reads 1008 as a deliberate close and will not reconnect from it.
     ws.close(1008, message);
   } catch (error) {
     logger.error(error, "Failed to send error response");


### PR DESCRIPTION
Fixes #2464

## Problem

When an App requests a stream while the glasses are off WiFi, the cloud replies with `WIFI_NOT_CONNECTED`. That is meant as a warning about **one request** — but `sendError()` closed the connection with code 1008 on **every** error, non-fatal ones included.

The SDK treats 1008 as a deliberate close and does not reconnect, so a warning about a single stream request permanently ended the App's whole session. `handleStreamRequest` already treated WiFi as the non-fatal case; `sendError` was the one place that didn't.

## Fix

Add `NON_FATAL_ERROR_CODES` and skip the close for codes in it. `WIFI_NOT_CONNECTED` is the only member; every other code — auth failures, malformed messages, internal errors — closes exactly as before.

The send-failure path is untouched: if the error payload itself can't be sent, the socket still closes with 1011 regardless of the code.

## Scope

Cloud only, two files:

- `cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts` — the fix (+ `sendError` exported so it can be tested)
- `cloud/packages/cloud/src/services/session/handlers/app-message-handler.test.ts` — new

## Test evidence

`bun test src/services/session/handlers/app-message-handler.test.ts` from `cloud/packages/cloud`:

```
 10 pass
 0 fail
 19 expect() calls
```

Covering:

- `WIFI_NOT_CONNECTED` reports the error and leaves the socket open (the regression guard)
- every other `AppErrorCode` still closes with 1008 — the list is derived from the enum, so a newly added code is covered automatically
- a failed send still closes with 1011

No UI changes, so no screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes App session WebSocket lifecycle on errors, but behavior is narrowly limited to WIFI_NOT_CONNECTED with regression tests; other error paths unchanged.
> 
> **Overview**
> Fixes a regression where **`sendError`** always closed the App WebSocket with **1008**, so a **`WIFI_NOT_CONNECTED`** response to a single stream attempt tore down the whole session (the SDK does not reconnect after 1008).
> 
> **`NON_FATAL_ERROR_CODES`** now gates the close: **`WIFI_NOT_CONNECTED`** still sends a **`CONNECTION_ERROR`** payload but leaves the socket open; all other **`AppErrorCode`** values still close with **1008**. If sending the error fails, the socket still closes with **1011**.
> 
> Stream start/stop handlers use a shared **`streamErrorCode`** helper so tagged WiFi failures (and the legacy **`no_wifi_connection`** message) map to **`WIFI_NOT_CONNECTED`** instead of **`INTERNAL_ERROR`**—including managed streams, which previously always reported internal errors on failure.
> 
> **`sendError`** is exported and covered by new unit tests for non-fatal vs fatal codes and the send-failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5916db493014033446925d7c5df926de8a5841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the App WebSocket open on non-fatal errors so a WiFi warning doesn’t end the session. Classification now runs through `streamErrorCode` across unmanaged and managed stream handlers; only fatal errors close with 1008.

- **Bug Fixes**
  - Added `NON_FATAL_ERROR_CODES`; `WIFI_NOT_CONNECTED` is non-fatal and keeps the socket open.
  - Introduced `streamErrorCode` and used it in `handleStreamRequest`, `handleManagedStreamRequest`, and `handleManagedStreamStop` so WiFi failures don’t close the socket.
  - Other errors still close with 1008; failed sends close with 1011. Exported `sendError` and added tests for both paths.

<sup>Written for commit df5916db493014033446925d7c5df926de8a5841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

