### PR TITLE
Sync staging Mentra Live docs to frozen docs

### DIFF
--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.3")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.5")
 }
 ```
 

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -453,7 +453,7 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.3` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.5` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 

--- a/docs/mentra-live/examples.mdx
+++ b/docs/mentra-live/examples.mdx
@@ -6,7 +6,7 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
-The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.3` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.5` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.3`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.5`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.3"
+  from: "0.1.21-beta.5"
 )
 ```
 

--- a/docs/mentra-live/overview.mdx
+++ b/docs/mentra-live/overview.mdx
@@ -27,7 +27,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
-- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.3`.
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.5`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
@@ -35,7 +35,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.3` must use the matching Mentra Live `0.1.21-beta.3` software release.
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.5` must use the matching Mentra Live `0.1.21-beta.5` software release.
 </Warning>
 
 <CardGroup cols={2}>

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -11,7 +11,7 @@ Use a physical phone for Bluetooth testing. Simulators and emulators are useful 
 </Warning>
 
 <Warning>
-This quickstart uses Bluetooth SDK `0.1.21-beta.3`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.3` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+This quickstart uses Bluetooth SDK `0.1.21-beta.5`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.5` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
 </Warning>
 
 ## Step 1: Install The SDK
@@ -20,7 +20,7 @@ This quickstart uses Bluetooth SDK `0.1.21-beta.3`. Before testing SDK features,
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.3
+bun add @mentra/bluetooth-sdk@0.1.21-beta.5
 bunx expo install expo-build-properties
 ```
 
@@ -95,7 +95,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.3")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.5")
 }
 ```
 
@@ -112,14 +112,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.21-beta.3`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.21-beta.5`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.3"
+  from: "0.1.21-beta.5"
 )
 ```
 

--- a/docs/mentra-live/react-native-expo.mdx
+++ b/docs/mentra-live/react-native-expo.mdx
@@ -11,13 +11,13 @@ Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the
 </Warning>
 
 <Warning>
-SDK `0.1.21-beta.3` requires the matching Mentra Live `0.1.21-beta.3` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+SDK `0.1.21-beta.5` requires the matching Mentra Live `0.1.21-beta.5` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
 </Warning>
 
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.3
+bun add @mentra/bluetooth-sdk@0.1.21-beta.5
 bunx expo install expo-build-properties
 ```
 

--- a/docs/mentra-live/software-update.mdx
+++ b/docs/mentra-live/software-update.mdx
@@ -10,12 +10,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-beta.3` | Mentra Live software `0.1.21-beta.3` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.3` | Mentra Live software `0.1.21-beta.3` |
-| iOS `MentraBluetoothSDK` version `0.1.21-beta.3` | Mentra Live software `0.1.21-beta.3` |
+| React Native `@mentra/bluetooth-sdk@0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| iOS `MentraBluetoothSDK` version `0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.3`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.3` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.5`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.5` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -28,7 +28,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-beta.3`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.3/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `0.1.21-beta.5`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.5/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -60,7 +60,7 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 6. Wait until the app reports that the update is complete. The glasses may restart during installation.
 7. Reconnect and run **Check OTA** again to confirm that no update remains.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.3`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.5`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
@@ -68,7 +68,7 @@ Use this path when the software currently installed on Mentra Live cannot run th
 
 All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
 
-For the latest `0.1.21-beta.3` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.3-`.
+For the latest `0.1.21-beta.5` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.5-`.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -80,13 +80,13 @@ Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.3-build>.apk"
+  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.5-build>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-beta.3` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.3` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `0.1.21-beta.5` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.5` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -62,7 +62,7 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 
 Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
 
-If your app uses SDK `0.1.21-beta.3`, [install the matching Mentra Live `0.1.21-beta.3` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+If your app uses SDK `0.1.21-beta.5`, [install the matching Mentra Live `0.1.21-beta.5` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
 
 ## Optional Local Stream Preview Does Not Show Video
 


### PR DESCRIPTION
## Summary

- replace `docs/mentra-live/` with the current `origin/staging:mintlify-docs/mentra-live/` content
- promote the published Mentra Live documentation from `0.1.21-beta.3` to `0.1.21-beta.5`
- keep the PR limited to the Mentra Live documentation subtree

## Why

The frozen documentation branch should publish the same Mentra Live guidance that is now on `staging`.

## Impact

The frozen docs will show the current beta.5 SDK coordinates, compatibility guidance, example links, and software-update instructions.

## Source

- staging commit: `8582d633bd9cf45938c5a3f8f652d262e002ff62`
- frozen-docs base: `25124e7c9b07081e80d753dfb6f4da16fcd363a7`

## Validation

- confirmed all 14 files in `docs/mentra-live/` match the corresponding blobs from `origin/staging:mintlify-docs/mentra-live/`
- confirmed the diff changes only nine files under `docs/mentra-live/`
- `jq empty docs/docs.json`
- `git diff --check origin/frozen-docs...HEAD`
- `npx -y mint@latest export` under Node 20.20.1: exported 75 pages successfully
- Mintlify reported two pre-existing parse warnings outside the changed subtree

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only version string and link updates under `docs/mentra-live/`; no application or SDK code changes.
> 
> **Overview**
> Updates frozen **Mentra Live** documentation so every published SDK and glasses-software reference points at **`0.1.21-beta.5`** instead of **`0.1.21-beta.3`**.
> 
> The changes span install snippets (Android Maven, iOS SwiftPM, React Native `bun add`), compatibility warnings, OTA/API notes, troubleshooting, and **software-update** assets—including the Starter Kit example APK and ADB `asg-client-sdk-0.1.21-beta.5` filenames. No API or behavioral doc rewrites beyond the version alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb30c726f89b2893f8c14ff8a573adeaf750f9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->