### PR TITLE
Serialize OTA starts and recover late BES proof

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -200,6 +200,13 @@ public class AsgConstants {
     /** Delay before probing the alternate UART baud after ASG starts at the rendezvous rate. */
     public static final long UART_BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
 
+    /**
+     * Grace after bounded UART recovery is exhausted before a BES OTA timeout becomes terminal.
+     * BES can finish rebooting after the transport scan, and an exact target-version reply from
+     * that later Linux boot is authoritative.
+     */
+    public static final long BES_OTA_RECOVERY_FAILURE_GRACE_MS = 30000;
+
     /** Number of spaced system-version probes used to tolerate short BES UART restart windows. */
     public static final int UART_RECOVERY_PROBES_PER_BURST = 5;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -335,7 +335,7 @@ public final class BesOtaStateStore {
                     return TransitionResult.PERSISTENCE_FAILURE;
                 }
                 return verification == VerificationDecision.SECOND_BOOT_FAILED
-                        ? TransitionResult.ALREADY_TERMINAL
+                        ? TransitionResult.APPLIED
                         : TransitionResult.REJECTED;
             }
             if (current.state == State.AUTH_ATTEMPTED) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -5,12 +5,15 @@ import android.content.SharedPreferences;
 import android.os.Process;
 import android.os.SystemClock;
 import android.util.Log;
+
 import com.mentra.asg_client.io.ota.utils.BesFirmwareArtifactValidator.ValidatedBesArtifact;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.util.Locale;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Single durable authority for legacy BES OTA admission, apply, verification, and terminal state.
@@ -297,6 +300,51 @@ public final class BesOtaStateStore {
         }
     }
 
+    /**
+     * Atomically select and commit the version-proof transition for a later Linux boot.
+     *
+     * <p>The recovery timeout finalizer runs on another thread. Keeping state selection,
+     * verification-boot claiming, and completion under the transition lock guarantees that an exact
+     * proof is applied either to the active record or to the narrowly eligible timeout terminal; it
+     * cannot be lost between a stale manager snapshot and the selected transition.
+     */
+    public TransitionResult completeVersionProofAfterRestart(
+            String ownerSessionId, String currentBootId, String actualVersion) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            String owner = canonicalNonempty(ownerSessionId);
+            logDecision(
+                    "reconcile_restart_version_proof",
+                    "requested_owner="
+                            + diagnosticValue(owner)
+                            + " requested_boot="
+                            + diagnosticValue(canonicalBootId(currentBootId))
+                            + " actual="
+                            + diagnosticValue(canonicalVersion(actualVersion)),
+                    current);
+            if (!current.isValid() || !current.ownerSessionId.equals(owner)) {
+                return TransitionResult.REJECTED;
+            }
+            if (current.state == State.APPLY_PENDING) {
+                VerificationDecision verification = claimOrResumeVerificationBoot(currentBootId);
+                if (verification == VerificationDecision.CLAIMED
+                        || verification == VerificationDecision.RESUME) {
+                    return completeVerified(owner, currentBootId, actualVersion);
+                }
+                if (verification == VerificationDecision.PERSISTENCE_FAILURE) {
+                    return TransitionResult.PERSISTENCE_FAILURE;
+                }
+                return verification == VerificationDecision.SECOND_BOOT_FAILED
+                        ? TransitionResult.ALREADY_TERMINAL
+                        : TransitionResult.REJECTED;
+            }
+            if (current.state == State.AUTH_ATTEMPTED) {
+                return completeRecoveredAfterRestart(owner, currentBootId, actualVersion);
+            }
+            return completeLateExactTargetAfterRecoveryTimeout(owner, currentBootId, actualVersion);
+        }
+    }
+
     /** Exact post-apply readback is the only success transition. */
     public TransitionResult completeVerified(
             String ownerSessionId, String currentBootId, String actualVersion) {
@@ -435,8 +483,7 @@ public final class BesOtaStateStore {
             Snapshot verified =
                     current.withVerificationBoot(boot)
                             .asTerminal(TerminalStatus.SUCCESS, "verified");
-            return putLocked(
-                            "complete_late_timeout_version_proof", current, verified)
+            return putLocked("complete_late_timeout_version_proof", current, verified)
                     ? TransitionResult.APPLIED
                     : TransitionResult.PERSISTENCE_FAILURE;
         }
@@ -624,7 +671,8 @@ public final class BesOtaStateStore {
             Log.w(
                     TAG,
                     diagnosticPrefix(operation)
-                            + " durable state readback differs immediately after successful commit");
+                            + " durable state readback differs immediately after successful"
+                            + " commit");
         }
         return committed;
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaStateStore.java
@@ -392,6 +392,56 @@ public final class BesOtaStateStore {
         }
     }
 
+    /**
+     * Replace only a transport-recovery timeout with exact target-version proof from a later boot.
+     *
+     * <p>Recovery timing is not proof that the installation failed. A fresh framed version reply
+     * from a different Linux boot is stronger evidence, but it must never erase authorization,
+     * protocol, artifact, or version failures.
+     */
+    public TransitionResult completeLateExactTargetAfterRecoveryTimeout(
+            String ownerSessionId, String currentBootId, String actualVersion) {
+        synchronized (TRANSITION_LOCK) {
+            Snapshot current = readLocked();
+            String owner = canonicalNonempty(ownerSessionId);
+            String boot = canonicalBootId(currentBootId);
+            String actual = canonicalVersion(actualVersion);
+            boolean eligibleTimeout =
+                    current.isValid()
+                            && current.state == State.TERMINAL
+                            && current.terminalStatus == TerminalStatus.FAILURE
+                            && ("recovery_timeout".equals(current.terminalCode)
+                                    || "verification_timeout".equals(current.terminalCode));
+            if (!eligibleTimeout
+                    || !current.ownerSessionId.equals(owner)
+                    || boot == null
+                    || boot.equals(current.authorizationBootId)
+                    || !current.targetVersion.equals(actual)) {
+                logDecision(
+                        "late_timeout_version_proof_rejected",
+                        "requested_owner="
+                                + diagnosticValue(owner)
+                                + " requested_boot="
+                                + diagnosticValue(boot)
+                                + " actual="
+                                + diagnosticValue(actual),
+                        current);
+                return current.isValid()
+                                && current.state == State.TERMINAL
+                                && current.ownerSessionId.equals(owner)
+                        ? TransitionResult.ALREADY_TERMINAL
+                        : TransitionResult.REJECTED;
+            }
+            Snapshot verified =
+                    current.withVerificationBoot(boot)
+                            .asTerminal(TerminalStatus.SUCCESS, "verified");
+            return putLocked(
+                            "complete_late_timeout_version_proof", current, verified)
+                    ? TransitionResult.APPLIED
+                    : TransitionResult.PERSISTENCE_FAILURE;
+        }
+    }
+
     /** Monotonic owner-checked failure transition. Failure never erases authorization history. */
     public TransitionResult fail(String ownerSessionId, String stableCode) {
         synchronized (TRANSITION_LOCK) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.bluetooth.managers;
 
 import android.content.Context;
 import android.util.Log;
+
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.BesOtaStateStore;
 import com.mentra.asg_client.io.bes.BesOtaUartListener;
@@ -27,6 +28,10 @@ import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrat
 import com.mentra.asg_client.service.utils.SysProp;
 import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.utils.WakeLockManager;
+
+import org.greenrobot.eventbus.EventBus;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -40,8 +45,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import org.greenrobot.eventbus.EventBus;
-import org.json.JSONObject;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -1666,36 +1669,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (skipReason != null) {
             return;
         }
-        BesOtaStateStore.TransitionResult completed;
-        if (snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING) {
-            BesOtaStateStore.VerificationDecision verification =
-                    besOtaStateStore.claimOrResumeVerificationBoot(currentBootId);
-            Log.i(
-                    TAG,
-                    "BES_OTA_DIAG version_proof_claim result="
-                            + verification
-                            + " actual="
-                            + diagnosticActualVersion
-                            + " snapshot={"
-                            + besOtaStateStore.read().toDiagnosticString()
-                            + "}");
-            if (verification != BesOtaStateStore.VerificationDecision.CLAIMED
-                    && verification != BesOtaStateStore.VerificationDecision.RESUME) {
-                Log.e(TAG, "BES post-apply verification boot rejected: " + verification);
-                return;
-            }
-            completed =
-                    besOtaStateStore.completeVerified(
-                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
-        } else if (snapshot.getState() == BesOtaStateStore.State.AUTH_ATTEMPTED) {
-            completed =
-                    besOtaStateStore.completeRecoveredAfterRestart(
-                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
-        } else {
-            completed =
-                    besOtaStateStore.completeLateExactTargetAfterRecoveryTimeout(
-                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
-        }
+        BesOtaStateStore.TransitionResult completed =
+                besOtaStateStore.completeVersionProofAfterRestart(
+                        snapshot.getOwnerSessionId(), currentBootId, actualVersion);
         Log.i(
                 TAG,
                 "BES_OTA_DIAG version_proof_complete result="

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -1220,13 +1221,53 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (snapshot.isValid()
                 && (snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING
                         || snapshot.getState() == BesOtaStateStore.State.AUTH_ATTEMPTED)) {
-            String timeoutCode =
-                    snapshot.getState() == BesOtaStateStore.State.APPLY_PENDING
-                            ? "verification_timeout"
-                            : "recovery_timeout";
-            BesOtaStateStore.TransitionResult result =
-                    besOtaStateStore.fail(snapshot.getOwnerSessionId(), timeoutCode);
-            Log.e(TAG, "BES OTA restart recovery timed out: " + result);
+            String ownerSessionId = snapshot.getOwnerSessionId();
+            BesOtaStateStore.State expectedState = snapshot.getState();
+            Log.w(
+                    TAG,
+                    "BES OTA recovery scan exhausted; waiting "
+                            + AsgConstants.BES_OTA_RECOVERY_FAILURE_GRACE_MS
+                            + "ms for exact version proof");
+            try {
+                fileTransferExecutor.schedule(
+                        () -> finalizeBesRecoveryTimeout(ownerSessionId, expectedState),
+                        AsgConstants.BES_OTA_RECOVERY_FAILURE_GRACE_MS,
+                        TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException e) {
+                Log.w(TAG, "BES recovery grace not scheduled while manager is shutting down", e);
+            }
+        }
+    }
+
+    private void finalizeBesRecoveryTimeout(
+            String ownerSessionId, BesOtaStateStore.State expectedState) {
+        BesOtaStateStore.Snapshot current = besOtaStateStore.read();
+        if (!current.isValid()
+                || current.getState() != expectedState
+                || !ownerSessionId.equals(current.getOwnerSessionId())) {
+            Log.i(
+                    TAG,
+                    "BES_OTA_DIAG recovery_timeout_deferred disposition=cancelled snapshot={"
+                            + current.toDiagnosticString()
+                            + "}");
+            return;
+        }
+        String timeoutCode =
+                expectedState == BesOtaStateStore.State.APPLY_PENDING
+                        ? "verification_timeout"
+                        : "recovery_timeout";
+        BesOtaStateStore.TransitionResult result =
+                besOtaStateStore.fail(ownerSessionId, timeoutCode);
+        Log.e(
+                TAG,
+                "BES_OTA_DIAG recovery_timeout_deferred disposition="
+                        + result
+                        + " code="
+                        + timeoutCode
+                        + " snapshot={"
+                        + besOtaStateStore.read().toDiagnosticString()
+                        + "}");
+        if (result == BesOtaStateStore.TransitionResult.APPLIED) {
             EventBus.getDefault().post(BesOtaProgressEvent.createFailed(timeoutCode));
         }
     }
@@ -1602,7 +1643,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (!snapshot.isValid()) {
             skipReason = "invalid_or_idle_state";
         } else if (snapshot.getState() != BesOtaStateStore.State.APPLY_PENDING
-                && snapshot.getState() != BesOtaStateStore.State.AUTH_ATTEMPTED) {
+                && snapshot.getState() != BesOtaStateStore.State.AUTH_ATTEMPTED
+                && !isRecoverableBesOtaTimeout(snapshot)) {
             skipReason = "state_not_recoverable";
         } else if (currentBootId == null) {
             skipReason = "missing_current_boot";
@@ -1645,9 +1687,13 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             completed =
                     besOtaStateStore.completeVerified(
                             snapshot.getOwnerSessionId(), currentBootId, actualVersion);
-        } else {
+        } else if (snapshot.getState() == BesOtaStateStore.State.AUTH_ATTEMPTED) {
             completed =
                     besOtaStateStore.completeRecoveredAfterRestart(
+                            snapshot.getOwnerSessionId(), currentBootId, actualVersion);
+        } else {
+            completed =
+                    besOtaStateStore.completeLateExactTargetAfterRecoveryTimeout(
                             snapshot.getOwnerSessionId(), currentBootId, actualVersion);
         }
         Log.i(
@@ -1679,6 +1725,16 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             + actualVersion);
             EventBus.getDefault().post(BesOtaProgressEvent.createFailed(failureCode));
         }
+    }
+
+    private static boolean isRecoverableBesOtaTimeout(BesOtaStateStore.Snapshot snapshot) {
+        if (snapshot.getState() != BesOtaStateStore.State.TERMINAL
+                || snapshot.getTerminalStatus() != BesOtaStateStore.TerminalStatus.FAILURE) {
+            return false;
+        }
+        String terminalCode = snapshot.getTerminalCode();
+        return "recovery_timeout".equals(terminalCode)
+                || "verification_timeout".equals(terminalCode);
     }
 
     private void cacheBesBaudSwitchVersion(JSONObject bData) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -192,6 +192,18 @@ public class BesOtaStateStoreTest {
     }
 
     @Test
+    public void restartVersionProofPublishesNewSecondBootFailure() {
+        reserveAndMarkApply();
+        assertThat(store.claimOrResumeVerificationBoot(BOOT_B))
+                .isEqualTo(VerificationDecision.CLAIMED);
+
+        assertThat(store.completeVersionProofAfterRestart(OWNER, BOOT_C, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("verification_boot_changed");
+    }
+
+    @Test
     public void restartVersionProofAtomicallyCompletesRecoveredAuthorization() {
         reserve();
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -153,6 +153,58 @@ public class BesOtaStateStoreTest {
     }
 
     @Test
+    public void recoveryTimeoutCanBeSupersededByExactTargetOnLaterBoot() {
+        reserve();
+        assertThat(store.fail(OWNER, "recovery_timeout")).isEqualTo(TransitionResult.APPLIED);
+
+        assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+        assertThat(store.read().getTerminalCode()).isEqualTo("verified");
+        assertThat(store.read().getVerificationBootId()).isEqualTo(BOOT_B);
+    }
+
+    @Test
+    public void verificationTimeoutCanBeSupersededByExactTargetOnLaterBoot() {
+        reserveAndMarkApply();
+        assertThat(store.fail(OWNER, "verification_timeout")).isEqualTo(TransitionResult.APPLIED);
+
+        assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+    }
+
+    @Test
+    public void lateTimeoutProofRequiresOwnerLaterBootAndExactTarget() {
+        reserve();
+        store.fail(OWNER, "recovery_timeout");
+
+        assertThat(
+                        store.completeLateExactTargetAfterRecoveryTimeout(
+                                OTHER_OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.REJECTED);
+        assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OWNER, BOOT_A, TARGET))
+                .isEqualTo(TransitionResult.ALREADY_TERMINAL);
+        assertThat(
+                        store.completeLateExactTargetAfterRecoveryTimeout(
+                                OWNER, BOOT_B, "26.7.30.3"))
+                .isEqualTo(TransitionResult.ALREADY_TERMINAL);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("recovery_timeout");
+    }
+
+    @Test
+    public void nonTimeoutFailureCannotBeSupersededByVersionProof() {
+        reserve();
+        store.fail(OWNER, "response_timeout");
+
+        assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.ALREADY_TERMINAL);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("response_timeout");
+    }
+
+    @Test
     public void failedTerminalCannotRetireInAuthorizationBoot() {
         reserve();
         store.fail(OWNER, "install_failed");

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaStateStoreTest.java
@@ -10,6 +10,7 @@ import com.mentra.asg_client.io.bes.BesOtaStateStore.TerminalStatus;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.TransitionResult;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.UartPolicy;
 import com.mentra.asg_client.io.bes.BesOtaStateStore.VerificationDecision;
+
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +18,12 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
@@ -175,19 +182,90 @@ public class BesOtaStateStoreTest {
     }
 
     @Test
+    public void restartVersionProofAtomicallyCompletesApplyPending() {
+        reserveAndMarkApply();
+
+        assertThat(store.completeVersionProofAfterRestart(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+        assertThat(store.read().getVerificationBootId()).isEqualTo(BOOT_B);
+    }
+
+    @Test
+    public void restartVersionProofAtomicallyCompletesRecoveredAuthorization() {
+        reserve();
+
+        assertThat(store.completeVersionProofAfterRestart(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+        assertThat(store.read().getVerificationBootId()).isEqualTo(BOOT_B);
+    }
+
+    @Test
+    public void restartVersionProofAtomicallySupersedesOnlyEligibleTimeout() {
+        reserve();
+        assertThat(store.fail(OWNER, "recovery_timeout")).isEqualTo(TransitionResult.APPLIED);
+
+        assertThat(store.completeVersionProofAfterRestart(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.APPLIED);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+    }
+
+    @Test
+    public void restartVersionProofKeepsNonTimeoutFailureTerminal() {
+        reserve();
+        assertThat(store.fail(OWNER, "response_timeout")).isEqualTo(TransitionResult.APPLIED);
+
+        assertThat(store.completeVersionProofAfterRestart(OWNER, BOOT_B, TARGET))
+                .isEqualTo(TransitionResult.ALREADY_TERMINAL);
+        assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
+        assertThat(store.read().getTerminalCode()).isEqualTo("response_timeout");
+    }
+
+    @Test
+    public void restartVersionProofCannotBeLostToConcurrentRecoveryTimeout() throws Exception {
+        reserve();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            Future<TransitionResult> proof =
+                    executor.submit(
+                            () -> {
+                                start.await();
+                                return store.completeVersionProofAfterRestart(
+                                        OWNER, BOOT_B, TARGET);
+                            });
+            Future<TransitionResult> timeout =
+                    executor.submit(
+                            () -> {
+                                start.await();
+                                return store.fail(OWNER, "recovery_timeout");
+                            });
+
+            start.countDown();
+            assertThat(proof.get(2, TimeUnit.SECONDS)).isEqualTo(TransitionResult.APPLIED);
+            TransitionResult timeoutResult = timeout.get(2, TimeUnit.SECONDS);
+            assertThat(
+                            timeoutResult == TransitionResult.APPLIED
+                                    || timeoutResult == TransitionResult.ALREADY_TERMINAL)
+                    .isTrue();
+            assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.SUCCESS);
+            assertThat(store.read().getTerminalCode()).isEqualTo("verified");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     public void lateTimeoutProofRequiresOwnerLaterBootAndExactTarget() {
         reserve();
         store.fail(OWNER, "recovery_timeout");
 
-        assertThat(
-                        store.completeLateExactTargetAfterRecoveryTimeout(
-                                OTHER_OWNER, BOOT_B, TARGET))
+        assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OTHER_OWNER, BOOT_B, TARGET))
                 .isEqualTo(TransitionResult.REJECTED);
         assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OWNER, BOOT_A, TARGET))
                 .isEqualTo(TransitionResult.ALREADY_TERMINAL);
-        assertThat(
-                        store.completeLateExactTargetAfterRecoveryTimeout(
-                                OWNER, BOOT_B, "26.7.30.3"))
+        assertThat(store.completeLateExactTargetAfterRecoveryTimeout(OWNER, BOOT_B, "26.7.30.3"))
                 .isEqualTo(TransitionResult.ALREADY_TERMINAL);
         assertThat(store.read().getTerminalStatus()).isEqualTo(TerminalStatus.FAILURE);
         assertThat(store.read().getTerminalCode()).isEqualTo("recovery_timeout");
@@ -253,8 +331,7 @@ public class BesOtaStateStoreTest {
         assertThat(store.reconcileStartup(BOOT_A)).isEqualTo(StartupDecision.RECOVERY_PROBE_ONLY);
         assertThat(store.read().getState()).isEqualTo(State.TERMINAL);
         assertThat(store.read().getTerminalCode()).isEqualTo("interrupted");
-        assertThat(store.uartPolicy(BOOT_A, false, null))
-                .isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+        assertThat(store.uartPolicy(BOOT_A, false, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
         assertThat(store.uartPolicy(BOOT_A, true, null)).isEqualTo(UartPolicy.NORMAL);
         assertThat(store.prepareForNewSession(BOOT_A, true))
                 .isEqualTo(StartDecision.RESTART_REQUIRED);
@@ -265,8 +342,7 @@ public class BesOtaStateStoreTest {
         reserve();
         assertThat(store.fail(OWNER, "response_timeout")).isEqualTo(TransitionResult.APPLIED);
 
-        assertThat(store.uartPolicy(BOOT_A, false, null))
-                .isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
+        assertThat(store.uartPolicy(BOOT_A, false, null)).isEqualTo(UartPolicy.RECOVERY_PROBE_ONLY);
         assertThat(store.uartPolicy(BOOT_A, true, null)).isEqualTo(UartPolicy.NORMAL);
         assertThat(store.prepareForNewSession(BOOT_A, true))
                 .isEqualTo(StartDecision.RESTART_REQUIRED);

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -204,8 +204,12 @@ version name after the fact.
 - **Hard reboot after apply** — Android filesystem persistence can expose the earlier authorization
   record even when apply was committed and acknowledged immediately before power loss. On a later
   Linux boot, ASG keeps that record quarantined while bounded raw-first recovery runs: raw `0x9a`
-  fails the update, an exact target `sr_syvr` completes it, and a mismatch or timeout fails it. A
-  process restart in the original Linux boot remains an immediate failure.
+  fails the update and an exact target `sr_syvr` completes it. Exhausting the transport scan starts
+  a short grace window because BES may still be rebooting. Even after that grace expires, a fresh
+  framed reply from the later boot may supersede only `recovery_timeout` or
+  `verification_timeout`, and only when it exactly matches the requested target. Authorization,
+  artifact, protocol, raw-mode, and version-mismatch failures remain terminal. A process restart in
+  the original Linux boot remains an immediate failure.
 
 ## Logcat tags
 

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -1433,13 +1433,14 @@ class OtaInstallCoordinator {
 
       if (this.otaStartOwnership !== ownership) return
 
-      // A received ota_status/legacy progress event proves that this exact
-      // logical start was accepted. Its application-level ack may be lost while
-      // the update continues; never create another transaction or fail a live,
-      // restarting, or completed session because that stale promise timed out.
-      if (this.hasFirstActivity) {
+      // A received ota_status/legacy progress event, or the exact legacy APK
+      // build-number proof, proves that this logical start was accepted. Its
+      // application-level ack may be lost while the update continues; never
+      // create another transaction or fail a live, restarting, or completed
+      // session because that stale promise timed out.
+      if (this.hasFirstActivity || this.apkCompletedViaBuildIncrease) {
         ownership.outcome = "acknowledged"
-        console.log("[OTA_PROGRESS] ota_start rejection arrived after OTA activity — ignoring stale rejection")
+        console.log("[OTA_PROGRESS] ota_start rejection arrived after acceptance proof — ignoring stale rejection")
         return
       }
 

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -216,6 +216,13 @@ class OtaInstallCoordinator {
   // timeout. Keep that ownership across attach/detach so a remount, watchdog, or
   // query fallback can never open a second native request beside it.
   private otaStartInFlight: Promise<void> | null = null
+  // Explicit UI retries are new logical attempts. Native completion callbacks carry
+  // this generation so an older request cannot acknowledge, retry, or fail the new
+  // attempt while it drains. If native still owns the previous request, the fresh
+  // request remains queued until that ownership ends.
+  private otaStartAttemptId = 0
+  private otaStartRequiresFreshRequestAttempt: number | null = null
+  private otaStartIgnoreUnscopedAckAttempt: number | null = null
   private hasReceivedAck = false
   private hasFirstActivity = false
   // Stuck-at-zero watchdog clears only on first NON-ZERO progress; "first activity"
@@ -317,6 +324,10 @@ class OtaInstallCoordinator {
       return
     }
     console.log("[OTA_PROGRESS] retry pressed, clearing state and re-sending ota_start")
+    this.otaStartAttemptId += 1
+    const retryAttemptId = this.otaStartAttemptId
+    this.otaStartRequiresFreshRequestAttempt = this.otaStartInFlight ? retryAttemptId : null
+    this.otaStartIgnoreUnscopedAckAttempt = this.otaStartInFlight ? retryAttemptId : null
     // Batch like the old event handler: React ran the whole handler (including
     // the ota_start send) before re-rendering + re-running effects.
     const wasReacting = this.reacting
@@ -1008,8 +1019,20 @@ class OtaInstallCoordinator {
   // --- BLE OTA event listeners (engine GlobalEventEmitter, fed by OtaService) ---
 
   private readonly handleAck = (): void => {
+    if (this.otaStartIgnoreUnscopedAckAttempt === this.otaStartAttemptId) {
+      console.log("[OTA_PROGRESS] ignoring unscoped ota_start_ack while a fresh retry is queued")
+      return
+    }
+    this.handleAckForAttempt(this.otaStartAttemptId)
+  }
+
+  private handleAckForAttempt(attemptId: number): void {
+    if (attemptId !== this.otaStartAttemptId) return
     if (this.hasReceivedAck) return
     console.log("[OTA_PROGRESS] ota_start_ack received")
+    if (this.otaStartIgnoreUnscopedAckAttempt === attemptId) {
+      this.otaStartIgnoreUnscopedAckAttempt = null
+    }
     this.hasReceivedAck = true
     this.clearRetryTimeout()
   }
@@ -1296,6 +1319,12 @@ class OtaInstallCoordinator {
     }, stuckTimeoutMs)
   }
 
+  /** Arm the 0%-stuck watchdog only when this logical session has none. */
+  private maybeArmStuckWatchdog(): void {
+    if (this.stuckTimeout || this.hasFirstNonZeroProgress) return
+    this.armStuckWatchdogOnly()
+  }
+
   private sendOtaStartWithWatchdogs(): Promise<void> {
     // INVARIANT BACKSTOP — not normal control flow. Every entry point that can drive the
     // glasses (connect-edge, query fallback, retry, mount) carries its own detour gate with the
@@ -1310,14 +1339,47 @@ class OtaInstallCoordinator {
       return Promise.resolve()
     }
     if (this.otaStartInFlight) {
-      console.log("[OTA_PROGRESS] ota_start already in flight — joining existing native request")
-      return this.otaStartInFlight
+      const ownedRequest = this.otaStartInFlight
+      const attemptId = this.otaStartAttemptId
+      this.maybeStartGlobalTimeout()
+      this.maybeArmStuckWatchdog()
+
+      if (this.otaStartRequiresFreshRequestAttempt !== attemptId) {
+        console.log("[OTA_PROGRESS] ota_start already in flight — joining existing native request")
+        return ownedRequest
+      }
+
+      console.log("[OTA_PROGRESS] fresh ota_start queued behind previous native request")
+      return ownedRequest.then(() => {
+        if (attemptId !== this.otaStartAttemptId) {
+          console.log("[OTA_PROGRESS] queued ota_start superseded by a newer retry")
+          return
+        }
+        if (this.hasFirstActivity || this.computeDisplayStateNow() !== "starting") {
+          console.log("[OTA_PROGRESS] OTA activity arrived while retry was queued — no new ota_start")
+          this.otaStartRequiresFreshRequestAttempt = null
+          this.otaStartIgnoreUnscopedAckAttempt = null
+          return
+        }
+        if (!this.attached || !isGlassesConnected(useGlassesStore.getState().connection)) {
+          console.log("[OTA_PROGRESS] queued ota_start waiting for an attached connected session")
+          return
+        }
+        // The previous request has settled, so releasing this exact ownership is
+        // safe even if its cleanup continuation has not run yet.
+        if (this.otaStartInFlight === ownedRequest) this.otaStartInFlight = null
+        return this.sendOtaStartWithWatchdogs()
+      })
     }
     this.maybeStartGlobalTimeout()
     this.hasReceivedAck = false
-    this.armStuckWatchdogOnly()
+    this.maybeArmStuckWatchdog()
 
-    const request = this.performOtaStart()
+    const attemptId = this.otaStartAttemptId
+    if (this.otaStartRequiresFreshRequestAttempt === attemptId) {
+      this.otaStartRequiresFreshRequestAttempt = null
+    }
+    const request = this.performOtaStart(attemptId)
     this.otaStartInFlight = request
     void request.finally(() => {
       if (this.otaStartInFlight === request) this.otaStartInFlight = null
@@ -1325,18 +1387,27 @@ class OtaInstallCoordinator {
     return request
   }
 
-  private async performOtaStart(): Promise<void> {
+  private async performOtaStart(attemptId: number): Promise<void> {
     try {
       const state = useGlassesStore.getState()
       const otaVersionUrl = resolveOtaManifestUrl(state.otaVersionUrl, state.buildNumber)
       console.log(`[OTA_PROGRESS] sending ota_start with manifest URL: ${otaVersionUrl}`)
       await BluetoothSdk.startOtaUpdate(otaVersionUrl)
+      if (attemptId !== this.otaStartAttemptId) {
+        console.log("[OTA_PROGRESS] ignoring ota_start ack from a superseded attempt")
+        return
+      }
       // The public SDK promise resolves only from ota_start_ack. Treat that
       // resolution as the acknowledgement even if the parallel event dispatch
       // reaches the coordinator later (or is dropped by a remount).
-      this.handleAck()
+      this.handleAckForAttempt(attemptId)
     } catch (err) {
       console.warn("[OTA_PROGRESS] sendOtaStart threw", err)
+
+      if (attemptId !== this.otaStartAttemptId) {
+        console.log("[OTA_PROGRESS] ignoring ota_start rejection from a superseded attempt")
+        return
+      }
 
       // A received ota_status/legacy progress event proves that this exact
       // logical start was accepted. Its application-level ack may be lost while
@@ -1353,7 +1424,9 @@ class OtaInstallCoordinator {
         this.retryCount += 1
         const retryIntervalMs = this.isLegacySessionShapeNow() ? LEGACY_RETRY_INTERVAL_MS : RETRY_INTERVAL_MS
         console.log(
-          `[OTA_PROGRESS] ota_start request ended without ack or activity; retrying after ${retryIntervalMs}ms (attempt ${this.retryCount + 1}/${MAX_RETRIES})`,
+          `[OTA_PROGRESS] ota_start request ended without ack or activity; retrying after ${retryIntervalMs}ms (attempt ${
+            this.retryCount + 1
+          }/${MAX_RETRIES})`,
         )
         this.retryTimeout = setTimeout(() => {
           this.retryTimeout = null

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -379,7 +379,6 @@ class OtaInstallCoordinator {
       this.setSawReconnectEdge(false)
       this.setErrorMsg("")
       this.setContinueButtonDisabled(false)
-      this.setApkCompletedViaBuildIncrease(false)
       this.setLegacyApkSettleHold(false)
       this.setMtkSimulatedPercent(null)
       this.lastRealMtkProgress = 0
@@ -539,6 +538,7 @@ class OtaInstallCoordinator {
     this.otaStartOwnership = null
     this.hasFirstActivity = false
     this.hasFirstNonZeroProgress = false
+    this.apkCompletedViaBuildIncrease = false
     return true
   }
 

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -2,8 +2,8 @@
  * OtaInstallCoordinator — engine-owned OTA install state machine (WP 8B).
  *
  * Owns every timer/retry/sequencing rule that used to live in the host screen
- * `mobile/src/app/ota/progress.tsx`: the global session timeout, the no-ack
- * retry watchdog, the stuck-at-zero watchdog, the progress-stall watchdog keyed
+ * `mobile/src/app/ota/progress.tsx`: the global session timeout, serialized
+ * ota_start retries, the stuck-at-zero watchdog, the progress-stall watchdog keyed
  * on a staleness signature, connect-edge arbitration (initial mount vs
  * reconnect vs post-APK reboot), the ota_query_status reply fallback, the ping
  * keepalive, the ota_start_ack / mtk_update_complete listeners, and terminal
@@ -11,10 +11,7 @@
  * `snapshot()`/`onSnapshot()` plus the `attach()/detach()/retry()/finish()`
  * commands (exposed as `engine.ota.installSession`).
  *
- * Behavior contract: everything here was MOVED, not changed — every timer
- * duration (see ./otaInstallPolicy), arbitration rule, and "[OTA_PROGRESS]"
- * log line is a field-debugging contract and stays byte-identical to the old
- * screen. The reaction pass mirrors the old component's effect ordering: a
+ * The reaction pass mirrors the old component's effect ordering: a
  * pass diffs the store-derived inputs (connected / otaStatus / otaProgress /
  * displayState / stall signature) exactly like the old effect dep arrays, and
  * state written mid-pass queues a follow-up pass — the same way a setState
@@ -212,9 +209,13 @@ class OtaInstallCoordinator {
   private mtkStallDetectTimer: ReturnType<typeof setTimeout> | null = null
   private mtkSimTickTimer: ReturnType<typeof setInterval> | null = null
 
-  // Retry / ack bookkeeping (no glasses source)
+  // Request / retry bookkeeping (no glasses source)
   // At most one apk-install status poll in flight (native rejects concurrent queries).
   private apkInstallPollInFlight = false
+  // The native SDK owns one ota_start request until its application-level ack or
+  // timeout. Keep that ownership across attach/detach so a remount, watchdog, or
+  // query fallback can never open a second native request beside it.
+  private otaStartInFlight: Promise<void> | null = null
   private hasReceivedAck = false
   private hasFirstActivity = false
   // Stuck-at-zero watchdog clears only on first NON-ZERO progress; "first activity"
@@ -837,7 +838,7 @@ class OtaInstallCoordinator {
       }
     }
 
-    // Any glasses activity (ota_status or otaProgress) clears the no-ack retry watchdog.
+    // Any glasses activity proves the logical ota_start was accepted.
     if ((otaStatusChanged || otaProgressChanged) && (otaStatus || otaProgress)) {
       this.onFirstActivity()
     }
@@ -1226,7 +1227,7 @@ class OtaInstallCoordinator {
   }
 
   /**
-   * "Glasses are talking to us" — clears the no-ack retry watchdog only.
+   * "Glasses are talking to us" — suppresses retry if the native request later rejects.
    * Important: this does NOT clear the stuck-at-zero watchdog; that one fires
    * on real progress > 0% (see {@link onFirstNonZeroProgress}).
    */
@@ -1272,36 +1273,13 @@ class OtaInstallCoordinator {
     }, globalTimeoutMs)
   }
 
-  private armAckAndStuckWatchdogsOnly(): void {
-    this.clearRetryTimeout()
+  private armStuckWatchdogOnly(): void {
     this.clearStuckTimeout()
 
     // Durations resolved at arm time (WP 8C-b): legacy-shaped sessions get the
     // padded values progress-legacy.tsx used for old (< 37) builds.
     const legacySession = this.isLegacySessionShapeNow()
-    const retryIntervalMs = legacySession ? LEGACY_RETRY_INTERVAL_MS : RETRY_INTERVAL_MS
     const stuckTimeoutMs = legacySession ? LEGACY_DOWNLOAD_STUCK_TIMEOUT_MS : DOWNLOAD_STUCK_TIMEOUT_MS
-
-    this.retryTimeout = setTimeout(() => {
-      this.retryTimeout = null
-      if (this.hasReceivedAck || this.hasFirstActivity) return
-      if (this.computeDisplayStateNow() !== "starting") return
-      if (this.retryCount < MAX_RETRIES - 1) {
-        this.retryCount += 1
-        this.hasReceivedAck = false
-        console.log(
-          `[OTA_PROGRESS] watchdog: no ack in ${retryIntervalMs}ms, retrying ota_start (attempt ${this.retryCount})`,
-        )
-        void this.sendOtaStartWithWatchdogs(true)
-          .then(() => {
-            this.armAckAndStuckWatchdogsOnly()
-          })
-          .catch(() => {})
-      } else {
-        console.log(`[OTA_PROGRESS] watchdog: ota_start ack never received after ${MAX_RETRIES} attempts, failing`)
-        this.setErrorMsg(OtaProgressMessages.noAckResponse)
-      }
-    }, retryIntervalMs)
 
     this.stuckTimeout = setTimeout(() => {
       this.stuckTimeout = null
@@ -1318,7 +1296,7 @@ class OtaInstallCoordinator {
     }, stuckTimeoutMs)
   }
 
-  private async sendOtaStartWithWatchdogs(retryAlreadyCounted = false): Promise<void> {
+  private sendOtaStartWithWatchdogs(): Promise<void> {
     // INVARIANT BACKSTOP — not normal control flow. Every entry point that can drive the
     // glasses (connect-edge, query fallback, retry, mount) carries its own detour gate with the
     // right behavior for that site; this final check only exists so that a FUTURE entry point
@@ -1329,25 +1307,54 @@ class OtaInstallCoordinator {
       console.error(
         "[OTA_PROGRESS] BACKSTOP: refused ota_start during a latched version-change detour — a caller is missing its detour gate",
       )
-      return
+      return Promise.resolve()
+    }
+    if (this.otaStartInFlight) {
+      console.log("[OTA_PROGRESS] ota_start already in flight — joining existing native request")
+      return this.otaStartInFlight
     }
     this.maybeStartGlobalTimeout()
     this.hasReceivedAck = false
-    this.armAckAndStuckWatchdogsOnly()
+    this.armStuckWatchdogOnly()
+
+    const request = this.performOtaStart()
+    this.otaStartInFlight = request
+    void request.finally(() => {
+      if (this.otaStartInFlight === request) this.otaStartInFlight = null
+    })
+    return request
+  }
+
+  private async performOtaStart(): Promise<void> {
     try {
       const state = useGlassesStore.getState()
       const otaVersionUrl = resolveOtaManifestUrl(state.otaVersionUrl, state.buildNumber)
       console.log(`[OTA_PROGRESS] sending ota_start with manifest URL: ${otaVersionUrl}`)
       await BluetoothSdk.startOtaUpdate(otaVersionUrl)
+      // The public SDK promise resolves only from ota_start_ack. Treat that
+      // resolution as the acknowledgement even if the parallel event dispatch
+      // reaches the coordinator later (or is dropped by a remount).
+      this.handleAck()
     } catch (err) {
       console.warn("[OTA_PROGRESS] sendOtaStart threw", err)
-      this.clearRetryTimeout()
+
+      // A received ota_status/legacy progress event proves that this exact
+      // logical start was accepted. Its application-level ack may be lost while
+      // the update continues; never create another transaction or fail a live,
+      // restarting, or completed session because that stale promise timed out.
+      if (this.hasFirstActivity || this.computeDisplayStateNow() !== "starting") {
+        console.log("[OTA_PROGRESS] ota_start rejection arrived after OTA activity — ignoring stale rejection")
+        return
+      }
+
+      if (!this.attached) return
       this.clearStuckTimeout()
       if (this.retryCount < MAX_RETRIES - 1) {
-        if (!retryAlreadyCounted) {
-          this.retryCount += 1
-        }
+        this.retryCount += 1
         const retryIntervalMs = this.isLegacySessionShapeNow() ? LEGACY_RETRY_INTERVAL_MS : RETRY_INTERVAL_MS
+        console.log(
+          `[OTA_PROGRESS] ota_start request ended without ack or activity; retrying after ${retryIntervalMs}ms (attempt ${this.retryCount + 1}/${MAX_RETRIES})`,
+        )
         this.retryTimeout = setTimeout(() => {
           this.retryTimeout = null
           void this.sendOtaStartWithWatchdogs()

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -145,6 +145,13 @@ export interface OtaInstallSnapshot {
   versionChangePhase: "installing" | "restarting" | "verifying" | null
 }
 
+type OtaStartOutcome = "pending" | "acknowledged" | "rejected"
+
+interface OtaStartOwnership {
+  outcome: OtaStartOutcome
+  promise: Promise<void>
+}
+
 class OtaInstallCoordinator {
   private attached = false
 
@@ -213,17 +220,10 @@ class OtaInstallCoordinator {
   // At most one apk-install status poll in flight (native rejects concurrent queries).
   private apkInstallPollInFlight = false
   // The native SDK owns one ota_start request until its application-level ack or
-  // timeout. Keep that ownership across attach/detach so a remount, watchdog, or
-  // query fallback can never open a second native request beside it.
-  private otaStartInFlight: Promise<void> | null = null
-  // Explicit UI retries are new logical attempts. Native completion callbacks carry
-  // this generation so an older request cannot acknowledge, retry, or fail the new
-  // attempt while it drains. If native still owns the previous request, the fresh
-  // request remains queued until that ownership ends.
-  private otaStartAttemptId = 0
-  private otaStartRequiresFreshRequestAttempt: number | null = null
-  private otaStartIgnoreUnscopedAckAttempt: number | null = null
-  private hasReceivedAck = false
+  // timeout. Keep pending ownership across attach/detach, and retain the settled
+  // outcome while attached so Retry/query fallback cannot reinterpret an accepted
+  // command as permission to start a second OTA transaction.
+  private otaStartOwnership: OtaStartOwnership | null = null
   private hasFirstActivity = false
   // Stuck-at-zero watchdog clears only on first NON-ZERO progress; "first activity"
   // alone (e.g. ota_status with stepPercent=0) used to clear it too eagerly.
@@ -306,6 +306,11 @@ class OtaInstallCoordinator {
     GlobalEventEmitter.off("glasses_session_changed", this.handleGlassesSessionChanged)
     this.clearAllOtaTimers()
     this.clearContinueLockoutTimer()
+    // Only native command ownership survives a remount. Once the command has
+    // settled, the glasses store/durable ota_status is the session authority.
+    if (this.otaStartOwnership?.outcome !== "pending") {
+      this.otaStartOwnership = null
+    }
     this.resetSessionState()
   }
 
@@ -323,11 +328,42 @@ class OtaInstallCoordinator {
       this.emitInternalChange()
       return
     }
-    console.log("[OTA_PROGRESS] retry pressed, clearing state and re-sending ota_start")
-    this.otaStartAttemptId += 1
-    const retryAttemptId = this.otaStartAttemptId
-    this.otaStartRequiresFreshRequestAttempt = this.otaStartInFlight ? retryAttemptId : null
-    this.otaStartIgnoreUnscopedAckAttempt = this.otaStartInFlight ? retryAttemptId : null
+    const store = useGlassesStore.getState()
+    const otaStatus = store.otaStatus
+    const otaProgress = store.otaProgress
+    const authoritativeFailure = otaStatus?.status === "failed" || otaProgress?.status === "FAILED"
+    const hasUnfinishedSession =
+      (!!otaStatus &&
+        otaStatus.status !== "idle" &&
+        otaStatus.status !== "failed" &&
+        otaStatus.status !== "complete") ||
+      (!!otaProgress && otaProgress.status !== "FAILED" && otaProgress.status !== "FINISHED")
+    const shouldReconcile =
+      this.otaStartOwnership?.outcome === "pending" ||
+      (!authoritativeFailure &&
+        (this.otaStartOwnership?.outcome === "acknowledged" || this.hasFirstActivity || hasUnfinishedSession))
+
+    if (shouldReconcile) {
+      console.log("[OTA_PROGRESS] retry pressed for an existing OTA session — reconciling without ota_start")
+      this.clearPerStepTimers()
+      this.clearLegacyApkSettleTimer()
+      this.clearMtkSimulationTimers()
+      this.clearContinueLockoutTimer()
+      this.setErrorMsg("")
+      this.maybeStartGlobalTimeout()
+      this.maybeArmStuckWatchdog()
+      if (isGlassesConnected(store.connection)) {
+        if (this.otaStartOwnership?.outcome === "pending") {
+          void this.sendOtaStartWithWatchdogs()
+        } else {
+          void BluetoothSdk.sendOtaQueryStatus().catch(() => {})
+          this.armQueryReplyFallback("retry")
+        }
+      }
+      return
+    }
+
+    console.log("[OTA_PROGRESS] retry pressed after a rejected or terminal attempt — starting a fresh ota_start")
     // Batch like the old event handler: React ran the whole handler (including
     // the ota_start send) before re-rendering + re-running effects.
     const wasReacting = this.reacting
@@ -338,8 +374,7 @@ class OtaInstallCoordinator {
       this.clearMtkSimulationTimers()
       this.clearContinueLockoutTimer()
       this.retryCount = 0
-      this.hasFirstActivity = false
-      this.hasReceivedAck = false
+      if (!this.prepareFreshOtaStartAttempt()) return
       this.resetBesRestartAttempt()
       this.setSawReconnectEdge(false)
       this.setErrorMsg("")
@@ -348,7 +383,6 @@ class OtaInstallCoordinator {
       this.setLegacyApkSettleHold(false)
       this.setMtkSimulatedPercent(null)
       this.lastRealMtkProgress = 0
-      const store = useGlassesStore.getState()
       store.setOtaProgress(null)
       store.setOtaStatus(null)
       if (isGlassesConnected(useGlassesStore.getState().connection)) {
@@ -366,6 +400,9 @@ class OtaInstallCoordinator {
    * clear the stale build number so the next check re-reads version_info.
    */
   finish(): void {
+    if (this.otaStartOwnership?.outcome !== "pending") {
+      this.otaStartOwnership = null
+    }
     useGlassesStore.getState().setOtaUpdateAvailable(null)
     if (this.apkStepSeen) {
       BluetoothSdk.updateGlasses({buildNumber: ""})
@@ -479,7 +516,6 @@ class OtaInstallCoordinator {
     this.mtkSimulatedPercent = null
     this.lastRealMtkProgress = 0
     this.apkInstallPollInFlight = false
-    this.hasReceivedAck = false
     this.hasFirstActivity = false
     this.hasFirstNonZeroProgress = false
     this.retryCount = 0
@@ -492,6 +528,18 @@ class OtaInstallCoordinator {
     this.lastDisplayState = null
     this.lastStallSig = ""
     this.reactQueued = false
+  }
+
+  /** Begin a genuinely new command attempt only after native ownership has settled. */
+  private prepareFreshOtaStartAttempt(): boolean {
+    if (this.otaStartOwnership?.outcome === "pending") {
+      console.error("[OTA_PROGRESS] refused fresh ota_start while native still owns the previous request")
+      return false
+    }
+    this.otaStartOwnership = null
+    this.hasFirstActivity = false
+    this.hasFirstNonZeroProgress = false
+    return true
   }
 
   /** Reset only the reboot lifecycle that belongs to one install attempt. */
@@ -715,10 +763,10 @@ class OtaInstallCoordinator {
       this.versionChangeSession &&
       !this.versionChangeInstallStarted &&
       // Only latch from a status that belongs to THIS session: an install/apk status is a
-      // response to our own ota_start (hasReceivedAck), so a leftover from a prior session
+      // response to our own acknowledged ota_start, so a leftover from a prior session
       // sitting in the store at mount cannot prematurely enter the detour wait (which would
       // suppress ota_start and hang the fresh downgrade until the global timeout).
-      this.hasReceivedAck &&
+      this.otaStartOwnership?.outcome === "acknowledged" &&
       otaStatus?.stepType === "apk" &&
       otaStatus.phase === "install"
     ) {
@@ -958,6 +1006,9 @@ class OtaInstallCoordinator {
     }
 
     console.log(`[OTA_PROGRESS] ${label}: reconnected, sending ota_query_status`)
+    if (this.otaStartOwnership?.outcome === "pending") {
+      void this.sendOtaStartWithWatchdogs()
+    }
     void BluetoothSdk.sendOtaQueryStatus()
     this.armQueryReplyFallback("reconnect")
     return true
@@ -999,15 +1050,21 @@ class OtaInstallCoordinator {
     const isIdleStatus = !!storeState.otaStatus && storeState.otaStatus.sessionId === ""
     const noSessionYet = (!storeState.otaStatus && !storeState.otaProgress) || isIdleStatus
     if (noSessionYet) {
+      if (!isIdleStatus && this.otaStartOwnership?.outcome === "acknowledged") {
+        console.log("[OTA_PROGRESS] initial mount, acknowledged session has no cached status — reconciling")
+        void BluetoothSdk.sendOtaQueryStatus().catch(() => {})
+        this.armQueryReplyFallback("initial-mount")
+        return
+      }
       console.log(
         isIdleStatus
           ? "[OTA_PROGRESS] initial mount, idle status (no sessionId), sending ota_start"
           : "[OTA_PROGRESS] initial mount, no session in store, sending ota_start",
       )
       this.retryCount = 0
-      this.hasFirstActivity = false
-      this.hasFirstNonZeroProgress = false
-      this.hasReceivedAck = false
+      if (isIdleStatus && this.otaStartOwnership?.outcome !== "pending" && !this.prepareFreshOtaStartAttempt()) {
+        return
+      }
       void this.sendOtaStartWithWatchdogs()
     } else {
       console.log("[OTA_PROGRESS] initial mount, session exists, sending ota_query_status")
@@ -1019,21 +1076,11 @@ class OtaInstallCoordinator {
   // --- BLE OTA event listeners (engine GlobalEventEmitter, fed by OtaService) ---
 
   private readonly handleAck = (): void => {
-    if (this.otaStartIgnoreUnscopedAckAttempt === this.otaStartAttemptId) {
-      console.log("[OTA_PROGRESS] ignoring unscoped ota_start_ack while a fresh retry is queued")
-      return
-    }
-    this.handleAckForAttempt(this.otaStartAttemptId)
-  }
-
-  private handleAckForAttempt(attemptId: number): void {
-    if (attemptId !== this.otaStartAttemptId) return
-    if (this.hasReceivedAck) return
+    const ownership = this.otaStartOwnership
+    if (!ownership || ownership.outcome === "rejected") return
+    if (ownership.outcome === "acknowledged") return
     console.log("[OTA_PROGRESS] ota_start_ack received")
-    if (this.otaStartIgnoreUnscopedAckAttempt === attemptId) {
-      this.otaStartIgnoreUnscopedAckAttempt = null
-    }
-    this.hasReceivedAck = true
+    ownership.outcome = "acknowledged"
     this.clearRetryTimeout()
   }
 
@@ -1257,6 +1304,9 @@ class OtaInstallCoordinator {
   private onFirstActivity(): void {
     if (this.hasFirstActivity) return
     this.hasFirstActivity = true
+    if (this.otaStartOwnership?.outcome === "pending") {
+      this.otaStartOwnership.outcome = "acknowledged"
+    }
     this.clearRetryTimeout()
   }
 
@@ -1338,86 +1388,61 @@ class OtaInstallCoordinator {
       )
       return Promise.resolve()
     }
-    if (this.otaStartInFlight) {
-      const ownedRequest = this.otaStartInFlight
-      const attemptId = this.otaStartAttemptId
+    const existingOwnership = this.otaStartOwnership
+    if (existingOwnership?.outcome === "pending") {
       this.maybeStartGlobalTimeout()
       this.maybeArmStuckWatchdog()
-
-      if (this.otaStartRequiresFreshRequestAttempt !== attemptId) {
-        console.log("[OTA_PROGRESS] ota_start already in flight — joining existing native request")
-        return ownedRequest
-      }
-
-      console.log("[OTA_PROGRESS] fresh ota_start queued behind previous native request")
-      return ownedRequest.then(() => {
-        if (attemptId !== this.otaStartAttemptId) {
-          console.log("[OTA_PROGRESS] queued ota_start superseded by a newer retry")
-          return
-        }
-        if (this.hasFirstActivity || this.computeDisplayStateNow() !== "starting") {
-          console.log("[OTA_PROGRESS] OTA activity arrived while retry was queued — no new ota_start")
-          this.otaStartRequiresFreshRequestAttempt = null
-          this.otaStartIgnoreUnscopedAckAttempt = null
-          return
-        }
-        if (!this.attached || !isGlassesConnected(useGlassesStore.getState().connection)) {
-          console.log("[OTA_PROGRESS] queued ota_start waiting for an attached connected session")
-          return
-        }
-        // The previous request has settled, so releasing this exact ownership is
-        // safe even if its cleanup continuation has not run yet.
-        if (this.otaStartInFlight === ownedRequest) this.otaStartInFlight = null
-        return this.sendOtaStartWithWatchdogs()
-      })
+      console.log("[OTA_PROGRESS] ota_start already pending — adopting existing native request")
+      return existingOwnership.promise
+    }
+    if (existingOwnership?.outcome === "acknowledged") {
+      this.maybeStartGlobalTimeout()
+      this.maybeArmStuckWatchdog()
+      console.log("[OTA_PROGRESS] ota_start already acknowledged — refusing duplicate start")
+      return Promise.resolve()
+    }
+    if (existingOwnership?.outcome === "rejected" && !this.prepareFreshOtaStartAttempt()) {
+      return Promise.resolve()
     }
     this.maybeStartGlobalTimeout()
-    this.hasReceivedAck = false
     this.maybeArmStuckWatchdog()
 
-    const attemptId = this.otaStartAttemptId
-    if (this.otaStartRequiresFreshRequestAttempt === attemptId) {
-      this.otaStartRequiresFreshRequestAttempt = null
+    const ownership: OtaStartOwnership = {
+      outcome: "pending",
+      promise: Promise.resolve(),
     }
-    const request = this.performOtaStart(attemptId)
-    this.otaStartInFlight = request
-    void request.finally(() => {
-      if (this.otaStartInFlight === request) this.otaStartInFlight = null
-    })
-    return request
+    ownership.promise = this.performOtaStart(ownership)
+    this.otaStartOwnership = ownership
+    return ownership.promise
   }
 
-  private async performOtaStart(attemptId: number): Promise<void> {
+  private async performOtaStart(ownership: OtaStartOwnership): Promise<void> {
     try {
       const state = useGlassesStore.getState()
       const otaVersionUrl = resolveOtaManifestUrl(state.otaVersionUrl, state.buildNumber)
       console.log(`[OTA_PROGRESS] sending ota_start with manifest URL: ${otaVersionUrl}`)
       await BluetoothSdk.startOtaUpdate(otaVersionUrl)
-      if (attemptId !== this.otaStartAttemptId) {
-        console.log("[OTA_PROGRESS] ignoring ota_start ack from a superseded attempt")
-        return
-      }
+      if (this.otaStartOwnership !== ownership) return
       // The public SDK promise resolves only from ota_start_ack. Treat that
       // resolution as the acknowledgement even if the parallel event dispatch
       // reaches the coordinator later (or is dropped by a remount).
-      this.handleAckForAttempt(attemptId)
+      this.handleAck()
     } catch (err) {
       console.warn("[OTA_PROGRESS] sendOtaStart threw", err)
 
-      if (attemptId !== this.otaStartAttemptId) {
-        console.log("[OTA_PROGRESS] ignoring ota_start rejection from a superseded attempt")
-        return
-      }
+      if (this.otaStartOwnership !== ownership) return
 
       // A received ota_status/legacy progress event proves that this exact
       // logical start was accepted. Its application-level ack may be lost while
       // the update continues; never create another transaction or fail a live,
       // restarting, or completed session because that stale promise timed out.
       if (this.hasFirstActivity || this.computeDisplayStateNow() !== "starting") {
+        ownership.outcome = "acknowledged"
         console.log("[OTA_PROGRESS] ota_start rejection arrived after OTA activity — ignoring stale rejection")
         return
       }
 
+      ownership.outcome = "rejected"
       if (!this.attached) return
       this.clearStuckTimeout()
       if (this.retryCount < MAX_RETRIES - 1) {
@@ -1441,16 +1466,15 @@ class OtaInstallCoordinator {
 
   /**
    * After sending ota_query_status, wait QUERY_REPLY_TIMEOUT_MS for the glasses
-   * to reply with a useful ota_status. If nothing arrives (e.g. the glasses'
-   * OTA session was wiped between mount and reconnect), or the glasses reply
-   * with an explicit "idle" status (no session), fall back to ota_start so the
-   * user doesn't sit on a spinner forever.
+   * to reply with a useful ota_status. A unified session may start again only
+   * after an explicit "idle" reply. Legacy builds ignore ota_query_status, so
+   * their established timeout fallback remains the compatibility path.
    *
    * Cleared as soon as a non-idle otaStatus or any otaProgress lands in the
    * store (see the reaction block above). An idle reply intentionally does NOT
    * cancel the fallback, so reconnects against a wiped/lost session still recover.
    */
-  private armQueryReplyFallback(reason: "reconnect" | "initial-mount"): void {
+  private armQueryReplyFallback(reason: "reconnect" | "initial-mount" | "retry"): void {
     this.clearQueryReplyTimeout()
     this.queryReplyTimeout = setTimeout(() => {
       this.queryReplyTimeout = null
@@ -1463,15 +1487,22 @@ class OtaInstallCoordinator {
       // through the reaction pass. Only a unified reply suppresses the fallback.
       const legacySession = this.isLegacySessionShapeNow()
       if (!legacySession && hasRecoveringOtaReply(state.otaStatus, state.otaProgress)) return
+      const explicitIdle = state.otaStatus?.status === "idle"
+      if (!legacySession && !explicitIdle) {
+        console.log(
+          `[OTA_PROGRESS] watchdog: ota_query_status got no authoritative idle reply in ${QUERY_REPLY_TIMEOUT_MS}ms (reason=${reason}); preserving the existing session`,
+        )
+        return
+      }
       // Don't fire if we've left the active phase (e.g. user backed out, error overlay).
       if (isTerminalForWatchdog(this.computeDisplayStateNow())) return
       console.log(
-        `[OTA_PROGRESS] watchdog: ota_query_status got no useful reply in ${QUERY_REPLY_TIMEOUT_MS}ms (reason=${reason}), falling back to ota_start`,
+        `[OTA_PROGRESS] watchdog: ${
+          explicitIdle ? "idle ota_status" : "legacy query timeout"
+        } (reason=${reason}), falling back to ota_start`,
       )
       this.retryCount = 0
-      this.hasFirstActivity = false
-      this.hasFirstNonZeroProgress = false
-      this.hasReceivedAck = false
+      if (this.otaStartOwnership?.outcome !== "pending" && !this.prepareFreshOtaStartAttempt()) return
       void this.sendOtaStartWithWatchdogs()
     }, QUERY_REPLY_TIMEOUT_MS)
   }

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -538,7 +538,7 @@ class OtaInstallCoordinator {
     this.otaStartOwnership = null
     this.hasFirstActivity = false
     this.hasFirstNonZeroProgress = false
-    this.apkCompletedViaBuildIncrease = false
+    this.setApkCompletedViaBuildIncrease(false)
     return true
   }
 

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -1020,10 +1020,11 @@ class OtaInstallCoordinator {
 
     if (!connected) {
       console.log("[OTA_PROGRESS] connect-edge: disconnected")
-      // Also drop a pending query-reply fallback: firing ota_start into a dead
-      // link can only produce a false "failed" state, and the reconnect edge
-      // re-queries and re-arms this fallback anyway.
+      // Also drop pending query/retry sends: firing ota_start into a dead link
+      // can only produce a false "failed" state. Reconnect arbitration first
+      // queries durable status and re-arms the one permitted fallback.
       this.clearQueryReplyTimeout()
+      this.clearRetryTimeout()
       return
     }
 
@@ -1436,7 +1437,7 @@ class OtaInstallCoordinator {
       // logical start was accepted. Its application-level ack may be lost while
       // the update continues; never create another transaction or fail a live,
       // restarting, or completed session because that stale promise timed out.
-      if (this.hasFirstActivity || this.computeDisplayStateNow() !== "starting") {
+      if (this.hasFirstActivity) {
         ownership.outcome = "acknowledged"
         console.log("[OTA_PROGRESS] ota_start rejection arrived after OTA activity — ignoring stale rejection")
         return
@@ -1445,6 +1446,12 @@ class OtaInstallCoordinator {
       ownership.outcome = "rejected"
       if (!this.attached) return
       this.clearStuckTimeout()
+      if (!isGlassesConnected(useGlassesStore.getState().connection)) {
+        console.log(
+          "[OTA_PROGRESS] ota_start request ended while disconnected; deferring retry to reconnect arbitration",
+        )
+        return
+      }
       if (this.retryCount < MAX_RETRIES - 1) {
         this.retryCount += 1
         const retryIntervalMs = this.isLegacySessionShapeNow() ? LEGACY_RETRY_INTERVAL_MS : RETRY_INTERVAL_MS
@@ -1455,6 +1462,10 @@ class OtaInstallCoordinator {
         )
         this.retryTimeout = setTimeout(() => {
           this.retryTimeout = null
+          if (!isGlassesConnected(useGlassesStore.getState().connection)) {
+            console.log("[OTA_PROGRESS] ota_start retry paused while disconnected; reconnect arbitration will resume")
+            return
+          }
           void this.sendOtaStartWithWatchdogs()
         }, retryIntervalMs)
       } else {
@@ -1467,8 +1478,10 @@ class OtaInstallCoordinator {
   /**
    * After sending ota_query_status, wait QUERY_REPLY_TIMEOUT_MS for the glasses
    * to reply with a useful ota_status. A unified session may start again only
-   * after an explicit "idle" reply. Legacy builds ignore ota_query_status, so
-   * their established timeout fallback remains the compatibility path.
+   * after an explicit "idle" reply, or after a locally rejected ota_start has
+   * produced no activity and no authoritative reply across reconnect. Legacy
+   * builds ignore ota_query_status, so their established timeout fallback
+   * remains the compatibility path.
    *
    * Cleared as soon as a non-idle otaStatus or any otaProgress lands in the
    * store (see the reaction block above). An idle reply intentionally does NOT
@@ -1488,7 +1501,8 @@ class OtaInstallCoordinator {
       const legacySession = this.isLegacySessionShapeNow()
       if (!legacySession && hasRecoveringOtaReply(state.otaStatus, state.otaProgress)) return
       const explicitIdle = state.otaStatus?.status === "idle"
-      if (!legacySession && !explicitIdle) {
+      const rejectedStart = this.otaStartOwnership?.outcome === "rejected"
+      if (!legacySession && !explicitIdle && !rejectedStart) {
         console.log(
           `[OTA_PROGRESS] watchdog: ota_query_status got no authoritative idle reply in ${QUERY_REPLY_TIMEOUT_MS}ms (reason=${reason}); preserving the existing session`,
         )
@@ -1496,11 +1510,10 @@ class OtaInstallCoordinator {
       }
       // Don't fire if we've left the active phase (e.g. user backed out, error overlay).
       if (isTerminalForWatchdog(this.computeDisplayStateNow())) return
-      console.log(
-        `[OTA_PROGRESS] watchdog: ${
-          explicitIdle ? "idle ota_status" : "legacy query timeout"
-        } (reason=${reason}), falling back to ota_start`,
-      )
+      let fallbackCause = "legacy query timeout"
+      if (explicitIdle) fallbackCause = "idle ota_status"
+      else if (rejectedStart) fallbackCause = "rejected ota_start with no recovery reply"
+      console.log(`[OTA_PROGRESS] watchdog: ${fallbackCause} (reason=${reason}), falling back to ota_start`)
       this.retryCount = 0
       if (this.otaStartOwnership?.outcome !== "pending" && !this.prepareFreshOtaStartAttempt()) return
       void this.sendOtaStartWithWatchdogs()

--- a/mobile/modules/engine/src/services/otaInstallPolicy.ts
+++ b/mobile/modules/engine/src/services/otaInstallPolicy.ts
@@ -10,6 +10,7 @@ import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk/internal"
 export const MINIMUM_OTA_STATUS_BUILD = 37
 
 export const MAX_RETRIES = 3
+/** Wait between ended native ota_start requests; never overlaps a pending request. */
 export const RETRY_INTERVAL_MS = 5000
 /** APK/BES and general install when progress events are expected */
 export const PROGRESS_TIMEOUT_MS = 120_000
@@ -119,7 +120,6 @@ export function selectOtaProtocolProfile(
 }
 
 export const OtaProgressMessages = {
-  noAckResponse: "Unable to start update. Glasses did not respond.",
   stalledOrStuck: "Update may have failed. Ensure glasses have internet access and try again.",
   globalTimeout: "Update took too long. Please try again.",
   sendOtaStartFailed: "Failed to communicate with glasses.",

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -106,9 +106,7 @@ function idleStatus(): OtaStatus {
 }
 
 async function flushNativeStartPromise(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
-  await Promise.resolve()
+  await jest.advanceTimersByTimeAsync(0)
 }
 
 beforeEach(() => {
@@ -227,6 +225,46 @@ describe("OtaInstallCoordinator ota_start request ownership", () => {
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
     expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
     expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
+  })
+
+  it("queues an explicit retry behind the previous request and ignores its stale ack", async () => {
+    setGlassesConnected()
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+    bluetoothSdkMock.startOtaUpdate
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecond = resolve
+          }),
+      )
+    otaInstallCoordinator.attach()
+
+    await jest.advanceTimersByTimeAsync(DOWNLOAD_STUCK_TIMEOUT_MS)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
+
+    otaInstallCoordinator.retry()
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    // An unscoped event from the previous native request must not acknowledge
+    // the fresh logical attempt while that request still owns the bridge.
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    expect((otaInstallCoordinator as unknown as {hasReceivedAck: boolean}).hasReceivedAck).toBe(false)
+
+    resolveFirst()
+    await flushNativeStartPromise()
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+    expect((otaInstallCoordinator as unknown as {hasReceivedAck: boolean}).hasReceivedAck).toBe(false)
+
+    resolveSecond()
+    await flushNativeStartPromise()
+    expect((otaInstallCoordinator as unknown as {hasReceivedAck: boolean}).hasReceivedAck).toBe(true)
   })
 })
 
@@ -496,6 +534,56 @@ describe("OtaInstallCoordinator detach()", () => {
 
     expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
     expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
+  })
+
+  it("re-arms the 0%-stuck watchdog when a remount adopts the native request", async () => {
+    setGlassesConnected()
+    let resolveStart!: () => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve
+        }),
+    )
+    otaInstallCoordinator.attach()
+
+    otaInstallCoordinator.detach()
+    otaInstallCoordinator.attach()
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    resolveStart()
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(DOWNLOAD_STUCK_TIMEOUT_MS)
+
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.stalledOrStuck)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
+  })
+
+  it("re-arms the global timeout when a remount adopts the native request", async () => {
+    setGlassesConnected()
+    let resolveStart!: () => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve
+        }),
+    )
+    otaInstallCoordinator.attach()
+
+    otaInstallCoordinator.detach()
+    otaInstallCoordinator.attach()
+    resolveStart()
+    await flushNativeStartPromise()
+
+    // Steadily advancing progress keeps every per-step watchdog quiet; only the
+    // re-armed session cap can fail this adopted request.
+    for (let minute = 1; minute * 60_000 <= GLOBAL_OTA_TIMEOUT_MS; minute++) {
+      useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: minute, overallPercent: minute}))
+      await jest.advanceTimersByTimeAsync(60_000)
+    }
+
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.globalTimeout)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
   })
 })
 

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -1206,6 +1206,25 @@ describe("OtaInstallCoordinator APK completion by build-number increase (WP 8C-c
     expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
   })
 
+  it("does not carry build-number completion proof into a fresh rejected attempt", async () => {
+    setLegacyGlassesConnected("33")
+    seedLegacyApkUpdateAvailable()
+    otaInstallCoordinator.attach()
+    await flushNativeStartPromise()
+
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "45"})
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+    otaInstallCoordinator.finish()
+
+    bluetoothSdkMock.startOtaUpdate.mockRejectedValue(new Error("fresh native rejection"))
+    otaInstallCoordinator.retry()
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(LEGACY_RETRY_INTERVAL_MS)
+
+    // One completed request plus the fresh request and its first serialized retry.
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(3)
+  })
+
   it("does not fire without an apk step in the selected update", () => {
     setLegacyGlassesConnected("33")
     useGlassesStore.getState().setOtaUpdateAvailable({

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -1180,6 +1180,32 @@ describe("OtaInstallCoordinator APK completion by build-number increase (WP 8C-c
     expect(snap.errorMsg).toBe("")
   })
 
+  it("does not retry when a late native rejection follows exact build-number completion", async () => {
+    setLegacyGlassesConnected("33")
+    seedLegacyApkUpdateAvailable()
+    let rejectStart!: (reason: Error) => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject
+        }),
+    )
+    otaInstallCoordinator.attach()
+
+    // Legacy version_info is the only completion signal; no ota_start_ack or
+    // ota_status/progress event arrives before the native promise rejects.
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "45"})
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+
+    rejectStart(new Error("late native timeout"))
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(LEGACY_RETRY_INTERVAL_MS * MAX_RETRIES)
+
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("complete")
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
+  })
+
   it("does not fire without an apk step in the selected update", () => {
     setLegacyGlassesConnected("33")
     useGlassesStore.getState().setOtaUpdateAvailable({

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -227,23 +227,15 @@ describe("OtaInstallCoordinator ota_start request ownership", () => {
     expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
   })
 
-  it("queues an explicit retry behind the previous request and ignores its stale ack", async () => {
+  it("adopts a pending request on Retry and never queues a second ota_start after its ack", async () => {
     setGlassesConnected()
     let resolveFirst!: () => void
-    let resolveSecond!: () => void
-    bluetoothSdkMock.startOtaUpdate
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveFirst = resolve
-          }),
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveSecond = resolve
-          }),
-      )
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve
+        }),
+    )
     otaInstallCoordinator.attach()
 
     await jest.advanceTimersByTimeAsync(DOWNLOAD_STUCK_TIMEOUT_MS)
@@ -251,20 +243,33 @@ describe("OtaInstallCoordinator ota_start request ownership", () => {
 
     otaInstallCoordinator.retry()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
 
-    // An unscoped event from the previous native request must not acknowledge
-    // the fresh logical attempt while that request still owns the bridge.
+    // Both public delivery surfaces refer to the same owned request. Neither
+    // the listener event nor the correlated promise may create another start.
     GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
-    expect((otaInstallCoordinator as unknown as {hasReceivedAck: boolean}).hasReceivedAck).toBe(false)
-
     resolveFirst()
     await flushNativeStartPromise()
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
-    expect((otaInstallCoordinator as unknown as {hasReceivedAck: boolean}).hasReceivedAck).toBe(false)
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
 
-    resolveSecond()
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it("starts a fresh attempt after an authoritative failure and resets the 0%-stuck watchdog", async () => {
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
     await flushNativeStartPromise()
-    expect((otaInstallCoordinator as unknown as {hasReceivedAck: boolean}).hasReceivedAck).toBe(true)
+
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: 40, overallPercent: 40}))
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({status: "failed", stepPercent: 40, overallPercent: 40}))
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
+
+    otaInstallCoordinator.retry()
+    await flushNativeStartPromise()
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+
+    await jest.advanceTimersByTimeAsync(DOWNLOAD_STUCK_TIMEOUT_MS)
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.stalledOrStuck)
   })
 })
 
@@ -295,6 +300,17 @@ describe("OtaInstallCoordinator query-status arbitration with an existing sessio
     useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: 12, overallPercent: 12}))
     await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS * 2)
 
+    expect(bluetoothSdkMock.startOtaUpdate).not.toHaveBeenCalled()
+  })
+
+  it("does not create a unified ota_start when reconciliation gets no authoritative reply", async () => {
+    setGlassesConnected()
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: 10, overallPercent: 10}))
+    otaInstallCoordinator.attach()
+
+    await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS)
+
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
     expect(bluetoothSdkMock.startOtaUpdate).not.toHaveBeenCalled()
   })
 })
@@ -395,13 +411,14 @@ describe("OtaInstallCoordinator version-change detour retry gate", () => {
     errorSpy.mockRestore()
   })
 
-  it("retry outside a detour still re-sends ota_start", async () => {
+  it("retry outside a detour reconciles an acknowledged start without re-sending ota_start", async () => {
     setGlassesConnected()
     otaInstallCoordinator.attach()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
     await flushNativeStartPromise()
     otaInstallCoordinator.retry()
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -652,7 +669,7 @@ describe("OtaInstallCoordinator legacy ota_progress normalization (WP 8C-a)", ()
     expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
   })
 
-  it("glasses_session_changed acts as the reconnect edge: queries status and falls back to ota_start", async () => {
+  it("glasses_session_changed queries status without restarting a silent unified session", async () => {
     // The BES keeps the BLE link alive across the asg restart, so no physical
     // connect edge fires; the sid change is the only restart signal.
     setGlassesConnected()
@@ -665,10 +682,10 @@ describe("OtaInstallCoordinator legacy ota_progress normalization (WP 8C-a)", ()
     GlobalEventEmitter.emit("glasses_session_changed", {previousSid: "", sid: "abcd1234"})
     expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
 
-    // No useful reply (session lost on the glasses): the fallback re-sends ota_start.
+    // No authoritative reply is ambiguous: preserve the accepted unified session.
     useGlassesStore.getState().setOtaStatus(null)
     await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS)
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalled()
+    expect(bluetoothSdkMock.startOtaUpdate).not.toHaveBeenCalled()
   })
 
   it("glasses_session_changed after APK completion queries the ASG-owned session without sending ota_start", async () => {

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -105,11 +105,17 @@ function idleStatus(): OtaStatus {
   }
 }
 
+async function flushNativeStartPromise(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 beforeEach(() => {
   jest.useFakeTimers()
   otaInstallCoordinator.detach()
   useGlassesStore.getState().reset()
-  bluetoothSdkMock.startOtaUpdate.mockClear()
+  bluetoothSdkMock.startOtaUpdate.mockReset().mockResolvedValue(undefined)
   bluetoothSdkMock.sendOtaQueryStatus.mockClear()
   bluetoothSdkMock.requestVersionInfo.mockClear()
   bluetoothSdkMock.updateGlasses.mockClear()
@@ -141,7 +147,7 @@ describe("OtaInstallCoordinator initial-mount arbitration", () => {
     const snap = otaInstallCoordinator.snapshot()
     expect(snap.errorMsg).toBe(OtaProgressMessages.globalTimeout)
     expect(snap.displayState).toBe("failed")
-    // The no-ack retry watchdog never re-sent (ack + first activity cleared it).
+    // The acknowledged native request never re-sent.
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
   })
 
@@ -153,36 +159,74 @@ describe("OtaInstallCoordinator initial-mount arbitration", () => {
   })
 })
 
-describe("OtaInstallCoordinator no-ack retry watchdog", () => {
-  it("retries ota_start at RETRY_INTERVAL_MS up to MAX_RETRIES then fails with noAckResponse", async () => {
+describe("OtaInstallCoordinator ota_start request ownership", () => {
+  it("keeps exactly one ota_start while the native request is pending", async () => {
     setGlassesConnected()
+    let rejectStart!: (reason: Error) => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject
+        }),
+    )
     otaInstallCoordinator.attach()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
 
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    rejectStart(new Error("native timeout"))
+    await Promise.resolve()
     await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(3)
-    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
-
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(MAX_RETRIES)
-    const snap = otaInstallCoordinator.snapshot()
-    expect(snap.errorMsg).toBe(OtaProgressMessages.noAckResponse)
-    expect(snap.displayState).toBe("failed")
   })
 
-  it("ota_start_ack clears the retry watchdog (no further retries)", async () => {
+  it("serializes rejected native attempts and fails only after MAX_RETRIES ended requests", async () => {
     setGlassesConnected()
+    bluetoothSdkMock.startOtaUpdate.mockRejectedValue(new Error("native timeout"))
     otaInstallCoordinator.attach()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
 
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS - 1000)
-    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * 3)
+    await Promise.resolve()
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+    await Promise.resolve()
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
+
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(MAX_RETRIES)
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.sendOtaStartFailed)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
+  })
+
+  it("does not retry or fail when ota_start times out after BES completion activity", async () => {
+    setGlassesConnected()
+    let rejectStart!: (reason: Error) => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject
+        }),
+    )
+    otaInstallCoordinator.attach()
+
+    useGlassesStore.getState().setOtaStatus(
+      inProgressStatus({
+        stepType: "bes",
+        phase: "install",
+        status: "step_complete",
+        stepPercent: 100,
+        overallPercent: 100,
+      }),
+    )
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
+
+    rejectStart(new Error("OTA start command timed out waiting for glasses response."))
+    await Promise.resolve()
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
 
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
     expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
   })
 })
 
@@ -259,6 +303,8 @@ describe("OtaInstallCoordinator version-change detour retry gate", () => {
       useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 100}))
       expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
 
+      await flushNativeStartPromise()
+
       useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", status: "failed", error: errorCode}))
       expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
       otaInstallCoordinator.retry()
@@ -315,6 +361,7 @@ describe("OtaInstallCoordinator version-change detour retry gate", () => {
     setGlassesConnected()
     otaInstallCoordinator.attach()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+    await flushNativeStartPromise()
     otaInstallCoordinator.retry()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
   })
@@ -408,32 +455,40 @@ describe("OtaInstallCoordinator finish()", () => {
 })
 
 describe("OtaInstallCoordinator detach()", () => {
-  it("clears pending watchdogs; re-attach is a fresh session with fresh retry bookkeeping", async () => {
+  it("keeps a native ota_start single-flight across detach and re-attach", async () => {
     setGlassesConnected()
+    let rejectStart!: (reason: Error) => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject
+        }),
+    )
     otaInstallCoordinator.attach()
     expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
 
-    await jest.advanceTimersByTimeAsync(1000)
     otaInstallCoordinator.detach()
-
-    // No pending watchdog outlives detach: nothing re-fires, nothing fails.
-    await jest.advanceTimersByTimeAsync(GLOBAL_OTA_TIMEOUT_MS * 2)
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
-    expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
-
-    // Re-attach: fresh initial-mount arbitration + a full fresh retry cycle.
     otaInstallCoordinator.attach()
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+
+    // The screen remounted while native still owns the first request. Joining
+    // that request must not open a concurrent ota_start in the bridge.
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
     expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
-    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.noAckResponse)
-    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1 + MAX_RETRIES)
+
+    rejectStart(new Error("native timeout"))
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
+
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
   })
 
   it("after a failure resets session state so a re-attach starts clean", async () => {
     setGlassesConnected()
+    bluetoothSdkMock.startOtaUpdate.mockRejectedValue(new Error("native timeout"))
     otaInstallCoordinator.attach()
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * (MAX_RETRIES - 1))
     expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
 
     otaInstallCoordinator.detach()
@@ -934,14 +989,14 @@ describe("OtaInstallCoordinator APK completion by build-number increase (WP 8C-c
   it("build-number increase recovers a legacy session even from a watchdog failure", async () => {
     setLegacyGlassesConnected("33")
     seedLegacyApkUpdateAvailable()
+    bluetoothSdkMock.startOtaUpdate.mockRejectedValue(new Error("native timeout"))
     otaInstallCoordinator.attach()
 
-    // Old-build no-ack retry runs on the padded legacy interval (WP 8C-g).
-    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
-    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
-    await jest.advanceTimersByTimeAsync(LEGACY_RETRY_INTERVAL_MS * MAX_RETRIES)
+    // Old-build request failures retry serially on the padded legacy interval.
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(LEGACY_RETRY_INTERVAL_MS * (MAX_RETRIES - 1))
     expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
-    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.noAckResponse)
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.sendOtaStartFailed)
 
     useGlassesStore.getState().setGlassesInfo({buildNumber: "45"})
 

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -1218,6 +1218,7 @@ describe("OtaInstallCoordinator APK completion by build-number increase (WP 8C-c
 
     bluetoothSdkMock.startOtaUpdate.mockRejectedValue(new Error("fresh native rejection"))
     otaInstallCoordinator.retry()
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
     await flushNativeStartPromise()
     await jest.advanceTimersByTimeAsync(LEGACY_RETRY_INTERVAL_MS)
 

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -227,6 +227,76 @@ describe("OtaInstallCoordinator ota_start request ownership", () => {
     expect(otaInstallCoordinator.snapshot().displayState).toBe("restarting")
   })
 
+  it("defers a rejected start while disconnected and retries only after reconnect reconciliation is silent", async () => {
+    setGlassesConnected()
+    let rejectStart!: (reason: Error) => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject
+        }),
+    )
+    otaInstallCoordinator.attach()
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    rejectStart(new Error("native request failed during disconnect"))
+    await flushNativeStartPromise()
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS * MAX_RETRIES)
+
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
+
+    setGlassesConnected()
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS - 1)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it("preserves an active session reported while reconciling a disconnected rejected start", async () => {
+    setGlassesConnected()
+    let rejectStart!: (reason: Error) => void
+    bluetoothSdkMock.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject
+        }),
+    )
+    otaInstallCoordinator.attach()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    rejectStart(new Error("native request failed during disconnect"))
+    await flushNativeStartPromise()
+
+    setGlassesConnected()
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: 1, overallPercent: 1}))
+    await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS * 2)
+
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("updating")
+  })
+
+  it("cancels a scheduled start retry on disconnect so reconnect remains query-first", async () => {
+    setGlassesConnected()
+    bluetoothSdkMock.startOtaUpdate.mockRejectedValueOnce(new Error("native request failed"))
+    otaInstallCoordinator.attach()
+    await flushNativeStartPromise()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(RETRY_INTERVAL_MS)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS - RETRY_INTERVAL_MS)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+  })
+
   it("adopts a pending request on Retry and never queues a second ota_start after its ack", async () => {
     setGlassesConnected()
     let resolveFirst!: () => void

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -87,7 +87,7 @@ beforeEach(() => {
   useConnectionOverlayConfig.getState().clearConfig()
   mockReplace.mockClear()
   BluetoothSdk.sendOtaQueryStatus.mockClear()
-  BluetoothSdk.startOtaUpdate.mockClear()
+  BluetoothSdk.startOtaUpdate.mockReset().mockResolvedValue(undefined)
   stopOtaAutoChain()
 })
 
@@ -505,8 +505,9 @@ describe("progress.tsx display states", () => {
 })
 
 describe("progress.tsx watchdog timers", () => {
-  it("fails with no-ack message after max ota_start retries while still starting", async () => {
+  it("fails after max serialized native ota_start failures", async () => {
     setGlassesConnected()
+    BluetoothSdk.startOtaUpdate.mockRejectedValue(new Error("native timeout"))
     const {getByText} = render(<OtaProgressScreen />)
 
     await act(async () => {
@@ -514,24 +515,32 @@ describe("progress.tsx watchdog timers", () => {
     })
 
     expect(getByText("Update Failed")).toBeDefined()
-    expect(getByText(OtaProgressMessages.noAckResponse)).toBeDefined()
+    expect(getByText(OtaProgressMessages.sendOtaStartFailed)).toBeDefined()
+    expect(BluetoothSdk.startOtaUpdate).toHaveBeenCalledTimes(3)
   })
 
-  it("does not fail no-ack when ota_start_ack is received", async () => {
+  it("does not fail or duplicate ota_start while the native request is pending", async () => {
     setGlassesConnected()
+    let resolveStart!: (value: undefined) => void
+    BluetoothSdk.startOtaUpdate.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStart = resolve
+        }),
+    )
     const {queryByText} = render(<OtaProgressScreen />)
 
     await act(async () => {
-      await jest.advanceTimersByTimeAsync(4000)
-    })
-    act(() => {
-      GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
-    })
-    await act(async () => {
-      await jest.advanceTimersByTimeAsync(5100)
+      await jest.advanceTimersByTimeAsync(16_000)
     })
 
-    expect(queryByText(OtaProgressMessages.noAckResponse)).toBeNull()
+    expect(queryByText("Update Failed")).toBeNull()
+    expect(BluetoothSdk.startOtaUpdate).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveStart(undefined)
+      await Promise.resolve()
+    })
   })
 
   it("fails stuck-at-zero after DOWNLOAD_STUCK_TIMEOUT_MS in starting", async () => {
@@ -688,9 +697,15 @@ describe("progress.tsx reconnect", () => {
     expect(BluetoothSdk.startOtaUpdate).toHaveBeenCalled()
   })
 
-  it("retry button starts OTA", () => {
+  it("retry button starts OTA after the previous native request ended", async () => {
     setGlassesConnected()
     const {getByTestId} = render(<OtaProgressScreen />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    BluetoothSdk.startOtaUpdate.mockClear()
 
     act(() => {
       useGlassesStore.getState().setOtaStatus({
@@ -707,7 +722,7 @@ describe("progress.tsx reconnect", () => {
     })
 
     fireEvent.press(getByTestId("button-Retry"))
-    expect(BluetoothSdk.startOtaUpdate).toHaveBeenCalled()
+    expect(BluetoothSdk.startOtaUpdate).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary

- serialize mobile `ota_start` calls across retries and React screen remounts on both iOS and Android
- remove the independent five-second retry watchdog that could overlap the native bridge's 15-second request lifetime
- keep the durable BES OTA journal nonterminal for a 30-second grace period after the bounded UART recovery scan
- accept a late exact-target framed version proof from a later Linux boot only when it supersedes `recovery_timeout` or `verification_timeout`
- keep authorization, artifact, protocol, raw-mode, version-mismatch, and all other failures terminal

## Root causes

### Concurrent mobile starts

The mobile coordinator retried every 5 seconds while the native bridge retained one pending request for 15 seconds. A second logical `ota_start` could therefore be sent before the first request released ownership, even though each native bridge correctly allowed only one pending request.

### Premature BES reboot timeout

After BES apply, an abrupt MTK reboot can restore the earlier `AUTH_ATTEMPTED` filesystem record even though ASG committed and read back `APPLY_PENDING`. On the reproduced successful install, bounded UART recovery ended before BES finished rebooting. ASG immediately made the timeout terminal and then ignored stronger, exact target-version evidence that arrived 11.166 seconds later.

The journal remains the crash-safe authority that prevents ambiguous duplicate authorization/apply attempts. This change does not remove that safety. It gives the normal reboot a bounded grace period and permits only exact target proof from a different Linux boot to replace the two transport timing failures.

## Hardware evidence

Captured from Mentra Live `0123456789ABCDEF` during a successful BES `26.8.6.0` to `26.8.8.0` install:

```text
08-12 01:35:16.826 E K900BluetoothManager: BES_OTA_DIAG recovery_result=timeout current_boot=59337b6b-8687-4c8f-bd5a-268608de3149 framed_path=false snapshot={state=AUTH_ATTEMPTED owner=623dbe99 auth_boot=58c37b75-6aab-4757-aa63-e9cb92e6088a ... target=26.8.8.0 ...}
08-12 01:35:16.835 I BesOtaStateStore: BES_OTA_DIAG op=fail_recovery_timeout ... after={state=TERMINAL owner=623dbe99 ... target=26.8.8.0 terminal_status=FAILURE terminal_code=recovery_timeout ...} committed=true readback_match=true
08-12 01:35:28.001 I MentraBleTrace: ... payload={... "B":{"dpj":"26.8.8.0","phone_ble":1}}
08-12 01:35:28.005 I K900BluetoothManager: BES_OTA_DIAG version_proof actual=26.8.8.0 current_boot=59337b6b-8687-4c8f-bd5a-268608de3149 disposition=ignored reason=state_not_recoverable snapshot={state=TERMINAL owner=623dbe99 ... target=26.8.8.0 terminal_status=FAILURE terminal_code=recovery_timeout ...}
08-12 01:35:28.387 I BES-UART: UART link ready at fast baud 1152000
```

The authorization boot and proof boot differ, and the framed `dpj` value exactly equals the requested target. The phone independently received the same installed version, rechecked the manifest, and displayed success.

Earlier mobile evidence from the same hardware validation showed the overlapping-start symptom after successful transfer:

```text
17:29:30.470 ota_status: BES install step_complete, step_percent=100, overall_percent=100
17:29:30.473 [OTA_PROGRESS] displayState updating -> restarting
17:29:31.076 [OTA_PROGRESS] sendOtaStart threw Error: OTA start command timed out waiting for glasses response.
17:29:31.077 [OTA_PROGRESS] sendOtaStart failed after max retries, failing session
17:29:31.079 [OTA_PROGRESS] displayState restarting -> failed
17:30:54 BES version: 26.8.8.0; glasses_ready received
17:30:59 update check: no update available
```

## Validation

- iPhone hardware: one `ota_start`; BES transfer completed and the phone reached the success/up-to-date flow
- `./gradlew :app:testDebugUnitTest` — passed
- `./gradlew :app:testDebugUnitTest --tests 'com.mentra.asg_client.io.bes.BesOtaStateStoreTest'` — 33 passed
- `./scripts/check-android-compile.sh asg` — passed
- mobile coordinator/progress Jest suites — 94 passed
- `bun run compile` — passed
- `git diff --check` — passed

New state-machine coverage proves:

- `recovery_timeout` and `verification_timeout` can be superseded by exact target proof from the same owner on a later boot
- wrong owner, same boot, and wrong target cannot change the failure
- non-timeout failures remain immutable

The repository-wide Spotless task is currently blocked before completion by a pre-existing noncontiguous-import error in unchanged `MediaUploadQueueManager.java`; all touched Java files were formatted and compile successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OTA command sequencing on the phone and durable BES install/verification state on glasses; mistakes could cause duplicate installs or incorrect success/failure, though scope is narrowed by ownership gates and strict timeout-supersede rules with added tests.
> 
> **Overview**
> **Mobile OTA** replaces the overlapping 5-second “no ack” retry loop with **single-flight `ota_start` ownership** tied to the native bridge: one pending request at a time, retries only after the prior request settles, and **Retry/reconnect** mostly **reconcile** (`ota_query_status`) instead of firing another start. Late native rejections are ignored when progress or legacy build-number proof already shows acceptance; unified query fallbacks no longer start a new session on ambiguous silence.
> 
> **ASG BES OTA** waits **`BES_OTA_RECOVERY_FAILURE_GRACE_MS` (30s)** after the UART recovery scan before writing `recovery_timeout` / `verification_timeout`. **`BesOtaStateStore`** adds atomic **`completeVersionProofAfterRestart`** and **`completeLateExactTargetAfterRecoveryTimeout`**, so an exact target version from a **later Linux boot** can flip only those two timeout terminals to **verified**; other failure codes stay terminal. **`K900BluetoothManager`** routes post-reboot version proof through the store and accepts proof while those timeout terminals are still eligible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab15ab735432693f3429733a360a05d162c6cbaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Latest PR-head hardware verification

Verified on the phone-connected Mentra Live endpoint `192.168.1.152:5555` with PR head `54e9f3a249` installed on both the iPhone development app and ASG (`versionCode=50909543`). The FTDI/ADB/BLE identity was proven before the run: BT `CC:E7:DE:E0:02:3B`, adapter `AS49934J`, and flash ID `85-60-16`.

1. Factory downgrade to BES `26.8.6.0` passed 62/62 sector read-back checks and post-flash `version_info_3` verification.
2. The phone sent one `ota_start`; ASG acknowledged it and admitted durable owner `c8821c13`.
3. The BES OTA passed 70/70 segment CRC checks and confirmed `1137871/1137871` bytes.
4. ASG committed `APPLY_PENDING` with read-back, sent apply, received accepted `0x93`, and waited for reboot proof.
5. BES decompressed `1957116` bytes, verified image CRC `0xaf82ae4a`, committed the image, and rebooted.
6. After the glasses power button was pressed, the iPhone reconnected, received exact BES `26.8.8.0`, transitioned `restarting -> complete`, rechecked the manifest, and displayed `Up to date`.
7. The restarted ASG durable snapshot is terminal success with different authorization and verification boots: `auth_boot=01876d90-c2e1-4993-b38a-6d94ae687e6d`, `verify_boot=15fe69c1-ee54-4044-ba80-202621acdd7f`, `target=26.8.8.0`, `terminal_status=SUCCESS`, `terminal_code=verified`.

This run proves the normal customer path remains successful with the new recovery code installed. The specific late-timeout override branch did not need to fire in this run; its exact-owner/later-boot/exact-target restrictions are covered by the focused state-store tests, while the preceding hardware reproduction supplies the timing evidence for that branch.