### PR TITLE
Fix capsule header spacing

### DIFF
--- a/mobile/modules/miniapp/src/react/capsuleHeaderLayout.ts
+++ b/mobile/modules/miniapp/src/react/capsuleHeaderLayout.ts
@@ -1,0 +1,11 @@
+import type {MiniappCapsuleMenuRect} from "../globals"
+
+export function getCapsuleHeaderPaddingRight(
+  capsuleMenu: MiniappCapsuleMenuRect,
+  viewportWidth: number,
+  safeAreaRight: number,
+  rightGap: number,
+): number {
+  const capsuleOffsetFromContentRight = viewportWidth - capsuleMenu.left - safeAreaRight
+  return Math.max(rightGap, capsuleOffsetFromContentRight + rightGap)
+}

--- a/mobile/modules/miniapp/src/react/useCapsuleHeaderStyle.test.ts
+++ b/mobile/modules/miniapp/src/react/useCapsuleHeaderStyle.test.ts
@@ -1,0 +1,26 @@
+import {describe, expect, it} from "bun:test"
+
+import {getCapsuleHeaderPaddingRight} from "./capsuleHeaderLayout"
+
+const capsuleMenu = {
+  top: 12,
+  right: 380,
+  bottom: 52,
+  left: 300,
+  width: 80,
+  height: 40,
+}
+
+describe("getCapsuleHeaderPaddingRight", () => {
+  it("includes the host margin between the capsule and viewport edge", () => {
+    expect(getCapsuleHeaderPaddingRight(capsuleMenu, 400, 0, 16)).toBe(116)
+  })
+
+  it("does not double-count the safe-area inset", () => {
+    expect(getCapsuleHeaderPaddingRight(capsuleMenu, 400, 20, 16)).toBe(96)
+  })
+
+  it("always preserves the requested content gap", () => {
+    expect(getCapsuleHeaderPaddingRight({...capsuleMenu, left: 395}, 400, 20, 16)).toBe(16)
+  })
+})

--- a/mobile/modules/miniapp/src/react/useCapsuleHeaderStyle.ts
+++ b/mobile/modules/miniapp/src/react/useCapsuleHeaderStyle.ts
@@ -15,6 +15,7 @@
 
 import type {CSSProperties} from "react"
 
+import {getCapsuleHeaderPaddingRight} from "./capsuleHeaderLayout"
 import {useSafeArea} from "./useSafeArea"
 
 export interface UseCapsuleHeaderStyleOptions {
@@ -39,7 +40,11 @@ export function useCapsuleHeaderStyle(
     ? capsuleMenu.top + capsuleMenu.height / 2 - insets.top
     : fallbackMarginTop + height / 2
   const marginTop = Math.max(0, center - height / 2)
-  const paddingRight = capsuleMenu ? capsuleMenu.width + rightGap : leftPadding
+  const paddingRight = capsuleMenu
+    ? typeof window === "undefined"
+      ? capsuleMenu.width + rightGap
+      : getCapsuleHeaderPaddingRight(capsuleMenu, window.innerWidth, insets.right, rightGap)
+    : leftPadding
 
   return {
     display: "flex",


### PR DESCRIPTION
## Summary

- reserve header space from the capsule's actual left edge instead of assuming a fixed host margin
- account for the WebView's right safe-area inset without double-counting it
- preserve the configured minimum gap and the server-rendering fallback
- add focused layout-math tests

## Root cause

`useCapsuleHeaderStyle` reserved only `capsuleMenu.width + rightGap`. Any host margin wider than `rightGap` was omitted, allowing right-slot content to render beneath the floating capsule.

## Validation

- `bun test src/react/useCapsuleHeaderStyle.test.ts`
- `bun run typecheck`
- `bun run build`

Linear: https://linear.app/mentralabs/issue/OS-1900

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout math fix with unit tests; no auth, data, or security-sensitive changes.
> 
> **Overview**
> Fixes miniapp header right padding so content no longer sits under the floating capsule when the host margin is wider than `rightGap`.
> 
> `useCapsuleHeaderStyle` now derives padding from the capsule's actual left edge and viewport width via `getCapsuleHeaderPaddingRight`, subtracting the right safe-area inset so it isn't double-counted, while keeping the SSR fallback and minimum gap. Adds focused layout-math unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0361ada30a5c2aa8fb704397ec355d783d43dd39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix capsule header spacing by computing right padding from the capsule’s actual position and safe-area inset. Prevents right-slot content from overlapping the floating capsule across hosts.

- **Bug Fixes**
  - Measure from capsule `left` to viewport right, minus `safeArea.right`, then add `rightGap` (no double-count).
  - Preserve SSR fallback and the configured minimum gap.
  - Add `getCapsuleHeaderPaddingRight` and unit tests.
  - Addresses Linear OS-1900: right-slot content no longer renders under the capsule when host margin exceeds `rightGap`.

<sup>Written for commit 0361ada30a5c2aa8fb704397ec355d783d43dd39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

