### PR TITLE
Make EventKit the truth for iOS calendar permission

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -166,6 +166,8 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
           "Mentra accesses your calendar to display upcoming events and reminders directly on your smart glasses. For example, the app can show 'Meeting with John at 3 PM in Conference Room A' or remind you '15 minutes until dentist appointment' on your glasses display.",
         NSCalendarsFullAccessUsageDescription:
           "Mentra accesses your calendar to display upcoming events and reminders directly on your smart glasses. For example, the app can show 'Meeting with John at 3 PM in Conference Room A' or remind you '15 minutes until dentist appointment' on your glasses display.",
+        NSCalendarsWriteOnlyAccessUsageDescription:
+          "Mentra uses write-only calendar access to add events requested by miniapps to your calendar.",
         NSCalendarUsageDescription:
           "Mentra accesses your calendar to display upcoming events and reminders directly on your smart glasses. For example, the app can show 'Meeting with John at 3 PM in Conference Room A' or remind you '15 minutes until dentist appointment' on your glasses display.",
         NSPhotoLibraryUsageDescription:
@@ -284,6 +286,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
             "Camera",
             "Microphone",
             "Calendars",
+            "CalendarsWriteOnly",
             "Bluetooth",
             "LocationAccuracy",
             "LocationWhenInUse",

--- a/mobile/modules/engine/src/services/PhoneCalendarService.ts
+++ b/mobile/modules/engine/src/services/PhoneCalendarService.ts
@@ -1,4 +1,6 @@
 import * as Calendar from "expo-calendar"
+import {Platform} from "react-native"
+import {check, PERMISSIONS, RESULTS} from "react-native-permissions"
 
 import {MiniappErrorCode, type CalendarListResult} from "@mentra/miniapp"
 
@@ -12,14 +14,31 @@ import {
 
 export {PhoneCalendarError} from "./PhoneCalendarHelpers"
 
+/**
+ * expo-calendar reports anything below EventKit full access as not granted,
+ * so distinguish the states the user can actually fix. "Reopen the miniapp"
+ * is only true while the permission is undetermined — once iOS has resolved
+ * it (denied or write-only/limited), only Settings can change it.
+ */
+async function calendarPermissionMessage(status: Calendar.PermissionStatus): Promise<string> {
+  if (status === Calendar.PermissionStatus.UNDETERMINED) {
+    return "Calendar permission has not been granted yet. Reopen the miniapp and allow calendar access."
+  }
+  if (Platform.OS === "ios") {
+    const writeOnly = await check(PERMISSIONS.IOS.CALENDARS_WRITE_ONLY).catch(() => null)
+    if (writeOnly === RESULTS.GRANTED || writeOnly === RESULTS.LIMITED) {
+      return 'Calendar access is limited to write-only. Enable "Full Access" for Mentra in Settings › Privacy & Security › Calendars.'
+    }
+    return "Calendar access is denied. Enable it for Mentra in Settings › Privacy & Security › Calendars."
+  }
+  return "Calendar access is denied. Enable the Calendar permission for Mentra in your phone's app settings."
+}
+
 export async function listPhoneCalendarEvents(request: CalendarListRequest): Promise<CalendarListResult> {
   const {startsAt, endsAt, limit} = validateCalendarListRequest(request)
   const permission = await Calendar.getCalendarPermissionsAsync()
   if (permission.status !== "granted") {
-    throw new PhoneCalendarError(
-      MiniappErrorCode.PERMISSION_DENIED,
-      "Calendar permission is not granted. Reopen the miniapp and grant calendar access.",
-    )
+    throw new PhoneCalendarError(MiniappErrorCode.PERMISSION_DENIED, await calendarPermissionMessage(permission.status))
   }
 
   const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT)

--- a/mobile/src/utils/PermissionsUtils.tsx
+++ b/mobile/src/utils/PermissionsUtils.tsx
@@ -678,6 +678,7 @@ export const checkFeaturePermissions = async (featureKey: string): Promise<boole
         }
       } catch (error) {
         console.error(`Error checking iOS permission ${permission}:`, error)
+        allGranted = false
       }
     }
     return allGranted

--- a/mobile/src/utils/PermissionsUtils.tsx
+++ b/mobile/src/utils/PermissionsUtils.tsx
@@ -1,5 +1,6 @@
 import {AppletInterface, AppletPermission} from "@/../../cloud/packages/types/src"
 import CrustModule from "@mentra/crust"
+import * as ExpoCalendar from "expo-calendar"
 import {Alert, Linking, PermissionsAndroid, Platform} from "react-native"
 import BleManager from "react-native-ble-manager"
 import {check, PERMISSIONS, request, RESULTS} from "react-native-permissions"
@@ -200,7 +201,7 @@ export const hasPermissionBeenRequested = async (featureKey: string): Promise<bo
     console.log("Failed to get permission requested status, assuming it has not been requested", res.error)
     return false
   }
-  return true
+  return res.value === true
 }
 
 export const markPermissionGranted = async (featureKey: string): Promise<void> => {
@@ -216,7 +217,7 @@ export const hasPermissionBeenGranted = async (featureKey: string): Promise<bool
     console.log("Failed to get permission granted status", res.error)
     return false
   }
-  return true
+  return res.value === true
 }
 
 // Battery optimization permission temporarily disabled
@@ -470,8 +471,20 @@ export const requestFeaturePermissions = async (featureKey: string): Promise<boo
       try {
         const result = await request(permission)
         if (result === RESULTS.GRANTED) {
+          // iOS 17+ can resolve a scoped calendar grant (write-only / "Select
+          // Calendars…") as GRANTED without re-reading EventKit. expo-calendar
+          // (what actually reads events) requires full access, so verify
+          // against it before trusting the grant.
+          if (permission === PERMISSIONS.IOS.CALENDARS) {
+            const eventKit = await ExpoCalendar.getCalendarPermissionsAsync()
+            if (eventKit.status !== "granted") {
+              allGranted = false
+              await handlePreviouslyDeniedPermission(config)
+              return false
+            }
+          }
           partiallyGranted = true
-          await markPermissionGranted(permission)
+          await markPermissionGranted(featureKey)
         } else if (result === RESULTS.LIMITED) {
           partiallyGranted = true
           allGranted = false
@@ -647,20 +660,21 @@ export const checkFeaturePermissions = async (featureKey: string): Promise<boole
           return true
         }
 
+        if (permission === PERMISSIONS.IOS.CALENDARS) {
+          // EventKit is the source of truth for calendar reads: react-native-
+          // permissions can report a scoped (write-only/limited) grant as
+          // granted, while expo-calendar — what the runtime reads events with —
+          // requires full access.
+          const eventKit = await ExpoCalendar.getCalendarPermissionsAsync()
+          if (eventKit.status !== "granted") {
+            allGranted = false
+          }
+          continue
+        }
+
         const status = await check(permission)
         if (status != RESULTS.GRANTED && status != RESULTS.LIMITED) {
           allGranted = false
-        }
-
-        if (permission === PERMISSIONS.IOS.CALENDARS) {
-          // this permission is wierd and we should assume it's granted if we've been granted it before, but check for sure by requesting it:
-          if (await hasPermissionBeenGranted(permission)) {
-            // request the permission again to be sure (will do nothing if already granted)
-            const result = await request(permission)
-            if (result === RESULTS.GRANTED) {
-              return true
-            }
-          }
         }
       } catch (error) {
         console.error(`Error checking iOS permission ${permission}:`, error)


### PR DESCRIPTION
## Scope

Fixes the "Calendar permission is not granted. Reopen the miniapp and grant calendar access." error that Mentra Call (and any CALENDAR-declaring miniapp) hits on iOS even after the user granted calendar access. Traced from bug report `rep_01KZVYX8YK5JFCX3TF3JVDJ0E1` (iOS 26.5.2, app 3.0.0, Mentra Live).

Three stacked defects:

1. **Grant path trusted the wrong source.** react-native-permissions' iOS request handler resolves `GRANTED` from the EventKit completion callback without re-reading `EKEventStore.authorizationStatus`. On iOS 17+ a scoped grant (write-only / "Select Calendars…") therefore passes as granted — but the miniapp runtime reads events through expo-calendar, which requires `.fullAccess` and maps write-only to denied. Result: "granted, but still not granted."
2. **Stale flags suppressed re-prompting.** `hasPermissionBeenGranted`/`hasPermissionBeenRequested` returned `true` for any stored value (never read the stored boolean), and the granted flag was written under the raw iOS permission id (`ios.permission.CALENDARS`) but read back by feature key (`calendar`).
3. **The error message was wrong.** "Reopen the miniapp" only helps while the permission is undetermined; once iOS resolves it, only Settings can change it.

## Changes

- `mobile/src/utils/PermissionsUtils.tsx`
  - `checkFeaturePermissions` and `requestFeaturePermissions` verify `PERMISSIONS.IOS.CALENDARS` against `expo-calendar`'s `getCalendarPermissionsAsync()` — the same source of truth the miniapp runtime uses — replacing the old stale-flag + re-request special case.
  - Stored-flag helpers return the actual stored value; the granted flag is written under the feature key.
- `mobile/modules/engine/src/services/PhoneCalendarService.ts`
  - `PERMISSION_DENIED` message now distinguishes undetermined ("reopen and allow") from write-only (checked via `PERMISSIONS.IOS.CALENDARS_WRITE_ONLY`; "enable Full Access in Settings › Privacy & Security › Calendars") from denied.

## Test evidence

- `mobile/modules/engine`: `bun test src` — calendar/permissions suites pass; the 13 pre-existing `PhoneCameraFovCoordinator` failures (missing `BluetoothSdk.setCameraFovOverride` mock) are identical on clean `dev`.
- `mobile`: `bun run compile` — no new type errors (7 pre-existing errors identical on clean `dev`, none in touched files).
- `eslint` on both touched files: 0 errors.

Hardware verification still needed on an iOS device with write-only calendar access: the miniapp should now surface the "enable Full Access" message, and granting full access should make `listEvents` work without reinstalling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS permission gating and persistence for calendar miniapps; scope is limited to permission utilities and calendar listing, but incorrect checks could still block or mis-prompt users until verified on device.
> 
> **Overview**
> Fixes false **“Calendar permission is not granted”** errors on iOS when users grant scoped calendar access (write-only / “Select Calendars…”) that `react-native-permissions` reports as granted but **expo-calendar** (used to list events) does not.
> 
> **Permission flow** (`PermissionsUtils.tsx`): iOS calendar **request** and **check** now verify `PERMISSIONS.IOS.CALENDARS` against `expo-calendar.getCalendarPermissionsAsync()` instead of the old stale-storage + re-request workaround. Stored **requested/granted** flags now read the actual boolean from storage; **granted** is persisted under the **feature key** (`calendar`), not the raw iOS permission constant.
> 
> **Runtime errors** (`PhoneCalendarService.ts`): `PERMISSION_DENIED` messages distinguish **undetermined** (reopen miniapp), **write-only** (Settings → Full Access), and **denied**.
> 
> **App config**: Adds `NSCalendarsWriteOnlyAccessUsageDescription` and **`CalendarsWriteOnly`** in `react-native-permissions` for write-only calendar prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c1255f980d18fa5da46571695880a2974a0b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `expo-calendar` the source of truth for iOS calendar permission and add write-only config to stop false “not granted” errors after scoped grants on iOS 17+. Previously we trusted `react-native-permissions` (which can report write-only as granted) and stored stale flags; now we verify Full Access, fix flag storage, and show state-specific guidance.

- Verify `PERMISSIONS.IOS.CALENDARS` against `expo-calendar.getCalendarPermissionsAsync()` and treat write-only as not granted; use `PERMISSIONS.IOS.CALENDARS_WRITE_ONLY` to tailor messaging.
- Distinguish undetermined (“reopen and allow”), write-only (“enable Full Access” in Settings › Privacy & Security › Calendars), and denied in `PERMISSION_DENIED` errors.
- Read and write stored permission flags correctly: return the actual stored boolean and store granted under the feature key.
- Update build config: add `NSCalendarsWriteOnlyAccessUsageDescription` and include `CalendarsWriteOnly` in the `react-native-permissions` plugin config.

**Review notes**
- Changes are in `mobile/src/utils/PermissionsUtils.tsx`, `mobile/modules/engine/src/services/PhoneCalendarService.ts`, and `mobile/app.config.ts`.
- No migration required; rebuild iOS to apply the updated Info.plist. QA on iOS 17+: grant write-only via “Select Calendars…”, confirm the “enable Full Access” message, then grant Full Access and verify `listEvents` succeeds without reinstalling.

<sup>Written for commit a5c1255f980d18fa5da46571695880a2974a0b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

