### PR TITLE
Allow phone microphone fallback for miniapps

### DIFF
--- a/cloud/packages/cloud/src/services/session/HardwareCompatibilityService.ts
+++ b/cloud/packages/cloud/src/services/session/HardwareCompatibilityService.ts
@@ -89,7 +89,12 @@ export class HardwareCompatibilityService {
         return capabilities.hasDisplay;
 
       case HardwareType.MICROPHONE:
-        return capabilities.hasMicrophone;
+        // MentraOS always provides an audio-input path. When the connected
+        // glasses do not have an onboard microphone, the client falls back to
+        // the phone microphone. Keep `capabilities.hasMicrophone` reserved for
+        // describing the physical device; compatibility is about whether the
+        // requested input is available to the miniapp.
+        return true;
 
       case HardwareType.SPEAKER:
         return capabilities.hasSpeaker;

--- a/cloud/packages/cloud/src/services/session/__tests__/HardwareCompatibilityService.test.ts
+++ b/cloud/packages/cloud/src/services/session/__tests__/HardwareCompatibilityService.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="bun-types" />
+import {describe, expect, test} from "bun:test";
+import {
+  HardwareRequirementLevel,
+  HardwareType,
+} from "@mentra/sdk";
+
+import {vuzixZ100} from "../../../config/capabilities/vuzix-z100";
+import {AppI} from "../../../models/app.model";
+import {HardwareCompatibilityService} from "../HardwareCompatibilityService";
+
+function appWithRequirements(
+  hardwareRequirements: AppI["hardwareRequirements"],
+): AppI {
+  return {hardwareRequirements} as AppI;
+}
+
+describe("HardwareCompatibilityService", () => {
+  test("accepts a microphone requirement when glasses use the phone microphone fallback", () => {
+    expect(vuzixZ100.hasMicrophone).toBe(false);
+
+    const result = HardwareCompatibilityService.checkCompatibility(
+      appWithRequirements([
+        {
+          type: HardwareType.MICROPHONE,
+          level: HardwareRequirementLevel.REQUIRED,
+        },
+      ]),
+      vuzixZ100,
+    );
+
+    expect(result).toEqual({
+      isCompatible: true,
+      missingRequired: [],
+      missingOptional: [],
+      warnings: [],
+    });
+  });
+
+  test("continues to reject unavailable physical hardware", () => {
+    const result = HardwareCompatibilityService.checkCompatibility(
+      appWithRequirements([
+        {
+          type: HardwareType.MICROPHONE,
+          level: HardwareRequirementLevel.REQUIRED,
+        },
+        {
+          type: HardwareType.SPEAKER,
+          level: HardwareRequirementLevel.REQUIRED,
+        },
+      ]),
+      vuzixZ100,
+    );
+
+    expect(result.isCompatible).toBe(false);
+    expect(result.missingRequired).toEqual([
+      {
+        type: HardwareType.SPEAKER,
+        level: HardwareRequirementLevel.REQUIRED,
+      },
+    ]);
+  });
+});

--- a/mintlify-docs/app-devs/core-concepts/miniapp-manifest.mdx
+++ b/mintlify-docs/app-devs/core-concepts/miniapp-manifest.mdx
@@ -93,6 +93,14 @@ Each entry is `{ "type": "...", "level": "...", "description"?: "..." }`.
   hidden in the Mentra Miniapp Store and launcher on incompatible devices).
 - **`OPTIONAL`**: incompatible glasses still run the miniapp, in a degraded state.
 
+<Note>
+`MICROPHONE` means that the miniapp needs audio input. MentraOS satisfies this
+requirement with the connected glasses microphone when one is available and
+falls back to the phone microphone otherwise. A miniapp that requires audio is
+therefore compatible with glasses such as the Vuzix Z100 that do not have an
+onboard microphone.
+</Note>
+
 ## Editing the manifest
 
 You can edit `miniapp.json` by hand, or use the CLI's guided commands:

--- a/mobile/modules/engine/src/utils/hardware/__tests__/hardware.test.ts
+++ b/mobile/modules/engine/src/utils/hardware/__tests__/hardware.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from "bun:test"
+
+import {HardwareRequirementLevel, HardwareType} from "../../../types"
+import {vuzixZ100} from "../../../types/capabilities/vuzix-z100"
+import {HardwareCompatibility} from "../hardware"
+
+describe("HardwareCompatibility", () => {
+  test("accepts a microphone requirement when glasses use the phone microphone fallback", () => {
+    expect(vuzixZ100.hasMicrophone).toBe(false)
+
+    const result = HardwareCompatibility.checkCompatibility(
+      [{type: HardwareType.MICROPHONE, level: HardwareRequirementLevel.REQUIRED}],
+      vuzixZ100,
+    )
+
+    expect(result).toEqual({
+      isCompatible: true,
+      missingRequired: [],
+      missingOptional: [],
+      warnings: [],
+    })
+  })
+
+  test("continues to reject unavailable physical hardware", () => {
+    const result = HardwareCompatibility.checkCompatibility(
+      [
+        {type: HardwareType.MICROPHONE, level: HardwareRequirementLevel.REQUIRED},
+        {type: HardwareType.SPEAKER, level: HardwareRequirementLevel.REQUIRED},
+      ],
+      vuzixZ100,
+    )
+
+    expect(result.isCompatible).toBe(false)
+    expect(result.missingRequired).toEqual([{type: HardwareType.SPEAKER, level: HardwareRequirementLevel.REQUIRED}])
+  })
+})

--- a/mobile/modules/engine/src/utils/hardware/hardware.ts
+++ b/mobile/modules/engine/src/utils/hardware/hardware.ts
@@ -1,11 +1,4 @@
-import {
-  Capabilities,
-  HardwareRequirement,
-  HardwareType,
-  HardwareRequirementLevel,
-  DeviceTypes,
-} from "../../types"
-import {simulatedGlasses} from "../../types"
+import {Capabilities, DeviceTypes, HardwareRequirement, HardwareRequirementLevel, HardwareType, simulatedGlasses} from "../../types"
 
 /**
  * Result of a hardware compatibility check
@@ -86,7 +79,12 @@ export class HardwareCompatibility {
         return capabilities.hasDisplay
 
       case HardwareType.MICROPHONE:
-        return capabilities.hasMicrophone
+        // MentraOS always provides an audio-input path. When the connected
+        // glasses do not have an onboard microphone, the engine falls back to
+        // the phone microphone. Keep `capabilities.hasMicrophone` reserved for
+        // physical-device/source selection; app compatibility is about whether
+        // the requested input is available to the miniapp.
+        return true
 
       case HardwareType.SPEAKER:
         return capabilities.hasSpeaker


### PR DESCRIPTION
## Summary

- treat `MICROPHONE` hardware requirements as satisfied by the MentraOS audio-input path
- preserve physical glasses capability data so microphone source selection still falls back correctly
- apply the compatibility rule in both the mobile engine and cloud
- document the phone microphone fallback and add Z100 regression coverage

## Root cause

The launcher and cloud compatibility checks interpreted `MICROPHONE` as requiring an onboard glasses microphone. The Vuzix Z100 correctly reports `hasMicrophone: false`, so mic-dependent miniapps such as Merge and Mentra AI were marked incompatible even though MentraOS supplies audio through the phone microphone.

## User impact

Mic-dependent miniapps can launch on display-only glasses such as the Vuzix Z100. Other unavailable physical hardware requirements, such as `SPEAKER`, remain incompatible.

Reported in `rep_01KZXTHK4PJZ7RRCEAGY3QW4TR`.

## Validation

- `bun test src/utils/hardware/__tests__/hardware.test.ts`
- `bun run build` in `mobile/modules/engine`
- `bun test src/services/session/__tests__/HardwareCompatibilityService.test.ts`
- `bun run build` in `cloud/packages/cloud`
- targeted ESLint for the changed mobile and cloud TypeScript files
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow miniapps that require audio input to run on display-only glasses by treating `MICROPHONE` as satisfied via MentraOS’ phone microphone fallback. Previously, compatibility checks required an onboard glasses microphone and blocked apps on devices like the Vuzix Z100; now they pass while other physical requirements (e.g., `SPEAKER`) still gate compatibility.

**Changes**
- Cloud and mobile compatibility checks return compatible for `MICROPHONE`; `hasMicrophone` still reflects physical device for source selection.
- Adds regression tests covering Z100 mic fallback and continued rejection of missing `SPEAKER`.
- Updates miniapp manifest docs to clarify that `MICROPHONE` means “audio input,” with automatic fallback to the phone mic.

**Rollout/Migration**
- No migration required. Existing manifests that declare `MICROPHONE` will now run on glasses without onboard mics; other requirements are unchanged.

<sup>Written for commit ca096ba0a5b54c83989e7b3a9ffeb5b67f117c85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in launcher/store gating logic with mirrored cloud/mobile rules and targeted tests; no auth or data-path changes.
> 
> **Overview**
> **`MICROPHONE` hardware requirements** are no longer tied to onboard glasses mics. Cloud `HardwareCompatibilityService` and the mobile engine `HardwareCompatibility` helper now treat a required `MICROPHONE` as always satisfied, reflecting MentraOS’s audio-input path (glasses mic when present, otherwise phone mic). **`capabilities.hasMicrophone`** stays a physical-device flag for source selection only.
> 
> Regression tests on **Vuzix Z100** (`hasMicrophone: false`) cover mic-required apps passing and missing **`SPEAKER`** still failing. The miniapp manifest docs add a note that `MICROPHONE` means audio input with automatic phone fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca096ba0a5b54c83989e7b3a9ffeb5b67f117c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->