### PR TITLE
Fix iPad pairing layout and device runner support

### DIFF
--- a/mobile/scripts/ios.mjs
+++ b/mobile/scripts/ios.mjs
@@ -21,57 +21,54 @@ const listDevices = async () => {
   return json.result?.devices ?? []
 }
 
-const isIphone = (d) =>
-  d.hardwareProperties?.deviceType === "iPhone" ||
-  d.capabilities?.some((c) => c.name === "iPhone") ||
-  d.deviceProperties?.marketingName?.includes("iPhone")
+const isSupportedIosDevice = (d) =>
+  d.hardwareProperties?.platform === "iOS" ||
+  ["iPhone", "iPad"].includes(d.hardwareProperties?.deviceType) ||
+  d.capabilities?.some((c) => ["iPhone", "iPad"].includes(c.name)) ||
+  /iPhone|iPad/.test(d.deviceProperties?.marketingName ?? "")
 
-let pairedIphones = (await listDevices()).filter(
+let pairedDevices = (await listDevices()).filter(
   (d) =>
-    isIphone(d) &&
+    isSupportedIosDevice(d) &&
     d.connectionProperties?.pairingState === "paired" &&
     d.connectionProperties?.tunnelState !== "unavailable",
 )
 
-let connected = pairedIphones.find(
-  (d) => d.connectionProperties?.tunnelState === "connected",
-)
+let connected = pairedDevices.find((d) => d.connectionProperties?.tunnelState === "connected")
 
-// A newly plugged/unlocked iPhone can show as paired+wired but
+// A newly plugged/unlocked iOS device can show as paired+wired but
 // tunnelState=disconnected until a CoreDevice command touches it. Warm the
 // tunnel once before failing, then re-read the list the build path uses.
-if (!connected && pairedIphones.length > 0) {
-  const candidate = pairedIphones.find((d) => d.connectionProperties?.transportType === "wired") ?? pairedIphones[0]
+if (!connected && pairedDevices.length > 0) {
+  const candidate = pairedDevices.find((d) => d.connectionProperties?.transportType === "wired") ?? pairedDevices[0]
   const candidateId = candidate.hardwareProperties?.udid ?? candidate.identifier
   if (candidateId) {
-    console.log(`Warming iPhone tunnel for ${candidate.deviceProperties.name} (${candidateId})...`)
+    console.log(`Warming iOS device tunnel for ${candidate.deviceProperties.name} (${candidateId})...`)
     try {
       await $`xcrun devicectl device info details --device ${candidateId} --timeout 15`
     } catch (error) {
-      console.warn(`Could not warm iPhone tunnel: ${error}`)
+      console.warn(`Could not warm iOS device tunnel: ${error}`)
     }
-    pairedIphones = (await listDevices()).filter(
+    pairedDevices = (await listDevices()).filter(
       (d) =>
-        isIphone(d) &&
+        isSupportedIosDevice(d) &&
         d.connectionProperties?.pairingState === "paired" &&
         d.connectionProperties?.tunnelState !== "unavailable",
     )
-    connected = pairedIphones.find((d) => d.connectionProperties?.tunnelState === "connected")
+    connected = pairedDevices.find((d) => d.connectionProperties?.tunnelState === "connected")
   }
 }
 
 if (!connected) {
-  if (pairedIphones.length > 0) {
-    const offline = pairedIphones[0]
+  if (pairedDevices.length > 0) {
+    const offline = pairedDevices[0]
     console.error(
-      `iPhone "${offline.deviceProperties.name}" is paired but not connected (tunnel: ${offline.connectionProperties.tunnelState}).`,
+      `iOS device "${offline.deviceProperties.name}" is paired but not connected (tunnel: ${offline.connectionProperties.tunnelState}).`,
     )
-    console.error(
-      "Plug in via USB, unlock the device, tap Trust on the device, then retry.",
-    )
+    console.error("Plug in via USB, unlock the device, tap Trust on the device, then retry.")
     process.exit(1)
   }
-  console.error("No physical iPhone found")
+  console.error("No physical iPhone or iPad found")
   process.exit(1)
 }
 
@@ -105,6 +102,7 @@ await $({stdio: "inherit"})`xcodebuild \
   -destination id=${deviceUdid} \
   -derivedDataPath ${derivedData} \
   -allowProvisioningUpdates \
+  -allowProvisioningDeviceRegistration \
   build`
 
 // The bundle is named after PRODUCT_NAME ("Mentra"), not the scheme/project

--- a/mobile/src/app/pairing/prep-controller.tsx
+++ b/mobile/src/app/pairing/prep-controller.tsx
@@ -1,6 +1,6 @@
 import {ControllerTypes, DeviceTypes} from "@/../../cloud/packages/types/src"
 import {useRoute} from "@react-navigation/native"
-import {Linking, PermissionsAndroid, Image, Platform, View} from "react-native"
+import {Linking, PermissionsAndroid, Image, Platform, ScrollView, View} from "react-native"
 import type {Permission} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
@@ -207,7 +207,10 @@ export default function PairingPrepScreen() {
     const {theme} = useAppTheme()
 
     return (
-      <View className="flex-1 flex-col justify-start mt-6">
+      <ScrollView
+        className="flex-1 mt-6"
+        contentContainerStyle={{paddingBottom: theme.spacing.s6}}
+        showsVerticalScrollIndicator>
         <View className="flex-col items-center justify-center bg-primary-foreground rounded-xl mb-6">
           <Image
             source={require("../../../assets/glasses/even_realities_g2/even_realities_g2.png")}
@@ -230,7 +233,7 @@ export default function PairingPrepScreen() {
           />
           <Text className="text-lg text-secondary-foreground" text="2. Place your G2 in the charging case." />
         </View>
-      </View>
+      </ScrollView>
     )
   }
 

--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -315,7 +315,10 @@ export default function PairingPrepScreen() {
     const {theme} = useAppTheme()
 
     return (
-      <View className="flex-1 flex-col justify-start mt-6">
+      <ScrollView
+        className="flex-1 mt-6"
+        contentContainerStyle={{paddingBottom: theme.spacing.s6}}
+        showsVerticalScrollIndicator>
         <View className="flex-col items-center justify-center bg-primary-foreground rounded-xl mb-6">
           <Image source={require("../../../assets/glasses/g1.png")} resizeMode="contain" className="w-50 h-25" />
           <Icon name="chevron-down" size={36} color={theme.colors.text} />
@@ -337,7 +340,7 @@ export default function PairingPrepScreen() {
             text="2. Place your G1 in the charging case with the lid open."
           />
         </View>
-      </View>
+      </ScrollView>
     )
   }
 
@@ -362,7 +365,10 @@ export default function PairingPrepScreen() {
     const {theme} = useAppTheme()
 
     return (
-      <View className="flex-1 flex-col justify-start mt-6">
+      <ScrollView
+        className="flex-1 mt-6"
+        contentContainerStyle={{paddingBottom: theme.spacing.s6}}
+        showsVerticalScrollIndicator>
         <View className="flex-col items-center justify-center bg-primary-foreground rounded-xl mb-6">
           <Image
             source={require("../../../assets/glasses/even_realities_g2/even_realities_g2.png")}
@@ -385,7 +391,7 @@ export default function PairingPrepScreen() {
           />
           <Text className="text-lg text-secondary-foreground" text="2. Place your G2 in the charging case." />
         </View>
-      </View>
+      </ScrollView>
     )
   }
 


### PR DESCRIPTION
## Summary

- allow the local iOS runner to discover and deploy to physical iPads as well as iPhones
- make the G1, G2, and R1 pairing instructions vertically scrollable
- keep the pairing header and action buttons fixed while the instructional content scrolls

## Why

App Review reported that the G2 pairing screen was crowded and difficult to use on an iPad Air 11-inch. The fixed instruction area could extend underneath the `Continue to pairing` button, hiding the second step with no way to scroll to it.

This keeps the existing artwork sizing and desktop-style structure while allowing the middle content to adapt to shorter or larger-screen layouts.

## Validation

- built, installed, and launched the Mentra App on a connected physical iPad using `bun ios`
- hot-reloaded the updated pairing UI on the iPad
- `bunx prettier --check scripts/ios.mjs src/app/pairing/prep.tsx src/app/pairing/prep-controller.tsx`
- `bunx eslint src/app/pairing/prep.tsx src/app/pairing/prep-controller.tsx` (0 errors; 7 pre-existing warnings)
- `node --check mobile/scripts/ios.mjs`
- `git diff --check`

`bun run compile` still reports unrelated pre-existing type errors in the engine services, migration tests, and notification utilities; none are in the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout and dev-tooling changes only; no auth, data, or pairing business-logic changes beyond scroll containers and device discovery.
> 
> **Overview**
> Addresses App Review feedback on crowded G2 pairing on iPad by making **G1, G2, and R1** prep instruction blocks scrollable in `prep.tsx` and `prep-controller.tsx`, while the screen stays `preset="fixed"` so the header and action buttons remain visible.
> 
> The local **`bun ios`** script (`ios.mjs`) now treats **iPads** as deploy targets via broader `devicectl` detection (`isSupportedIosDevice`), renames iPhone-specific messaging to generic iOS device wording, and passes **`-allowProvisioningDeviceRegistration`** to `xcodebuild` to ease on-device installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd9b9a85f93508330b1fa9bd32f4e2365db1ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->