### PR TITLE
Add BES reset command for MTK factory flashing

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -175,6 +175,16 @@ public class AsgConstants {
     /** Debug BES intent extra carrying a stable identifier for durable state. */
     public static final String DEBUG_BES_OTA_ARTIFACT_ID_EXTRA = "artifact_id";
 
+    /** ADB/local command that reboots BES before handing MTK to a factory USB flasher. */
+    public static final String COMMAND_REBOOT_BES_FOR_MTK_FLASH =
+            "reboot_bes_for_mtk_flash";
+
+    /** Correlation field used to prove that the requested BES reboot reached the UART worker. */
+    public static final String MTK_FLASH_REQUEST_ID_FIELD = "request_id";
+
+    /** BES command that resets the MCU without rebooting the running MTK Android system. */
+    public static final String BES_REBOOT_COMMAND = "cs_rebt";
+
     /**
      * Exclusive decompressed destination limit in the deployed ota_copy bootloader:
      * NEW_IMAGE_FLASH_OFFSET (0x200000) - OTA_CODE_OFFSET (0x20000). Images at or above this size

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PowerCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PowerCommandHandler.java
@@ -2,11 +2,14 @@ package com.mentra.asg_client.service.core.handlers;
 
 import android.content.Context;
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.service.legacy.interfaces.ICommandHandler;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import com.mentra.asg_client.service.system.core.SystemControllerFactory;
 import com.mentra.asg_client.service.utils.ServiceConstants;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import org.json.JSONObject;
 
@@ -33,7 +36,11 @@ public class PowerCommandHandler implements ICommandHandler {
 
     @Override
     public Set<String> getSupportedCommandTypes() {
-        return Set.of(CMD_SHUTDOWN, CMD_REBOOT, CMD_SET_SYSTEM_TIME);
+        return Set.of(
+                CMD_SHUTDOWN,
+                CMD_REBOOT,
+                CMD_SET_SYSTEM_TIME,
+                AsgConstants.COMMAND_REBOOT_BES_FOR_MTK_FLASH);
     }
 
     @Override
@@ -46,6 +53,8 @@ public class PowerCommandHandler implements ICommandHandler {
                     return handleReboot();
                 case CMD_SET_SYSTEM_TIME:
                     return handleSetSystemTime(data);
+                case AsgConstants.COMMAND_REBOOT_BES_FOR_MTK_FLASH:
+                    return handleBesRebootForMtkFlash(data);
                 default:
                     Log.e(TAG, "Unsupported power command: " + commandType);
                     return false;
@@ -86,6 +95,51 @@ public class PowerCommandHandler implements ICommandHandler {
             return true;
         } catch (Exception e) {
             Log.e(TAG, "❌ Error initiating reboot", e);
+            return false;
+        }
+    }
+
+    /**
+     * Queue a BES-only reboot and log the caller's request id when the UART write completes.
+     * Android must stay alive so the host can prove the same ADB identity before entering
+     * Preloader with a freshly reset BES MTK-start retry budget.
+     */
+    private boolean handleBesRebootForMtkFlash(JSONObject data) {
+        String requestId =
+                data == null
+                        ? ""
+                        : data.optString(AsgConstants.MTK_FLASH_REQUEST_ID_FIELD, "").trim();
+        if (!requestId.matches("[A-Za-z0-9_-]{8,64}")) {
+            Log.e(TAG, "MTK_FLASH_BES_RESET rejected invalid request_id");
+            return false;
+        }
+        if (serviceManager == null || serviceManager.getBluetoothManager() == null) {
+            Log.e(TAG, "MTK_FLASH_BES_RESET request_id=" + requestId + " transport unavailable");
+            return false;
+        }
+
+        try {
+            JSONObject command = new JSONObject();
+            command.put("C", AsgConstants.BES_REBOOT_COMMAND);
+            command.put("V", 1);
+            command.put("B", "");
+            IBluetoothManager transport = serviceManager.getBluetoothManager();
+            boolean queued =
+                    transport.sendMessage(
+                            command.toString().getBytes(StandardCharsets.UTF_8),
+                            success ->
+                                    Log.i(
+                                            TAG,
+                                            "MTK_FLASH_BES_RESET request_id="
+                                                    + requestId
+                                                    + " uart_write="
+                                                    + success));
+            Log.i(
+                    TAG,
+                    "MTK_FLASH_BES_RESET request_id=" + requestId + " queued=" + queued);
+            return queued;
+        } catch (Exception e) {
+            Log.e(TAG, "MTK_FLASH_BES_RESET request_id=" + requestId + " failed", e);
             return false;
         }
     }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PowerCommandHandlerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PowerCommandHandlerTest.java
@@ -1,13 +1,23 @@
 package com.mentra.asg_client.service.core.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
 import android.content.Intent;
 import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import com.mentra.asg_client.service.utils.ServiceConstants;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +29,40 @@ import org.robolectric.shadows.ShadowBuild;
 @RunWith(RobolectricTestRunner.class)
 @Config(application = Application.class, sdk = 33)
 public class PowerCommandHandlerTest {
+
+    @Test
+    public void besRebootForMtkFlash_queuesExactUartCommand() throws Exception {
+        Application app = ApplicationProvider.getApplicationContext();
+        AsgClientServiceManager serviceManager = mock(AsgClientServiceManager.class);
+        ICompanionTransport transport = mock(ICompanionTransport.class);
+        when(serviceManager.getBluetoothManager()).thenReturn(transport);
+        when(transport.sendMessage(any(byte[].class), any())).thenReturn(true);
+        PowerCommandHandler handler = new PowerCommandHandler(app, serviceManager);
+
+        boolean handled =
+                handler.handleCommand(
+                        AsgConstants.COMMAND_REBOOT_BES_FOR_MTK_FLASH,
+                        new JSONObject().put(AsgConstants.MTK_FLASH_REQUEST_ID_FIELD, "abc12345"));
+
+        assertThat(handled).isTrue();
+        verify(transport)
+                .sendMessage(
+                        eq(besCommand().toString().getBytes(StandardCharsets.UTF_8)), any());
+    }
+
+    @Test
+    public void besRebootForMtkFlash_rejectsMissingRequestId() {
+        Application app = ApplicationProvider.getApplicationContext();
+        AsgClientServiceManager serviceManager = mock(AsgClientServiceManager.class);
+        PowerCommandHandler handler = new PowerCommandHandler(app, serviceManager);
+
+        boolean handled =
+                handler.handleCommand(
+                        AsgConstants.COMMAND_REBOOT_BES_FOR_MTK_FLASH, new JSONObject());
+
+        assertThat(handled).isFalse();
+        verify(serviceManager, org.mockito.Mockito.never()).getBluetoothManager();
+    }
 
     @Test
     public void setSystemTime_validTimestamp_routesToSystemController() throws Exception {
@@ -54,5 +98,9 @@ public class PowerCommandHandlerTest {
         PowerCommandHandler handler = new PowerCommandHandler(app, null);
 
         assertThat(handler.handleCommand(ServiceConstants.COMMAND_SET_SYSTEM_TIME, null)).isFalse();
+    }
+
+    private static JSONObject besCommand() throws JSONException {
+        return new JSONObject().put("C", "cs_rebt").put("V", 1).put("B", "");
     }
 }


### PR DESCRIPTION
## What changed

- adds an explicit `reboot_bes_for_mtk_flash` local/ADB command to the existing power command handler;
- validates a per-run request id before doing anything;
- writes the existing `cs_rebt` command through the MTK-to-BES UART transport;
- logs both queue acceptance and the asynchronous UART write result with that request id;
- keeps Android running so a host flasher can verify the same ADB device before entering Preloader.

## Why

BES tracks three failed 30-second MTK starts for its entire own boot. Factory flashes and read-only DA probes consume those attempts. When the counter reaches zero, BES reuses the “battery low” prompt and powers MTK off even when the battery is healthy. A button-triggered MTK power cycle does not reset the counter.

The Mac flasher therefore needs to reset BES before it reboots MTK into Preloader. Doing that through ASG's already-established UART is deterministic even while the paired iPhone owns the BES BLE connection. The host correlates the unique request id with `uart_write=true`; it does not treat broadcast delivery or queue acceptance alone as success.

## Validation

- `./gradlew :app:testDebugUnitTest --tests '*PowerCommandHandlerTest'`
- `./gradlew :app:assembleDebug`
- Debug APK built successfully with production-compatible signing.
- `git diff --check`

## Hardware gate

After one-time recovery of the currently exhausted BES retry counter, install this APK and prove:

1. targeted ADB command reports the exact request id with `uart_write=true`;
2. BES reboots while Android and the same `ro.serialno` remain available;
3. the unattended MTK read-only probe returns Android without a power press, cable reconnect, or administrator password;
4. a subsequent full MTK flash does the same.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches power/UART control used for factory tooling; scope is narrow and gated on request-id validation, but a bad reset path could affect BES/MTK bring-up during flashing.
> 
> **Overview**
> Adds an ADB/local **`reboot_bes_for_mtk_flash`** path on `PowerCommandHandler` so factory hosts can reset the BES MCU (via existing **`cs_rebt`** UART framing) **without** rebooting MTK Android—preserving ADB identity while clearing BES’s exhausted MTK-start retry budget before Preloader.
> 
> The handler requires a validated **`request_id`** (8–64 alphanumeric/`_-`), queues the command through the Bluetooth/UART transport, and logs **`queued`** plus async **`uart_write`** outcomes keyed by that id. **`AsgConstants`** centralizes the command name, correlation field, and BES reboot opcode. Unit tests cover successful UART enqueue and rejection when `request_id` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbda7ae64aeedef3eaf6f31167ab2fd0a21c29ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->