### PR TITLE
Gate pipeline FPS telemetry and harden WHIP/RTMP ingest

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -37,6 +37,17 @@ public class AsgConstants {
     public static final long STREAM_METRICS_INTERVAL_MS = 1_000L;
 
     /**
+     * 1Hz encoder FPS/bitrate/dropped-frame telemetry ({@code [STREAM_QUALITY]} and BLE {@code
+     * stream_status.stats}). Lifecycle {@code stream_status} (started/stopped/error) is unaffected.
+     * Keep false in production; flip locally to debug the Mentra Call FPS ladder.
+     *
+     * <p>Double gate: reporters are not scheduled, and {@code onStreamMetrics} returns immediately
+     * so accidental emission cannot reach BLE. Manual acceptance with every layer false: join
+     * waterfall yes; STREAM_QUALITY / BLE stats / encoder-stats / watch-stats / debug ingest no.
+     */
+    public static final boolean ENABLE_PIPELINE_FPS_TELEMETRY = false;
+
+    /**
      * Local-testing stopgap that disables the 60s keep-alive watchdog for RTMP/SRT/WHIP streams.
      * When true, {@code scheduleStreamTimeout()} early-returns and an orphaned stream (lost
      * phone/cloud keep-alives via BLE disconnect or killed app) never auto-stops, holding the

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/PeriodicStreamMetricsReporter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/PeriodicStreamMetricsReporter.java
@@ -3,6 +3,7 @@ package com.mentra.asg_client.io.streaming.services;
 import android.os.Handler;
 import android.util.Log;
 import androidx.annotation.Nullable;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.streaming.interfaces.StreamingStatusCallback;
 
 /** Periodically forwards stream telemetry while an RTMP or SRT publisher is active. */
@@ -125,6 +126,9 @@ final class PeriodicStreamMetricsReporter {
     }
 
     void start() {
+        if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) {
+            return;
+        }
         stop();
         mHandler.postDelayed(mReportRunnable, mIntervalMs);
     }
@@ -134,6 +138,9 @@ final class PeriodicStreamMetricsReporter {
     }
 
     static void logQuality(String source, @Nullable String streamId, MetricsSample sample) {
+        if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) {
+            return;
+        }
         String temp =
                 Double.isFinite(sample.temperatureC)
                         ? String.format(java.util.Locale.US, "%.1f", sample.temperatureC)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
@@ -450,6 +450,28 @@ public class RtmpStreamingService extends Service {
                     Log.i(TAG, "RTMP connection successful");
 
                     synchronized (mStateLock) {
+                        // stopStream() is async. An in-flight RTMP handshake can
+                        // complete after Mentra Call already sent stop — that used
+                        // to flip us back to STREAMING and keep BLE "streaming"
+                        // status (and metrics) alive with no streamId.
+                        if (mStreamState != StreamState.STARTING) {
+                            Log.w(TAG, "Ignoring RTMP onSuccess in state " + mStreamState
+                                    + " (stop already requested)");
+                            stopMetricsReporting();
+                            if (mStreamState == StreamState.IDLE || mStreamState == StreamState.STOPPING) {
+                                mReconnectHandler.post(() -> {
+                                    synchronized (mStateLock) {
+                                        if (mStreamState == StreamState.STARTING
+                                                || mStreamState == StreamState.STREAMING) {
+                                            return;
+                                        }
+                                    }
+                                    forceStopStreamingInternal(false);
+                                });
+                            }
+                            return;
+                        }
+
                         // NOW we're actually streaming
                         mStreamState = StreamState.STREAMING;
                         mIsStreaming = true;
@@ -1341,6 +1363,9 @@ public class RtmpStreamingService extends Service {
     }
 
     private void startMetricsReporting() {
+        if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) {
+            return;
+        }
         if (mMetricsReporter != null) {
             mMetricsReporter.start();
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
@@ -454,15 +454,21 @@ public class RtmpStreamingService extends Service {
                         // complete after Mentra Call already sent stop — that used
                         // to flip us back to STREAMING and keep BLE "streaming"
                         // status (and metrics) alive with no streamId.
+                        if (mStreamState == StreamState.STREAMING && mIsStreaming) {
+                            startMetricsReporting();
+                            return;
+                        }
                         if (mStreamState != StreamState.STARTING) {
                             Log.w(TAG, "Ignoring RTMP onSuccess in state " + mStreamState
                                     + " (stop already requested)");
                             stopMetricsReporting();
-                            if (mStreamState == StreamState.IDLE || mStreamState == StreamState.STOPPING) {
+                            // IDLE already completed teardown — don't emit a second stop.
+                            if (mStreamState == StreamState.STOPPING) {
                                 mReconnectHandler.post(() -> {
                                     synchronized (mStateLock) {
                                         if (mStreamState == StreamState.STARTING
-                                                || mStreamState == StreamState.STREAMING) {
+                                                || mStreamState == StreamState.STREAMING
+                                                || mStreamState == StreamState.IDLE) {
                                             return;
                                         }
                                     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -329,6 +329,12 @@ public class SrtStreamingService extends Service {
         public void onSuccess() {
           Log.i(TAG, "SRT connection successful");
           synchronized (mStateLock) {
+            if (mStreamState != StreamState.STARTING) {
+              Log.w(TAG, "Ignoring SRT onSuccess in state " + mStreamState
+                  + " (stop already requested)");
+              stopMetricsReporting();
+              return;
+            }
             mStreamState = StreamState.STREAMING;
             mIsStreaming = true;
             mIsStreamingActive = true;
@@ -815,6 +821,9 @@ public class SrtStreamingService extends Service {
   }
 
   private void startMetricsReporting() {
+    if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) {
+      return;
+    }
     if (mMetricsReporter != null) {
       mMetricsReporter.start();
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -329,6 +329,10 @@ public class SrtStreamingService extends Service {
         public void onSuccess() {
           Log.i(TAG, "SRT connection successful");
           synchronized (mStateLock) {
+            if (mStreamState == StreamState.STREAMING && mIsStreaming) {
+              startMetricsReporting();
+              return;
+            }
             if (mStreamState != StreamState.STARTING) {
               Log.w(TAG, "Ignoring SRT onSuccess in state " + mStreamState
                   + " (stop already requested)");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -144,7 +144,7 @@ public class WhipStreamingService extends Service {
   private volatile boolean mWhipStreamingNotified = false;
   /** Bumped on each new PeerConnection so queued ICE/HTTP callbacks cannot act on a later negotiation. */
   private volatile int mNegotiationGeneration = 0;
-  private Runnable mPostOfferTimeoutRunnable = () -> postOfferIfReady("timeout");
+  private Runnable mPostOfferTimeoutRunnable = () -> {};
   private Runnable mIceConnectTimeoutRunnable = this::failIceConnectTimeout;
 
   private IHardwareManager mHardwareManager;
@@ -593,7 +593,7 @@ public class WhipStreamingService extends Service {
                 + ICE_GATHER_POST_TIMEOUT_MS + "ms");
             mPostOfferTimeoutRunnable = () -> {
               if (generation != mNegotiationGeneration) return;
-              postOfferIfReady("timeout");
+              postOfferIfReady("timeout", generation);
             };
             mMainHandler.postDelayed(mPostOfferTimeoutRunnable, ICE_GATHER_POST_TIMEOUT_MS);
           }
@@ -734,9 +734,12 @@ public class WhipStreamingService extends Service {
    * POST the local SDP once. Triggered by first srflx, the gather timeout, or
    * GATHERING COMPLETE — whichever wins. Later triggers are no-ops.
    */
-  private void postOfferIfReady(String reason) {
+  private void postOfferIfReady(String reason, int generation) {
     PeerConnection peerConnection;
     synchronized (mStateLock) {
+      if (generation != mNegotiationGeneration) {
+        return;
+      }
       if (mWhipOfferPosted) {
         return;
       }
@@ -757,11 +760,13 @@ public class WhipStreamingService extends Service {
     if (localSdp != null) {
       Log.i(TAG, "Posting WHIP offer after ICE trigger=" + reason
           + " candidates=" + mIceCandidateCount);
-      postOfferToWhip(localSdp, mNegotiationGeneration);
+      postOfferToWhip(localSdp, generation);
     } else {
       Log.e(TAG, "WHIP POST trigger=" + reason + " but local SDP is null");
       synchronized (mStateLock) {
-        mWhipOfferPosted = false;
+        if (generation == mNegotiationGeneration) {
+          mWhipOfferPosted = false;
+        }
       }
       handleStartupFailure("local_sdp_missing", "Local SDP unavailable before WHIP POST");
     }
@@ -850,10 +855,7 @@ public class WhipStreamingService extends Service {
         .url(mWhipUrl)
         .post(body)
         .addHeader("Content-Type", "application/sdp");
-    if (mAuthToken != null && !mAuthToken.isEmpty()) {
-      String token = mAuthToken.startsWith("Bearer ") ? mAuthToken : "Bearer " + mAuthToken;
-      requestBuilder.addHeader("Authorization", token);
-    }
+    addWhipAuth(requestBuilder);
     Request request = requestBuilder.build();
 
     mHttpClient.newCall(request).enqueue(new Callback() {
@@ -935,12 +937,15 @@ public class WhipStreamingService extends Service {
             logStartupStage("whip_answer_applied");
             Log.i(TAG, "WHIP answer applied, waiting for ICE connect (max "
                 + ICE_CONNECT_TIMEOUT_MS + "ms)");
-            mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
-            mIceConnectTimeoutRunnable = () -> {
+            mMainHandler.post(() -> {
               if (generation != mNegotiationGeneration) return;
-              failIceConnectTimeout();
-            };
-            mMainHandler.postDelayed(mIceConnectTimeoutRunnable, ICE_CONNECT_TIMEOUT_MS);
+              mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+              mIceConnectTimeoutRunnable = () -> {
+                if (generation != mNegotiationGeneration) return;
+                failIceConnectTimeout();
+              };
+              mMainHandler.postDelayed(mIceConnectTimeoutRunnable, ICE_CONNECT_TIMEOUT_MS);
+            });
           }
 
           @Override
@@ -963,11 +968,18 @@ public class WhipStreamingService extends Service {
     });
   }
 
+  private void addWhipAuth(Request.Builder builder) {
+    if (mAuthToken == null || mAuthToken.isEmpty()) return;
+    String token = mAuthToken.startsWith("Bearer ") ? mAuthToken : "Bearer " + mAuthToken;
+    builder.addHeader("Authorization", token);
+  }
+
   private void deleteWhipResource(String resourceUrl) {
-    Request request = new Request.Builder()
+    Request.Builder requestBuilder = new Request.Builder()
         .url(resourceUrl)
-        .delete()
-        .build();
+        .delete();
+    addWhipAuth(requestBuilder);
+    Request request = requestBuilder.build();
 
     mHttpClient.newCall(request).enqueue(new Callback() {
       @Override
@@ -1003,7 +1015,7 @@ public class WhipStreamingService extends Service {
       if (isStale()) return;
       if (newState == PeerConnection.IceGatheringState.COMPLETE) {
         logStartupStage("ice_gathering_complete", "candidates=" + mIceCandidateCount);
-        postOfferIfReady("complete");
+        postOfferIfReady("complete", generation);
       }
     }
 
@@ -1078,7 +1090,7 @@ public class WhipStreamingService extends Service {
       if (candidate.sdp != null && candidate.sdp.contains("typ srflx")) {
         mMainHandler.post(() -> {
           if (isStale()) return;
-          postOfferIfReady("srflx");
+          postOfferIfReady("srflx", generation);
         });
       }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -764,9 +764,10 @@ public class WhipStreamingService extends Service {
     } else {
       Log.e(TAG, "WHIP POST trigger=" + reason + " but local SDP is null");
       synchronized (mStateLock) {
-        if (generation == mNegotiationGeneration) {
-          mWhipOfferPosted = false;
+        if (generation != mNegotiationGeneration) {
+          return;
         }
+        mWhipOfferPosted = false;
       }
       handleStartupFailure("local_sdp_missing", "Local SDP unavailable before WHIP POST");
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -142,8 +142,10 @@ public class WhipStreamingService extends Service {
   private static final long ICE_CONNECT_TIMEOUT_MS = 8000L;
   private volatile boolean mWhipOfferPosted = false;
   private volatile boolean mWhipStreamingNotified = false;
-  private final Runnable mPostOfferTimeoutRunnable = () -> postOfferIfReady("timeout");
-  private final Runnable mIceConnectTimeoutRunnable = this::failIceConnectTimeout;
+  /** Bumped on each new PeerConnection so queued ICE/HTTP callbacks cannot act on a later negotiation. */
+  private volatile int mNegotiationGeneration = 0;
+  private Runnable mPostOfferTimeoutRunnable = () -> postOfferIfReady("timeout");
+  private Runnable mIceConnectTimeoutRunnable = this::failIceConnectTimeout;
 
   private IHardwareManager mHardwareManager;
 
@@ -536,6 +538,7 @@ public class WhipStreamingService extends Service {
   }
 
   private void createPeerConnectionAndOffer() {
+    final int generation = ++mNegotiationGeneration;
     mWhipOfferPosted = false;
     mWhipStreamingNotified = false;
     if (mMainHandler != null) {
@@ -558,7 +561,7 @@ public class WhipStreamingService extends Service {
         PeerConnection.ContinualGatheringPolicy.GATHER_ONCE;
 
     mPeerConnection = mPeerConnectionFactory.createPeerConnection(
-        rtcConfig, new WhipPeerConnectionObserver());
+        rtcConfig, new WhipPeerConnectionObserver(generation));
 
     if (mPeerConnection == null) {
       throw new IllegalStateException("Failed to create PeerConnection");
@@ -581,16 +584,23 @@ public class WhipStreamingService extends Service {
     mPeerConnection.createOffer(new SdpObserver() {
       @Override
       public void onCreateSuccess(SessionDescription offer) {
+        if (generation != mNegotiationGeneration || mPeerConnection == null) return;
         mPeerConnection.setLocalDescription(new SdpObserver() {
           @Override
           public void onSetSuccess() {
+            if (generation != mNegotiationGeneration) return;
             Log.d(TAG, "Local description set, posting WHIP offer after first srflx or "
                 + ICE_GATHER_POST_TIMEOUT_MS + "ms");
+            mPostOfferTimeoutRunnable = () -> {
+              if (generation != mNegotiationGeneration) return;
+              postOfferIfReady("timeout");
+            };
             mMainHandler.postDelayed(mPostOfferTimeoutRunnable, ICE_GATHER_POST_TIMEOUT_MS);
           }
 
           @Override
           public void onSetFailure(String error) {
+            if (generation != mNegotiationGeneration) return;
             handleStartupFailure("set_local_description_failed", "setLocalDescription failed: " + error);
           }
 
@@ -601,6 +611,7 @@ public class WhipStreamingService extends Service {
 
       @Override
       public void onCreateFailure(String error) {
+        if (generation != mNegotiationGeneration) return;
         handleStartupFailure("create_offer_failed", "createOffer failed: " + error);
       }
 
@@ -746,7 +757,7 @@ public class WhipStreamingService extends Service {
     if (localSdp != null) {
       Log.i(TAG, "Posting WHIP offer after ICE trigger=" + reason
           + " candidates=" + mIceCandidateCount);
-      postOfferToWhip(localSdp);
+      postOfferToWhip(localSdp, mNegotiationGeneration);
     } else {
       Log.e(TAG, "WHIP POST trigger=" + reason + " but local SDP is null");
       synchronized (mStateLock) {
@@ -804,20 +815,30 @@ public class WhipStreamingService extends Service {
   }
 
   private void failIceConnectTimeout() {
+    boolean reconnecting;
     synchronized (mStateLock) {
       if (mWhipStreamingNotified) return;
       if (mStreamState != StreamState.STARTING && mStreamState != StreamState.RECONNECTING) {
         return;
       }
-      mWhipStreamingNotified = true;
+      reconnecting = mIsReconnecting;
+      if (!reconnecting) {
+        mWhipStreamingNotified = true;
+      }
     }
     if (mMainHandler != null) {
       mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
     }
+    // Reconnect attempts also pass through STARTING. A mid-call ICE miss must
+    // retry, not run the terminal first-start failure path.
+    if (reconnecting) {
+      attemptReconnect("ICE did not connect");
+      return;
+    }
     handleStartupFailure("ice_timeout", "ICE did not connect; WHIP media path failed");
   }
 
-  private void postOfferToWhip(SessionDescription offer) {
+  private void postOfferToWhip(SessionDescription offer, int generation) {
     logStartupStage("whip_request_started");
     Log.d(TAG, "POSTing SDP offer to WHIP URL: " + mWhipUrl);
     logSdpVideoSection("Offer", offer.description);
@@ -838,6 +859,17 @@ public class WhipStreamingService extends Service {
     mHttpClient.newCall(request).enqueue(new Callback() {
       @Override
       public void onResponse(Call call, Response response) throws IOException {
+        if (generation != mNegotiationGeneration) {
+          String location = response.header("Location");
+          if (location != null) {
+            String staleUrl = location.startsWith("http")
+                ? location
+                : buildAbsoluteUrl(mWhipUrl, location);
+            deleteWhipResource(staleUrl);
+          }
+          response.close();
+          return;
+        }
         if (response.code() != 201) {
           String msg = "WHIP server returned " + response.code();
           handleStartupFailure("http_" + response.code(), msg);
@@ -869,7 +901,8 @@ public class WhipStreamingService extends Service {
         // Don't dereference a released peer connection or revive a torn-down session.
         PeerConnection peerConnection;
         synchronized (mStateLock) {
-          if (mPeerConnection == null || mStreamState == StreamState.STOPPING
+          if (generation != mNegotiationGeneration || mPeerConnection == null
+              || mStreamState == StreamState.STOPPING
               || mStreamState == StreamState.IDLE) {
             Log.w(TAG, "WHIP answer received but stream already stopping/stopped, ignoring");
             if (resourceUrl != null) {
@@ -892,7 +925,8 @@ public class WhipStreamingService extends Service {
           @Override
           public void onSetSuccess() {
             synchronized (mStateLock) {
-              if (mPeerConnection == null || mStreamState == StreamState.STOPPING
+              if (generation != mNegotiationGeneration || mPeerConnection == null
+                  || mStreamState == StreamState.STOPPING
                   || mStreamState == StreamState.IDLE) {
                 Log.w(TAG, "WHIP remote description set but stream already stopping/stopped, ignoring");
                 return;
@@ -902,11 +936,16 @@ public class WhipStreamingService extends Service {
             Log.i(TAG, "WHIP answer applied, waiting for ICE connect (max "
                 + ICE_CONNECT_TIMEOUT_MS + "ms)");
             mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+            mIceConnectTimeoutRunnable = () -> {
+              if (generation != mNegotiationGeneration) return;
+              failIceConnectTimeout();
+            };
             mMainHandler.postDelayed(mIceConnectTimeoutRunnable, ICE_CONNECT_TIMEOUT_MS);
           }
 
           @Override
           public void onSetFailure(String error) {
+            if (generation != mNegotiationGeneration) return;
             handleStartupFailure("set_remote_description_failed", "setRemoteDescription failed: " + error);
           }
 
@@ -917,6 +956,7 @@ public class WhipStreamingService extends Service {
 
       @Override
       public void onFailure(Call call, IOException e) {
+        if (generation != mNegotiationGeneration) return;
         Log.e(TAG, "WHIP request failed", e);
         handleStartupFailure("whip_request_failed", "WHIP request failed: " + e.getMessage());
       }
@@ -947,10 +987,20 @@ public class WhipStreamingService extends Service {
   // -----------------------------------------------------------------------
 
   private class WhipPeerConnectionObserver implements PeerConnection.Observer {
+    private final int generation;
+
+    WhipPeerConnectionObserver(int generation) {
+      this.generation = generation;
+    }
+
+    private boolean isStale() {
+      return generation != mNegotiationGeneration;
+    }
 
     @Override
     public void onIceGatheringChange(PeerConnection.IceGatheringState newState) {
       Log.d(TAG, "ICE gathering state: " + newState);
+      if (isStale()) return;
       if (newState == PeerConnection.IceGatheringState.COMPLETE) {
         logStartupStage("ice_gathering_complete", "candidates=" + mIceCandidateCount);
         postOfferIfReady("complete");
@@ -960,10 +1010,12 @@ public class WhipStreamingService extends Service {
     @Override
     public void onConnectionChange(PeerConnection.PeerConnectionState newState) {
       Log.d(TAG, "PeerConnection state: " + newState);
+      if (isStale()) return;
       if (newState == PeerConnection.PeerConnectionState.FAILED) {
         mMainHandler.post(() -> {
+          if (isStale()) return;
           synchronized (mStateLock) {
-            if (mStreamState == StreamState.STARTING) {
+            if (mStreamState == StreamState.STARTING && !mIsReconnecting) {
               failIceConnectTimeout();
               return;
             }
@@ -971,10 +1023,14 @@ public class WhipStreamingService extends Service {
           attemptReconnect("PeerConnection failed");
         });
       } else if (newState == PeerConnection.PeerConnectionState.CONNECTED) {
-        mMainHandler.post(WhipStreamingService.this::completeWhipStartupIfNeeded);
+        mMainHandler.post(() -> {
+          if (isStale()) return;
+          completeWhipStartupIfNeeded();
+        });
       } else if (newState == PeerConnection.PeerConnectionState.DISCONNECTED) {
         Log.w(TAG, "PeerConnection disconnected — waiting before reconnect");
         mMainHandler.postDelayed(() -> {
+          if (isStale()) return;
           synchronized (mStateLock) {
             if (mStreamState != StreamState.STREAMING) return;
           }
@@ -991,11 +1047,24 @@ public class WhipStreamingService extends Service {
     @Override
     public void onIceConnectionChange(PeerConnection.IceConnectionState iceConnectionState) {
       Log.d(TAG, "ICE connection state: " + iceConnectionState);
+      if (isStale()) return;
       if (iceConnectionState == PeerConnection.IceConnectionState.CONNECTED
           || iceConnectionState == PeerConnection.IceConnectionState.COMPLETED) {
-        mMainHandler.post(WhipStreamingService.this::completeWhipStartupIfNeeded);
+        mMainHandler.post(() -> {
+          if (isStale()) return;
+          completeWhipStartupIfNeeded();
+        });
       } else if (iceConnectionState == PeerConnection.IceConnectionState.FAILED) {
-        mMainHandler.post(WhipStreamingService.this::failIceConnectTimeout);
+        mMainHandler.post(() -> {
+          if (isStale()) return;
+          synchronized (mStateLock) {
+            if (mStreamState == StreamState.STARTING && !mIsReconnecting) {
+              failIceConnectTimeout();
+              return;
+            }
+          }
+          attemptReconnect("ICE failed");
+        });
       }
     }
 
@@ -1004,9 +1073,13 @@ public class WhipStreamingService extends Service {
 
     @Override
     public void onIceCandidate(IceCandidate candidate) {
+      if (isStale()) return;
       mIceCandidateCount++;
       if (candidate.sdp != null && candidate.sdp.contains("typ srflx")) {
-        mMainHandler.post(() -> postOfferIfReady("srflx"));
+        mMainHandler.post(() -> {
+          if (isStale()) return;
+          postOfferIfReady("srflx");
+        });
       }
     }
     @Override public void onAddStream(MediaStream stream) {}
@@ -1022,6 +1095,7 @@ public class WhipStreamingService extends Service {
   // -----------------------------------------------------------------------
 
   private void releaseWebRtc() {
+    mNegotiationGeneration++;
     if (mMainHandler != null) {
       mMainHandler.removeCallbacks(mPostOfferTimeoutRunnable);
       mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -131,6 +131,20 @@ public class WhipStreamingService extends Service {
   // HTTP client for WHIP signaling
   private OkHttpClient mHttpClient;
 
+  /** Local candidates gathered for the current negotiation attempt; diagnostic only. */
+  private volatile int mIceCandidateCount = 0;
+
+  // WHIP has no trickle ICE. GATHER_ONCE + STUN can sit in GATHERING for minutes
+  // after the useful host/srflx candidates are already in the local SDP. Phone
+  // startExternallyManagedStream times out at 15s, so POST as soon as we have a
+  // server-reflexive candidate, or after a short cap, whichever comes first.
+  private static final long ICE_GATHER_POST_TIMEOUT_MS = 1500L;
+  private static final long ICE_CONNECT_TIMEOUT_MS = 8000L;
+  private volatile boolean mWhipOfferPosted = false;
+  private volatile boolean mWhipStreamingNotified = false;
+  private final Runnable mPostOfferTimeoutRunnable = () -> postOfferIfReady("timeout");
+  private final Runnable mIceConnectTimeoutRunnable = this::failIceConnectTimeout;
+
   private IHardwareManager mHardwareManager;
 
   // ---- State management ----
@@ -155,6 +169,8 @@ public class WhipStreamingService extends Service {
 
   private Handler mMainHandler;
   private long mStartupStartedAtMs;
+  /** Last `[STREAM_STARTUP]` stage successfully logged; used as `failedStage` context on failure. */
+  private volatile String mLastStartupStage = "not_started";
 
   private long mLastVideoBytesSent = 0;
   private long mLastAudioBytesSent = 0;
@@ -163,6 +179,7 @@ public class WhipStreamingService extends Service {
   private final Runnable mStatsRunnable = new Runnable() {
     @Override
     public void run() {
+      if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) return;
       if (mPeerConnection == null) return;
       mPeerConnection.getStats(report -> {
         long videoBytesTotal = 0, audioBytesTotal = 0;
@@ -328,8 +345,7 @@ public class WhipStreamingService extends Service {
   private void startStreaming() {
     // Check if camera is busy with photo/video capture
     if (CameraNeoService.isCameraInUse()) {
-      Log.e(TAG, "Cannot start WHIP stream - camera is busy with photo/video capture");
-      handleStartupFailure("camera_busy");
+      handleStartupFailure("camera_busy", "Cannot start WHIP stream - camera is busy with photo/video capture");
       return;
     }
 
@@ -368,7 +384,7 @@ public class WhipStreamingService extends Service {
       logStartupStage("offer_requested");
     } catch (Exception e) {
       Log.e(TAG, "Failed to start streaming", e);
-      handleStartupFailure("Failed to start: " + e.getMessage());
+      handleStartupFailure("exception", "Failed to start: " + e.getMessage());
     }
   }
 
@@ -463,6 +479,12 @@ public class WhipStreamingService extends Service {
     mEglBase = EglBase.create();
 
     PeerConnectionFactory.Options factoryOptions = new PeerConnectionFactory.Options();
+    // Loopback interfaces (127.0.0.1, ::1) can never reach an external STUN server, but the
+    // ICE agent still waits out the full STUN retransmission timeout on them before declaring
+    // gathering complete, which was delaying the WHIP offer by ~40s. Ignoring loopback here
+    // makes the network monitor skip it entirely so gathering completes as soon as the real
+    // network interface's candidates (including srflx) are ready.
+    factoryOptions.networkIgnoreMask = PeerConnectionFactory.Options.ADAPTER_TYPE_LOOPBACK;
     mPeerConnectionFactory = PeerConnectionFactory.builder()
         .setOptions(factoryOptions)
         .setVideoEncoderFactory(
@@ -514,9 +536,20 @@ public class WhipStreamingService extends Service {
   }
 
   private void createPeerConnectionAndOffer() {
-    // No STUN/TURN needed for WHIP: we connect outbound to a known server,
-    // so host candidates (local IP) are sufficient. STUN only adds latency here.
+    mWhipOfferPosted = false;
+    mWhipStreamingNotified = false;
+    if (mMainHandler != null) {
+      mMainHandler.removeCallbacks(mPostOfferTimeoutRunnable);
+      mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+    }
+
     List<PeerConnection.IceServer> iceServers = new ArrayList<>();
+    String stunServer = mStreamConfig.getStunServer();
+    if (stunServer != null && !stunServer.isEmpty()) {
+      iceServers.add(PeerConnection.IceServer.builder(stunServer).createIceServer());
+    }
+
+    mIceCandidateCount = 0;
 
     PeerConnection.RTCConfiguration rtcConfig =
         new PeerConnection.RTCConfiguration(iceServers);
@@ -551,13 +584,14 @@ public class WhipStreamingService extends Service {
         mPeerConnection.setLocalDescription(new SdpObserver() {
           @Override
           public void onSetSuccess() {
-            Log.d(TAG, "Local description set, waiting for ICE gathering");
+            Log.d(TAG, "Local description set, posting WHIP offer after first srflx or "
+                + ICE_GATHER_POST_TIMEOUT_MS + "ms");
+            mMainHandler.postDelayed(mPostOfferTimeoutRunnable, ICE_GATHER_POST_TIMEOUT_MS);
           }
 
           @Override
           public void onSetFailure(String error) {
-            Log.e(TAG, "setLocalDescription failed: " + error);
-            handleStartupFailure("setLocalDescription failed: " + error);
+            handleStartupFailure("set_local_description_failed", "setLocalDescription failed: " + error);
           }
 
           @Override public void onCreateSuccess(SessionDescription sdp) {}
@@ -567,8 +601,7 @@ public class WhipStreamingService extends Service {
 
       @Override
       public void onCreateFailure(String error) {
-        Log.e(TAG, "createOffer failed: " + error);
-        handleStartupFailure("createOffer failed: " + error);
+        handleStartupFailure("create_offer_failed", "createOffer failed: " + error);
       }
 
       @Override public void onSetSuccess() {}
@@ -686,6 +719,104 @@ public class WhipStreamingService extends Service {
     Log.i(TAG, label + " video section:\n" + section);
   }
 
+  /**
+   * POST the local SDP once. Triggered by first srflx, the gather timeout, or
+   * GATHERING COMPLETE — whichever wins. Later triggers are no-ops.
+   */
+  private void postOfferIfReady(String reason) {
+    PeerConnection peerConnection;
+    synchronized (mStateLock) {
+      if (mWhipOfferPosted) {
+        return;
+      }
+      if (mPeerConnection == null || mStreamState == StreamState.STOPPING
+          || mStreamState == StreamState.IDLE) {
+        Log.w(TAG, "Skipping WHIP POST (" + reason + "): stream already stopping/stopped");
+        return;
+      }
+      mWhipOfferPosted = true;
+      peerConnection = mPeerConnection;
+    }
+    if (mMainHandler != null) {
+      mMainHandler.removeCallbacks(mPostOfferTimeoutRunnable);
+    }
+
+    SessionDescription localSdp = peerConnection.getLocalDescription();
+
+    if (localSdp != null) {
+      Log.i(TAG, "Posting WHIP offer after ICE trigger=" + reason
+          + " candidates=" + mIceCandidateCount);
+      postOfferToWhip(localSdp);
+    } else {
+      Log.e(TAG, "WHIP POST trigger=" + reason + " but local SDP is null");
+      synchronized (mStateLock) {
+        mWhipOfferPosted = false;
+      }
+      handleStartupFailure("local_sdp_missing", "Local SDP unavailable before WHIP POST");
+    }
+  }
+
+  private void completeWhipStartupIfNeeded() {
+    synchronized (mStateLock) {
+      if (mWhipStreamingNotified) return;
+      if (mPeerConnection == null || mStreamState == StreamState.STOPPING
+          || mStreamState == StreamState.IDLE) {
+        return;
+      }
+      mWhipStreamingNotified = true;
+      mStreamState = StreamState.STREAMING;
+    }
+    if (mMainHandler != null) {
+      mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+    }
+    logStartupStage("streaming_live", "candidates=" + mIceCandidateCount);
+
+    SessionDescription remote = mPeerConnection != null ? mPeerConnection.getRemoteDescription() : null;
+    String answerSdp = remote != null ? remote.description : "";
+    mLastVideoBytesSent = 0;
+    mLastAudioBytesSent = 0;
+    mLastStatsAtMs = SystemClock.elapsedRealtime();
+    if (!mIsReconnecting || mStreamStartedAtMs == 0) {
+      mStreamStartedAtMs = mLastStatsAtMs;
+    }
+    if (AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) {
+      mMainHandler.postDelayed(mStatsRunnable, AsgConstants.STREAM_METRICS_INTERVAL_MS);
+    }
+    scheduleStreamTimeout(mCurrentStreamId);
+    startBatteryMonitoring();
+    Log.i(TAG, "Streaming started via WHIP, negotiated video codec: "
+        + firstVideoCodecFromSdp(answerSdp));
+    if (mLedEnabled && mHardwareManager != null && mHardwareManager.supportsRecordingLed()) {
+      mHardwareManager.setRecordingLedOn();
+    }
+    if (mSoundEnabled && mHardwareManager != null && mHardwareManager.supportsAudioPlayback()) {
+      mHardwareManager.playAudioAsset(AudioAssets.VIDEO_RECORDING_START);
+    }
+    if (mIsReconnecting) {
+      int attempt = mReconnectAttempts;
+      mIsReconnecting = false;
+      mReconnectAttempts = 0;
+      notifyReconnected(mWhipUrl, attempt);
+    } else {
+      notifyStarted(mWhipUrl);
+    }
+    updateNotification("Streaming");
+  }
+
+  private void failIceConnectTimeout() {
+    synchronized (mStateLock) {
+      if (mWhipStreamingNotified) return;
+      if (mStreamState != StreamState.STARTING && mStreamState != StreamState.RECONNECTING) {
+        return;
+      }
+      mWhipStreamingNotified = true;
+    }
+    if (mMainHandler != null) {
+      mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+    }
+    handleStartupFailure("ice_timeout", "ICE did not connect; WHIP media path failed");
+  }
+
   private void postOfferToWhip(SessionDescription offer) {
     logStartupStage("whip_request_started");
     Log.d(TAG, "POSTing SDP offer to WHIP URL: " + mWhipUrl);
@@ -709,8 +840,7 @@ public class WhipStreamingService extends Service {
       public void onResponse(Call call, Response response) throws IOException {
         if (response.code() != 201) {
           String msg = "WHIP server returned " + response.code();
-          Log.e(TAG, msg);
-          handleStartupFailure(msg);
+          handleStartupFailure("http_" + response.code(), msg);
           return;
         }
 
@@ -724,9 +854,15 @@ public class WhipStreamingService extends Service {
 
         String answerSdp = response.body() != null ? response.body().string() : "";
         if (answerSdp.isEmpty()) {
-          handleStartupFailure("WHIP server returned empty SDP answer");
+          handleStartupFailure("empty_answer_sdp", "WHIP server returned empty SDP answer");
           return;
         }
+
+        int remoteCandidateCount = 0;
+        for (String line : answerSdp.split("\r?\n")) {
+          if (line.startsWith("a=candidate")) remoteCandidateCount++;
+        }
+        logStartupStage("whip_answer_received", "remoteCandidates=" + remoteCandidateCount);
 
         // A late WHIP answer can arrive after the stream was stopped or its startup failed
         // and WebRTC was torn down (releaseWebRtc nulls mPeerConnection on another thread).
@@ -756,48 +892,22 @@ public class WhipStreamingService extends Service {
           @Override
           public void onSetSuccess() {
             synchronized (mStateLock) {
-              // Teardown may have happened between the guard above and this callback.
               if (mPeerConnection == null || mStreamState == StreamState.STOPPING
                   || mStreamState == StreamState.IDLE) {
                 Log.w(TAG, "WHIP remote description set but stream already stopping/stopped, ignoring");
                 return;
               }
-              mStreamState = StreamState.STREAMING;
             }
-            mLastVideoBytesSent = 0;
-            mLastAudioBytesSent = 0;
-            mLastStatsAtMs = SystemClock.elapsedRealtime();
-            if (!mIsReconnecting || mStreamStartedAtMs == 0) {
-              mStreamStartedAtMs = mLastStatsAtMs;
-            }
-            mMainHandler.postDelayed(
-                mStatsRunnable, AsgConstants.STREAM_METRICS_INTERVAL_MS);
-            scheduleStreamTimeout(mCurrentStreamId);
-            startBatteryMonitoring();
             logStartupStage("whip_answer_applied");
-            Log.i(TAG, "Streaming started via WHIP, negotiated video codec: "
-                + firstVideoCodecFromSdp(answerSdp));
-            if (mLedEnabled && mHardwareManager != null && mHardwareManager.supportsRecordingLed()) {
-              mHardwareManager.setRecordingLedOn();
-            }
-            if (mSoundEnabled && mHardwareManager != null && mHardwareManager.supportsAudioPlayback()) {
-              mHardwareManager.playAudioAsset(AudioAssets.VIDEO_RECORDING_START);
-            }
-            if (mIsReconnecting) {
-              int attempt = mReconnectAttempts;
-              mIsReconnecting = false;
-              mReconnectAttempts = 0;
-              notifyReconnected(mWhipUrl, attempt);
-            } else {
-              notifyStarted(mWhipUrl);
-            }
-            updateNotification("Streaming");
+            Log.i(TAG, "WHIP answer applied, waiting for ICE connect (max "
+                + ICE_CONNECT_TIMEOUT_MS + "ms)");
+            mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+            mMainHandler.postDelayed(mIceConnectTimeoutRunnable, ICE_CONNECT_TIMEOUT_MS);
           }
 
           @Override
           public void onSetFailure(String error) {
-            Log.e(TAG, "setRemoteDescription failed: " + error);
-            handleStartupFailure("setRemoteDescription failed: " + error);
+            handleStartupFailure("set_remote_description_failed", "setRemoteDescription failed: " + error);
           }
 
           @Override public void onCreateSuccess(SessionDescription sdp) {}
@@ -808,7 +918,7 @@ public class WhipStreamingService extends Service {
       @Override
       public void onFailure(Call call, IOException e) {
         Log.e(TAG, "WHIP request failed", e);
-        handleStartupFailure("WHIP request failed: " + e.getMessage());
+        handleStartupFailure("whip_request_failed", "WHIP request failed: " + e.getMessage());
       }
     });
   }
@@ -842,20 +952,8 @@ public class WhipStreamingService extends Service {
     public void onIceGatheringChange(PeerConnection.IceGatheringState newState) {
       Log.d(TAG, "ICE gathering state: " + newState);
       if (newState == PeerConnection.IceGatheringState.COMPLETE) {
-        logStartupStage("ice_gathering_complete");
-        synchronized (mStateLock) {
-          if (mPeerConnection == null || mStreamState == StreamState.STOPPING || mStreamState == StreamState.IDLE) {
-            Log.w(TAG, "ICE gathering complete but stream already stopping/stopped, ignoring");
-            return;
-          }
-        }
-        SessionDescription localSdp = mPeerConnection.getLocalDescription();
-        if (localSdp != null) {
-          postOfferToWhip(localSdp);
-        } else {
-          Log.e(TAG, "ICE gathering complete but local SDP is null");
-          handleStartupFailure("Local SDP unavailable after ICE gathering");
-        }
+        logStartupStage("ice_gathering_complete", "candidates=" + mIceCandidateCount);
+        postOfferIfReady("complete");
       }
     }
 
@@ -863,7 +961,17 @@ public class WhipStreamingService extends Service {
     public void onConnectionChange(PeerConnection.PeerConnectionState newState) {
       Log.d(TAG, "PeerConnection state: " + newState);
       if (newState == PeerConnection.PeerConnectionState.FAILED) {
-        mMainHandler.post(() -> attemptReconnect("PeerConnection failed"));
+        mMainHandler.post(() -> {
+          synchronized (mStateLock) {
+            if (mStreamState == StreamState.STARTING) {
+              failIceConnectTimeout();
+              return;
+            }
+          }
+          attemptReconnect("PeerConnection failed");
+        });
+      } else if (newState == PeerConnection.PeerConnectionState.CONNECTED) {
+        mMainHandler.post(WhipStreamingService.this::completeWhipStartupIfNeeded);
       } else if (newState == PeerConnection.PeerConnectionState.DISCONNECTED) {
         Log.w(TAG, "PeerConnection disconnected — waiting before reconnect");
         mMainHandler.postDelayed(() -> {
@@ -883,11 +991,24 @@ public class WhipStreamingService extends Service {
     @Override
     public void onIceConnectionChange(PeerConnection.IceConnectionState iceConnectionState) {
       Log.d(TAG, "ICE connection state: " + iceConnectionState);
+      if (iceConnectionState == PeerConnection.IceConnectionState.CONNECTED
+          || iceConnectionState == PeerConnection.IceConnectionState.COMPLETED) {
+        mMainHandler.post(WhipStreamingService.this::completeWhipStartupIfNeeded);
+      } else if (iceConnectionState == PeerConnection.IceConnectionState.FAILED) {
+        mMainHandler.post(WhipStreamingService.this::failIceConnectTimeout);
+      }
     }
 
     @Override public void onIceConnectionReceivingChange(boolean receiving) {}
     @Override public void onIceCandidatesRemoved(IceCandidate[] candidates) {}
-    @Override public void onIceCandidate(IceCandidate candidate) {}
+
+    @Override
+    public void onIceCandidate(IceCandidate candidate) {
+      mIceCandidateCount++;
+      if (candidate.sdp != null && candidate.sdp.contains("typ srflx")) {
+        mMainHandler.post(() -> postOfferIfReady("srflx"));
+      }
+    }
     @Override public void onAddStream(MediaStream stream) {}
     @Override public void onRemoveStream(MediaStream stream) {}
     @Override public void onDataChannel(DataChannel dataChannel) {}
@@ -901,6 +1022,12 @@ public class WhipStreamingService extends Service {
   // -----------------------------------------------------------------------
 
   private void releaseWebRtc() {
+    if (mMainHandler != null) {
+      mMainHandler.removeCallbacks(mPostOfferTimeoutRunnable);
+      mMainHandler.removeCallbacks(mIceConnectTimeoutRunnable);
+    }
+    mWhipOfferPosted = false;
+    mWhipStreamingNotified = false;
     if (mVideoCapturer != null) {
       try { mVideoCapturer.stopCapture(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
       mVideoCapturer.dispose();
@@ -956,12 +1083,17 @@ public class WhipStreamingService extends Service {
     updateNotification("Stream failed");
   }
 
-  private void handleStartupFailure(String error) {
+  /**
+   * @param reasonCode short, aggregable failure code (e.g. "ice_timeout", "http_403")
+   * @param message human-readable detail, forwarded to status listeners / UI
+   */
+  private void handleStartupFailure(String reasonCode, String message) {
     if (mMainHandler != null && Looper.myLooper() != Looper.getMainLooper()) {
-      mMainHandler.post(() -> handleStartupFailure(error));
+      mMainHandler.post(() -> handleStartupFailure(reasonCode, message));
       return;
     }
-    notifyError(error);
+    logStartupFailure(reasonCode);
+    notifyError(message);
     cleanupFailedStartup();
   }
 
@@ -1024,6 +1156,7 @@ public class WhipStreamingService extends Service {
       long droppedFrames,
       long durationSeconds,
       double temperatureC) {
+    if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) return;
     StreamingStatusCallback callback = sStatusCallback;
     String streamId = mCurrentStreamId;
     if (callback == null) return;
@@ -1075,13 +1208,33 @@ public class WhipStreamingService extends Service {
   // -----------------------------------------------------------------------
 
   private void logStartupStage(String stage) {
+    logStartupStage(stage, null);
+  }
+
+  /** @param extra optional additional "key=value" fields appended to the stage line */
+  private void logStartupStage(String stage, String extra) {
     if (mStartupStartedAtMs == 0) return;
-    Log.i(
+    mLastStartupStage = stage;
+    StringBuilder line = new StringBuilder("[STREAM_STARTUP] streamId=")
+        .append(mCurrentStreamId)
+        .append(" stage=").append(stage)
+        .append(" elapsedMs=").append(SystemClock.elapsedRealtime() - mStartupStartedAtMs);
+    if (extra != null && !extra.isEmpty()) {
+      line.append(' ').append(extra);
+    }
+    Log.i(TAG, line.toString());
+  }
+
+  /** Structured startup failure: aggregable by `reason` instead of grepping message prose. */
+  private void logStartupFailure(String reasonCode) {
+    if (mStartupStartedAtMs == 0) return;
+    Log.w(
         TAG,
-        "[STREAM_STARTUP] stage="
-            + stage
-            + " elapsedMs="
-            + (SystemClock.elapsedRealtime() - mStartupStartedAtMs));
+        "[STREAM_STARTUP] streamId=" + mCurrentStreamId
+            + " stage=startup_failed"
+            + " failedStage=" + mLastStartupStage
+            + " elapsedMs=" + (SystemClock.elapsedRealtime() - mStartupStartedAtMs)
+            + " reason=" + reasonCode);
   }
 
   private String buildAbsoluteUrl(String base, String location) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/media/managers/MediaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/media/managers/MediaManager.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.service.media.managers;
 
 import android.content.Context;
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.streaming.events.StreamingCommand;
 import com.mentra.asg_client.io.streaming.interfaces.StreamingStatusCallback;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
@@ -400,6 +401,9 @@ public class MediaManager implements IMediaManager {
                     long droppedFrames,
                     long durationSeconds,
                     double temperatureC) {
+                if (!AsgConstants.ENABLE_PIPELINE_FPS_TELEMETRY) {
+                    return;
+                }
                 try {
                     JSONObject status = new JSONObject();
                     status.put("type", "stream_status");

--- a/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
@@ -99,10 +99,11 @@ export function createCloudflareStreamProvider(): StreamProvider {
           // header comment. We don't use the saved VOD after the call, so
           // auto-delete it as soon as Cloudflare allows instead of letting it
           // eat the account's storage quota (which caused ingest to be refused
-          // at `publish` once the account went over its cap). Cloudflare's
-          // minimum for deleteRecordingAfterDays is 30 (valid range 30-1096);
-          // anything lower fails live-input validation.
-          recording: { mode: "automatic", deleteRecordingAfterDays: 30 },
+          // at `publish` once the account went over its cap).
+          // deleteRecordingAfterDays is a top-level live-input field (not
+          // nested under recording); Cloudflare's minimum is 30 (range 30-1096).
+          recording: { mode: "automatic" },
+          deleteRecordingAfterDays: 30,
         }),
       });
       const body = (await res.json()) as LiveInputResult;

--- a/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
@@ -94,16 +94,7 @@ export function createCloudflareStreamProvider(): StreamProvider {
         headers: { ...authHeaders, "Content-Type": "application/json" },
         body: JSON.stringify({
           meta: { name: `mentra-${mentraUserId}` },
-          // Cloudflare only serves live HLS/DASH manifests when recording is
-          // on (there's no "relay only, keep nothing" mode) — see provider
-          // header comment. We don't use the saved VOD after the call, so
-          // auto-delete it as soon as Cloudflare allows instead of letting it
-          // eat the account's storage quota (which caused ingest to be refused
-          // at `publish` once the account went over its cap).
-          // deleteRecordingAfterDays is a top-level live-input field (not
-          // nested under recording); Cloudflare's minimum is 30 (range 30-1096).
           recording: { mode: "automatic" },
-          deleteRecordingAfterDays: 30,
         }),
       });
       const body = (await res.json()) as LiveInputResult;

--- a/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
@@ -94,7 +94,13 @@ export function createCloudflareStreamProvider(): StreamProvider {
         headers: { ...authHeaders, "Content-Type": "application/json" },
         body: JSON.stringify({
           meta: { name: `mentra-${mentraUserId}` },
-          recording: { mode: "automatic" },
+          // Cloudflare only serves live HLS/DASH manifests when recording is
+          // on (there's no "relay only, keep nothing" mode) — see provider
+          // header comment. We don't use the saved VOD after the call, so
+          // auto-delete it fast instead of letting it eat the account's
+          // storage quota (which caused ingest to be refused at `publish`
+          // once the account went over its cap).
+          recording: { mode: "automatic", deleteRecordingAfterDays: 1 },
         }),
       });
       const body = (await res.json()) as LiveInputResult;

--- a/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
@@ -97,10 +97,12 @@ export function createCloudflareStreamProvider(): StreamProvider {
           // Cloudflare only serves live HLS/DASH manifests when recording is
           // on (there's no "relay only, keep nothing" mode) — see provider
           // header comment. We don't use the saved VOD after the call, so
-          // auto-delete it fast instead of letting it eat the account's
-          // storage quota (which caused ingest to be refused at `publish`
-          // once the account went over its cap).
-          recording: { mode: "automatic", deleteRecordingAfterDays: 1 },
+          // auto-delete it as soon as Cloudflare allows instead of letting it
+          // eat the account's storage quota (which caused ingest to be refused
+          // at `publish` once the account went over its cap). Cloudflare's
+          // minimum for deleteRecordingAfterDays is 30 (valid range 30-1096);
+          // anything lower fails live-input validation.
+          recording: { mode: "automatic", deleteRecordingAfterDays: 30 },
         }),
       });
       const body = (await res.json()) as LiveInputResult;

--- a/mobile/modules/engine/src/services/PhoneCalendarService.ts
+++ b/mobile/modules/engine/src/services/PhoneCalendarService.ts
@@ -14,14 +14,18 @@ import {
 
 export {PhoneCalendarError} from "./PhoneCalendarHelpers"
 
+type CalendarPermissionStatus = Awaited<
+  ReturnType<typeof Calendar.getCalendarPermissionsAsync>
+>["status"]
+
 /**
  * expo-calendar reports anything below EventKit full access as not granted,
  * so distinguish the states the user can actually fix. "Reopen the miniapp"
  * is only true while the permission is undetermined — once iOS has resolved
  * it (denied or write-only/limited), only Settings can change it.
  */
-async function calendarPermissionMessage(status: Calendar.PermissionStatus): Promise<string> {
-  if (status === Calendar.PermissionStatus.UNDETERMINED) {
+async function calendarPermissionMessage(status: CalendarPermissionStatus): Promise<string> {
+  if (status === "undetermined") {
     return "Calendar permission has not been granted yet. Reopen the miniapp and allow calendar access."
   }
   if (Platform.OS === "ios") {

--- a/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
@@ -104,8 +104,10 @@ export interface StartManagedOptions {
    *   - "whip": WebRTC ingest -> WHEP playback (<1s glass-to-screen), but NO
    *     HLS/DASH playback and NO recording (Cloudflare limitation; the returned
    *     hlsUrl will serve 204 forever).
+   *   - "rtmp": RTMPS ingest over TCP 443 -> HLS playback. Survives networks
+   *     that drop WHIP/SRT UDP.
    */
-  ingest?: "srt" | "whip"
+  ingest?: "srt" | "whip" | "rtmp"
 }
 
 export interface StreamPublisherStartResult {
@@ -332,7 +334,34 @@ export class PhoneStreamCoordinator {
     packageName: string,
     opts: StartManagedOptions,
   ): Promise<ManagedStartResult> {
+    try {
+      return await this.executeStartManaged(packageName, opts)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (
+        opts.ingest === "whip" &&
+        /WebRTC ingest never reached|ICE did not connect|timed out waiting/i.test(message)
+      ) {
+        console.warn("[STREAM] WHIP ingest failed, retrying over RTMP:", message)
+        return this.executeStartManaged(packageName, {...opts, ingest: "rtmp"})
+      }
+      throw err
+    }
+  }
+
+  private async executeStartManaged(
+    packageName: string,
+    opts: StartManagedOptions,
+  ): Promise<ManagedStartResult> {
     const startupStartedAtMs = Date.now()
+    // streamId doesn't exist yet — it's minted a few lines below, once we
+    // know this is a fresh provision rather than a join onto an existing one.
+    console.info("[STREAM_STARTUP]", {
+      stage: "requested",
+      packageName,
+      ingest: opts.ingest,
+      elapsedMs: 0,
+    })
     // Two-phase: the entry-claim runs under the transition lock; the wait for
     // HLS readiness happens AFTER the lock releases so a long warm-up doesn't
     // block subsequent start/stop transitions on this coordinator.
@@ -827,7 +856,7 @@ export class PhoneStreamCoordinator {
   }
 }
 
-function pickIngestUrl(p: ProvisionResult, preference?: "srt" | "whip"): string {
+function pickIngestUrl(p: ProvisionResult, preference?: "srt" | "whip" | "rtmp"): string {
   // Glasses' StreamCommandHandler detects protocol from URL prefix.
   //
   // Default priority: SRT > RTMP > WHIP. SRT first: Cloudflare's WebRTC (WHIP)
@@ -838,13 +867,17 @@ function pickIngestUrl(p: ProvisionResult, preference?: "srt" | "whip"): string 
   //
   // "whip" preference flips the trade: sub-second WHEP playback for
   // live-monitor use cases, accepting no HLS and no recording.
+  // "rtmp" prefers TCP 443 ingest so networks that drop WHIP/SRT UDP still
+  // get HLS playback (Mentra Call Teams in restricted networks).
   //
   // Throw if none resolved so the caller's Promise rejects with a clear
   // message rather than the glasses' "unknown protocol" error.
   const url =
     preference === "whip"
       ? p.webrtcPublishUrl || p.srtUrl || p.rtmpUrl
-      : p.srtUrl || p.rtmpUrl || p.webrtcPublishUrl
+      : preference === "rtmp"
+        ? p.rtmpUrl || p.srtUrl || p.webrtcPublishUrl
+        : p.srtUrl || p.rtmpUrl || p.webrtcPublishUrl
   if (!url) {
     throw new Error("Cloudflare provision returned no usable ingest URL")
   }

--- a/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
@@ -340,7 +340,7 @@ export class PhoneStreamCoordinator {
       const message = err instanceof Error ? err.message : String(err)
       if (
         opts.ingest === "whip" &&
-        /WebRTC ingest never reached|ICE did not connect|timed out waiting/i.test(message)
+        /WebRTC ingest never reached|ICE did not connect/i.test(message)
       ) {
         console.warn("[STREAM] WHIP ingest failed, retrying over RTMP:", message)
         return this.executeStartManaged(packageName, {...opts, ingest: "rtmp"})

--- a/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
@@ -203,19 +203,22 @@ describe("PhoneStreamCoordinator", () => {
       await coord.stop("com.a")
     })
 
-    test("WHIP startup rejects when Cloudflare never reports the publisher", async () => {
+    test("WHIP startup falls back to RTMP when Cloudflare never reports the publisher", async () => {
       getManagedStreamStatus.mockImplementation(async () => ({isConnected: false, viewerCount: 0}))
       const coord = new PhoneStreamCoordinator({
         cloudflareStartupPollInitialMs: 1,
         cloudflareStatusPollMs: 5,
+        hlsReadinessInitialDelayMs: 5,
         hlsReadinessPollMs: 5,
         hlsReadinessMaxAttempts: 1,
         keepAliveIntervalMs: 10_000,
       })
 
-      await expect(coord.startManaged("com.a", {ingest: "whip"})).rejects.toThrow(
-        "WebRTC ingest never reached Cloudflare",
-      )
+      const result = await coord.startManaged("com.a", {ingest: "whip"})
+      expect(result.mode).toBe("hls")
+      const arg = startExternallyManagedStream.mock.calls.at(-1)![0] as {streamUrl: string}
+      expect(arg.streamUrl).toBe("rtmp://ingest.test/abc")
+      await coord.stop("com.a")
     })
 
     test("startManaged provisions Cloudflare and resolves when HLS is ready", async () => {
@@ -251,6 +254,20 @@ describe("PhoneStreamCoordinator", () => {
       expect(arg.audio).toEqual({bitrate: 64_000})
       expect("keepAlive" in arg).toBe(false)
       expect("keepAliveIntervalSeconds" in arg).toBe(false)
+    })
+
+    test("RTMP preference publishes to the RTMP ingest URL", async () => {
+      const coord = new PhoneStreamCoordinator({
+        hlsReadinessInitialDelayMs: 5,
+        hlsReadinessPollMs: 5,
+        cloudflareStatusPollMs: 1000,
+        keepAliveIntervalMs: 10_000,
+      })
+      const result = await coord.startManaged("com.a", {ingest: "rtmp"})
+      expect(result.mode).toBe("hls")
+      const arg = startExternallyManagedStream.mock.calls[0]![0] as {streamUrl: string}
+      expect(arg.streamUrl).toBe("rtmp://ingest.test/abc")
+      await coord.stop("com.a")
     })
 
     test("second miniapp joins existing managed stream and gets same URLs", async () => {
@@ -348,7 +365,7 @@ describe("PhoneStreamCoordinator", () => {
       expect(streaming.map((u) => u.pkg).sort()).toEqual(["com.a", "com.b"])
     })
 
-    test("fanout preserves live bitrate and temperature telemetry", async () => {
+    test("fanout strips live bitrate telemetry when FPS telemetry is off", async () => {
       const coord = new PhoneStreamCoordinator({
         hlsReadinessInitialDelayMs: 5,
         hlsReadinessPollMs: 5,
@@ -369,12 +386,7 @@ describe("PhoneStreamCoordinator", () => {
         stats: {bitrate: 912_345, fps: 19.8, duration: 31, temperatureC: 54.6},
       } as never)
 
-      expect(telemetry?.stats).toEqual({
-        bitrate: 912_345,
-        fps: 19.8,
-        duration: 31,
-        temperatureC: 54.6,
-      })
+      expect(telemetry?.stats).toBeUndefined()
       await coord.stop("com.a")
     })
 

--- a/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
@@ -203,6 +203,25 @@ describe("PhoneStreamCoordinator", () => {
       await coord.stop("com.a")
     })
 
+    test("WHIP BLE start timeout does not fall back to RTMP", async () => {
+      startExternallyManagedStream.mockRejectedValueOnce(
+        new Error("Request timed out waiting for glasses response."),
+      )
+      const coord = new PhoneStreamCoordinator({
+        cloudflareStartupPollInitialMs: 1,
+        cloudflareStatusPollMs: 5,
+        hlsReadinessInitialDelayMs: 5,
+        hlsReadinessPollMs: 5,
+        keepAliveIntervalMs: 10_000,
+      })
+
+      await expect(coord.startManaged("com.a", {ingest: "whip"})).rejects.toThrow(
+        /timed out waiting for glasses response/,
+      )
+      expect(provisionManagedStream).toHaveBeenCalledTimes(1)
+      expect(startExternallyManagedStream).toHaveBeenCalledTimes(1)
+    })
+
     test("WHIP startup falls back to RTMP when Cloudflare never reports the publisher", async () => {
       getManagedStreamStatus.mockImplementation(async () => ({isConnected: false, viewerCount: 0}))
       const coord = new PhoneStreamCoordinator({

--- a/mobile/modules/engine/src/services/__tests__/slimStreamStatus.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/slimStreamStatus.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, test} from "bun:test"
+
+import type {StreamStatusEvent} from "@mentra/bluetooth-sdk/internal"
+
+import {slimStreamStatusEvent} from "../slimStreamStatus"
+
+const event: StreamStatusEvent = {
+  type: "stream_status",
+  kind: "lifecycle",
+  status: "streaming",
+  streamId: "phone-1",
+  timestamp: 1_700_000_000_000,
+  stats: {bitrate: 912_345, fps: 19.8, droppedFrames: 2, duration: 31},
+}
+
+describe("slimStreamStatusEvent", () => {
+  test("drops stats when FPS telemetry is off without mutating the incoming event", () => {
+    const slim = slimStreamStatusEvent(event, {enableFpsTelemetry: false})
+    expect(slim.stats).toBeUndefined()
+    expect(slim).toMatchObject({
+      type: "stream_status",
+      kind: "lifecycle",
+      status: "streaming",
+      streamId: "phone-1",
+    })
+    expect(event.stats).toEqual({bitrate: 912_345, fps: 19.8, droppedFrames: 2, duration: 31})
+  })
+
+  test("keeps stats when FPS telemetry is on", () => {
+    const slim = slimStreamStatusEvent(event, {enableFpsTelemetry: true})
+    expect(slim.stats).toEqual(event.stats)
+  })
+})

--- a/mobile/modules/engine/src/services/slimStreamStatus.ts
+++ b/mobile/modules/engine/src/services/slimStreamStatus.ts
@@ -1,10 +1,22 @@
 import type {StreamStatusEvent} from "@mentra/bluetooth-sdk/internal"
 
+/**
+ * 1Hz encoder FPS/bitrate telemetry on `stream_status.stats`.
+ * Lifecycle status (started/stopped/error) is unaffected.
+ * Keep false in production; flip locally to debug the Mentra Call FPS ladder.
+ *
+ * Compatibility kill switch: old glasses can still emit stats. Copy onto a new object;
+ * never mutate the incoming event. Manual acceptance with every layer false: join
+ * waterfall yes; BLE stream_status.stats / STREAM_QUALITY / encoder-stats / watch-stats no.
+ */
+export const ENABLE_PIPELINE_FPS_TELEMETRY = false
+
 /** Fields forwarded to cloud / miniapps after the first resolvedConfig ack. */
 export function slimStreamStatusEvent(
   event: StreamStatusEvent,
-  options: {includeResolvedConfig?: boolean} = {},
+  options: {includeResolvedConfig?: boolean; enableFpsTelemetry?: boolean} = {},
 ): Record<string, unknown> {
+  const enableFpsTelemetry = options.enableFpsTelemetry ?? ENABLE_PIPELINE_FPS_TELEMETRY
   const slim: Record<string, unknown> = {
     type: "stream_status",
     kind: event.kind,
@@ -16,10 +28,9 @@ export function slimStreamStatusEvent(
   if (options.includeResolvedConfig && event.resolvedConfig) {
     slim.resolvedConfig = event.resolvedConfig
   }
-  // Live telemetry passes straight through — unlike resolvedConfig it changes
-  // per event, and the signature dedupe upstream only suppresses identical
-  // payloads.
-  if (event.stats) slim.stats = event.stats
+  // Compatibility kill switch: old glasses may still emit 1Hz stats. Copy onto a
+  // new object; never mutate `event` — other consumers may still need the original.
+  if (enableFpsTelemetry && event.stats) slim.stats = event.stats
   return slim
 }
 

--- a/mobile/modules/miniapp/src/modules/stream.ts
+++ b/mobile/modules/miniapp/src/modules/stream.ts
@@ -77,8 +77,10 @@ export interface StartStreamOptions {
    *     and automatic recording.
    *   - "whip": sub-second WebRTC playback (use `webrtcUrl`/WHEP), but no
    *     HLS/DASH and no recording.
+   *   - "rtmp": RTMPS ingest over TCP 443 → HLS playback. Use when WHIP/SRT
+   *     UDP is blocked (then play `hlsUrl`, not WHEP).
    */
-  ingest?: "srt" | "whip"
+  ingest?: "srt" | "whip" | "rtmp"
   /** Optional Bearer token for direct WHIP Authorization (custom authenticated endpoints). */
   authToken?: string
 }


### PR DESCRIPTION
## Summary
- **Pipeline FPS/bitrate telemetry is default-off** (`ENABLE_PIPELINE_FPS_TELEMETRY = false`). Glasses skip 1Hz `STREAM_QUALITY`, periodic metrics reporters, WHIP WebRTC stats, and BLE `onStreamMetrics`. The phone `slimStreamStatus` drops `stats` on forwarded events so older firmware cannot leak telemetry upstream. Lifecycle `stream_status` still flows.
- **WHIP startup is bounded** for Mentra Call’s 15s phone timeout: offer POST on first srflx or a 1.5s ICE gather cap; “streaming live” only after ICE connects, with an 8s ICE failure path. Stale PeerConnection/HTTP callbacks are tagged with a negotiation generation so reconnect cannot complete a previous offer. ICE failure during reconnect retries instead of aborting the call. RTMP/SRT ignore a late `onSuccess` after stop so BLE does not stay stuck “streaming”; an IDLE late-success is a no-op.
- **WHIP ingest falls back to RTMP** when Cloudflare never reports the publisher or ICE never connects. Miniapps can also request `ingest: "rtmp"` directly. A BLE start timeout is **not** treated as a WHIP failure.

Mentra Call companion (merged): https://github.com/Mentra-Community/Mentra-Call/pull/16

Host QR-scan overlay is **not** in this PR.

## Test plan
- [ ] With the flag false: join waterfall still works; no `STREAM_QUALITY` / encoder-stats / BLE stats / watch-stats.
- [ ] With the flag true (rebuild glasses + phone): stats appear on BLE `stream_status` and are forwarded.
- [ ] WHIP that never ICE-connects falls back to RTMP and Mentra Call still gets a playback URL.
- [ ] BLE start timeout on WHIP does **not** retry RTMP.
- [ ] Miniapp `ingest: "rtmp"` publishes to the RTMP ingest URL.
- [ ] Stop during RTMP start does not leave glasses BLE status as streaming, and does not emit a duplicate stop after IDLE.
- [ ] Mid-call WHIP ICE failure reconnects instead of ending the session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live streaming paths (WHIP ICE timing, RTMP/SRT connection races, managed ingest fallback) that affect Mentra Call reliability; telemetry gating is low risk but spans glasses BLE and phone fanout.
> 
> **Overview**
> **Pipeline FPS/bitrate telemetry is off by default** via `ENABLE_PIPELINE_FPS_TELEMETRY` on glasses and phone. Glasses skip 1Hz metrics reporters, `STREAM_QUALITY`, WHIP stats, and BLE `onStreamMetrics`; the phone strips `stats` in `slimStreamStatus` so older firmware cannot leak telemetry upstream. Lifecycle `stream_status` is unchanged.
> 
> **WHIP startup is bounded for Mentra Call’s ~15s phone timeout:** the offer POSTs on first srflx or a 1.5s ICE gather cap (not full gathering), loopback is ignored to avoid ~40s STUN delays, optional STUN from config is used, and “streaming live” only after ICE connects with an 8s failure path. Negotiation **generation** invalidates stale ICE/HTTP callbacks; mid-call ICE failures **reconnect** instead of ending the session. Structured `[STREAM_STARTUP]` failure codes replace ad-hoc messages.
> 
> **RTMP/SRT** ignore a late `onSuccess` after stop so BLE does not stay stuck “streaming”; RTMP can force teardown from `STOPPING` without a duplicate stop after IDLE.
> 
> **Phone managed streams:** `ingest: "rtmp"` is supported; WHIP auto-retries **RTMP** when Cloudflare never reports the publisher or ICE never connects—**not** on BLE start timeout. Minor: calendar permission typing fix in `PhoneCalendarService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee1b4363e1b54efd65d7f5c0a95c307fdc0bdf39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->