### PR TITLE
Add miniapp scanQr overlay that keeps the session alive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -424,3 +424,7 @@ miniapps/navigation/build/
 # Downloaded bug report bundles (scripts/fetch-incident-logs.sh)
 incident-logs/
 asg_client/StreamPackLite.zip
+
+# Local temp artifacts and generated decks
+tmp/
+output/

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
     "<rootDir>/src/services/streaming/",
     // bun:test suites — run via `bun test`, not Jest (cannot resolve "bun:test").
     "<rootDir>/src/stores/settings.test.ts",
+    "<rootDir>/src/services/qrScanRequest.test.ts",
     "<rootDir>/src/__tests__/app/miniapps/settings/camera.test.tsx",
   ],
   transformIgnorePatterns: [

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -124,10 +124,19 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
       return (baseResolveRequest ?? context.resolveRequest)(context, target, platform)
     }
   }
-  // @mentra/engine -> src/index.ts. Keep this limited to the public root export
-  // so future engine internals do not become implicit app import surface area.
+  // @mentra/engine (+ /internal, /devtools) -> TypeScript SOURCE. The package
+  // "default" export points at build/, and Metro will happily bundle that stale
+  // compile if we only alias the root specifier. LocalMiniappRuntime lives on
+  // /internal — that's why miniapp_scan_qr stayed unimplemented until this
+  // alias covered the subpath too.
   if (moduleName === "@mentra/engine") {
     return (baseResolveRequest ?? context.resolveRequest)(context, path.join(ENGINE_SRC, "index"), platform)
+  }
+  if (moduleName === "@mentra/engine/internal") {
+    return (baseResolveRequest ?? context.resolveRequest)(context, path.join(ENGINE_SRC, "internal"), platform)
+  }
+  if (moduleName === "@mentra/engine/devtools") {
+    return (baseResolveRequest ?? context.resolveRequest)(context, path.join(ENGINE_SRC, "devtools"), platform)
   }
   const miniappAlias = MINIAPP_ALIASES[moduleName]
   if (miniappAlias) return (baseResolveRequest ?? context.resolveRequest)(context, miniappAlias, platform)

--- a/mobile/modules/engine/src/engine.ts
+++ b/mobile/modules/engine/src/engine.ts
@@ -8,7 +8,7 @@
  * live on the `@mentra/engine/internal` entry (and the debug singletons on
  * `@mentra/engine/devtools`); they shrink as screens move onto `engine.*`.
  */
-import {configure, start as bootstrapStart, stop as bootstrapStop} from "./runtime/bootstrap"
+import {configure, start as bootstrapStart, stop as bootstrapStop, updateUiSeams} from "./runtime/bootstrap"
 import {cloudClientService} from "./services/CloudClientService"
 import {hydrateDeviceStore, demoteOrphanedDefaultWearable} from "./services/DeviceStoreHydration"
 import {startGlassesSettingsSync, stopGlassesSettingsSync} from "./services/GlassesSettingsSync"
@@ -46,6 +46,8 @@ import {logBuffer} from "./utils/devLogging"
 export const engine = {
   /** Front door — hand engine auth + config, then start/stop the runtime. */
   configure,
+  /** Merge host-UI seams on a running runtime (scan overlay, wifi setup, …). */
+  updateUiSeams,
   /** Start the runtime: mark started + construct/connect the cloud client + begin
    * syncing device settings to the glasses. */
   async start() {

--- a/mobile/modules/engine/src/index.ts
+++ b/mobile/modules/engine/src/index.ts
@@ -32,6 +32,8 @@ export type {
   IslandConfigValues,
   IslandAnalytics,
   IslandUiSeams,
+  ScanQrOptions,
+  ScanQrResult,
   SubjectTokenType,
 } from "./runtime/bootstrap"
 

--- a/mobile/modules/engine/src/runtime/__tests__/scanQrSeam.test.ts
+++ b/mobile/modules/engine/src/runtime/__tests__/scanQrSeam.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, test} from "bun:test"
+
+import {invokeScanQrSeam, ScanQrNotConfiguredError} from "../scanQrSeam"
+
+describe("invokeScanQrSeam", () => {
+  test("throws NOT_IMPLEMENTED when the host overlay is not registered", async () => {
+    await expect(invokeScanQrSeam(undefined, {title: "Scan"})).rejects.toMatchObject({
+      name: "ScanQrNotConfiguredError",
+      code: "NOT_IMPLEMENTED",
+      message: "QR scanning is not configured on this host. Reload the Mentra App and try again.",
+    })
+    expect(new ScanQrNotConfiguredError()).toBeInstanceOf(Error)
+  })
+
+  test("forwards string title and hint to the host seam", async () => {
+    const calls: Array<{title?: string; hint?: string}> = []
+    const result = await invokeScanQrSeam(async options => {
+      calls.push(options ?? {})
+      return {data: "https://meet.google.com/abc-defg-hij"}
+    }, {title: "Scan meeting QR", hint: "Point the camera", extra: 1})
+    expect(calls).toEqual([{title: "Scan meeting QR", hint: "Point the camera"}])
+    expect(result).toEqual({data: "https://meet.google.com/abc-defg-hij"})
+  })
+
+  test("drops non-string title and hint", async () => {
+    const calls: Array<{title?: string; hint?: string}> = []
+    await invokeScanQrSeam(async options => {
+      calls.push(options ?? {})
+      return {cancelled: true}
+    }, {title: 12, hint: null})
+    expect(calls).toEqual([{}])
+  })
+})

--- a/mobile/modules/engine/src/runtime/__tests__/uiSeams.test.ts
+++ b/mobile/modules/engine/src/runtime/__tests__/uiSeams.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="bun-types" />
+
+import {afterEach, beforeEach, describe, expect, test} from "bun:test"
+
+import {configure, getUiSeams, resetForTests, start, stop, updateUiSeams} from "../bootstrap"
+
+const auth = {
+  getSubjectToken: async () => ({token: "test", type: "supabase" as const}),
+}
+
+describe("updateUiSeams", () => {
+  beforeEach(() => {
+    resetForTests()
+  })
+
+  afterEach(async () => {
+    await stop()
+    resetForTests()
+  })
+
+  test("is ignored before configure", () => {
+    updateUiSeams({
+      scanQr: async () => ({cancelled: true}),
+    })
+    expect(getUiSeams().scanQr).toBeUndefined()
+  })
+
+  test("attaches scanQr after configure, including after start", async () => {
+    configure({auth})
+    expect(getUiSeams().scanQr).toBeUndefined()
+
+    const scanQr = async () => ({data: "payload"} as const)
+    updateUiSeams({scanQr})
+    expect(getUiSeams().scanQr).toBe(scanQr)
+
+    await start()
+    const late = async () => ({cancelled: true} as const)
+    updateUiSeams({scanQr: late})
+    expect(getUiSeams().scanQr).toBe(late)
+  })
+
+  test("survives a configure() that is ignored after start", async () => {
+    const scanQr = async () => ({cancelled: true} as const)
+    configure({auth, ui: {scanQr}})
+    await start()
+    configure({auth, ui: {}})
+    expect(getUiSeams().scanQr).toBe(scanQr)
+  })
+})

--- a/mobile/modules/engine/src/runtime/bootstrap.ts
+++ b/mobile/modules/engine/src/runtime/bootstrap.ts
@@ -51,7 +51,20 @@ export interface IslandUiSeams {
    * flow. Absent ⇒ miniapps get NOT_IMPLEMENTED for the request.
    */
   requestWifiSetup?: (reason?: string, packageName?: string) => Promise<void> | void
+  /**
+   * `session.system.scanQr` — open a phone-camera QR scanner overlay. Must NOT
+   * clear miniapp foreground: UI_CLOSE on a live call hangs it up. Absent ⇒
+   * miniapps get NOT_IMPLEMENTED.
+   */
+  scanQr?: (options?: ScanQrOptions) => Promise<ScanQrResult>
 }
+
+export interface ScanQrOptions {
+  title?: string
+  hint?: string
+}
+
+export type ScanQrResult = {data: string} | {cancelled: true}
 
 export interface IslandConfigureOptions {
   /** REQUIRED — the only must-have seam. The host owns login; engine owns the rest. */
@@ -81,6 +94,19 @@ export function configure(opts: IslandConfigureOptions): void {
   options = opts
 }
 
+/**
+ * Merge host-UI seams after configure/start. UI capabilities (scan overlay,
+ * wifi setup) are looked up per request, so this is safe on a running runtime.
+ * Used so Metro reloads can attach seams that missed the original configure().
+ */
+export function updateUiSeams(ui: IslandUiSeams): void {
+  if (!options) {
+    console.warn("engine.updateUiSeams() called before engine.configure(); ignored")
+    return
+  }
+  options = {...options, ui: {...options.ui, ...ui}}
+}
+
 /** Mark the runtime started. Idempotent. */
 export async function start(): Promise<void> {
   if (started) return
@@ -97,6 +123,12 @@ export async function stop(): Promise<void> {
 
 export function isStarted(): boolean {
   return started
+}
+
+/** Test-only: wipe configure state so suites can start from a cold host. */
+export function resetForTests(): void {
+  options = null
+  started = false
 }
 
 /** The host-supplied auth provider, or null if not configured yet. */

--- a/mobile/modules/engine/src/runtime/scanQrSeam.ts
+++ b/mobile/modules/engine/src/runtime/scanQrSeam.ts
@@ -1,0 +1,20 @@
+import type {ScanQrOptions, ScanQrResult} from "./bootstrap"
+
+export class ScanQrNotConfiguredError extends Error {
+  readonly code = "NOT_IMPLEMENTED"
+  constructor() {
+    super("QR scanning is not configured on this host. Reload the Mentra App and try again.")
+    this.name = "ScanQrNotConfiguredError"
+  }
+}
+
+export async function invokeScanQrSeam(
+  scanQr: ((options?: ScanQrOptions) => Promise<ScanQrResult>) | undefined,
+  payload: Record<string, unknown> = {},
+): Promise<ScanQrResult> {
+  if (!scanQr) throw new ScanQrNotConfiguredError()
+  return scanQr({
+    title: typeof payload.title === "string" ? payload.title : undefined,
+    hint: typeof payload.hint === "string" ? payload.hint : undefined,
+  })
+}

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -66,6 +66,7 @@ import {
   type TtsSynthesisResult,
 } from "../runtime/config"
 import {getAnalytics, getUiSeams} from "../runtime/bootstrap"
+import {invokeScanQrSeam} from "../runtime/scanQrSeam"
 import {normalizeStreamAudioConfig, normalizeStreamVideoConfig} from "../runtime/streamConfig"
 import {toLanguageHint} from "@mentra/cloud-protocol/languages"
 import type {AudioSubscription, LanguageSource, TranscriptionData, TranslationData} from "@mentra/cloud-protocol"
@@ -1027,6 +1028,11 @@ class LocalMiniappRuntime {
     // liveness watchdog just because its PONG replies queue behind real work.
     this.handlePong(packageName)
 
+    if (requestType === "miniapp_scan_qr") {
+      void this.handleScanQr(packageName, payload, requestId)
+      return
+    }
+
     // Console-tap forwarding. The miniapp's console.log/warn/etc is wrapped
     // (via injected shim from miniappGlobals.ts) to post a `dev_log`
     // envelope. We fan out to two destinations:
@@ -1201,6 +1207,9 @@ class LocalMiniappRuntime {
         break
       case MiniappRequestType.DOWNLOAD:
         this.handleDownload(packageName, payload, requestId)
+        break
+      case MiniappRequestType.SCAN_QR:
+        void this.handleScanQr(packageName, payload, requestId)
         break
 
       // Persistent binary blob storage (session.blob)
@@ -3085,6 +3094,29 @@ class LocalMiniappRuntime {
       this.sendResult(packageName, requestId, false, undefined, {
         code: MiniappErrorCode.INTERNAL,
         message: err instanceof Error ? err.message : "Loudness gate set-enabled error",
+      })
+    }
+  }
+
+  /**
+   * session.system.scanQr — host camera overlay. Must not clear miniapp
+   * foreground; the host seam is responsible for presenting a Modal on top.
+   */
+  private async handleScanQr(
+    packageName: string,
+    payload: Record<string, unknown>,
+    requestId?: string,
+  ): Promise<void> {
+    try {
+      const result = await invokeScanQrSeam(getUiSeams().scanQr, payload)
+      this.sendResult(packageName, requestId, true, result)
+    } catch (err) {
+      if (!getUiSeams().scanQr) {
+        console.warn(`${LOG_TAG}: scanQr seam missing — QR overlay is not registered`)
+      }
+      this.sendResult(packageName, requestId, false, undefined, {
+        code: (err as {code?: string}).code || MiniappErrorCode.INTERNAL,
+        message: err instanceof Error ? err.message : "QR scan failed",
       })
     }
   }

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -1028,11 +1028,6 @@ class LocalMiniappRuntime {
     // liveness watchdog just because its PONG replies queue behind real work.
     this.handlePong(packageName)
 
-    if (requestType === "miniapp_scan_qr") {
-      void this.handleScanQr(packageName, payload, requestId)
-      return
-    }
-
     // Console-tap forwarding. The miniapp's console.log/warn/etc is wrapped
     // (via injected shim from miniappGlobals.ts) to post a `dev_log`
     // envelope. We fan out to two destinations:
@@ -3115,7 +3110,7 @@ class LocalMiniappRuntime {
         console.warn(`${LOG_TAG}: scanQr seam missing — QR overlay is not registered`)
       }
       this.sendResult(packageName, requestId, false, undefined, {
-        code: (err as {code?: string}).code || MiniappErrorCode.INTERNAL,
+        code: (err as {code?: string} | null | undefined)?.code || MiniappErrorCode.INTERNAL,
         message: err instanceof Error ? err.message : "QR scan failed",
       })
     }

--- a/mobile/modules/miniapp/src/background/index.ts
+++ b/mobile/modules/miniapp/src/background/index.ts
@@ -116,7 +116,14 @@ export type {
 } from "../modules/display"
 export type {DashboardMode} from "../modules/dashboard"
 export type {PlayAudioOptions, SpeakOptions, SpeakResult, SpeakerState, SpeakerStateEvent} from "../modules/speaker"
-export type {ShareOptions, ShareResult, DownloadOptions, DownloadResult} from "../modules/system"
+export type {
+  ShareOptions,
+  ShareResult,
+  DownloadOptions,
+  DownloadResult,
+  ScanQrOptions,
+  ScanQrResult,
+} from "../modules/system"
 export type {TranscriptionConfig, TranscriptionOptions} from "../modules/transcription"
 export type {PermissionErrorEvent} from "../modules/permissions"
 export type {

--- a/mobile/modules/miniapp/src/index.ts
+++ b/mobile/modules/miniapp/src/index.ts
@@ -130,7 +130,14 @@ export type {
   StreamStatus,
   StreamVideoConfig,
 } from "./modules/stream"
-export type {ShareOptions, ShareResult, DownloadOptions, DownloadResult} from "./modules/system"
+export type {
+  ShareOptions,
+  ShareResult,
+  DownloadOptions,
+  DownloadResult,
+  ScanQrOptions,
+  ScanQrResult,
+} from "./modules/system"
 export type {MiniappInfo, MiniappActionInfo, MiniappCompatibility, ListMiniappsOptions} from "./modules/miniapps"
 export type {ActionContext, ActionHandler, InvokeOptions} from "./modules/actions"
 

--- a/mobile/modules/miniapp/src/modules/system.test.ts
+++ b/mobile/modules/miniapp/src/modules/system.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, test} from "bun:test"
+
+import {MiniappRequestType} from "../protocol"
+import type {MiniappSession} from "../session"
+import {SystemModule} from "./system"
+
+function mockSession<T>(result: T) {
+  const requestCalls: object[] = []
+  const requestOptions: (object | undefined)[] = []
+  const session = {
+    sendRequest: (payload: object, options?: object) => {
+      requestCalls.push(payload)
+      requestOptions.push(options)
+      return Promise.resolve(result)
+    },
+  } as unknown as MiniappSession
+
+  return {session, requestCalls, requestOptions}
+}
+
+describe("SystemModule.scanQr", () => {
+  test("sends miniapp_scan_qr with no host timeout", async () => {
+    const {session, requestCalls, requestOptions} = mockSession({data: "https://meet.google.com/abc-defg-hij"})
+    const system = new SystemModule(session)
+
+    await expect(system.scanQr({title: "Scan meeting QR", hint: "Point the camera"})).resolves.toEqual({
+      data: "https://meet.google.com/abc-defg-hij",
+    })
+    expect(requestCalls).toEqual([
+      {
+        type: MiniappRequestType.SCAN_QR,
+        title: "Scan meeting QR",
+        hint: "Point the camera",
+      },
+    ])
+    expect(requestOptions).toEqual([{timeoutMs: 0}])
+  })
+
+  test("treats a missing result as cancelled", async () => {
+    const {session} = mockSession(undefined)
+    const system = new SystemModule(session)
+    await expect(system.scanQr()).resolves.toEqual({cancelled: true})
+  })
+})

--- a/mobile/modules/miniapp/src/modules/system.ts
+++ b/mobile/modules/miniapp/src/modules/system.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview SystemModule — OS-level utilities (share, open URL, clipboard, download).
+ * @fileoverview SystemModule — OS-level utilities (share, open URL, clipboard, download, QR scan).
  *
  * These bridge to native phone capabilities via LocalMiniappRuntime.
  */
@@ -37,6 +37,15 @@ export interface DownloadResult {
   cancelled?: boolean
 }
 
+export interface ScanQrOptions {
+  /** Header title on the phone scanner overlay. */
+  title?: string
+  /** Hint shown over the camera viewfinder. */
+  hint?: string
+}
+
+export type ScanQrResult = {data: string; cancelled?: false} | {cancelled: true; data?: undefined}
+
 export class SystemModule {
   constructor(private readonly session: MiniappSession) {}
 
@@ -72,5 +81,21 @@ export class SystemModule {
       ...options,
     })
     return result ?? { success: false }
+  }
+
+  /**
+   * Open the phone camera QR scanner as a host overlay. Does not unmount the
+   * miniapp (so live sessions survive the scan). Resolves with the raw QR
+   * payload, or `{cancelled: true}` if the user dismisses the scanner.
+   */
+  async scanQr(options: ScanQrOptions = {}): Promise<ScanQrResult> {
+    const result = await this.session.sendRequest<ScanQrResult>(
+      {
+        type: MiniappRequestType.SCAN_QR,
+        ...options,
+      },
+      {timeoutMs: 0},
+    )
+    return result ?? { cancelled: true }
   }
 }

--- a/mobile/modules/miniapp/src/protocol.test.ts
+++ b/mobile/modules/miniapp/src/protocol.test.ts
@@ -53,6 +53,7 @@ describe("MiniappRequestType wire values", () => {
   test("OPEN_URL", () => expect(MiniappRequestType.OPEN_URL).toBe("miniapp_open_url"))
   test("COPY_CLIPBOARD", () => expect(MiniappRequestType.COPY_CLIPBOARD).toBe("miniapp_copy_clipboard"))
   test("DOWNLOAD", () => expect(MiniappRequestType.DOWNLOAD).toBe("miniapp_download"))
+  test("SCAN_QR", () => expect(MiniappRequestType.SCAN_QR).toBe("miniapp_scan_qr"))
 })
 
 describe("MiniappResponseType wire values", () => {

--- a/mobile/modules/miniapp/src/protocol.ts
+++ b/mobile/modules/miniapp/src/protocol.ts
@@ -136,6 +136,11 @@ export enum MiniappRequestType {
   COPY_CLIPBOARD = "miniapp_copy_clipboard",
   /** Download a file (triggers OS share sheet for save location). */
   DOWNLOAD = "miniapp_download",
+  /**
+   * Open a phone-camera QR scanner overlay. Host must not unmount the miniapp
+   * (clearing foreground fires UI_CLOSE and can hang up live sessions).
+   */
+  SCAN_QR = "miniapp_scan_qr",
 
   /**
    * Phone-local persistent binary blob storage, scoped to (userId, packageName).

--- a/mobile/modules/miniapp/src/transport/mock.test.ts
+++ b/mobile/modules/miniapp/src/transport/mock.test.ts
@@ -100,6 +100,20 @@ describe("MockTransport", () => {
     expect(payload.data).toEqual({events: [], truncated: false})
   })
 
+  test("SCAN_QR returns cancelled so mock hosts never open a camera", async () => {
+    const t = new MockTransport({silent: true})
+    const received: string[] = []
+    t.onMessage((raw) => received.push(raw))
+    await t.open()
+
+    t.send(envelope({type: MiniappRequestType.SCAN_QR, title: "Scan"}, "rid-qr"))
+    await new Promise((r) => queueMicrotask(() => r(null)))
+
+    const payload = parseEnvelope(received[0])!.payload as {ok: boolean; data: {cancelled: boolean}}
+    expect(payload.ok).toBe(true)
+    expect(payload.data).toEqual({cancelled: true})
+  })
+
   test("CAMERA_FOV returns a synthetic ready result", async () => {
     const t = new MockTransport({silent: true})
     const received: string[] = []

--- a/mobile/modules/miniapp/src/transport/mock.ts
+++ b/mobile/modules/miniapp/src/transport/mock.ts
@@ -246,6 +246,9 @@ function syntheticDataFor(requestId: string, requestType: string, requestPayload
     case MiniappRequestType.SET_WIFI_ADB_STATE:
       return {ok: true}
 
+    case MiniappRequestType.SCAN_QR:
+      return {cancelled: true}
+
     default:
       return null
   }

--- a/mobile/src/effects/AllEffects.tsx
+++ b/mobile/src/effects/AllEffects.tsx
@@ -11,6 +11,7 @@ import {ScreenshotFeedbackPrompt} from "@/effects/ScreenshotFeedbackPrompt"
 import NavigationHost from "@/effects/NavigationHost"
 import CapsuleMenu from "@/effects/CapsuleMenu"
 import Compositor from "@/effects/Compositor"
+import {QrScanOverlay} from "@/effects/QrScanOverlay"
 // import TranscriptionsListener from "@/effects/TranscriptionsListener"
 // import SherpaTest from "@/effects/SherpaTest"
 // import WhisperTest from "@/effects/WhisperTest"
@@ -34,6 +35,7 @@ export const AllEffects = () => {
       <ScreenshotFeedbackPrompt />
       <CapsuleMenu forceShow={false} />
       <Compositor />
+      <QrScanOverlay />
       <MemoryWarningMonitor />
     </>
   )

--- a/mobile/src/effects/QrScanOverlay.tsx
+++ b/mobile/src/effects/QrScanOverlay.tsx
@@ -1,0 +1,123 @@
+import {CameraView, useCameraPermissions} from "expo-camera"
+import * as Haptics from "expo-haptics"
+import {useEffect, useState, useSyncExternalStore, type ReactNode} from "react"
+import {Linking, Modal, Text as RNText, View} from "react-native"
+
+import {engine} from "@mentra/engine"
+import {Button, Header, Screen, Text} from "@/components/ignite"
+import {useAppTheme} from "@/contexts/ThemeContext"
+import {translate} from "@/i18n"
+import {completeQrScan, getQrScanRequest, requestPhoneQrScan, subscribeQrScan} from "@/services/qrScanRequest"
+import showAlert from "@/utils/AlertUtils"
+
+function useQrScanRequest() {
+  return useSyncExternalStore(subscribeQrScan, getQrScanRequest, getQrScanRequest)
+}
+
+/**
+ * Phone-camera QR scanner presented as a Modal over the still-mounted miniapp
+ * WebView. Do not navigate or clearForeground from here — that fires UI_CLOSE.
+ */
+export function QrScanOverlay() {
+  const request = useQrScanRequest()
+  const {theme} = useAppTheme()
+  const [permission, requestPermission] = useCameraPermissions()
+  const [scanned, setScanned] = useState(false)
+
+  useEffect(() => {
+    if (typeof engine.updateUiSeams === "function") {
+      engine.updateUiSeams({scanQr: requestPhoneQrScan})
+    }
+  }, [])
+
+  useEffect(() => {
+    setScanned(false)
+    if (request && permission && !permission.granted && permission.canAskAgain) {
+      void requestPermission()
+    }
+  }, [request?.id, permission, requestPermission])
+
+  if (!request) return null
+
+  const cancel = () => completeQrScan({cancelled: true})
+  const title = request.options.title?.trim() || translate("qrScan:defaultTitle")
+  const hint = request.options.hint?.trim() || translate("qrScan:defaultHint")
+
+  const onScanned = ({data}: {data: string}) => {
+    if (scanned) return
+    setScanned(true)
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {})
+    completeQrScan({data})
+  }
+
+  let body: ReactNode
+  if (!permission) {
+    body = (
+      <View className="flex-1 items-center justify-center">
+        <Text className="text-[14px]" tx="qrScan:checkingPermission" />
+      </View>
+    )
+  } else if (!permission.granted) {
+    body = (
+      <View className="flex-1 justify-center px-6">
+        <View className="rounded-xl bg-white dark:bg-zinc-900 p-6 items-center gap-3">
+          <Text className="text-lg font-semibold text-center" tx="qrScan:permissionTitle" />
+          <Text
+            className="text-[13px] text-muted-foreground text-center mb-2 leading-[18px]"
+            tx="qrScan:permissionBody"
+          />
+          <Button
+            tx={permission.canAskAgain ? "qrScan:grantAccess" : "qrScan:openSettings"}
+            onPress={async () => {
+              if (permission.canAskAgain) {
+                await requestPermission()
+                return
+              }
+              try {
+                await Linking.openSettings()
+              } catch {
+                showAlert(translate("qrScan:permissionDeniedTitle"), translate("qrScan:permissionDeniedBody"), [
+                  {text: "OK"},
+                ])
+              }
+            }}
+            preset="alternate"
+            flexContainer={false}
+          />
+        </View>
+      </View>
+    )
+  } else {
+    body = (
+      <View className="flex-1 mx-4 mt-4 mb-12 rounded-xl max-h-[420px] overflow-hidden bg-white">
+        <CameraView
+          style={{flex: 1}}
+          facing="back"
+          barcodeScannerSettings={{barcodeTypes: ["qr"]}}
+          onBarcodeScanned={scanned ? undefined : onScanned}
+        />
+        {!scanned && (
+          <View className="absolute inset-0 items-center justify-center" pointerEvents="none">
+            <View className="w-[240px] h-[240px] rounded-xl border-2 border-indigo-500" />
+          </View>
+        )}
+        {!scanned && (
+          <View className="absolute left-0 right-0 bottom-6 items-center" pointerEvents="none">
+            <RNText className="text-[13px] px-3 py-1.5 rounded-full overflow-hidden text-white bg-black/50">
+              {hint}
+            </RNText>
+          </View>
+        )}
+      </View>
+    )
+  }
+
+  return (
+    <Modal visible animationType="slide" presentationStyle="fullScreen" onRequestClose={cancel}>
+      <Screen preset="fixed" backgroundColor={theme.colors.background}>
+        <Header title={title} leftIcon="chevron-left" onLeftPress={cancel} />
+        {body}
+      </Screen>
+    </Modal>
+  )
+}

--- a/mobile/src/effects/QrScanOverlay.tsx
+++ b/mobile/src/effects/QrScanOverlay.tsx
@@ -1,6 +1,6 @@
 import {CameraView, useCameraPermissions} from "expo-camera"
 import * as Haptics from "expo-haptics"
-import {useEffect, useState, useSyncExternalStore, type ReactNode} from "react"
+import {useEffect, useRef, useState, useSyncExternalStore, type ReactNode} from "react"
 import {Linking, Modal, Text as RNText, View} from "react-native"
 
 import {engine} from "@mentra/engine"
@@ -23,6 +23,7 @@ export function QrScanOverlay() {
   const {theme} = useAppTheme()
   const [permission, requestPermission] = useCameraPermissions()
   const [scanned, setScanned] = useState(false)
+  const askedPermissionForId = useRef<number | null>(null)
 
   useEffect(() => {
     if (typeof engine.updateUiSeams === "function") {
@@ -32,14 +33,20 @@ export function QrScanOverlay() {
 
   useEffect(() => {
     setScanned(false)
-    if (request && permission && !permission.granted && permission.canAskAgain) {
-      void requestPermission()
-    }
-  }, [request?.id, permission, requestPermission])
+    if (!request) askedPermissionForId.current = null
+  }, [request?.id])
+
+  useEffect(() => {
+    if (!request || !permission || permission.granted || !permission.canAskAgain) return
+    if (askedPermissionForId.current === request.id) return
+    askedPermissionForId.current = request.id
+    void requestPermission()
+  }, [request, permission, requestPermission])
 
   if (!request) return null
 
-  const cancel = () => completeQrScan({cancelled: true})
+  const requestId = request.id
+  const cancel = () => completeQrScan({cancelled: true}, requestId)
   const title = request.options.title?.trim() || translate("qrScan:defaultTitle")
   const hint = request.options.hint?.trim() || translate("qrScan:defaultHint")
 
@@ -47,7 +54,7 @@ export function QrScanOverlay() {
     if (scanned) return
     setScanned(true)
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {})
-    completeQrScan({data})
+    completeQrScan({data}, requestId)
   }
 
   let body: ReactNode

--- a/mobile/src/i18n/ar.ts
+++ b/mobile/src/i18n/ar.ts
@@ -116,6 +116,18 @@ const ar = {
       content: "لم تتم اضافة اي مفضلات حتى الان. اضغط على القلب في إحدى الحلقات لإضافته الى المفضلة.",
     },
   },
+  qrScan: {
+    defaultTitle: "مسح رمز QR",
+    defaultHint: "وجّه الكاميرا نحو رمز QR",
+    checkingPermission: "جارٍ التحقق من إذن الكاميرا\u2026",
+    permissionTitle: "يلزم الوصول إلى الكاميرا",
+    permissionBody:
+      "نحتاج إلى الكاميرا لمسح رموز QR. تُستخدم الكاميرا فقط أثناء فتح هذه الشاشة.",
+    grantAccess: "منح إذن الكاميرا",
+    openSettings: "فتح الإعدادات",
+    permissionDeniedTitle: "تم رفض الإذن",
+    permissionDeniedBody: "يرجى تفعيل إذن الكاميرا في الإعدادات لمسح رموز QR.",
+  },
 } satisfies TranslationResource
 
 export default ar

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -723,6 +723,18 @@ const en = {
     miniappUrlFetchErrorBody: "Could not fetch miniapp.json from {{url}}",
     miniappUrlRecentTitle: "Recent",
   },
+  qrScan: {
+    defaultTitle: "Scan QR code",
+    defaultHint: "Point the camera at a QR code",
+    checkingPermission: "Checking camera permission\u2026",
+    permissionTitle: "Camera access needed",
+    permissionBody:
+      "We need your camera to scan QR codes. The camera is only used while this screen is open.",
+    grantAccess: "Grant Camera Access",
+    openSettings: "Open Settings",
+    permissionDeniedTitle: "Permission Denied",
+    permissionDeniedBody: "Please enable camera access in Settings to scan QR codes.",
+  },
   miniappDevSettings: {
     title: "Miniapp Developer",
     headline: "Build a miniapp",

--- a/mobile/src/i18n/es.ts
+++ b/mobile/src/i18n/es.ts
@@ -128,6 +128,18 @@ const es = {
         "No se han agregado episodios favoritos todavía. ¡Presiona el corazón dentro de un episodio para agregarlo a tus favoritos!",
     },
   },
+  qrScan: {
+    defaultTitle: "Escanear código QR",
+    defaultHint: "Apunta la cámara a un código QR",
+    checkingPermission: "Comprobando permiso de cámara\u2026",
+    permissionTitle: "Se necesita acceso a la cámara",
+    permissionBody:
+      "Necesitamos tu cámara para escanear códigos QR. Solo se usa mientras esta pantalla está abierta.",
+    grantAccess: "Permitir acceso a la cámara",
+    openSettings: "Abrir ajustes",
+    permissionDeniedTitle: "Permiso denegado",
+    permissionDeniedBody: "Activa el acceso a la cámara en Ajustes para escanear códigos QR.",
+  },
 } satisfies TranslationResource
 
 export default es

--- a/mobile/src/i18n/fr.ts
+++ b/mobile/src/i18n/fr.ts
@@ -127,6 +127,18 @@ const fr = {
         "Aucun favori n'a été ajouté pour le moment. Appuyez sur le cœur d'un épisode pour l'ajouter à vos favoris !",
     },
   },
+  qrScan: {
+    defaultTitle: "Scanner un code QR",
+    defaultHint: "Pointez la caméra vers un code QR",
+    checkingPermission: "Vérification de l'autorisation caméra\u2026",
+    permissionTitle: "Accès à la caméra requis",
+    permissionBody:
+      "Nous avons besoin de votre caméra pour scanner des codes QR. Elle n'est utilisée que tant que cet écran est ouvert.",
+    grantAccess: "Autoriser l'accès à la caméra",
+    openSettings: "Ouvrir les réglages",
+    permissionDeniedTitle: "Autorisation refusée",
+    permissionDeniedBody: "Activez l'accès à la caméra dans les Réglages pour scanner des codes QR.",
+  },
 } satisfies TranslationResource
 
 export default fr

--- a/mobile/src/i18n/hi.ts
+++ b/mobile/src/i18n/hi.ts
@@ -124,6 +124,18 @@ const hi = {
         "अभी तक कोई पसंदीदा नहीं जोड़ा गया है। इसे अपने पसंदीदा में जोड़ने के लिए किसी एपिसोड पर दिल पर टैप करें!",
     },
   },
+  qrScan: {
+    defaultTitle: "QR कोड स्कैन करें",
+    defaultHint: "कैमरा QR कोड की ओर करें",
+    checkingPermission: "कैमरा अनुमति जाँची जा रही है\u2026",
+    permissionTitle: "कैमरा ऐक्सेस चाहिए",
+    permissionBody:
+      "QR कोड स्कैन करने के लिए कैमरा चाहिए। कैमरा केवल इस स्क्रीन के खुले रहने तक इस्तेमाल होता है।",
+    grantAccess: "कैमरा ऐक्सेस दें",
+    openSettings: "सेटिंग खोलें",
+    permissionDeniedTitle: "अनुमति अस्वीकृत",
+    permissionDeniedBody: "QR कोड स्कैन करने के लिए सेटिंग में कैमरा ऐक्सेस चालू करें।",
+  },
 } satisfies TranslationResource
 
 export default hi

--- a/mobile/src/i18n/ja.ts
+++ b/mobile/src/i18n/ja.ts
@@ -125,6 +125,18 @@ const ja = {
         "お気に入りのエピソードがまだありません。エピソードにあるハートマークにタップして、お気に入りに追加しましょう！",
     },
   },
+  qrScan: {
+    defaultTitle: "QRコードをスキャン",
+    defaultHint: "カメラをQRコードに向けてください",
+    checkingPermission: "カメラの許可を確認しています\u2026",
+    permissionTitle: "カメラへのアクセスが必要です",
+    permissionBody:
+      "QRコードのスキャンにカメラを使います。この画面を開いている間だけ使用します。",
+    grantAccess: "カメラへのアクセスを許可",
+    openSettings: "設定を開く",
+    permissionDeniedTitle: "許可が拒否されました",
+    permissionDeniedBody: "QRコードをスキャンするには、設定でカメラへのアクセスを有効にしてください。",
+  },
 } satisfies TranslationResource
 
 export default ja

--- a/mobile/src/i18n/ko.ts
+++ b/mobile/src/i18n/ko.ts
@@ -121,6 +121,18 @@ const ko = {
       content: "즐겨찾기가 없습니다. 에피소드에 있는 하트를 눌러서 즐겨찾기에 추가하세요.",
     },
   },
+  qrScan: {
+    defaultTitle: "QR 코드 스캔",
+    defaultHint: "카메라를 QR 코드에 맞춰 주세요",
+    checkingPermission: "카메라 권한을 확인하는 중\u2026",
+    permissionTitle: "카메라 접근이 필요합니다",
+    permissionBody:
+      "QR 코드를 스캔하려면 카메라가 필요합니다. 이 화면이 열려 있는 동안에만 사용합니다.",
+    grantAccess: "카메라 접근 허용",
+    openSettings: "설정 열기",
+    permissionDeniedTitle: "권한이 거부됨",
+    permissionDeniedBody: "QR 코드를 스캔하려면 설정에서 카메라 접근을 켜 주세요.",
+  },
 } satisfies TranslationResource
 
 export default ko

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -12,6 +12,7 @@ import {CHINA_HIDDEN_APPS, isChinaBuild, notifyPackageName} from "@/constants/mi
 import {migrate} from "@/services/Migrations"
 import {buildSpokenNotification} from "@/services/notifications/spokenNotification"
 import {cloudConfigValues} from "@/services/cloudClient"
+import {requestPhoneQrScan} from "@/services/qrScanRequest"
 import {engine, BgTimer, SETTINGS} from "@mentra/engine"
 import {
   appRegistry,
@@ -422,6 +423,8 @@ class MantleManager {
               },
             ])
           }),
+        // Overlay only — never clearForeground. UI_CLOSE hangs up live calls.
+        scanQr: (options) => requestPhoneQrScan(options),
       },
     })
     await engine.start()

--- a/mobile/src/services/qrScanRequest.test.ts
+++ b/mobile/src/services/qrScanRequest.test.ts
@@ -1,0 +1,43 @@
+import {afterEach, describe, expect, test} from "bun:test"
+
+import {completeQrScan, getQrScanRequest, requestPhoneQrScan, subscribeQrScan} from "./qrScanRequest"
+
+describe("qrScanRequest", () => {
+  afterEach(() => {
+    completeQrScan({cancelled: true})
+  })
+
+  test("exposes a stable snapshot for the pending overlay", async () => {
+    const seen: Array<number | null> = []
+    const unsubscribe = subscribeQrScan(() => {
+      seen.push(getQrScanRequest()?.id ?? null)
+    })
+
+    const pending = requestPhoneQrScan({title: "Scan meeting QR"})
+    const first = getQrScanRequest()
+    const second = getQrScanRequest()
+    expect(first).toEqual({id: expect.any(Number), options: {title: "Scan meeting QR"}})
+    expect(second).toBe(first)
+
+    completeQrScan({data: "https://meet.google.com/abc-defg-hij"})
+    await expect(pending).resolves.toEqual({data: "https://meet.google.com/abc-defg-hij"})
+    expect(getQrScanRequest()).toBeNull()
+    expect(seen).toEqual([first!.id, null])
+    unsubscribe()
+  })
+
+  test("a second request cancels the first without dropping the new overlay", async () => {
+    const first = requestPhoneQrScan({title: "one"})
+    const second = requestPhoneQrScan({title: "two"})
+    expect(getQrScanRequest()?.options).toEqual({title: "two"})
+
+    await expect(first).resolves.toEqual({cancelled: true})
+    completeQrScan({cancelled: true})
+    await expect(second).resolves.toEqual({cancelled: true})
+  })
+
+  test("completeQrScan is a no-op when nothing is pending", () => {
+    expect(() => completeQrScan({data: "late"})).not.toThrow()
+    expect(getQrScanRequest()).toBeNull()
+  })
+})

--- a/mobile/src/services/qrScanRequest.test.ts
+++ b/mobile/src/services/qrScanRequest.test.ts
@@ -40,4 +40,32 @@ describe("qrScanRequest", () => {
     expect(() => completeQrScan({data: "late"})).not.toThrow()
     expect(getQrScanRequest()).toBeNull()
   })
+
+  test("a stale overlay completion does not settle the replacement request", async () => {
+    const first = requestPhoneQrScan({title: "one"})
+    const firstId = getQrScanRequest()!.id
+    const second = requestPhoneQrScan({title: "two"})
+    const secondId = getQrScanRequest()!.id
+
+    await expect(first).resolves.toEqual({cancelled: true})
+    completeQrScan({data: "https://stale.example/qr"}, firstId)
+    expect(getQrScanRequest()?.id).toBe(secondId)
+
+    completeQrScan({data: "https://fresh.example/qr"}, secondId)
+    await expect(second).resolves.toEqual({data: "https://fresh.example/qr"})
+    expect(getQrScanRequest()).toBeNull()
+  })
+
+  test("a throwing subscriber cannot leave scanQr pending", async () => {
+    const unsubscribe = subscribeQrScan(() => {
+      throw new Error("overlay exploded")
+    })
+    try {
+      const pending = requestPhoneQrScan({title: "scan"})
+      expect(() => completeQrScan({data: "ok"})).not.toThrow()
+      await expect(pending).resolves.toEqual({data: "ok"})
+    } finally {
+      unsubscribe()
+    }
+  })
 })

--- a/mobile/src/services/qrScanRequest.ts
+++ b/mobile/src/services/qrScanRequest.ts
@@ -20,7 +20,13 @@ let current: PendingScan | null = null
 const listeners = new Set<() => void>()
 
 function emit(): void {
-  for (const listener of listeners) listener()
+  for (const listener of listeners) {
+    try {
+      listener()
+    } catch (err) {
+      console.warn("qrScanRequest listener failed", err)
+    }
+  }
 }
 
 export function subscribeQrScan(listener: () => void): () => void {
@@ -63,6 +69,7 @@ export function requestPhoneQrScan(options: ScanQrOptions = {}): Promise<ScanQrR
   return promise
 }
 
-export function completeQrScan(result: ScanQrResult): void {
+export function completeQrScan(result: ScanQrResult, requestId?: number): void {
+  if (requestId !== undefined && current?.id !== requestId) return
   current?.settle(result)
 }

--- a/mobile/src/services/qrScanRequest.ts
+++ b/mobile/src/services/qrScanRequest.ts
@@ -1,0 +1,68 @@
+export interface ScanQrOptions {
+  title?: string
+  hint?: string
+}
+
+export type ScanQrResult = {data: string} | {cancelled: true}
+
+export interface PhoneQrScanRequest {
+  id: number
+  options: ScanQrOptions
+}
+
+type PendingScan = PhoneQrScanRequest & {
+  snapshot: PhoneQrScanRequest
+  settle: (result: ScanQrResult) => void
+}
+
+let seq = 0
+let current: PendingScan | null = null
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+export function subscribeQrScan(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function getQrScanRequest(): PhoneQrScanRequest | null {
+  return current?.snapshot ?? null
+}
+
+/**
+ * Host seam for `session.system.scanQr`. Presents a Modal overlay via
+ * `QrScanOverlay` — does not clear miniapp foreground.
+ */
+export function requestPhoneQrScan(options: ScanQrOptions = {}): Promise<ScanQrResult> {
+  const previous = current
+  const id = ++seq
+  let settled = false
+  const snapshot: PhoneQrScanRequest = {id, options}
+
+  const promise = new Promise<ScanQrResult>((resolve) => {
+    const settle = (result: ScanQrResult) => {
+      if (settled) return
+      settled = true
+      if (current?.id === id) {
+        current = null
+        emit()
+      }
+      resolve(result)
+    }
+
+    current = {id, options, snapshot, settle}
+    emit()
+    previous?.settle({cancelled: true})
+  })
+
+  return promise
+}
+
+export function completeQrScan(result: ScanQrResult): void {
+  current?.settle(result)
+}

--- a/sdk/example-oem-app/src/engineRuntime.ts
+++ b/sdk/example-oem-app/src/engineRuntime.ts
@@ -27,6 +27,10 @@ export async function startEngineRuntime(log: EngineLogger): Promise<() => void>
     ui: {
       // Engine dispatches miniapp wifi-setup requests here; the OEM owns the screen.
       requestWifiSetup: (reason) => log(`wifi setup requested (${reason ?? "no reason"})`),
+      scanQr: async (options) => {
+        log(`scanQr requested (${options?.title ?? "no title"})`)
+        return {cancelled: true}
+      },
     },
   }
   engine.configure(options)


### PR DESCRIPTION
## Summary
- Add `session.system.scanQr` as a phone-camera overlay instead of a full-screen route, so scanning a QR does not clear miniapp foreground / fire `UI_CLOSE` (that hangs up live calls).
- Wire the host seam through engine UI seams + Metro aliases for `@mentra/engine/internal`, so the overlay actually loads from source instead of a stale `build/` compile.
- Cover the protocol, mock transport, host request queue, and seam attach/reload path with unit tests.

## Test plan
- [ ] `cd mobile && bun test src/services/qrScanRequest.test.ts modules/engine/src/runtime/__tests__/scanQrSeam.test.ts modules/engine/src/runtime/__tests__/uiSeams.test.ts modules/miniapp/src/modules/system.test.ts`
- [ ] From a miniapp, call `session.system.scanQr()` while a live session is up — overlay appears, session stays connected
- [ ] Scan a code → `{data: "..."}`; dismiss → `{cancelled: true}`
- [ ] Deny camera permission → overlay shows the grant/settings copy, does not crash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches miniapp bridge, foreground/session semantics, and camera permissions; behavior is well-tested but wrong overlay lifecycle could still affect live calls.
> 
> **Overview**
> Introduces **`session.system.scanQr`** for miniapps: a new `miniapp_scan_qr` request, `SystemModule.scanQr()` (no request timeout), and runtime handling that delegates to a host **`scanQr` UI seam** instead of navigation that would clear foreground and fire `UI_CLOSE`.
> 
> The Mentra host registers that seam via **`engine.updateUiSeams`** (merge after configure/start) and **`QrScanOverlay`**: a full-screen modal with `expo-camera`, permission UX, and a small **`qrScanRequest`** pub/sub queue. **`MantleManager`** also wires `scanQr` at configure time. Missing seam yields **`NOT_IMPLEMENTED`** with a reload hint.
> 
> **Metro** now resolves `@mentra/engine/internal` and `/devtools` to TypeScript source so dev bundles pick up `LocalMiniappRuntime` changes (not stale `build/`). Unit tests cover the seam, UI seam lifecycle, protocol, mock transport, and host request queue; i18n adds `qrScan` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cea1d5df1e012fdeb341eac40c2cc975a54f4e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->