### PR TITLE
Stop WHIP ingest from falling back to RTMP

### DIFF
--- a/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
@@ -334,25 +334,6 @@ export class PhoneStreamCoordinator {
     packageName: string,
     opts: StartManagedOptions,
   ): Promise<ManagedStartResult> {
-    try {
-      return await this.executeStartManaged(packageName, opts)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      if (
-        opts.ingest === "whip" &&
-        /WebRTC ingest never reached|ICE did not connect/i.test(message)
-      ) {
-        console.warn("[STREAM] WHIP ingest failed, retrying over RTMP:", message)
-        return this.executeStartManaged(packageName, {...opts, ingest: "rtmp"})
-      }
-      throw err
-    }
-  }
-
-  private async executeStartManaged(
-    packageName: string,
-    opts: StartManagedOptions,
-  ): Promise<ManagedStartResult> {
     const startupStartedAtMs = Date.now()
     // streamId doesn't exist yet — it's minted a few lines below, once we
     // know this is a fresh provision rather than a join onto an existing one.
@@ -868,7 +849,8 @@ function pickIngestUrl(p: ProvisionResult, preference?: "srt" | "whip" | "rtmp")
   // "whip" preference flips the trade: sub-second WHEP playback for
   // live-monitor use cases, accepting no HLS and no recording.
   // "rtmp" prefers TCP 443 ingest so networks that drop WHIP/SRT UDP still
-  // get HLS playback (Mentra Call Teams in restricted networks).
+  // get HLS playback. Callers must request it explicitly; WHIP starts do not
+  // fall back to RTMP.
   //
   // Throw if none resolved so the caller's Promise rejects with a clear
   // message rather than the glasses' "unknown protocol" error.

--- a/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
@@ -222,7 +222,7 @@ describe("PhoneStreamCoordinator", () => {
       expect(startExternallyManagedStream).toHaveBeenCalledTimes(1)
     })
 
-    test("WHIP startup falls back to RTMP when Cloudflare never reports the publisher", async () => {
+    test("WHIP startup fails when Cloudflare never reports the publisher", async () => {
       getManagedStreamStatus.mockImplementation(async () => ({isConnected: false, viewerCount: 0}))
       const coord = new PhoneStreamCoordinator({
         cloudflareStartupPollInitialMs: 1,
@@ -233,11 +233,12 @@ describe("PhoneStreamCoordinator", () => {
         keepAliveIntervalMs: 10_000,
       })
 
-      const result = await coord.startManaged("com.a", {ingest: "whip"})
-      expect(result.mode).toBe("hls")
-      const arg = startExternallyManagedStream.mock.calls.at(-1)![0] as {streamUrl: string}
-      expect(arg.streamUrl).toBe("rtmp://ingest.test/abc")
-      await coord.stop("com.a")
+      await expect(coord.startManaged("com.a", {ingest: "whip"})).rejects.toThrow(
+        /WebRTC ingest never reached Cloudflare/,
+      )
+      expect(startExternallyManagedStream).toHaveBeenCalledTimes(1)
+      const arg = startExternallyManagedStream.mock.calls[0]![0] as {streamUrl: string}
+      expect(arg.streamUrl).toBe("https://ingest.test/abc/whip")
     })
 
     test("startManaged provisions Cloudflare and resolves when HLS is ready", async () => {


### PR DESCRIPTION
## Summary
- Remove the `startManaged` catch that retried Cloudflare ingest as RTMP after WHIP ICE / publisher timeout.
- WHIP failures now surface to the caller; RTMP remains available only when requested explicitly.
- Update coordinator tests to expect a WHIP failure instead of a silent RTMP retry.

## Test plan
- [x] `bun test modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts` (23 pass)
- [ ] Mentra Call join on a network where WHIP ICE succeeds (should stay WHIP)
- [ ] Mentra Call join on a network that drops UDP ICE (should fail closed, not silently switch to RTMP)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-call streaming behavior on networks where WHIP fails—users see errors instead of a silent switch to HLS/RTMP, which is intentional but affects Mentra Call reliability UX.
> 
> **Overview**
> **WHIP managed streams no longer auto-retry on RTMP** when WebRTC ingest fails (ICE timeout or Cloudflare never reporting the publisher). Those errors now reject `startManaged` instead of silently switching ingest protocol.
> 
> The `startManaged` wrapper and `executeStartManaged` helper are collapsed into one path. `pickIngestUrl` docs now state that **RTMP is only used when callers pass `ingest: "rtmp"`**—not as a WHIP fallback.
> 
> Tests were updated so a stuck WHIP publisher expects rejection (`WebRTC ingest never reached Cloudflare`) and a single glasses start on the WHIP URL, not a second start on RTMP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b43a4dda123170ef028c6fc3970170ed994d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->