### PR TITLE
Delete Cloudflare Stream recordings instead of leaking them

### DIFF
--- a/cloud-v2/packages/runtime/src/index.ts
+++ b/cloud-v2/packages/runtime/src/index.ts
@@ -42,6 +42,10 @@ import {
   stopOwnershipRefreshLoop,
 } from "./services/session/ownership";
 import {
+  startStreamSweepLoop,
+  stopStreamSweepLoop,
+} from "./services/stream/stream.service";
+import {
   onTranscript,
   startWorkerPool,
   stopWorkerPool,
@@ -258,6 +262,12 @@ export async function startRuntime(opts: StartRuntimeOptions = {}): Promise<Runt
     onLostOwnership: dropUserSessionsForLostOwnership,
   });
 
+  // Reclaim Cloudflare Stream inputs and recordings whose stream ended without
+  // a stop() -- a disconnect, a closed app, a pod restart. Left alone these
+  // accumulate until the account hits its storage quota, at which point
+  // Cloudflare accepts new live inputs but rejects the broadcast at publish.
+  startStreamSweepLoop();
+
   // The REST surface (Hono): subscriptions today, health, camera later. The WS
   // upgrade is tried first; everything else falls through to this app.
   const apiApp = createApiApp({ readinessChecks: [redisReadinessCheck] });
@@ -290,6 +300,7 @@ export async function startRuntime(opts: StartRuntimeOptions = {}): Promise<Runt
     wsUrl: `ws://localhost:${boundHttpPort}/ws/session`,
     async stop() {
       stopOwnershipRefreshLoop();
+      stopStreamSweepLoop();
       await stopWorkerPool();
       server.stop();
       await stopUdpIngress();

--- a/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
@@ -21,12 +21,43 @@
  *   GET    /accounts/:acct/stream/live_inputs/:uid   -> { result: { status: { current: {...} } } }
  *   DELETE /accounts/:acct/stream/live_inputs/:uid
  *   POST   /accounts/:acct/stream/live_inputs/:uid/outputs   (restream destinations)
+ *   GET    /accounts/:acct/stream/live_inputs/:uid/videos     (recordings of this input)
+ *   DELETE /accounts/:acct/stream/:videoUid                   (a recording)
+ *
+ * Recordings are separate objects from the live input and outlive it: deleting
+ * an input orphans its recordings, which keep counting against the account's
+ * storage quota. Recording cannot simply be turned off -- HLS playback requires
+ * `mode: automatic` -- so `stop()` deletes the recordings before the input, and
+ * `deleteRecordingAfterDays` is set as a floor for anything that slips past.
  */
 
 import type { ManagedStream, StreamOptions, StreamStatusResult } from "@mentra/cloud-protocol/camera";
 import type { StreamProvider } from "../stream.service";
 
 const CF_API = "https://api.cloudflare.com/client/v4";
+
+/** Cloudflare's minimum for `deleteRecordingAfterDays`. A floor, not the policy. */
+const RECORDING_RETENTION_DAYS = 30;
+
+/** `GET /live_inputs` -- every input on the account. */
+interface LiveInputListResult {
+  result?: Array<{
+    uid: string;
+    created?: string;
+    modified?: string;
+    status?: { current?: { state?: string | null } | null } | null;
+  }>;
+  success: boolean;
+}
+
+/** `GET /live_inputs/:uid/videos` -- the recordings produced by an input. */
+interface VideoListResult {
+  result?: Array<{
+    uid: string;
+    status?: { state?: string } | null;
+  }>;
+  success: boolean;
+}
 
 interface LiveInputResult {
   result?: {
@@ -85,6 +116,76 @@ export function createCloudflareStreamProvider(): StreamProvider {
     };
   }
 
+  /**
+   * Delete every finished recording belonging to a live input.
+   *
+   * Best-effort by design: a stream that has just ended may not have a
+   * recording yet (Cloudflare takes up to ~60s to make one available), and a
+   * failure here must not stop the caller from tearing the input down. What
+   * this misses, the sweeper and `deleteRecordingAfterDays` catch.
+   *
+   * Returns the number deleted, so callers can log it.
+   */
+  async function deleteRecordings(inputUid: string): Promise<number> {
+    const listed = await fetch(`${base}/${inputUid}/videos`, { headers: authHeaders });
+    if (!listed.ok) return 0;
+
+    const body = (await listed.json()) as VideoListResult;
+    const videos = body.result ?? [];
+    let deleted = 0;
+
+    for (const video of videos) {
+      // An in-progress broadcast is not a recording yet. Deleting it would
+      // kill a live stream.
+      if (video.status?.state === "live-inprogress") continue;
+
+      const res = await fetch(`${CF_API}/accounts/${accountId}/stream/${video.uid}`, {
+        method: "DELETE",
+        headers: authHeaders,
+      });
+      if (res.ok || res.status === 404) deleted += 1;
+    }
+    return deleted;
+  }
+
+  /**
+   * Reclaim what `stop()` never got to.
+   *
+   * `stop()` only runs when a client explicitly ends a stream. A stream that
+   * ends because the device dropped, the app closed, or the pod restarted
+   * leaves its input and recordings behind forever. That is the leak that
+   * filled the account: thousands of abandoned inputs, each with recordings
+   * still billed against the storage quota.
+   *
+   * Deletes inputs (and their recordings) last modified before the cutoff,
+   * skipping anything currently connected. Idempotent: a 404 counts as done,
+   * so concurrent pods sweeping at once is harmless.
+   */
+  async function sweep(olderThanMs: number): Promise<{ recordings: number; inputs: number }> {
+    const cutoff = Date.now() - olderThanMs;
+    let recordings = 0;
+    let inputs = 0;
+
+    const listed = await fetch(base, { headers: authHeaders });
+    if (!listed.ok) return { recordings, inputs };
+
+    const body = (await listed.json()) as LiveInputListResult;
+    for (const input of body.result ?? []) {
+      const modified = Date.parse(input.modified ?? input.created ?? "");
+      if (!Number.isFinite(modified) || modified >= cutoff) continue;
+
+      // Never touch an input a device is publishing to right now.
+      const state = input.status?.current?.state ?? null;
+      if (state === "connected" || state === "live") continue;
+
+      recordings += await deleteRecordings(input.uid);
+
+      const res = await fetch(`${base}/${input.uid}`, { method: "DELETE", headers: authHeaders });
+      if (res.ok || res.status === 404) inputs += 1;
+    }
+    return { recordings, inputs };
+  }
+
   return {
     name: "cloudflare",
 
@@ -94,7 +195,14 @@ export function createCloudflareStreamProvider(): StreamProvider {
         headers: { ...authHeaders, "Content-Type": "application/json" },
         body: JSON.stringify({
           meta: { name: `mentra-${mentraUserId}` },
+          // `automatic` is required: HLS/DASH playback does not work with
+          // recording off, and Mentra Call needs the live HLS URL.
           recording: { mode: "automatic" },
+          // Backstop only. `stop()` deletes recordings explicitly; this bounds
+          // anything it misses (a stream that ends by disconnect, a failed
+          // delete). Cloudflare's minimum for this field is 30 days, so it
+          // cannot replace explicit deletion.
+          deleteRecordingAfterDays: RECORDING_RETENTION_DAYS,
         }),
       });
       const body = (await res.json()) as LiveInputResult;
@@ -167,6 +275,14 @@ export function createCloudflareStreamProvider(): StreamProvider {
     },
 
     async stop(streamId: string): Promise<void> {
+      // Recordings first, then the input. Deleting the input orphans its
+      // recordings -- they survive, keep counting against the storage quota,
+      // and are no longer reachable through the input's /videos listing -- so
+      // the order matters. Once the account is over quota Cloudflare still
+      // creates live inputs but rejects the broadcast at publish, which
+      // surfaces to the user as a network failure.
+      await deleteRecordings(streamId);
+
       const res = await fetch(`${base}/${streamId}`, {
         method: "DELETE",
         headers: authHeaders,
@@ -175,5 +291,8 @@ export function createCloudflareStreamProvider(): StreamProvider {
         throw new Error(`cloudflare live input delete failed: ${res.status}`);
       }
     },
+
+    deleteRecordings,
+    sweep,
   };
 }

--- a/cloud-v2/packages/runtime/src/services/stream/stream.service.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/stream.service.ts
@@ -14,13 +14,29 @@
  */
 
 import type { ManagedStream, StreamOptions, StreamStatusResult } from "@mentra/cloud-protocol/camera";
+import { createLogger } from "@mentra/cloud-shared";
 import { createCloudflareStreamProvider } from "./providers/cloudflare-stream.provider";
+
+const logger = createLogger("audio").child({ service: "stream.service" });
 
 export interface StreamProvider {
   readonly name: string;
   provision(mentraUserId: string, opts: StreamOptions): Promise<ManagedStream>;
   status(streamId: string): Promise<StreamStatusResult>;
   stop(streamId: string): Promise<void>;
+  /**
+   * Delete the finished recordings belonging to a stream, returning how many
+   * went. `stop()` already does this; it is exposed so the sweeper can reclaim
+   * recordings whose stream ended without anyone calling `stop()`.
+   *
+   * Optional: a provider that does not record has nothing to delete.
+   */
+  deleteRecordings?(streamId: string): Promise<number>;
+  /**
+   * Delete recordings and inputs abandoned before `olderThanMs`, returning what
+   * was reclaimed. Optional for the same reason.
+   */
+  sweep?(olderThanMs: number): Promise<{ recordings: number; inputs: number }>;
 }
 
 let provider: StreamProvider | null = null;
@@ -39,4 +55,60 @@ export function getStreamProvider(): StreamProvider {
 /** Test/boot hook: reset the cached provider. */
 export function resetStreamProvider(): void {
   provider = null;
+}
+
+// === Recording sweep loop ===
+
+/** How often to sweep. Cheap: one list call plus deletes for what it finds. */
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * How stale an input must be before the sweeper reclaims it. Comfortably longer
+ * than any real session, so a long-running stream is never cut short.
+ */
+const SWEEP_MIN_AGE_MS = 6 * 60 * 60 * 1000;
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the background sweep that reclaims abandoned live inputs and their
+ * recordings.
+ *
+ * `stop()` handles the tidy case, but it only runs when a client explicitly
+ * ends a stream; anything that ends by disconnect leaks. Recordings cannot be
+ * disabled (HLS playback needs `mode: automatic`), and Cloudflare's built-in
+ * `deleteRecordingAfterDays` has a 30-day minimum, so without this the account
+ * fills and Cloudflare starts rejecting broadcasts at publish -- which reaches
+ * the user as an unexplained network failure.
+ *
+ * Call once at startup. Idempotent, so a second call cannot create a duplicate
+ * timer. Every pod running this is fine: deletes are idempotent and a 404
+ * counts as success.
+ */
+export function startStreamSweepLoop(): void {
+  if (sweepTimer) return;
+
+  const run = async () => {
+    try {
+      const p = getStreamProvider();
+      if (!p.sweep) return;
+      const { recordings, inputs } = await p.sweep(SWEEP_MIN_AGE_MS);
+      if (recordings || inputs) {
+        logger.info({ recordings, inputs }, "stream sweep reclaimed abandoned inputs");
+      }
+    } catch (err) {
+      // A provider that is not configured, or a Cloudflare blip. Next tick retries.
+      logger.warn({ err }, "stream sweep failed");
+    }
+  };
+
+  sweepTimer = setInterval(run, SWEEP_INTERVAL_MS);
+  void run();
+}
+
+/** Test/shutdown hook: stop the sweep loop. */
+export function stopStreamSweepLoop(): void {
+  if (!sweepTimer) return;
+  clearInterval(sweepTimer);
+  sweepTimer = null;
 }

--- a/cloud-v2/tests/stream.recording-cleanup.test.ts
+++ b/cloud-v2/tests/stream.recording-cleanup.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Recording cleanup on the Cloudflare Stream provider (stubbed fetch).
+ *
+ * The account filled up because recordings outlive the live input that made
+ * them: deleting an input orphans its recordings, which keep counting against
+ * the storage quota until Cloudflare starts rejecting broadcasts at publish.
+ * Recording cannot be turned off (HLS playback needs `mode: automatic`), so the
+ * provider has to delete recordings itself.
+ *
+ * These assert the parts that are easy to get subtly wrong -- ordering, and
+ * which things must never be deleted -- against a stubbed API rather than a
+ * real account, so they run everywhere and cost nothing.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createCloudflareStreamProvider } from "../packages/runtime/src/services/stream/providers/cloudflare-stream.provider";
+
+const ACCT = "acct123";
+const realFetch = globalThis.fetch;
+
+/** Requests the stub saw, in order, as "METHOD /path". */
+let calls: string[] = [];
+
+interface Route {
+  videos?: Array<{ uid: string; status?: { state?: string } }>;
+  inputs?: Array<{
+    uid: string;
+    modified?: string;
+    status?: { current?: { state?: string | null } | null } | null;
+  }>;
+}
+
+function stubFetch(routes: Route) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    calls.push(`${method} ${new URL(url).pathname}`);
+
+    if (method === "GET" && url.endsWith("/videos")) {
+      return new Response(JSON.stringify({ success: true, result: routes.videos ?? [] }));
+    }
+    if (method === "GET" && url.endsWith("/live_inputs")) {
+      return new Response(JSON.stringify({ success: true, result: routes.inputs ?? [] }));
+    }
+    return new Response(JSON.stringify({ success: true, result: {} }));
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  calls = [];
+  process.env.CF_STREAM_ACCOUNT_ID = ACCT;
+  process.env.CF_STREAM_API_TOKEN = "token";
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("recording cleanup", () => {
+  test("stop() deletes recordings before deleting the input", async () => {
+    stubFetch({ videos: [{ uid: "vid1", status: { state: "ready" } }] });
+
+    await createCloudflareStreamProvider().stop("input1");
+
+    const recording = calls.indexOf(`DELETE /client/v4/accounts/${ACCT}/stream/vid1`);
+    const input = calls.indexOf(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/input1`);
+
+    expect(recording).toBeGreaterThanOrEqual(0);
+    expect(input).toBeGreaterThanOrEqual(0);
+    // Order is the whole point: once the input is gone its recordings are no
+    // longer reachable through /videos, so deleting it first strands them.
+    expect(recording).toBeLessThan(input);
+  });
+
+  test("a broadcast still in progress is never deleted", async () => {
+    stubFetch({
+      videos: [
+        { uid: "live1", status: { state: "live-inprogress" } },
+        { uid: "done1", status: { state: "ready" } },
+      ],
+    });
+
+    const deleted = await createCloudflareStreamProvider().deleteRecordings!("input1");
+
+    expect(deleted).toBe(1);
+    expect(calls).toContain(`DELETE /client/v4/accounts/${ACCT}/stream/done1`);
+    expect(calls).not.toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live1`);
+  });
+
+  test("sweep skips inputs that are too recent or still connected", async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const recent = new Date().toISOString();
+
+    stubFetch({
+      inputs: [
+        { uid: "stale", modified: old },
+        { uid: "fresh", modified: recent },
+        { uid: "busy", modified: old, status: { current: { state: "connected" } } },
+      ],
+      videos: [],
+    });
+
+    const { inputs } = await createCloudflareStreamProvider().sweep!(6 * 60 * 60 * 1000);
+
+    expect(inputs).toBe(1);
+    expect(calls).toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/stale`);
+    // A live session must survive the sweep, and so must anything recent.
+    expect(calls).not.toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/busy`);
+    expect(calls).not.toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/fresh`);
+  });
+
+  test("provision sets a retention floor for recordings it cannot delete itself", async () => {
+    let sentBody = "";
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBody = String(init?.body ?? "");
+      return new Response(JSON.stringify({ success: true, result: { uid: "u1" } }));
+    }) as typeof fetch;
+
+    await createCloudflareStreamProvider().provision("user1", {});
+
+    expect(JSON.parse(sentBody).deleteRecordingAfterDays).toBe(30);
+    // Recording must stay on: HLS playback does not work without it.
+    expect(JSON.parse(sentBody).recording.mode).toBe("automatic");
+  });
+});


### PR DESCRIPTION
Mentra Call could not start live streams today. It presented as a network fault, but the Cloudflare Stream account was over its storage quota. When full, Cloudflare still creates live inputs and then rejects the broadcast at publish, so the failure surfaces nowhere near its cause.

Verified against the account before any changes:

```
videoCount:               5,746
totalStorageMinutes:      12,469.79
totalStorageMinutesLimit: 10,000
scheduledDeletion set on:  0 of 5,746
```

A 1,000-video sample was 100% live-input recordings, dating back to 2026-05-07. Nothing had ever been cleaned up.

**Recording cannot be turned off.** HLS playback does not work with recording disabled, and Mentra Call needs the live HLS URL to put the glasses camera into Teams. So recordings have to be deleted after the fact.

## What this changes

**`stop()` deletes recordings before deleting the input.** Order is the whole point. Recordings are separate objects that outlive the input, and once the input is gone they are no longer reachable through its `/videos` listing while still counting against the quota. That is how thousands accumulated without anyone seeing them.

**A sweep loop reclaims what `stop()` never sees.** `stop()` only runs when a client explicitly ends a stream; anything ending by disconnect, closed app or pod restart leaks. The account had **3,627 abandoned live inputs** still on it, and that number grew by 52 during the investigation. The loop deletes inputs older than six hours along with their recordings, skipping any still connected. It follows the existing `startOwnershipRefreshLoop` pattern, is idempotent, and counts a 404 as success, so every pod running it is harmless.

**`provision()` sets `deleteRecordingAfterDays` as a floor.** Cloudflare's minimum is 30 days, far too coarse to be the actual policy, but it bounds anything both paths miss.

## Worth knowing

**All three environments share one Stream account** (`CF_STREAM_ACCOUNT_ID` is identical in dev, staging and prod). Dev testing consumes the quota prod Mentra Call depends on, so this was a production availability risk rather than a dev inconvenience. Separating them, or alarming on quota, is worth considering separately.

## Testing

Stubbed API rather than a real account, so they run everywhere and cost nothing. They cover the failure modes that are silent when wrong:

- recordings are deleted **before** the input
- an in-progress broadcast is never deleted
- the sweep leaves recent and still-connected inputs alone
- `provision` keeps `recording.mode: automatic` while setting the retention floor

`bunx tsc --noEmit -p packages/runtime` clean; new tests plus the existing unit suites pass (22 tests).

## Backlog cleanup

The existing 5,746 recordings are being purged separately with a paced script (skipping anything live). Down to ~5,229 videos / 9,929 minutes as of writing. The plan limit has also been raised to 14,000, so the immediate outage is already cleared; this PR stops it recurring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-stream lifecycle and destructive Cloudflare API calls; guards skip active broadcasts and connected inputs, with tests on ordering and sweep filters.
> 
> **Overview**
> Fixes Cloudflare Stream storage quota exhaustion by **deleting recordings before live inputs** and **reclaiming abandoned resources** when clients never call `stop()`.
> 
> **Explicit teardown:** `stop()` now lists an input’s `/videos`, deletes finished recordings (skips `live-inprogress`), then deletes the live input so recordings are not orphaned and still billed.
> 
> **Background sweep:** Runtime starts an hourly `startStreamSweepLoop()` (stopped on shutdown) that calls provider `sweep()` for inputs older than six hours, skipping `connected`/`live` states; concurrent pods are treated as safe via idempotent deletes.
> 
> **Provision backstop:** New live inputs still use `recording.mode: automatic` (required for HLS) and set **`deleteRecordingAfterDays: 30`** as Cloudflare’s minimum retention floor.
> 
> Stubbed tests cover delete ordering, in-progress broadcast safety, sweep filters, and provision payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677689320c1c1fc82bec7c636b5b491ecfdb732b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete Cloudflare Stream recordings and reclaim abandoned inputs to stop storage leaks that blocked live publish. Previously `stop()` deleted the input and left recordings; now it deletes recordings first, and a background sweep cleans up streams that ended without `stop()`.

- `stop()` now deletes finished recordings before deleting the input; treats 404 as success and never deletes an in-progress broadcast.
- Adds an hourly sweep that deletes recordings and inputs last modified >6h ago, skipping inputs in "connected" or "live" states; idempotent and safe across pods.
- `provision()` keeps `recording.mode: "automatic"` and sets `deleteRecordingAfterDays: 30` as a retention floor.
- Wires the sweep into runtime startup/shutdown; the Cloudflare provider exposes `deleteRecordings()` and `sweep()`.
- Adds tests with a stubbed API for ordering, live-stream safety, sweep filtering, and retention configuration.

<sup>Written for commit 677689320c1c1fc82bec7c636b5b491ecfdb732b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

