### PR TITLE
fix(MentraLive): make LC3 characteristics optional and stop service discovery racing CTKD bonding

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -172,6 +172,28 @@ class MentraLive : SGCManager() {
         private const val BONDING_RETRY_DELAY_MS =
                 1500L // Delay before retry to let user see dialog again
 
+        /**
+         * GATT status reported when the link-layer security challenge fails, i.e. the stored link
+         * key is rejected by the peer. Seen when a previous bond attempt was torn down before it
+         * reached BOND_BONDED, leaving an unusable half-written bond record.
+         */
+        private const val GATT_AUTH_CHALLENGE_FAILED = 147
+
+        /**
+         * How long to wait for bonding to reach BOND_BONDED before treating it as stuck. A device
+         * left in BOND_BONDING never fires a further state change and createBond() is a no-op while
+         * it is in that state, so without this the deferred service discovery would never run.
+         */
+        private const val BONDING_COMPLETION_TIMEOUT_MS = 20000L
+
+        /**
+         * How many connect-then-drop cycles without ever reaching readiness are tolerated before
+         * the bond is judged unusable. A half-written bond reports BOND_BONDED and lets the link
+         * come up, so it never surfaces as a connection error — repeated useless sessions are the
+         * only signal available from the public API.
+         */
+        private const val UNUSABLE_BOND_FAILURE_THRESHOLD = 3
+
         private const val CORE_TOKEN_MAX_RETRIES = 3
         private const val CORE_TOKEN_RETRY_DELAY_MS = 250L
 
@@ -284,6 +306,22 @@ class MentraLive : SGCManager() {
     private var isBtClassicConnected = false
     private var bondingReceiver: BroadcastReceiver? = null
     private var bondingRetryCount = 0
+
+    /**
+     * Set when service discovery has been deferred until bonding completes. Running GATT operations
+     * while pairing is in flight races the CTKD exchange and corrupts the bond, so discovery is
+     * started from the BOND_BONDED handler instead.
+     */
+    private var pendingServiceDiscovery = false
+
+    /**
+     * Guards the one-shot bond removal performed when a connection fails with
+     * [GATT_AUTH_CHALLENGE_FAILED], so a rejected link key cannot loop.
+     */
+    private var hasClearedUnusableBond = false
+
+    /** Consecutive BLE sessions that connected but dropped before the glasses ever became ready. */
+    private var unusableBondFailureCount = 0
 
     // A2DP profile connection for already-bonded devices
     private var a2dpProfile: BluetoothA2dp? = null
@@ -1600,12 +1638,27 @@ class MentraLive : SGCManager() {
                                 connectA2dpProfile(connectedDevice!!)
                                 // Note: audioConnected will be set to true once A2DP profile
                                 // connects
-                            } else {
-                                createBond(connectedDevice!!)
-                            }
 
-                            // Discover services
-                            gatt.discoverServices()
+                                // Already bonded: the link is encrypted, discovery is safe now.
+                                pendingServiceDiscovery = false
+                                gatt.discoverServices()
+                            } else {
+                                // Defer service discovery until bonding completes.
+                                //
+                                // Calling discoverServices() here races the CTKD exchange: GATT
+                                // traffic on a not-yet-encrypted link causes the peer to drop the
+                                // connection mid-pairing, so the bond never advances past
+                                // BOND_BONDING. What is left on disk is a half-written record
+                                // (le_linkkey_known:T, le_authenticated:F, ble_enc_key_size:0,
+                                // bond_type:BOND_TYPE_UNKNOWN) which reports as BOND_BONDED but
+                                // fails every later connection with status 147.
+                                //
+                                // Discovery is started from the BOND_BONDED branch of the bonding
+                                // receiver instead.
+                                pendingServiceDiscovery = true
+                                createBond(connectedDevice!!)
+                                scheduleBondingWatchdog()
+                            }
 
                             // Reset reconnect attempts on successful connection
                             val previousAttempts = reconnectAttempts
@@ -1625,6 +1678,40 @@ class MentraLive : SGCManager() {
                             Bridge.log(
                                     "LIVE: 🔌 ⚠️ Disconnected from GATT server - Will attempt reconnection"
                             )
+
+                            // Detect a bond that reports BOND_BONDED but was never actually
+                            // authenticated (half-written record: le_authenticated:F,
+                            // ble_enc_key_size:0). Such a bond lets the GATT link come up and then
+                            // drop before the session is ever usable, so it arrives here as an
+                            // ordinary disconnect and never as a connection error — the
+                            // GATT_AUTH_CHALLENGE_FAILED path below cannot see it, and the
+                            // already-bonded branch keeps skipping re-bonding forever.
+                            //
+                            // Repeated connect->drop cycles that never reach readiness are the only
+                            // signal the public API exposes, so use that to clear the bond once and
+                            // let the device pair from scratch.
+                            if (!glassesReadyReceived) {
+                                unusableBondFailureCount++
+                                val staleBondDevice = connectedDevice
+                                if (unusableBondFailureCount >= UNUSABLE_BOND_FAILURE_THRESHOLD &&
+                                                !hasClearedUnusableBond &&
+                                                staleBondDevice != null &&
+                                                staleBondDevice.bondState ==
+                                                        BluetoothDevice.BOND_BONDED
+                                ) {
+                                    hasClearedUnusableBond = true
+                                    unusableBondFailureCount = 0
+                                    Bridge.log(
+                                            "LIVE: CTKD: " +
+                                                    UNUSABLE_BOND_FAILURE_THRESHOLD +
+                                                    " connect/drop cycles without readiness - bond reports BONDED but is unusable, removing it so the next attempt re-pairs"
+                                    )
+                                    removeBond(staleBondDevice)
+                                }
+                            } else {
+                                unusableBondFailureCount = 0
+                            }
+
                             isConnected = false
                             isConnecting = false
 
@@ -1693,6 +1780,24 @@ class MentraLive : SGCManager() {
                                         status +
                                         ") - Will retry reconnection"
                         )
+
+                        // A security-challenge failure means the stored link key is rejected by the
+                        // glasses, which no number of retries can fix. Drop the unusable bond once
+                        // so the next attempt pairs from scratch instead of looping until the
+                        // reconnect budget is exhausted.
+                        if (status == GATT_AUTH_CHALLENGE_FAILED &&
+                                        !hasClearedUnusableBond &&
+                                        connectedDevice != null
+                        ) {
+                            hasClearedUnusableBond = true
+                            Bridge.log(
+                                    "LIVE: CTKD: status=" +
+                                            GATT_AUTH_CHALLENGE_FAILED +
+                                            " - link key rejected, removing unusable bond so the next attempt re-pairs"
+                            )
+                            removeBond(connectedDevice!!)
+                        }
+
                         isConnected = false
                         isConnecting = false
                         glassesReady = false
@@ -1777,11 +1882,31 @@ class MentraLive : SGCManager() {
                             lc3ReadCharacteristic = service.getCharacteristic(LC3_READ_UUID)
                             lc3WriteCharacteristic = service.getCharacteristic(LC3_WRITE_UUID)
 
-                            // Check if we have required characteristics
+                            // Only the core TX/RX pair is genuinely required to run a session.
+                            //
+                            // The LC3 audio characteristics were previously treated as mandatory
+                            // ("always supported"), but that does not hold for glasses running
+                            // firmware older than the LC3 audio support. On those devices the
+                            // service and the core TX/RX characteristics are present and perfectly
+                            // usable, yet the connection was torn down with gatt.disconnect() and
+                            // retried forever — with no user-visible error, so it presents as an
+                            // infinite "connecting" spinner rather than "your glasses need a
+                            // firmware update".
+                            //
+                            // Degrade gracefully instead: run the session without LC3 audio. The
+                            // LC3 fields are nullable and the write path already null-checks them.
                             val hasRequiredCharacteristics =
-                                    (rxCharacteristic != null && txCharacteristic != null) &&
-                                            (lc3ReadCharacteristic != null &&
-                                                    lc3WriteCharacteristic != null)
+                                    rxCharacteristic != null && txCharacteristic != null
+
+                            if (hasRequiredCharacteristics &&
+                                            (lc3ReadCharacteristic == null ||
+                                                    lc3WriteCharacteristic == null)
+                            ) {
+                                Bridge.log(
+                                        "LIVE: ⚠️ LC3 audio characteristics absent - continuing without LC3 audio " +
+                                                "(glasses firmware likely predates LC3 support; core TX/RX are present)"
+                                )
+                            }
 
                             if (hasRequiredCharacteristics) {
                                 // BLE connection established, but we still need to wait for glasses
@@ -5935,6 +6060,18 @@ class MentraLive : SGCManager() {
                                                 audioConnected = true
                                                 bondingRetryCount =
                                                         0 // Reset retry counter on success
+                                                hasClearedUnusableBond = false
+
+                                                // Bonding is finished and the link is encrypted, so
+                                                // the discovery deferred at connect time can run
+                                                // now.
+                                                if (pendingServiceDiscovery) {
+                                                    pendingServiceDiscovery = false
+                                                    Bridge.log(
+                                                            "LIVE: CTKD: Bond complete - starting deferred service discovery"
+                                                    )
+                                                    bluetoothGatt?.discoverServices()
+                                                }
                                                 // Both BLE and BT Classic are now connected via
                                                 // CTKD
 
@@ -6078,6 +6215,42 @@ class MentraLive : SGCManager() {
             Bridge.log("LIVE: CTKD: Error creating bond: " + e.message)
             return false
         }
+    }
+
+    /**
+     * Fail-safe for bonding that never resolves. If the bond has not reached BOND_BONDED by the
+     * timeout, the deferred service discovery would otherwise never run, so drop the partial bond
+     * and let the normal reconnect path pair again from a clean state.
+     */
+    private fun scheduleBondingWatchdog() {
+        handler.postDelayed(
+                Runnable {
+                    if (isKilled || !pendingServiceDiscovery) {
+                        return@Runnable
+                    }
+                    val device = connectedDevice
+                    if (device != null && device.bondState == BluetoothDevice.BOND_BONDED) {
+                        // Bond completed but the receiver did not fire (e.g. it was registered
+                        // late); run the deferred discovery rather than tearing anything down.
+                        pendingServiceDiscovery = false
+                        Bridge.log(
+                                "LIVE: CTKD: Bond already complete at watchdog - starting deferred service discovery"
+                        )
+                        bluetoothGatt?.discoverServices()
+                        return@Runnable
+                    }
+                    pendingServiceDiscovery = false
+                    Bridge.log(
+                            "LIVE: CTKD: ⏱️ Bonding did not complete within " +
+                                    BONDING_COMPLETION_TIMEOUT_MS +
+                                    "ms - clearing partial bond and reconnecting"
+                    )
+                    if (device != null) {
+                        removeBond(device)
+                    }
+                },
+                BONDING_COMPLETION_TIMEOUT_MS
+        )
     }
 
     /** Remove bond with device to disconnect BT Classic */

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3515,6 +3515,54 @@ class MentraLive : SGCManager() {
                     } catch (e: JSONException) {
                         Log.e(TAG, "Error parsing networks_neo", e)
                     }
+                } else if (json.has("networks")) {
+                    // Legacy scan format, sent by glasses firmware that predates `networks_neo`:
+                    // a plain array of SSID strings rather than objects carrying security info.
+                    //
+                    // Without this branch the reply is parsed as zero networks and an empty list is
+                    // dispatched, so the scan appears to time out ("timed out waiting for glasses
+                    // response") even though the glasses answered correctly and the SSIDs are
+                    // sitting in the received payload.
+                    //
+                    // The consumer defaults requiresPassword to true and signalStrength to -100
+                    // when absent, so an SSID-only entry maps correctly.
+                    try {
+                        val legacyNetworksArray = json.getJSONArray("networks")
+
+                        for (i in 0 until legacyNetworksArray.length()) {
+                            // Tolerate either bare strings or objects, since firmware revisions
+                            // differ in what they put in this array.
+                            val entry = legacyNetworksArray.opt(i)
+                            val networkMap = HashMap<String, Any>()
+
+                            if (entry is JSONObject) {
+                                val keys = entry.keys()
+                                while (keys.hasNext()) {
+                                    val key = keys.next()
+                                    networkMap[key] = entry.get(key)
+                                }
+                                if (!networkMap.containsKey("ssid")) {
+                                    continue
+                                }
+                            } else {
+                                val ssid = entry?.toString().orEmpty()
+                                if (ssid.isEmpty()) {
+                                    continue
+                                }
+                                networkMap["ssid"] = ssid
+                            }
+
+                            networks.add(networkMap)
+                        }
+
+                        Bridge.log(
+                                "Received legacy WiFi scan results: " +
+                                        networks.size +
+                                        " networks (SSID only; glasses firmware predates networks_neo)"
+                        )
+                    } catch (e: JSONException) {
+                        Log.e(TAG, "Error parsing legacy networks array", e)
+                    }
                 }
 
                 val scanComplete =


### PR DESCRIPTION
# Mentra Live never connects: LC3 characteristics treated as mandatory, plus a bonding race that corrupts the LE bond

Two independent defects. Either one alone prevents Mentra Live glasses from ever connecting, and both
present to the user identically: the pairing screen spins forever with no error, no timeout, and no
diagnostic. Fixing only the second reveals the first.

Both are fixed and verified on hardware — see "Verification" below.

## Environment

| | |
|---|---|
| App | `com.mentra.mentra` v3.0.0 |
| Phone | realme GT 7 Pro (RMX5011) |
| OS | Android 16, ColorOS V16.1.0 (`RMX5011_16.0.7.200(EX01)`) |
| Glasses | Mentra Live, firmware without LC3 audio characteristics |
| Service | `00004860-0000-1000-8000-00805f9b34fb`, exposing 4 characteristics |

Permissions (`BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT`, `ACCESS_FINE_LOCATION`, `RECORD_AUDIO`), location
services, and battery-optimisation exemption were all verified correct throughout. None were the cause.

---

## Defect 1 (primary) — LC3 audio characteristics are required, not optional

`MentraLive.onServicesDiscovered` fetches the LC3 characteristics with the comment *"always supported"*
and folds them into the mandatory set:

```kotlin
// Get LC3 characteristics (always supported)
lc3ReadCharacteristic  = service.getCharacteristic(LC3_READ_UUID)
lc3WriteCharacteristic = service.getCharacteristic(LC3_WRITE_UUID)

val hasRequiredCharacteristics =
        (rxCharacteristic != null && txCharacteristic != null) &&
                (lc3ReadCharacteristic != null && lc3WriteCharacteristic != null)
...
} else {
    Log.e(TAG, "Required BLE characteristics not found")
    gatt.disconnect()
}
```

That assumption does not hold for glasses whose firmware predates LC3 audio. On this device the
service resolves and **the core TX/RX characteristics are present and fully usable** — only the LC3
pair is absent:

```
113 x LC3_READ characteristic not found
113 x LC3_WRITE characteristic not found
113 x Required BLE characteristics not found
  0 x RX characteristic (peripheral's TX) not found
  0 x TX characteristic (peripheral's RX) not found
```

The client therefore hangs up on a working connection and retries indefinitely. Nothing is surfaced to
the user, so a recoverable "your glasses need a firmware update" is presented as an infinite spinner.

**Fix:** require only the core TX/RX pair; log the absence of LC3 and continue without it. The LC3
fields are already nullable and the write path already null-checks them.

---

## Defect 2 — service discovery races CTKD bonding and corrupts the bond

`onConnectionStateChange` called `gatt.discoverServices()` immediately after `createBond()`:

```kotlin
if (connectedDevice!!.bondState == BluetoothDevice.BOND_BONDED) {
    connectA2dpProfile(connectedDevice!!)
} else {
    createBond(connectedDevice!!)
}

// Discover services
gatt.discoverServices()      // runs while pairing is still in flight
```

GATT traffic on a not-yet-encrypted link causes the peer to drop the connection mid-pairing:

```
16:29:54.18  CTKD: Creating bond with device MENTRA_LIVE_BLE_CA4D for CTKD
16:29:54.19  CTKD: Bond state changed ... Current: 11, Previous: 10
16:29:54.37  GATT services discovered
16:29:54.37  Disconnected from GATT server - Will attempt reconnection   (180ms after bonding began)
```

Bonding never advances past `BOND_BONDING`. What remains on disk is unusable but reports as bonded:

```
shim::record  name:"MENTRA_LIVE_BLE_CA4D"
  le_linkkey_known:T, le_authenticated:F, le_encrypted:F,
  ble_enc_key_size:0, bond_type:BOND_TYPE_UNKNOWN
```

Because `getBondState()` returns `BOND_BONDED`, the already-bonded branch skips re-bonding forever
while every connection fails its security handshake with `status=147`. **Across three capture sessions
the transition `BOND_BONDING -> BOND_BONDED` never occurred once.**

**Fix:** defer discovery to the `BOND_BONDED` callback; add a watchdog that clears a partial bond if
bonding never resolves; recover a device already carrying a corrupt bond by removing it after repeated
connect/drop cycles that never reach readiness. That last signal is necessary because such a bond
surfaces as an ordinary disconnect, not a connection error, so a `status=147` hook alone never fires.

### Why this is unrecoverable for users

Once the corrupt bond exists there is no user-accessible way to remove it:

- **App:** factory reset in `device-info.tsx` is gated on `glassesStatus.state === "connected"` — the
  recovery tool requires the connection that is broken.
- **Android Settings (ColorOS):** LE-only bonds are not listed, so "Forget" removes only the BR/EDR bond.
- **adb:** realme root-gates `pm clear`, `pm grant`, and `cmd bluetooth_manager factoryReset`.
- **Glasses-side factory reset (PWR x5):** per `FactoryResetEventSubscriber`, this reinstalls the ASG
  client APK and "intentionally does not wipe app data/settings"; no MCU command in `McuEventParser`
  clears Bluetooth pairing state.

The only remaining option was a full network reset of the phone, which also destroys all saved Wi-Fi
credentials — and even that does not help, because the client recreates the corrupt bond within 200ms
of the next attempt.

---

## Defect 3 — no user-facing error in any failure mode

Across every failure above the UI shows only a spinner: scan timeout elapsed, 20 reconnection attempts
exhausted, `status=147`, and 113 characteristic-validation failures all surface nothing. Users cannot
distinguish "still trying" from "permanently broken".

Related: tapping retry starts a new 60s scan without cancelling the previous one. Six `RegisterScanner`
calls in 11 seconds were logged, with `SCAN_FAILED_STOP_REQUEST` and `SCAN_FAILED_TIMEOUT_REQUEST` from
the system — Android throttles to ~5 scan starts per 30s and then silently refuses, so user retries
actively make recovery less likely.

---

## Verification

Built from source with both fixes and installed on the affected hardware.

**Before** — 113x `Required BLE characteristics not found`; no session ever established; `BOND_BONDED`
never reached.

**After:**

```
LC3 audio characteristics absent - continuing without LC3 audio
BLE reconnection fully ready (Core TX/RX ... verified)
MTU negotiation successful - changed to 512 bytes
All BLE notification descriptors written successfully
K900 SOC ready
Sending phone_ready to glasses (SOC ready) - waiting for glasses_ready response
Received glasses_ready message - SOC is booted and ready!
Audio: Both glasses_ready and audio connected - marking as fully connected
Heartbeat #6 sent
Received pong response - connection healthy
```

Stable session, bidirectional K900-protocol traffic, RSSI -67 to -76 dBm. `BOND_BONDING -> BOND_BONDED`
now occurs normally (observed 5x).

LC3 audio remains unavailable on this device, which is correct — the firmware genuinely lacks the
characteristics. The glasses are now reachable, which is the prerequisite for a firmware update.

## Note on firmware recovery

OTA is skipped on debug builds (`"skippedReason":"dev_build"`), and the released client cannot connect
to affected glasses at all because of Defect 1. Users on pre-LC3 firmware therefore have no path to the
firmware update that would resolve it. This is the main reason Defect 1 matters beyond the connection
failure itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers GATT service discovery until bonding completes, makes LC3 audio characteristics optional, and adds a fallback parser for legacy Wi‑Fi scans. Previously discovery ran mid-bond and LC3 was required, which corrupted CTKD bonds and blocked connections; Wi‑Fi scans from older firmware were parsed as empty and caused setup timeouts.

- Discovery starts after `BOND_BONDED`; a watchdog clears partial bonds if bonding stalls, and deferred discovery also starts if the bond completes before the receiver fires.
- Bond recovery: on `status=147` or after repeated connect/drop cycles without readiness, remove the stale bond once and re-pair.
- LC3 optional: when LC3 characteristics are absent, log and continue without LC3 audio.
- Wi‑Fi scan: parse legacy `networks` array (SSID-only or objects) when `networks_neo` is missing; existing defaults supply security and RSSI.
- No API changes.

<sup>Written for commit bc180a2c4ee62c5cc2330aedf3c5ad5701074979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

