### PR TITLE
Fix first-launch iOS calendar permission refresh

### DIFF
--- a/mobile/src/utils/PermissionsUtils.test.ts
+++ b/mobile/src/utils/PermissionsUtils.test.ts
@@ -1,0 +1,76 @@
+import * as ExpoCalendar from "expo-calendar"
+import {Platform} from "react-native"
+import {request} from "react-native-permissions"
+
+import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
+
+jest.mock("@mentra/crust", () => ({
+  __esModule: true,
+  default: {hasNotificationListenerPermission: jest.fn()},
+}))
+
+jest.mock("expo-calendar", () => ({
+  getCalendarPermissionsAsync: jest.fn(),
+  requestCalendarPermissionsAsync: jest.fn(),
+}))
+
+jest.mock("@/i18n", () => ({
+  translate: jest.fn((key: string) => key),
+}))
+
+jest.mock("@/utils/AlertUtils", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  showBluetoothAlert: jest.fn(),
+  showLocationAlert: jest.fn(),
+  showLocationServicesAlert: jest.fn(),
+}))
+
+jest.mock("@/utils/NotificationServiceUtils", () => ({
+  checkAndRequestNotificationAccessSpecialPermission: jest.fn(),
+}))
+
+const mockSave = jest.fn((_key: string, _value: unknown) => ({is_error: () => false}))
+jest.mock("@/utils/storage/storage", () => ({
+  storage: {
+    load: jest.fn(() => ({is_error: () => true})),
+    remove: jest.fn(() => ({is_error: () => false})),
+    save: (key: string, value: unknown) => mockSave(key, value),
+  },
+}))
+
+describe("requestFeaturePermissions calendar access", () => {
+  const originalPlatform = Platform.OS
+
+  beforeAll(() => {
+    Object.defineProperty(Platform, "OS", {configurable: true, value: "ios"})
+  })
+
+  afterAll(() => {
+    Object.defineProperty(Platform, "OS", {configurable: true, value: originalPlatform})
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("uses expo-calendar's returned grant instead of cross-checking another permission bridge", async () => {
+    ;(ExpoCalendar.getCalendarPermissionsAsync as jest.Mock).mockResolvedValue({
+      canAskAgain: true,
+      granted: false,
+      status: "undetermined",
+    })
+    ;(ExpoCalendar.requestCalendarPermissionsAsync as jest.Mock).mockResolvedValue({
+      canAskAgain: true,
+      granted: true,
+      status: "granted",
+    })
+
+    await expect(requestFeaturePermissions(PermissionFeatures.CALENDAR)).resolves.toBe(true)
+
+    expect(ExpoCalendar.requestCalendarPermissionsAsync).toHaveBeenCalledTimes(1)
+    expect(ExpoCalendar.getCalendarPermissionsAsync).toHaveBeenCalledTimes(1)
+    expect(request).not.toHaveBeenCalled()
+    expect(mockSave).toHaveBeenCalledWith("PERMISSION_GRANTED_calendar", true)
+  })
+})

--- a/mobile/src/utils/PermissionsUtils.tsx
+++ b/mobile/src/utils/PermissionsUtils.tsx
@@ -349,6 +349,20 @@ export const requestFeaturePermissions = async (featureKey: string): Promise<boo
   if (Platform.OS === "ios" && config.ios.length > 0) {
     for (const permission of config.ios) {
       try {
+        // Calendar reads and their permission prompt both belong to
+        // expo-calendar. Keeping the check, request, and eventual reads on
+        // the same EventKit bridge avoids a first-grant race where
+        // react-native-permissions resolves before expo-calendar observes the
+        // updated authorization state.
+        if (permission === PERMISSIONS.IOS.CALENDARS) {
+          const currentPermission = await ExpoCalendar.getCalendarPermissionsAsync()
+          if (currentPermission.status === "denied" && !currentPermission.canAskAgain) {
+            await handlePreviouslyDeniedPermission(config)
+            return false
+          }
+          continue
+        }
+
         // Check current status before requesting
         const currentStatus = await check(permission)
         console.log(`Current status for ${permission}:`, currentStatus)
@@ -469,20 +483,26 @@ export const requestFeaturePermissions = async (featureKey: string): Promise<boo
   if (Platform.OS === "ios" && config.ios.length > 0) {
     for (const permission of config.ios) {
       try {
-        const result = await request(permission)
-        if (result === RESULTS.GRANTED) {
-          // iOS 17+ can resolve a scoped calendar grant (write-only / "Select
-          // Calendars…") as GRANTED without re-reading EventKit. expo-calendar
-          // (what actually reads events) requires full access, so verify
-          // against it before trusting the grant.
-          if (permission === PERMISSIONS.IOS.CALENDARS) {
-            const eventKit = await ExpoCalendar.getCalendarPermissionsAsync()
-            if (eventKit.status !== "granted") {
-              allGranted = false
+        if (permission === PERMISSIONS.IOS.CALENDARS) {
+          // Use the permission response returned by the same native module
+          // that reads calendars. A separate immediate get call can still
+          // observe the pre-prompt state during the app's first session.
+          const eventKit = await ExpoCalendar.requestCalendarPermissionsAsync()
+          if (eventKit.status === "granted") {
+            partiallyGranted = true
+            await markPermissionGranted(featureKey)
+          } else {
+            allGranted = false
+            if (!eventKit.canAskAgain) {
               await handlePreviouslyDeniedPermission(config)
               return false
             }
           }
+          continue
+        }
+
+        const result = await request(permission)
+        if (result === RESULTS.GRANTED) {
           partiallyGranted = true
           await markPermissionGranted(featureKey)
         } else if (result === RESULTS.LIMITED) {


### PR DESCRIPTION
## Summary

- request and verify iOS calendar access through `expo-calendar`, the same EventKit bridge used to read events
- avoid rejecting a newly granted full-access permission because another native permission bridge has not refreshed yet
- add a regression test covering the first-session grant path

## Bug

On the first launch of Mentra Call, granting full calendar access could still produce a no-calendar-access error. Restarting the Mentra App made the same grant work.

Report: `rep_01M0EG1EDST6G3STS46FSTSVF1`

## Test plan

- `bun run test --runInBand src/utils/PermissionsUtils.test.ts`
- `bun run compile`
- `bun x prettier --check src/utils/PermissionsUtils.tsx src/utils/PermissionsUtils.test.ts`
- `bun x eslint src/utils/PermissionsUtils.tsx src/utils/PermissionsUtils.test.ts` (0 errors; existing warnings only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first‑launch iOS calendar permission refresh so a newly granted full calendar access is respected immediately. Before: we requested via `react-native-permissions` and cross‑checked `expo-calendar`, which could race and report “no access” on first app session. Now: we check and request only through `expo-calendar` and trust its returned grant.

- iOS CALENDARS: skip `react-native-permissions.request`; pre-check with `ExpoCalendar.getCalendarPermissionsAsync`, prompt with `ExpoCalendar.requestCalendarPermissionsAsync`, and handle “denied and can’t ask again” via the existing denied flow. On grant, mark the stored `PERMISSION_GRANTED_calendar` flag.
- Other permissions and Android paths are unchanged.
- Adds a regression test ensuring we don’t call `react-native-permissions.request` for calendar and that we persist the grant.

<sup>Written for commit 422e4296007ccd509c1a98cc422f0e2fb301ae0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS permission request behavior for calendar only; other features and Android are unchanged, but incorrect handling could still block miniapp calendar access on first session.
> 
> **Overview**
> Fixes a **first-launch iOS bug** where users could grant full calendar access but still see no-calendar-access until restarting the app.
> 
> **`requestFeaturePermissions` for `CALENDAR` on iOS** no longer uses `react-native-permissions` to request or cross-check `PERMISSIONS.IOS.CALENDARS`. Pre-request handling uses `ExpoCalendar.getCalendarPermissionsAsync` (including the permanently-denied path), and the prompt uses **`ExpoCalendar.requestCalendarPermissionsAsync`** with its returned status as the source of truth—matching the EventKit bridge used for reads and avoiding a race where the other bridge reports granted before EventKit updates.
> 
> Adds **`PermissionsUtils.test.ts`** regression coverage: calendar flow calls expo-calendar get/request once, does not call `react-native-permissions.request`, and persists `PERMISSION_GRANTED_calendar` on grant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422e4296007ccd509c1a98cc422f0e2fb301ae0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->