### PR TITLE
Publish latest Mentra Live BES and MTK firmware

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -2023,8 +2023,8 @@ public class OtaHelper {
      * MTK requires sequential updates - must find patch starting from current version.
      * @param patches Array of patch objects with start_firmware, end_firmware, url
      * @param currentVersion Current MTK firmware version as reported by
-     *     {@code ro.custom.ota.version}, e.g. "MentraLive_20260626"; both sides are
-     *     normalized before comparison, so a bare "20260626" would also match
+     *     {@code ro.custom.ota.version}, e.g. "MentraLive_20260820.1"; both sides are
+     *     normalized before comparison, so a bare "20260820.1" would also match
      * @return Matching patch object, or null if no match or version unknown
      */
     private JSONObject findMatchingMtkPatch(JSONArray patches, String currentVersion) {
@@ -2053,9 +2053,9 @@ public class OtaHelper {
     }
 
     /**
-     * Reduce an MTK version string to its bare date so manifest entries and the device
+     * Reduce an MTK version string to its version suffix so manifest entries and the device
      * property match regardless of any "MentraLive_"-style prefix. Both normally carry the
-     * prefix; this is defensive so a bare-date value on either side still matches.
+     * prefix; this is defensive so a bare suffix on either side still matches.
      */
     private String normalizeMtkFirmwareVersion(String version) {
         if (version == null) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/interfaces/ISystemController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/interfaces/ISystemController.java
@@ -31,10 +31,10 @@ public interface ISystemController {
 
     /**
      * Current MTK firmware version from {@code ro.custom.ota.version}, returned verbatim.
-     * Mentra Live firmware reports "MentraLive_YYYYMMDD" (e.g. "MentraLive_20260626"), the
-     * same form OTA manifest {@code start_firmware} entries use. Returns an empty string
-     * when the version is unavailable; the phone-side OTA checkers treat that as unknown
-     * and offer no MTK update.
+     * Mentra Live firmware reports "MentraLive_YYYYMMDD.N" (e.g. "MentraLive_20260820.1"),
+     * while older builds omit the revision suffix. OTA manifest {@code start_firmware}
+     * entries use the same form. Returns an empty string when the version is unavailable;
+     * the phone-side OTA checkers treat that as unknown and offer no MTK update.
      */
     String getSystemOtaVersion();
 

--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -41,11 +41,17 @@
       "end_firmware": "MentraLive_20260709",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
       "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
+    },
+    {
+      "start_firmware": "MentraLive_20260709",
+      "end_firmware": "MentraLive_20260820.2",
+      "url": "https://mtkfirmware.mentraglass.com/mtk_ota_update_20260709_20260820.2.zip",
+      "sha256": "d3b9c7c4b4205703568ed73f9ab3deabcc6a815f57d352fdac66b7755632cc9b"
     }
   ],
   "bes_firmware": {
-    "version": "26.8.8.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.8.0.bin",
-    "sha256": "aaf2da4d6868c375564ddfdff71fd919b26f5d8da8f11b12898e4cc3d94527b9"
+    "version": "26.8.19.4",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.19.4.bin",
+    "sha256": "3a878f3825e3ddfb9a1c7112852ff86aa07baac7d9860e2ee23057e80d8856a9"
   }
 }

--- a/asg_client/scripts/test-mtk-ota.sh
+++ b/asg_client/scripts/test-mtk-ota.sh
@@ -47,9 +47,9 @@ fail() {
     exit 1
 }
 
-extract_trailing_date() {
+extract_version_suffix() {
     local value="$1"
-    if [[ "$value" =~ ([0-9]{8})$ ]]; then
+    if [[ "$value" =~ ([0-9]{8}(\.[0-9]+)?)$ ]]; then
         echo "${BASH_REMATCH[1]}"
         return 0
     fi
@@ -256,11 +256,11 @@ if [ ! -f "$PATCH_PATH" ]; then
 fi
 
 PATCH_NAME="$(basename "$PATCH_PATH")"
-if [[ "$PATCH_NAME" =~ ([0-9]{8})_([0-9]{8})\.zip$ ]]; then
-    FILE_START_DATE="${BASH_REMATCH[1]}"
-    FILE_END_DATE="${BASH_REMATCH[2]}"
+if [[ "$PATCH_NAME" =~ ([0-9]{8}(\.[0-9]+)?)_([0-9]{8}(\.[0-9]+)?)\.zip$ ]]; then
+    FILE_START_VERSION="${BASH_REMATCH[1]}"
+    FILE_END_VERSION="${BASH_REMATCH[3]}"
 else
-    fail "Could not parse start/end dates from filename: $PATCH_NAME"
+    fail "Could not parse start/end versions from filename: $PATCH_NAME"
 fi
 
 DEVICE_VERSION="$(adb shell getprop ro.custom.ota.version 2>/dev/null | tr -d '\r\n')"
@@ -268,23 +268,23 @@ if [ -z "$DEVICE_VERSION" ]; then
     fail "Failed to read ro.custom.ota.version from device"
 fi
 
-if ! DEVICE_START_DATE="$(extract_trailing_date "$DEVICE_VERSION")"; then
-    fail "Device firmware version does not end with YYYYMMDD: $DEVICE_VERSION"
+if ! DEVICE_START_VERSION="$(extract_version_suffix "$DEVICE_VERSION")"; then
+    fail "Device firmware version does not end with YYYYMMDD or YYYYMMDD.N: $DEVICE_VERSION"
 fi
 
 START_FIRMWARE="${START_FIRMWARE_OVERRIDE:-$DEVICE_VERSION}"
-if ! START_DATE="$(extract_trailing_date "$START_FIRMWARE")"; then
-    fail "start_firmware does not end with YYYYMMDD: $START_FIRMWARE"
+if ! START_VERSION="$(extract_version_suffix "$START_FIRMWARE")"; then
+    fail "start_firmware does not end with YYYYMMDD or YYYYMMDD.N: $START_FIRMWARE"
 fi
 
-if [ "$FILE_START_DATE" != "$START_DATE" ]; then
-    fail "Patch start date ($FILE_START_DATE) does not match start_firmware date ($START_DATE)"
+if [ "$FILE_START_VERSION" != "$START_VERSION" ]; then
+    fail "Patch start version ($FILE_START_VERSION) does not match start_firmware version ($START_VERSION)"
 fi
 
 if [ -n "$END_FIRMWARE_OVERRIDE" ]; then
     END_FIRMWARE="$END_FIRMWARE_OVERRIDE"
 else
-    END_FIRMWARE="${START_FIRMWARE%$START_DATE}$FILE_END_DATE"
+    END_FIRMWARE="${START_FIRMWARE%$START_VERSION}$FILE_END_VERSION"
 fi
 
 if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- publish the verified current BES firmware `26.8.19.4` in `firmware_live.json`
- add the verified incremental MTK update path `MentraLive_20260709` to `MentraLive_20260820.2`
- document revision-suffixed MTK versions while retaining legacy date-only matching
- let the developer MTK OTA test script accept both `YYYYMMDD` and `YYYYMMDD.N`

## Artifact verification

### BES

- URL: `https://firmwarecdn.mentraglass.com/bes_firmware_26.8.19.4.bin`
- size: `1,131,832` bytes
- SHA-256: `3a878f3825e3ddfb9a1c7112852ff86aa07baac7d9860e2ee23057e80d8856a9`

### MTK

- URL: `https://mtkfirmware.mentraglass.com/mtk_ota_update_20260709_20260820.2.zip`
- size: `3,814,522` bytes
- SHA-256: `d3b9c7c4b4205703568ed73f9ab3deabcc6a815f57d352fdac66b7755632cc9b`
- public manifest: `https://mtkfirmware.mentraglass.com/latest.json`
- source release revision: `797457942467580ecbc582952a82d22cbb68da4e`

The downloaded OTA passed ZIP integrity checks and Android payload parsing. The payload contains 14 old-partition records, 1,158 operations, and 1,078 source-referencing operations, proving it is an A/B incremental delta rather than a renamed full OTA.

## Validation

- `./gradlew :app:testDebugUnitTest`
- `python3 -m json.tool asg_client/ota_manifests/firmware_live.json`
- `bash -n asg_client/scripts/test-mtk-ota.sh`
- `git diff --check`

`OtaHelper` production matching logic is unchanged. Existing date-only versions and patches remain supported; revision suffixes are preserved and compared exactly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Ships production firmware URLs and checksums that devices will download and flash. A bad artifact or mismatched start/end version would brick or fail sequential MTK updates.
> 
> **Overview**
> Publishes new Mentra Live firmware in `firmware_live.json`: BES **26.8.19.4** and an incremental MTK path from `MentraLive_20260709` to **`MentraLive_20260820.2`**.
> 
> Docs and the MTK OTA test script now treat version suffixes as `YYYYMMDD` or `YYYYMMDD.N`. Production patch matching is unchanged: it still strips a `MentraLive_` prefix and compares the remaining suffix exactly, so date-only builds keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f8b2da65f22fc357456ad5ed513bba21ec0d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->