### PR TITLE
Redact notification content from BLE traces

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/debug/BleTraceLogger.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/debug/BleTraceLogger.kt
@@ -11,8 +11,16 @@ object BleTraceLogger {
     private const val TAG = "MentraBleTrace"
     private const val MAX_PAYLOAD_CHARS = 3000
     private const val K900_TYPE = "k900"
+    private const val ANCS_COMMAND = "sr_ancs"
+    private const val CHUNK_TYPE = "ck"
+    private const val NOTIFICATION_EVENT = "phone_notification"
+    private const val NOTIFICATION_DISMISSED_EVENT = "phone_notification_dismissed"
+    private const val REDACTED = "<redacted>"
+    private const val REDACTED_CHUNK = "<redacted chunk data>"
     private val sensitiveKeyParts =
         listOf("password", "pass", "token", "secret", "authorization", "auth", "email", "serial")
+    private val ancsContentKeys = setOf("appIdentifier", "date", "title", "subtitle", "message")
+    private val notificationContentKeys = setOf("app", "title", "content", "packageName")
 
     @JvmStatic
     fun logJson(direction: String, layer: String, payload: JSONObject?, bytes: Int? = null) {
@@ -21,14 +29,14 @@ object BleTraceLogger {
             return
         }
 
-        val sanitized = sanitize(payload)
+        val sanitized = sanitizeForLogging(payload)
         Log.i(TAG, format(direction, layer, caller(), extractType(payload), bytes, sanitized.toString()))
     }
 
     @JvmStatic
     fun logMap(direction: String, layer: String, type: String?, payload: Map<String, Any>) {
         try {
-            val sanitized = sanitize(JSONObject(payload))
+            val sanitized = sanitizeForLogging(JSONObject(payload))
             Log.i(TAG, format(direction, layer, caller(), type ?: extractType(sanitized), null, sanitized.toString()))
         } catch (e: Exception) {
             Log.d(TAG, "BLE trace map logging failed", e)
@@ -97,6 +105,43 @@ object BleTraceLogger {
             output.put(key, sanitizeValue(key, value.opt(key)))
         }
         return output
+    }
+
+    /** Returns a diagnostic-safe copy without changing the payload delivered to SDK consumers. */
+    internal fun sanitizeForLogging(value: JSONObject): JSONObject {
+        val sanitized = sanitize(value)
+
+        if (value.optString("C") == ANCS_COMMAND) {
+            val body = sanitized.optJSONObject("B")
+            if (body == null) {
+                sanitized.put("B", REDACTED)
+            } else {
+                ancsContentKeys.forEach { key ->
+                    if (body.has(key)) {
+                        body.put(key, REDACTED)
+                    }
+                }
+            }
+        }
+
+        if (
+            value.optString("type") == NOTIFICATION_EVENT ||
+                value.optString("type") == NOTIFICATION_DISMISSED_EVENT
+        ) {
+            notificationContentKeys.forEach { key ->
+                if (sanitized.has(key)) {
+                    sanitized.put(key, REDACTED)
+                }
+            }
+        }
+
+        // Compact chunks can contain arbitrary reconstructed application data, including
+        // notification titles and bodies. Keep framing metadata, never the chunk contents.
+        if (value.optString("t") == CHUNK_TYPE && value.has("d")) {
+            sanitized.put("d", REDACTED_CHUNK)
+        }
+
+        return sanitized
     }
 
     private fun sanitize(value: JSONArray): JSONArray {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3138,13 +3138,8 @@ class MentraLive : SGCManager() {
 
     /** Process a JSON message */
     private fun processJsonMessage(json: JSONObject) {
-        // Demoted from INFO (Bridge.log) to DEBUG: per-type handlers below already log
-        // the messages that matter, and full payloads can leak PII (wifi SSID, bt_mac,
-        // OTA URLs) into the persisted file logger when they arrive every ~50ms during OTA.
-        // Re-enable on a debugging device via: adb shell setprop log.tag.MentraLive DEBUG
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-            Log.d(TAG, "LIVE: Got some JSON from glasses: " + json.toString())
-        }
+        // BleTraceLogger keeps the useful framing metadata while redacting secrets,
+        // compact chunk contents, and relayed notification content.
         BleTraceLogger.logJson("glasses_to_phone", "sdk_ble_event", json, null)
 
         if (MessageChunker.isChunkedMessage(json)) {

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/debug/BleTraceLoggerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/debug/BleTraceLoggerTest.kt
@@ -1,0 +1,83 @@
+package com.mentra.bluetoothsdk.debug
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class BleTraceLoggerTest {
+    @Test
+    fun `redacts notification content without mutating delivered payload`() {
+        val body =
+            JSONObject()
+                .put("event", 0)
+                .put("uid", 42)
+                .put("title", "Private title")
+                .put("subtitle", "Private subtitle")
+                .put("message", "Private message")
+                .put("appIdentifier", "com.example.private")
+                .put("date", "20260821T120000")
+                .put("messageSize", 15)
+        val payload = JSONObject().put("C", "sr_ancs").put("B", body)
+
+        val sanitized = BleTraceLogger.sanitizeForLogging(payload)
+        val sanitizedBody = sanitized.getJSONObject("B")
+
+        assertThat(sanitizedBody.getString("title")).isEqualTo("<redacted>")
+        assertThat(sanitizedBody.getString("subtitle")).isEqualTo("<redacted>")
+        assertThat(sanitizedBody.getString("message")).isEqualTo("<redacted>")
+        assertThat(sanitizedBody.getString("appIdentifier")).isEqualTo("<redacted>")
+        assertThat(sanitizedBody.getString("date")).isEqualTo("<redacted>")
+        assertThat(sanitizedBody.getInt("event")).isEqualTo(0)
+        assertThat(sanitizedBody.getInt("uid")).isEqualTo(42)
+        assertThat(sanitizedBody.getInt("messageSize")).isEqualTo(15)
+
+        assertThat(payload.getJSONObject("B").getString("title")).isEqualTo("Private title")
+        assertThat(payload.getJSONObject("B").getString("message")).isEqualTo("Private message")
+    }
+
+    @Test
+    fun `redacts compact chunk data while retaining reassembly metadata`() {
+        val payload =
+            JSONObject()
+                .put("t", "ck")
+                .put("id", "a7")
+                .put("c", 1)
+                .put("n", 4)
+                .put("d", "private chunk content")
+
+        val sanitized = BleTraceLogger.sanitizeForLogging(payload)
+
+        assertThat(sanitized.getString("d")).isEqualTo("<redacted chunk data>")
+        assertThat(sanitized.getString("id")).isEqualTo("a7")
+        assertThat(sanitized.getInt("c")).isEqualTo(1)
+        assertThat(sanitized.getInt("n")).isEqualTo(4)
+        assertThat(payload.getString("d")).isEqualTo("private chunk content")
+    }
+
+    @Test
+    fun `redacts notification event content while retaining routing metadata`() {
+        val payload =
+            JSONObject()
+                .put("type", "phone_notification")
+                .put("notificationId", "ancs-42")
+                .put("app", "com.example.private")
+                .put("title", "Private title")
+                .put("content", "Private message")
+                .put("packageName", "com.example.private")
+                .put("priority", "1")
+
+        val sanitized = BleTraceLogger.sanitizeForLogging(payload)
+
+        assertThat(sanitized.getString("app")).isEqualTo("<redacted>")
+        assertThat(sanitized.getString("title")).isEqualTo("<redacted>")
+        assertThat(sanitized.getString("content")).isEqualTo("<redacted>")
+        assertThat(sanitized.getString("packageName")).isEqualTo("<redacted>")
+        assertThat(sanitized.getString("notificationId")).isEqualTo("ancs-42")
+        assertThat(sanitized.getString("priority")).isEqualTo("1")
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift
@@ -6,7 +6,15 @@ enum BleTraceLogger {
     private static let log = OSLog(subsystem: "com.mentra.bluetoothsdk", category: "MentraBleTrace")
     private static let maxPayloadChars = 3000
     private static let k900Type = "k900"
+    private static let ancsCommand = "sr_ancs"
+    private static let chunkType = "ck"
+    private static let notificationEvent = "phone_notification"
+    private static let notificationDismissedEvent = "phone_notification_dismissed"
+    private static let redacted = "<redacted>"
+    private static let redactedChunk = "<redacted chunk data>"
     private static let sensitiveKeyParts = ["password", "pass", "token", "secret", "authorization", "auth", "email", "serial"]
+    private static let ancsContentKeys = ["appIdentifier", "date", "title", "subtitle", "message"]
+    private static let notificationContentKeys = ["app", "title", "content", "packageName"]
 
     static func logJson(
         direction: String,
@@ -29,7 +37,7 @@ enum BleTraceLogger {
             return
         }
 
-        let sanitized = sanitizeDictionary(payload)
+        let sanitized = sanitizeForLogging(payload)
         emit(format(
             direction: direction,
             layer: layer,
@@ -50,7 +58,7 @@ enum BleTraceLogger {
         sourceFunction: String = #function,
         sourceLine: Int = #line
     ) {
-        let sanitized = sanitizeDictionary(payload)
+        let sanitized = sanitizeForLogging(payload)
         emit(format(
             direction: direction,
             layer: layer,
@@ -118,6 +126,38 @@ enum BleTraceLogger {
             output[key] = sanitizeValue(key: key, value: child)
         }
         return output
+    }
+
+    /// Returns a diagnostic-safe copy without changing the payload delivered to SDK consumers.
+    static func sanitizeForLogging(_ value: [String: Any]) -> [String: Any] {
+        var sanitized = sanitizeDictionary(value)
+
+        if value["C"] as? String == ancsCommand {
+            if var body = sanitized["B"] as? [String: Any] {
+                for key in ancsContentKeys where body[key] != nil {
+                    body[key] = redacted
+                }
+                sanitized["B"] = body
+            } else {
+                sanitized["B"] = redacted
+            }
+        }
+
+        if value["type"] as? String == notificationEvent ||
+            value["type"] as? String == notificationDismissedEvent
+        {
+            for key in notificationContentKeys where sanitized[key] != nil {
+                sanitized[key] = redacted
+            }
+        }
+
+        // Compact chunks can contain arbitrary reconstructed application data, including
+        // notification titles and bodies. Keep framing metadata, never the chunk contents.
+        if value["t"] as? String == chunkType, value["d"] != nil {
+            sanitized["d"] = redactedChunk
+        }
+
+        return sanitized
     }
 
     private static func sanitizeArray(_ value: [Any]) -> [Any] {


### PR DESCRIPTION
## Summary

- redact compact chunk contents before Android and iOS BLE trace logging
- redact reconstructed ANCS and dispatched phone-notification content while preserving routing metadata
- remove the duplicate Android raw-JSON debug log
- leave the payload delivered to app consumers unchanged

Companion privacy hardening for Mentra-Community/mentra-live-bes#16.

## Validation

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `:mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.debug.BleTraceLoggerTest`
- `xcrun --sdk iphonesimulator swiftc -typecheck -target arm64-apple-ios15.1-simulator mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts notification and compact chunk contents from Android and iOS BLE trace logs to prevent PII leakage while preserving routing metadata. Previously traces logged full ANCS, dispatched phone-notification payloads, and chunk data; now we redact defined content keys and chunk bodies, and remove a duplicate Android raw-JSON debug log. Delivered payloads to SDK consumers are unchanged.

- Logging: Introduces sanitizeForLogging in `BleTraceLogger` and uses it in logJson/logMap. Redacts ANCS (`C=sr_ancs`) body keys: appIdentifier, date, title, subtitle, message. Redacts `phone_notification` and `phone_notification_dismissed` keys: app, title, content, packageName. Replaces compact chunk (`t=ck`) data field `d` with "<redacted chunk data>" while keeping framing (id, c, n).
- Android: Removes redundant DEBUG log in `MentraLive`, routes JSON through `BleTraceLogger` only. Adds unit tests to verify redaction and non-mutation of inputs.
- Rollout: No API changes and no migration required; logs will show "<redacted>" in affected fields.

<sup>Written for commit 3ac4afae0303cf552f63f683a382236425ef3ada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

