### PR TITLE
Support streaming over the Mentra Live hotspot

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -22,6 +22,9 @@ public class AsgConstants {
     /** Current Mentra Live Android hotspot gateway when interface discovery is unavailable. */
     public static final String DEFAULT_HOTSPOT_GATEWAY_IP = "192.168.43.1";
 
+    /** Canonical network interface used by the Mentra Live WiFi hotspot. */
+    public static final String MENTRA_LIVE_HOTSPOT_INTERFACE = "ap0";
+
     /** SmartXY setting containing the Mentra Live hotspot SSID. */
     public static final String K900_VENDOR_HOTSPOT_SSID_SETTING = "xy_ssid";
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/BaseNetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/BaseNetworkManager.java
@@ -14,12 +14,15 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.util.Log;
+
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.NetworkUtils;
 import com.mentra.asg_client.io.network.interfaces.INetworkController;
 import com.mentra.asg_client.io.network.interfaces.IWifiScanCallback;
 import com.mentra.asg_client.io.network.interfaces.NetworkStateListener;
 import com.mentra.asg_client.io.network.models.NetworkInfo;
+import com.mentra.asg_client.io.network.utils.HotspotNetworkUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -180,6 +183,7 @@ public abstract class BaseNetworkManager implements INetworkController {
     protected void notifyHotspotStateChanged(boolean isEnabled) {
         Log.d(TAG, "Hotspot state changed: " + (isEnabled ? "enabled" : "disabled"));
         this.isHotspotEnabled = isEnabled;
+        HotspotNetworkUtils.notifyHotspotStateChanged(isEnabled);
         for (NetworkStateListener listener : listeners) {
             try {
                 listener.onHotspotStateChanged(isEnabled);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -356,7 +356,8 @@ public class K900NetworkManager extends BaseNetworkManager {
 
     private String findLocalHotspotGatewayIp() {
         try {
-            NetworkInterface interfaceInfo = NetworkInterface.getByName("ap0");
+            NetworkInterface interfaceInfo =
+                    NetworkInterface.getByName(AsgConstants.MENTRA_LIVE_HOTSPOT_INTERFACE);
             String gatewayIp = findLocalHotspotGatewayIp(interfaceInfo, true);
             if (!gatewayIp.isEmpty()) {
                 return gatewayIp;
@@ -365,7 +366,7 @@ public class K900NetworkManager extends BaseNetworkManager {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces != null && interfaces.hasMoreElements()) {
                 NetworkInterface candidate = interfaces.nextElement();
-                if ("ap0".equals(candidate.getName())) {
+                if (AsgConstants.MENTRA_LIVE_HOTSPOT_INTERFACE.equals(candidate.getName())) {
                     continue;
                 }
                 gatewayIp = findLocalHotspotGatewayIp(candidate, false);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetector.java
@@ -27,7 +27,7 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
     private final HotspotNetworkUtils.HotspotStateListener mHotspotStateListener;
     private final Object mHotspotLock = new Object();
     private NetworkInformation mPublishedHotspot;
-    private volatile boolean mHotspotAvailable;
+    private volatile boolean mHotspotEnabled;
 
     public HotspotAwareNetworkChangeDetector(Observer observer, Context context) {
         this(
@@ -43,7 +43,7 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
         mObserver = observer;
         mDelegate = delegate;
         mHotspotSupplier = hotspotSupplier;
-        mHotspotAvailable = hotspotSupplier.get() != null;
+        mHotspotEnabled = hotspotSupplier.get() != null;
         mHotspotStateListener = this::onHotspotStateChanged;
         HotspotNetworkUtils.addHotspotStateListener(mHotspotStateListener);
     }
@@ -51,7 +51,7 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
     @Override
     public ConnectionType getCurrentConnectionType() {
         ConnectionType delegateType = mDelegate.getCurrentConnectionType();
-        if (delegateType == ConnectionType.CONNECTION_NONE && mHotspotAvailable) {
+        if (delegateType == ConnectionType.CONNECTION_NONE && mHotspotEnabled) {
             return ConnectionType.CONNECTION_WIFI;
         }
         return delegateType;
@@ -67,12 +67,14 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
         List<NetworkInformation> detectedNetworks = mDelegate.getActiveNetworkList();
         HotspotNetworkUtils.HotspotInterface hotspot;
         synchronized (mHotspotLock) {
-            hotspot = mHotspotAvailable ? mHotspotSupplier.get() : null;
-            mHotspotAvailable = hotspot != null;
-            mPublishedHotspot =
+            hotspot = mHotspotEnabled ? mHotspotSupplier.get() : null;
+            NetworkInformation currentHotspot =
                     hotspot != null && !containsInterface(detectedNetworks, hotspot.getName())
                             ? createNetworkInformation(hotspot)
                             : null;
+            if (currentHotspot != null) {
+                mPublishedHotspot = currentHotspot;
+            }
         }
         return mergeNetworks(detectedNetworks, hotspot);
     }
@@ -105,11 +107,11 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
         boolean disconnected = false;
         synchronized (mHotspotLock) {
             if (enabled) {
+                mHotspotEnabled = true;
                 if (mPublishedHotspot != null) {
                     return;
                 }
                 HotspotNetworkUtils.HotspotInterface hotspot = mHotspotSupplier.get();
-                mHotspotAvailable = hotspot != null;
                 if (hotspot != null
                         && containsInterface(mDelegate.getActiveNetworkList(), hotspot.getName())) {
                     return;
@@ -120,11 +122,11 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
                 }
                 mPublishedHotspot = connectedNetwork;
             } else if (mPublishedHotspot != null) {
-                mHotspotAvailable = false;
+                mHotspotEnabled = false;
                 mPublishedHotspot = null;
                 disconnected = true;
             } else {
-                mHotspotAvailable = false;
+                mHotspotEnabled = false;
             }
         }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetector.java
@@ -1,11 +1,14 @@
 package com.mentra.asg_client.io.network.utils;
 
 import android.content.Context;
+
+import org.webrtc.NetworkChangeDetector;
+import org.webrtc.NetworkMonitorAutoDetect;
+
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
-import org.webrtc.NetworkChangeDetector;
-import org.webrtc.NetworkMonitorAutoDetect;
+import java.util.function.Supplier;
 
 /**
  * Adds the local-only Mentra Live hotspot to WebRTC's Android network inventory.
@@ -18,17 +21,37 @@ import org.webrtc.NetworkMonitorAutoDetect;
 public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDetector {
     private static final long LOCAL_ONLY_NETWORK_HANDLE = 0L;
 
-    private final NetworkMonitorAutoDetect mDelegate;
+    private final NetworkChangeDetector mDelegate;
+    private final Observer mObserver;
+    private final Supplier<HotspotNetworkUtils.HotspotInterface> mHotspotSupplier;
+    private final HotspotNetworkUtils.HotspotStateListener mHotspotStateListener;
+    private final Object mHotspotLock = new Object();
+    private NetworkInformation mPublishedHotspot;
+    private volatile boolean mHotspotAvailable;
 
     public HotspotAwareNetworkChangeDetector(Observer observer, Context context) {
-        mDelegate = new NetworkMonitorAutoDetect(observer, context);
+        this(
+                observer,
+                new NetworkMonitorAutoDetect(observer, context),
+                HotspotNetworkUtils::getActiveHotspotInterface);
+    }
+
+    HotspotAwareNetworkChangeDetector(
+            Observer observer,
+            NetworkChangeDetector delegate,
+            Supplier<HotspotNetworkUtils.HotspotInterface> hotspotSupplier) {
+        mObserver = observer;
+        mDelegate = delegate;
+        mHotspotSupplier = hotspotSupplier;
+        mHotspotAvailable = hotspotSupplier.get() != null;
+        mHotspotStateListener = this::onHotspotStateChanged;
+        HotspotNetworkUtils.addHotspotStateListener(mHotspotStateListener);
     }
 
     @Override
     public ConnectionType getCurrentConnectionType() {
         ConnectionType delegateType = mDelegate.getCurrentConnectionType();
-        if (delegateType == ConnectionType.CONNECTION_NONE
-                && HotspotNetworkUtils.getActiveHotspotInterface() != null) {
+        if (delegateType == ConnectionType.CONNECTION_NONE && mHotspotAvailable) {
             return ConnectionType.CONNECTION_WIFI;
         }
         return delegateType;
@@ -42,7 +65,16 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
     @Override
     public List<NetworkInformation> getActiveNetworkList() {
         List<NetworkInformation> detectedNetworks = mDelegate.getActiveNetworkList();
-        return mergeNetworks(detectedNetworks, HotspotNetworkUtils.getActiveHotspotInterface());
+        HotspotNetworkUtils.HotspotInterface hotspot;
+        synchronized (mHotspotLock) {
+            hotspot = mHotspotAvailable ? mHotspotSupplier.get() : null;
+            mHotspotAvailable = hotspot != null;
+            mPublishedHotspot =
+                    hotspot != null && !containsInterface(detectedNetworks, hotspot.getName())
+                            ? createNetworkInformation(hotspot)
+                            : null;
+        }
+        return mergeNetworks(detectedNetworks, hotspot);
     }
 
     static List<NetworkInformation> mergeNetworks(
@@ -64,11 +96,56 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
 
     @Override
     public void destroy() {
+        HotspotNetworkUtils.removeHotspotStateListener(mHotspotStateListener);
         mDelegate.destroy();
+    }
+
+    void onHotspotStateChanged(boolean enabled) {
+        NetworkInformation connectedNetwork = null;
+        boolean disconnected = false;
+        synchronized (mHotspotLock) {
+            if (enabled) {
+                if (mPublishedHotspot != null) {
+                    return;
+                }
+                HotspotNetworkUtils.HotspotInterface hotspot = mHotspotSupplier.get();
+                mHotspotAvailable = hotspot != null;
+                if (hotspot != null
+                        && containsInterface(mDelegate.getActiveNetworkList(), hotspot.getName())) {
+                    return;
+                }
+                connectedNetwork = createNetworkInformation(hotspot);
+                if (connectedNetwork == null) {
+                    return;
+                }
+                mPublishedHotspot = connectedNetwork;
+            } else if (mPublishedHotspot != null) {
+                mHotspotAvailable = false;
+                mPublishedHotspot = null;
+                disconnected = true;
+            } else {
+                mHotspotAvailable = false;
+            }
+        }
+
+        if (connectedNetwork != null) {
+            mObserver.onNetworkConnect(connectedNetwork);
+            if (mDelegate.getCurrentConnectionType() == ConnectionType.CONNECTION_NONE) {
+                mObserver.onConnectionTypeChanged(ConnectionType.CONNECTION_WIFI);
+            }
+        } else if (disconnected) {
+            mObserver.onNetworkDisconnect(LOCAL_ONLY_NETWORK_HANDLE);
+            if (mDelegate.getCurrentConnectionType() == ConnectionType.CONNECTION_NONE) {
+                mObserver.onConnectionTypeChanged(ConnectionType.CONNECTION_NONE);
+            }
+        }
     }
 
     static NetworkInformation createNetworkInformation(
             HotspotNetworkUtils.HotspotInterface hotspot) {
+        if (hotspot == null) {
+            return null;
+        }
         List<InetAddress> addresses = hotspot.getAddresses();
         if (addresses.isEmpty()) {
             return null;
@@ -86,6 +163,9 @@ public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDet
     }
 
     private static boolean containsInterface(List<NetworkInformation> networks, String name) {
+        if (networks == null) {
+            return false;
+        }
         for (NetworkInformation network : networks) {
             if (name.equals(network.name)) {
                 return true;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetector.java
@@ -1,0 +1,96 @@
+package com.mentra.asg_client.io.network.utils;
+
+import android.content.Context;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import org.webrtc.NetworkChangeDetector;
+import org.webrtc.NetworkMonitorAutoDetect;
+
+/**
+ * Adds the local-only Mentra Live hotspot to WebRTC's Android network inventory.
+ *
+ * <p>Android's {@link android.net.ConnectivityManager} does not expose the tethering-side {@code
+ * ap0} interface as an Internet-capable {@link android.net.Network}, so the stock WebRTC detector
+ * omits it. Handle {@code 0} matches WebRTC's WiFi Direct behavior: ICE binds to the interface
+ * address without trying to bind the socket through a ConnectivityManager network handle.
+ */
+public final class HotspotAwareNetworkChangeDetector implements NetworkChangeDetector {
+    private static final long LOCAL_ONLY_NETWORK_HANDLE = 0L;
+
+    private final NetworkMonitorAutoDetect mDelegate;
+
+    public HotspotAwareNetworkChangeDetector(Observer observer, Context context) {
+        mDelegate = new NetworkMonitorAutoDetect(observer, context);
+    }
+
+    @Override
+    public ConnectionType getCurrentConnectionType() {
+        ConnectionType delegateType = mDelegate.getCurrentConnectionType();
+        if (delegateType == ConnectionType.CONNECTION_NONE
+                && HotspotNetworkUtils.getActiveHotspotInterface() != null) {
+            return ConnectionType.CONNECTION_WIFI;
+        }
+        return delegateType;
+    }
+
+    @Override
+    public boolean supportNetworkCallback() {
+        return mDelegate.supportNetworkCallback();
+    }
+
+    @Override
+    public List<NetworkInformation> getActiveNetworkList() {
+        List<NetworkInformation> detectedNetworks = mDelegate.getActiveNetworkList();
+        return mergeNetworks(detectedNetworks, HotspotNetworkUtils.getActiveHotspotInterface());
+    }
+
+    static List<NetworkInformation> mergeNetworks(
+            List<NetworkInformation> detectedNetworks,
+            HotspotNetworkUtils.HotspotInterface hotspot) {
+        List<NetworkInformation> result =
+                detectedNetworks == null ? new ArrayList<>() : new ArrayList<>(detectedNetworks);
+
+        if (hotspot == null || containsInterface(result, hotspot.getName())) {
+            return result;
+        }
+
+        NetworkInformation hotspotNetwork = createNetworkInformation(hotspot);
+        if (hotspotNetwork != null) {
+            result.add(hotspotNetwork);
+        }
+        return result;
+    }
+
+    @Override
+    public void destroy() {
+        mDelegate.destroy();
+    }
+
+    static NetworkInformation createNetworkInformation(
+            HotspotNetworkUtils.HotspotInterface hotspot) {
+        List<InetAddress> addresses = hotspot.getAddresses();
+        if (addresses.isEmpty()) {
+            return null;
+        }
+        IPAddress[] webRtcAddresses = new IPAddress[addresses.size()];
+        for (int i = 0; i < addresses.size(); i++) {
+            webRtcAddresses[i] = new IPAddress(addresses.get(i).getAddress());
+        }
+        return new NetworkInformation(
+                hotspot.getName(),
+                ConnectionType.CONNECTION_WIFI,
+                ConnectionType.CONNECTION_NONE,
+                LOCAL_ONLY_NETWORK_HANDLE,
+                webRtcAddresses);
+    }
+
+    private static boolean containsInterface(List<NetworkInformation> networks, String name) {
+        for (NetworkInformation network : networks) {
+            if (name.equals(network.name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
@@ -19,8 +19,10 @@ import java.util.concurrent.CopyOnWriteArraySet;
 /** Utilities for discovering and addressing the active Mentra Live hotspot interface. */
 public final class HotspotNetworkUtils {
     private static final String TAG = "HotspotNetworkUtils";
+    private static final Object HOTSPOT_STATE_LOCK = new Object();
     private static final Set<HotspotStateListener> HOTSPOT_STATE_LISTENERS =
             new CopyOnWriteArraySet<>();
+    private static Boolean sLastHotspotState;
 
     private HotspotNetworkUtils() {}
 
@@ -29,28 +31,50 @@ public final class HotspotNetworkUtils {
         void onHotspotStateChanged(boolean enabled);
     }
 
-    /** Registers a listener for hotspot lifecycle changes. */
+    /** Registers a listener and replays the latest hotspot lifecycle state, when known. */
     public static void addHotspotStateListener(HotspotStateListener listener) {
-        if (listener != null) {
+        synchronized (HOTSPOT_STATE_LOCK) {
+            if (listener == null) {
+                return;
+            }
             HOTSPOT_STATE_LISTENERS.add(listener);
+            if (sLastHotspotState != null) {
+                notifyListener(listener, sLastHotspotState);
+            }
         }
     }
 
     /** Removes a previously registered hotspot lifecycle listener. */
     public static void removeHotspotStateListener(HotspotStateListener listener) {
-        if (listener != null) {
-            HOTSPOT_STATE_LISTENERS.remove(listener);
+        synchronized (HOTSPOT_STATE_LOCK) {
+            if (listener != null) {
+                HOTSPOT_STATE_LISTENERS.remove(listener);
+            }
         }
     }
 
     /** Publishes a hotspot lifecycle change to in-process network consumers such as WebRTC. */
     public static void notifyHotspotStateChanged(boolean enabled) {
-        for (HotspotStateListener listener : HOTSPOT_STATE_LISTENERS) {
-            try {
-                listener.onHotspotStateChanged(enabled);
-            } catch (RuntimeException e) {
-                Log.w(TAG, "Hotspot state listener failed", e);
+        synchronized (HOTSPOT_STATE_LOCK) {
+            sLastHotspotState = enabled;
+            for (HotspotStateListener listener : HOTSPOT_STATE_LISTENERS) {
+                notifyListener(listener, enabled);
             }
+        }
+    }
+
+    static void resetHotspotStateForTests() {
+        synchronized (HOTSPOT_STATE_LOCK) {
+            sLastHotspotState = null;
+            HOTSPOT_STATE_LISTENERS.clear();
+        }
+    }
+
+    private static void notifyListener(HotspotStateListener listener, boolean enabled) {
+        try {
+            listener.onHotspotStateChanged(enabled);
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Hotspot state listener failed", e);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
@@ -9,20 +9,22 @@ import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.Map;
 
 /** Utilities for discovering and addressing the active Mentra Live hotspot interface. */
 public final class HotspotNetworkUtils {
     private static final String TAG = "HotspotNetworkUtils";
     private static final Object HOTSPOT_STATE_LOCK = new Object();
-    private static final Set<HotspotStateListener> HOTSPOT_STATE_LISTENERS =
-            new CopyOnWriteArraySet<>();
+    private static final Map<HotspotStateListener, HotspotStateRegistration>
+            HOTSPOT_STATE_LISTENERS = new HashMap<>();
     private static Boolean sLastHotspotState;
+    private static long sHotspotStateVersion;
 
     private HotspotNetworkUtils() {}
 
@@ -33,48 +35,127 @@ public final class HotspotNetworkUtils {
 
     /** Registers a listener and replays the latest hotspot lifecycle state, when known. */
     public static void addHotspotStateListener(HotspotStateListener listener) {
+        HotspotStateRegistration registration;
+        Boolean replayState;
+        long replayVersion;
         synchronized (HOTSPOT_STATE_LOCK) {
             if (listener == null) {
                 return;
             }
-            HOTSPOT_STATE_LISTENERS.add(listener);
-            if (sLastHotspotState != null) {
-                notifyListener(listener, sLastHotspotState);
-            }
+            registration =
+                    HOTSPOT_STATE_LISTENERS.computeIfAbsent(
+                            listener, HotspotStateRegistration::new);
+            replayState = sLastHotspotState;
+            replayVersion = sHotspotStateVersion;
+        }
+        if (replayState != null) {
+            enqueueHotspotState(registration, replayState, replayVersion);
         }
     }
 
     /** Removes a previously registered hotspot lifecycle listener. */
     public static void removeHotspotStateListener(HotspotStateListener listener) {
+        HotspotStateRegistration registration;
         synchronized (HOTSPOT_STATE_LOCK) {
-            if (listener != null) {
-                HOTSPOT_STATE_LISTENERS.remove(listener);
-            }
+            registration =
+                    listener == null ? null : HOTSPOT_STATE_LISTENERS.remove(listener);
+        }
+        if (registration != null) {
+            registration.deactivate();
         }
     }
 
     /** Publishes a hotspot lifecycle change to in-process network consumers such as WebRTC. */
     public static void notifyHotspotStateChanged(boolean enabled) {
+        List<HotspotStateRegistration> registrations;
+        long version;
         synchronized (HOTSPOT_STATE_LOCK) {
             sLastHotspotState = enabled;
-            for (HotspotStateListener listener : HOTSPOT_STATE_LISTENERS) {
-                notifyListener(listener, enabled);
-            }
+            version = ++sHotspotStateVersion;
+            registrations = new ArrayList<>(HOTSPOT_STATE_LISTENERS.values());
+        }
+        for (HotspotStateRegistration registration : registrations) {
+            enqueueHotspotState(registration, enabled, version);
         }
     }
 
     static void resetHotspotStateForTests() {
+        List<HotspotStateRegistration> registrations;
         synchronized (HOTSPOT_STATE_LOCK) {
             sLastHotspotState = null;
+            sHotspotStateVersion = 0;
+            registrations = new ArrayList<>(HOTSPOT_STATE_LISTENERS.values());
             HOTSPOT_STATE_LISTENERS.clear();
+        }
+        for (HotspotStateRegistration registration : registrations) {
+            registration.deactivate();
         }
     }
 
-    private static void notifyListener(HotspotStateListener listener, boolean enabled) {
-        try {
-            listener.onHotspotStateChanged(enabled);
-        } catch (RuntimeException e) {
-            Log.w(TAG, "Hotspot state listener failed", e);
+    private static void enqueueHotspotState(
+            HotspotStateRegistration registration, boolean enabled, long version) {
+        if (!registration.enqueue(enabled, version)) {
+            return;
+        }
+
+        HotspotStateEvent event;
+        while ((event = registration.next()) != null) {
+            try {
+                registration.listener.onHotspotStateChanged(event.enabled);
+            } catch (RuntimeException e) {
+                Log.w(TAG, "Hotspot state listener failed", e);
+            }
+        }
+    }
+
+    private static final class HotspotStateEvent {
+        final boolean enabled;
+
+        HotspotStateEvent(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    private static final class HotspotStateRegistration {
+        final HotspotStateListener listener;
+        final ArrayDeque<HotspotStateEvent> pendingEvents = new ArrayDeque<>();
+        boolean active = true;
+        boolean delivering;
+        long lastEnqueuedVersion = -1;
+
+        HotspotStateRegistration(HotspotStateListener listener) {
+            this.listener = listener;
+        }
+
+        synchronized boolean enqueue(boolean enabled, long version) {
+            if (!active || version <= lastEnqueuedVersion) {
+                return false;
+            }
+            lastEnqueuedVersion = version;
+            pendingEvents.add(new HotspotStateEvent(enabled));
+            if (delivering) {
+                return false;
+            }
+            delivering = true;
+            return true;
+        }
+
+        synchronized HotspotStateEvent next() {
+            if (!active) {
+                pendingEvents.clear();
+                delivering = false;
+                return null;
+            }
+            HotspotStateEvent event = pendingEvents.poll();
+            if (event == null) {
+                delivering = false;
+            }
+            return event;
+        }
+
+        synchronized void deactivate() {
+            active = false;
+            pendingEvents.clear();
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
@@ -1,0 +1,173 @@
+package com.mentra.asg_client.io.network.utils;
+
+import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+/** Utilities for discovering and addressing the active Mentra Live hotspot interface. */
+public final class HotspotNetworkUtils {
+    private static final String TAG = "HotspotNetworkUtils";
+
+    private HotspotNetworkUtils() {}
+
+    /** Snapshot of an active hotspot interface and the addresses WebRTC should expose for it. */
+    public static final class HotspotInterface {
+        private final String mName;
+        private final List<InetAddress> mAddresses;
+
+        HotspotInterface(String name, List<InetAddress> addresses) {
+            mName = name;
+            mAddresses = Collections.unmodifiableList(new ArrayList<>(addresses));
+        }
+
+        public String getName() {
+            return mName;
+        }
+
+        public List<InetAddress> getAddresses() {
+            return mAddresses;
+        }
+    }
+
+    /**
+     * Returns whether a stream endpoint is directly reachable through the active hotspot subnet.
+     *
+     * <p>The subnet is derived from the live {@code ap0} address and prefix instead of assuming
+     * that the platform will always assign {@code 192.168.43.0/24}.
+     */
+    public static boolean isEndpointOnActiveHotspot(String endpointUrl) {
+        Inet4Address endpointAddress = parseIpv4Endpoint(endpointUrl);
+        if (endpointAddress == null) {
+            return false;
+        }
+
+        try {
+            NetworkInterface hotspotInterface = findActiveHotspotNetworkInterface();
+            if (hotspotInterface == null) {
+                return false;
+            }
+            for (InterfaceAddress interfaceAddress : hotspotInterface.getInterfaceAddresses()) {
+                InetAddress localAddress = interfaceAddress.getAddress();
+                if (localAddress instanceof Inet4Address
+                        && isAddressInSubnet(
+                                endpointAddress,
+                                (Inet4Address) localAddress,
+                                interfaceAddress.getNetworkPrefixLength())) {
+                    Log.i(
+                            TAG,
+                            "Stream endpoint "
+                                    + endpointAddress.getHostAddress()
+                                    + " is reachable through "
+                                    + hotspotInterface.getName());
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to inspect the hotspot route", e);
+        }
+        return false;
+    }
+
+    /** Returns the active hotspot interface and its addresses, or {@code null} when inactive. */
+    public static HotspotInterface getActiveHotspotInterface() {
+        try {
+            NetworkInterface networkInterface = findActiveHotspotNetworkInterface();
+            if (networkInterface == null) {
+                return null;
+            }
+            List<InetAddress> addresses = Collections.list(networkInterface.getInetAddresses());
+            addresses.removeIf(
+                    address -> address.isLoopbackAddress() || address.isLinkLocalAddress());
+            if (addresses.isEmpty()) {
+                return null;
+            }
+            return new HotspotInterface(networkInterface.getName(), addresses);
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to inspect the active hotspot interface", e);
+            return null;
+        }
+    }
+
+    private static NetworkInterface findActiveHotspotNetworkInterface() throws Exception {
+        NetworkInterface canonical =
+                NetworkInterface.getByName(AsgConstants.MENTRA_LIVE_HOTSPOT_INTERFACE);
+        if (isActiveHotspotInterface(canonical)) {
+            return canonical;
+        }
+
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces != null && interfaces.hasMoreElements()) {
+            NetworkInterface candidate = interfaces.nextElement();
+            if (candidate.getName().startsWith("ap") && isActiveHotspotInterface(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isActiveHotspotInterface(NetworkInterface networkInterface)
+            throws Exception {
+        if (networkInterface == null || !networkInterface.isUp()) {
+            return false;
+        }
+        for (InterfaceAddress interfaceAddress : networkInterface.getInterfaceAddresses()) {
+            if (interfaceAddress.getAddress() instanceof Inet4Address) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static Inet4Address parseIpv4Endpoint(String endpointUrl) {
+        try {
+            String host = URI.create(endpointUrl).getHost();
+            if (host == null) {
+                return null;
+            }
+            String[] octets = host.split("\\.", -1);
+            if (octets.length != 4) {
+                return null;
+            }
+            byte[] address = new byte[4];
+            for (int i = 0; i < octets.length; i++) {
+                int value = Integer.parseInt(octets[i]);
+                if (value < 0 || value > 255) {
+                    return null;
+                }
+                address[i] = (byte) value;
+            }
+            return (Inet4Address) InetAddress.getByAddress(address);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    static boolean isAddressInSubnet(
+            Inet4Address candidate, Inet4Address localAddress, short prefixLength) {
+        if (prefixLength < 0 || prefixLength > 32) {
+            return false;
+        }
+        byte[] candidateBytes = candidate.getAddress();
+        byte[] localBytes = localAddress.getAddress();
+        int fullBytes = prefixLength / 8;
+        int remainingBits = prefixLength % 8;
+        for (int i = 0; i < fullBytes; i++) {
+            if (candidateBytes[i] != localBytes[i]) {
+                return false;
+            }
+        }
+        if (remainingBits == 0) {
+            return true;
+        }
+        int mask = 0xff << (8 - remainingBits);
+        return (candidateBytes[fullBytes] & mask) == (localBytes[fullBytes] & mask);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
@@ -36,8 +36,7 @@ public final class HotspotNetworkUtils {
     /** Registers a listener and replays the latest hotspot lifecycle state, when known. */
     public static void addHotspotStateListener(HotspotStateListener listener) {
         HotspotStateRegistration registration;
-        Boolean replayState;
-        long replayVersion;
+        boolean shouldDrain = false;
         synchronized (HOTSPOT_STATE_LOCK) {
             if (listener == null) {
                 return;
@@ -45,11 +44,12 @@ public final class HotspotNetworkUtils {
             registration =
                     HOTSPOT_STATE_LISTENERS.computeIfAbsent(
                             listener, HotspotStateRegistration::new);
-            replayState = sLastHotspotState;
-            replayVersion = sHotspotStateVersion;
+            if (sLastHotspotState != null) {
+                shouldDrain = registration.enqueue(sLastHotspotState, sHotspotStateVersion);
+            }
         }
-        if (replayState != null) {
-            enqueueHotspotState(registration, replayState, replayVersion);
+        if (shouldDrain) {
+            drainHotspotStates(registration);
         }
     }
 
@@ -67,15 +67,19 @@ public final class HotspotNetworkUtils {
 
     /** Publishes a hotspot lifecycle change to in-process network consumers such as WebRTC. */
     public static void notifyHotspotStateChanged(boolean enabled) {
-        List<HotspotStateRegistration> registrations;
+        List<HotspotStateRegistration> registrationsToDrain = new ArrayList<>();
         long version;
         synchronized (HOTSPOT_STATE_LOCK) {
             sLastHotspotState = enabled;
             version = ++sHotspotStateVersion;
-            registrations = new ArrayList<>(HOTSPOT_STATE_LISTENERS.values());
+            for (HotspotStateRegistration registration : HOTSPOT_STATE_LISTENERS.values()) {
+                if (registration.enqueue(enabled, version)) {
+                    registrationsToDrain.add(registration);
+                }
+            }
         }
-        for (HotspotStateRegistration registration : registrations) {
-            enqueueHotspotState(registration, enabled, version);
+        for (HotspotStateRegistration registration : registrationsToDrain) {
+            drainHotspotStates(registration);
         }
     }
 
@@ -92,12 +96,7 @@ public final class HotspotNetworkUtils {
         }
     }
 
-    private static void enqueueHotspotState(
-            HotspotStateRegistration registration, boolean enabled, long version) {
-        if (!registration.enqueue(enabled, version)) {
-            return;
-        }
-
+    private static void drainHotspotStates(HotspotStateRegistration registration) {
         HotspotStateEvent event;
         while ((event = registration.next()) != null) {
             try {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtils.java
@@ -1,7 +1,9 @@
 package com.mentra.asg_client.io.network.utils;
 
 import android.util.Log;
+
 import com.mentra.asg_client.AsgConstants;
+
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
@@ -11,12 +13,46 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /** Utilities for discovering and addressing the active Mentra Live hotspot interface. */
 public final class HotspotNetworkUtils {
     private static final String TAG = "HotspotNetworkUtils";
+    private static final Set<HotspotStateListener> HOTSPOT_STATE_LISTENERS =
+            new CopyOnWriteArraySet<>();
 
     private HotspotNetworkUtils() {}
+
+    /** Receives in-process hotspot lifecycle changes after the AP becomes ready or stops. */
+    public interface HotspotStateListener {
+        void onHotspotStateChanged(boolean enabled);
+    }
+
+    /** Registers a listener for hotspot lifecycle changes. */
+    public static void addHotspotStateListener(HotspotStateListener listener) {
+        if (listener != null) {
+            HOTSPOT_STATE_LISTENERS.add(listener);
+        }
+    }
+
+    /** Removes a previously registered hotspot lifecycle listener. */
+    public static void removeHotspotStateListener(HotspotStateListener listener) {
+        if (listener != null) {
+            HOTSPOT_STATE_LISTENERS.remove(listener);
+        }
+    }
+
+    /** Publishes a hotspot lifecycle change to in-process network consumers such as WebRTC. */
+    public static void notifyHotspotStateChanged(boolean enabled) {
+        for (HotspotStateListener listener : HOTSPOT_STATE_LISTENERS) {
+            try {
+                listener.onHotspotStateChanged(enabled);
+            } catch (RuntimeException e) {
+                Log.w(TAG, "Hotspot state listener failed", e);
+            }
+        }
+    }
 
     /** Snapshot of an active hotspot interface and the addresses WebRTC should expose for it. */
     public static final class HotspotInterface {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -23,6 +23,7 @@ import com.mentra.asg_client.audio.AudioAssets;
 import com.mentra.asg_client.camera.CameraNeoService;
 import com.mentra.asg_client.io.hardware.core.HardwareManagerFactory;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
+import com.mentra.asg_client.io.network.utils.HotspotAwareNetworkChangeDetector;
 import com.mentra.asg_client.io.streaming.config.WhipStreamConfig;
 import com.mentra.asg_client.io.streaming.interfaces.StreamingStatusCallback;
 import com.mentra.asg_client.service.core.constants.BatteryConstants;
@@ -41,6 +42,7 @@ import org.webrtc.IceCandidate;
 import org.webrtc.MediaConstraints;
 import org.webrtc.MediaStream;
 import org.webrtc.MediaStreamTrack;
+import org.webrtc.NetworkMonitor;
 import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.RtpCapabilities;
@@ -470,6 +472,10 @@ public class WhipStreamingService extends Service {
 
   private void initWebRtc() {
     if (!sPeerConnectionFactoryInitialized) {
+      // ConnectivityManager omits the tethering-side ap0 interface. Supply a detector that also
+      // inventories that local-only network so ICE can gather and bind an AP candidate.
+      NetworkMonitor.getInstance()
+          .setNetworkChangeDetectorFactory(HotspotAwareNetworkChangeDetector::new);
       PeerConnectionFactory.InitializationOptions initOptions =
           PeerConnectionFactory.InitializationOptions.builder(this)
               .setEnableInternalTracer(false)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/HotspotStreamActivityTracker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/HotspotStreamActivityTracker.java
@@ -1,0 +1,44 @@
+package com.mentra.asg_client.service.core.handlers;
+
+import android.util.Log;
+
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
+
+/** Keeps the hotspot idle clock aligned with the lifecycle of a hotspot-local stream. */
+final class HotspotStreamActivityTracker {
+    private static final String TAG = "HotspotStreamActivity";
+
+    private final INetworkManager mNetworkManager;
+    private volatile boolean mUsesLocalHotspotRoute;
+
+    HotspotStreamActivityTracker(INetworkManager networkManager) {
+        mNetworkManager = networkManager;
+    }
+
+    void onStreamStarted(boolean usesLocalHotspotRoute) {
+        mUsesLocalHotspotRoute = usesLocalHotspotRoute;
+        refreshHotspotActivity();
+    }
+
+    void onKeepAlive() {
+        refreshHotspotActivity();
+    }
+
+    void onStreamStopped() {
+        mUsesLocalHotspotRoute = false;
+    }
+
+    private void refreshHotspotActivity() {
+        if (!mUsesLocalHotspotRoute || mNetworkManager == null) {
+            return;
+        }
+        try {
+            if (mNetworkManager.isHotspotEnabled()) {
+                mNetworkManager.updateHttpActivity();
+            }
+        } catch (RuntimeException e) {
+            // Hotspot bookkeeping must never fail an otherwise valid stream command.
+            Log.w(TAG, "Could not refresh hotspot activity for local stream", e);
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -7,6 +7,7 @@ import android.hardware.camera2.CameraManager;
 import android.os.SystemClock;
 import android.util.Log;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
+import com.mentra.asg_client.io.network.utils.HotspotNetworkUtils;
 import com.mentra.asg_client.io.streaming.config.RtmpStreamConfig;
 import com.mentra.asg_client.io.streaming.config.WhipStreamConfig;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
@@ -157,9 +158,13 @@ public class StreamCommandHandler implements ICommandHandler {
                 Log.w(TAG, "⚠️ StateManager not available - skipping battery check");
             }
 
-            // WiFi check (WHIP streams may work on mobile data; skip only for WHIP if needed)
-            if (stateManager != null && !stateManager.isConnectedToWifi()) {
-                Log.e(TAG, "Cannot start stream - no WiFi connection");
+            // The hotspot is a directly connected local network, even though Android does not
+            // report it as a connected STA WiFi network.
+            boolean hasStaWifi = stateManager == null || stateManager.isConnectedToWifi();
+            boolean hasLocalHotspotRoute =
+                    !hasStaWifi && HotspotNetworkUtils.isEndpointOnActiveHotspot(streamUrl);
+            if (!hasStaWifi && !hasLocalHotspotRoute) {
+                Log.e(TAG, "Cannot start stream - no WiFi or local hotspot route");
                 sendStreamErrorStatus(streamId, ServiceConstants.ERROR_NO_WIFI_CONNECTION);
                 return false;
             }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -6,7 +6,9 @@ import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
 import android.os.SystemClock;
 import android.util.Log;
+
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.utils.HotspotNetworkUtils;
 import com.mentra.asg_client.io.streaming.config.RtmpStreamConfig;
 import com.mentra.asg_client.io.streaming.config.WhipStreamConfig;
@@ -22,10 +24,13 @@ import com.mentra.asg_client.service.system.core.SystemControllerFactory;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
 import com.mentra.asg_client.service.utils.ServiceConstants;
 import com.mentra.asg_client.service.utils.ServiceUtils;
+
 import io.github.thibaultbee.streampack.internal.sources.camera.CameraController;
-import java.util.Set;
+
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.Set;
 
 /**
  * Handler for streaming commands (RTMP, SRT, WHIP). Routes to the appropriate streaming service
@@ -51,12 +56,17 @@ public class StreamCommandHandler implements ICommandHandler {
     private final Context context;
     private final IStateManager stateManager;
     private final IMediaManager streamingManager;
+    private final HotspotStreamActivityTracker mHotspotActivityTracker;
 
     public StreamCommandHandler(
-            Context context, IStateManager stateManager, IMediaManager streamingManager) {
+            Context context,
+            IStateManager stateManager,
+            IMediaManager streamingManager,
+            INetworkManager networkManager) {
         this.context = context;
         this.stateManager = stateManager;
         this.streamingManager = streamingManager;
+        this.mHotspotActivityTracker = new HotspotStreamActivityTracker(networkManager);
     }
 
     @Override
@@ -161,8 +171,7 @@ public class StreamCommandHandler implements ICommandHandler {
             // The hotspot is a directly connected local network, even though Android does not
             // report it as a connected STA WiFi network.
             boolean hasStaWifi = stateManager == null || stateManager.isConnectedToWifi();
-            boolean hasLocalHotspotRoute =
-                    !hasStaWifi && HotspotNetworkUtils.isEndpointOnActiveHotspot(streamUrl);
+            boolean hasLocalHotspotRoute = HotspotNetworkUtils.isEndpointOnActiveHotspot(streamUrl);
             if (!hasStaWifi && !hasLocalHotspotRoute) {
                 Log.e(TAG, "Cannot start stream - no WiFi or local hotspot route");
                 sendStreamErrorStatus(streamId, ServiceConstants.ERROR_NO_WIFI_CONNECTION);
@@ -252,6 +261,8 @@ public class StreamCommandHandler implements ICommandHandler {
                         break;
                     }
             }
+
+            mHotspotActivityTracker.onStreamStarted(hasLocalHotspotRoute);
 
             return true;
         } catch (Exception e) {
@@ -376,20 +387,24 @@ public class StreamCommandHandler implements ICommandHandler {
             if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
                 sendStreamStoppingStatus(RtmpStreamingService.getCurrentStreamId());
                 RtmpStreamingService.stopStreaming(context);
+                mHotspotActivityTracker.onStreamStopped();
                 restoreEisAfterStreaming();
                 return true;
             } else if (SrtStreamingService.isStreaming() || SrtStreamingService.isReconnecting()) {
                 sendStreamStoppingStatus(SrtStreamingService.getCurrentStreamId());
                 SrtStreamingService.stopStreaming(context);
+                mHotspotActivityTracker.onStreamStopped();
                 restoreEisAfterStreaming();
                 return true;
             } else if (WhipStreamingService.isStreaming()
                     || WhipStreamingService.isReconnecting()) {
                 sendStreamStoppingStatus(WhipStreamingService.getCurrentStreamId());
                 WhipStreamingService.stopStreaming(context);
+                mHotspotActivityTracker.onStreamStopped();
                 restoreEisAfterStreaming();
                 return true;
             } else {
+                mHotspotActivityTracker.onStreamStopped();
                 streamingManager.sendStreamStatusResponse(
                         false, ServiceConstants.STATUS_ERROR, ServiceConstants.ERROR_NOT_STREAMING);
                 return false;
@@ -513,6 +528,7 @@ public class StreamCommandHandler implements ICommandHandler {
             if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
                 boolean valid = RtmpStreamingService.resetStreamTimeout(streamId);
                 if (valid || RtmpStreamingService.isStreaming()) {
+                    mHotspotActivityTracker.onKeepAlive();
                     streamingManager.sendKeepAliveAck(streamId, ackId);
                     return true;
                 }
@@ -521,6 +537,7 @@ public class StreamCommandHandler implements ICommandHandler {
             if (SrtStreamingService.isStreaming() || SrtStreamingService.isReconnecting()) {
                 boolean valid = SrtStreamingService.resetStreamTimeout(streamId);
                 if (valid || SrtStreamingService.isStreaming()) {
+                    mHotspotActivityTracker.onKeepAlive();
                     streamingManager.sendKeepAliveAck(streamId, ackId);
                     return true;
                 }
@@ -529,6 +546,7 @@ public class StreamCommandHandler implements ICommandHandler {
             if (WhipStreamingService.isStreaming() || WhipStreamingService.isReconnecting()) {
                 boolean valid = WhipStreamingService.resetStreamTimeout(streamId);
                 if (valid || WhipStreamingService.isStreaming()) {
+                    mHotspotActivityTracker.onKeepAlive();
                     streamingManager.sendKeepAliveAck(streamId, ackId);
                     return true;
                 }
@@ -547,6 +565,7 @@ public class StreamCommandHandler implements ICommandHandler {
     // -------------------------------------------------------------------------
 
     private boolean stopAllServices() {
+        mHotspotActivityTracker.onStreamStopped();
         boolean stoppedExistingStream = false;
         if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
             RtmpStreamingService.stopStreaming(context);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -528,7 +528,9 @@ public class StreamCommandHandler implements ICommandHandler {
             if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
                 boolean valid = RtmpStreamingService.resetStreamTimeout(streamId);
                 if (valid || RtmpStreamingService.isStreaming()) {
-                    mHotspotActivityTracker.onKeepAlive();
+                    if (valid) {
+                        mHotspotActivityTracker.onKeepAlive();
+                    }
                     streamingManager.sendKeepAliveAck(streamId, ackId);
                     return true;
                 }
@@ -537,7 +539,9 @@ public class StreamCommandHandler implements ICommandHandler {
             if (SrtStreamingService.isStreaming() || SrtStreamingService.isReconnecting()) {
                 boolean valid = SrtStreamingService.resetStreamTimeout(streamId);
                 if (valid || SrtStreamingService.isStreaming()) {
-                    mHotspotActivityTracker.onKeepAlive();
+                    if (valid) {
+                        mHotspotActivityTracker.onKeepAlive();
+                    }
                     streamingManager.sendKeepAliveAck(streamId, ackId);
                     return true;
                 }
@@ -546,7 +550,9 @@ public class StreamCommandHandler implements ICommandHandler {
             if (WhipStreamingService.isStreaming() || WhipStreamingService.isReconnecting()) {
                 boolean valid = WhipStreamingService.resetStreamTimeout(streamId);
                 if (valid || WhipStreamingService.isStreaming()) {
-                    mHotspotActivityTracker.onKeepAlive();
+                    if (valid) {
+                        mHotspotActivityTracker.onKeepAlive();
+                    }
                     streamingManager.sendKeepAliveAck(streamId, ackId);
                     return true;
                 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
@@ -408,7 +408,11 @@ public class CommandProcessor {
             Log.d(TAG, "✅ Registered KeepAwakeCommandHandler");
 
             commandHandlerRegistry.registerHandler(
-                    new StreamCommandHandler(context, stateManager, streamingManager));
+                    new StreamCommandHandler(
+                            context,
+                            stateManager,
+                            streamingManager,
+                            serviceManager.getNetworkManager()));
             Log.d(TAG, "✅ Registered StreamCommandHandler");
 
             commandHandlerRegistry.registerHandler(

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
@@ -1,0 +1,89 @@
+package com.mentra.asg_client.io.network.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.webrtc.NetworkChangeDetector;
+
+public class HotspotAwareNetworkChangeDetectorTest {
+    @Test
+    public void exposesHotspotAsLocalWifiNetwork() throws Exception {
+        HotspotNetworkUtils.HotspotInterface hotspot =
+                new HotspotNetworkUtils.HotspotInterface(
+                        "ap0", List.of(InetAddress.getByName("192.168.43.1")));
+
+        NetworkChangeDetector.NetworkInformation network =
+                HotspotAwareNetworkChangeDetector.createNetworkInformation(hotspot);
+
+        assertThat(network).isNotNull();
+        assertThat(network.name).isEqualTo("ap0");
+        assertThat(network.type).isEqualTo(NetworkChangeDetector.ConnectionType.CONNECTION_WIFI);
+        assertThat(network.handle).isZero();
+        assertThat(network.ipAddresses).hasSize(1);
+        assertThat(network.ipAddresses[0].address)
+                .containsExactly(InetAddress.getByName("192.168.43.1").getAddress());
+    }
+
+    @Test
+    public void keepsStaNetworkAndAddsHotspotNetwork() throws Exception {
+        NetworkChangeDetector.NetworkInformation staNetwork =
+                network("wlan0", 42L, "192.168.1.109");
+        HotspotNetworkUtils.HotspotInterface hotspot =
+                new HotspotNetworkUtils.HotspotInterface(
+                        "ap0", List.of(InetAddress.getByName("192.168.43.1")));
+
+        List<NetworkChangeDetector.NetworkInformation> networks =
+                HotspotAwareNetworkChangeDetector.mergeNetworks(List.of(staNetwork), hotspot);
+
+        assertThat(networks).extracting(network -> network.name).containsExactly("wlan0", "ap0");
+        assertThat(networks.get(0)).isSameAs(staNetwork);
+    }
+
+    @Test
+    public void doesNotDuplicateHotspotAlreadyReportedByAndroid() throws Exception {
+        NetworkChangeDetector.NetworkInformation hotspotNetwork =
+                network("ap0", 42L, "192.168.43.1");
+        HotspotNetworkUtils.HotspotInterface hotspot =
+                new HotspotNetworkUtils.HotspotInterface(
+                        "ap0", List.of(InetAddress.getByName("192.168.43.1")));
+
+        List<NetworkChangeDetector.NetworkInformation> networks =
+                HotspotAwareNetworkChangeDetector.mergeNetworks(List.of(hotspotNetwork), hotspot);
+
+        assertThat(networks).containsExactly(hotspotNetwork);
+    }
+
+    @Test
+    public void leavesDetectedNetworksUnchangedWithoutHotspot() throws Exception {
+        NetworkChangeDetector.NetworkInformation staNetwork =
+                network("wlan0", 42L, "192.168.1.109");
+
+        List<NetworkChangeDetector.NetworkInformation> networks =
+                HotspotAwareNetworkChangeDetector.mergeNetworks(List.of(staNetwork), null);
+
+        assertThat(networks).containsExactly(staNetwork);
+    }
+
+    @Test
+    public void ignoresHotspotWithoutUsableAddresses() {
+        HotspotNetworkUtils.HotspotInterface hotspot =
+                new HotspotNetworkUtils.HotspotInterface("ap0", Collections.emptyList());
+
+        assertThat(HotspotAwareNetworkChangeDetector.createNetworkInformation(hotspot)).isNull();
+    }
+
+    private static NetworkChangeDetector.NetworkInformation network(
+            String name, long handle, String address) throws Exception {
+        return new NetworkChangeDetector.NetworkInformation(
+                name,
+                NetworkChangeDetector.ConnectionType.CONNECTION_WIFI,
+                NetworkChangeDetector.ConnectionType.CONNECTION_NONE,
+                handle,
+                new NetworkChangeDetector.IPAddress[] {
+                    new NetworkChangeDetector.IPAddress(InetAddress.getByName(address).getAddress())
+                });
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
@@ -11,6 +11,8 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class HotspotAwareNetworkChangeDetectorTest {
@@ -156,6 +158,47 @@ public class HotspotAwareNetworkChangeDetectorTest {
                     .containsExactly("ap0");
         } finally {
             detector.destroy();
+        }
+    }
+
+    @Test
+    public void listenerCallbacksDoNotHoldRegistryLock() throws Exception {
+        CountDownLatch nestedNotificationReturned = new CountDownLatch(1);
+        CountDownLatch disabledDelivered = new CountDownLatch(1);
+        AtomicReference<Thread> nestedThread = new AtomicReference<>();
+        HotspotNetworkUtils.HotspotStateListener listener =
+                enabled -> {
+                    if (!enabled) {
+                        disabledDelivered.countDown();
+                        return;
+                    }
+                    Thread thread =
+                            new Thread(
+                                    () -> {
+                                        HotspotNetworkUtils.notifyHotspotStateChanged(false);
+                                        nestedNotificationReturned.countDown();
+                                    });
+                    nestedThread.set(thread);
+                    thread.start();
+                    try {
+                        assertThat(nestedNotificationReturned.await(2, TimeUnit.SECONDS)).isTrue();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError(e);
+                    }
+                };
+
+        HotspotNetworkUtils.addHotspotStateListener(listener);
+        try {
+            HotspotNetworkUtils.notifyHotspotStateChanged(true);
+
+            assertThat(disabledDelivered.await(2, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            HotspotNetworkUtils.removeHotspotStateListener(listener);
+            Thread thread = nestedThread.get();
+            if (thread != null) {
+                thread.join(2_000);
+            }
         }
     }
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
@@ -2,6 +2,8 @@ package com.mentra.asg_client.io.network.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.webrtc.NetworkChangeDetector;
 
@@ -12,6 +14,16 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class HotspotAwareNetworkChangeDetectorTest {
+    @Before
+    public void resetHotspotState() {
+        HotspotNetworkUtils.resetHotspotStateForTests();
+    }
+
+    @After
+    public void clearHotspotState() {
+        HotspotNetworkUtils.resetHotspotStateForTests();
+    }
+
     @Test
     public void exposesHotspotAsLocalWifiNetwork() throws Exception {
         HotspotNetworkUtils.HotspotInterface hotspot =
@@ -112,6 +124,39 @@ public class HotspotAwareNetworkChangeDetectorTest {
             detector.destroy();
         }
         assertThat(delegate.destroyed).isTrue();
+    }
+
+    @Test
+    public void replaysEnableNotificationMissedDuringConstruction() throws Exception {
+        HotspotNetworkUtils.HotspotInterface activeHotspot =
+                new HotspotNetworkUtils.HotspotInterface(
+                        "ap0", List.of(InetAddress.getByName("192.168.43.1")));
+        AtomicReference<HotspotNetworkUtils.HotspotInterface> hotspot = new AtomicReference<>();
+        RecordingObserver observer = new RecordingObserver();
+        FakeNetworkChangeDetector delegate =
+                new FakeNetworkChangeDetector(NetworkChangeDetector.ConnectionType.CONNECTION_NONE);
+
+        HotspotAwareNetworkChangeDetector detector =
+                new HotspotAwareNetworkChangeDetector(
+                        observer,
+                        delegate,
+                        () -> {
+                            if (hotspot.get() == null) {
+                                hotspot.set(activeHotspot);
+                                HotspotNetworkUtils.notifyHotspotStateChanged(true);
+                                return null;
+                            }
+                            return hotspot.get();
+                        });
+        try {
+            assertThat(observer.connectedNetworks).hasSize(1);
+            assertThat(observer.connectedNetworks.get(0).name).isEqualTo("ap0");
+            assertThat(detector.getActiveNetworkList())
+                    .extracting(network -> network.name)
+                    .containsExactly("ap0");
+        } finally {
+            detector.destroy();
+        }
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
@@ -2,11 +2,14 @@ package com.mentra.asg_client.io.network.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.InetAddress;
-import java.util.Collections;
-import java.util.List;
 import org.junit.Test;
 import org.webrtc.NetworkChangeDetector;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class HotspotAwareNetworkChangeDetectorTest {
     @Test
@@ -75,6 +78,65 @@ public class HotspotAwareNetworkChangeDetectorTest {
         assertThat(HotspotAwareNetworkChangeDetector.createNetworkInformation(hotspot)).isNull();
     }
 
+    @Test
+    public void emitsHotspotConnectAndDisconnectLifecycle() throws Exception {
+        AtomicReference<HotspotNetworkUtils.HotspotInterface> hotspot = new AtomicReference<>();
+        RecordingObserver observer = new RecordingObserver();
+        FakeNetworkChangeDetector delegate =
+                new FakeNetworkChangeDetector(NetworkChangeDetector.ConnectionType.CONNECTION_NONE);
+        HotspotAwareNetworkChangeDetector detector =
+                new HotspotAwareNetworkChangeDetector(observer, delegate, hotspot::get);
+        try {
+            hotspot.set(
+                    new HotspotNetworkUtils.HotspotInterface(
+                            "ap0", List.of(InetAddress.getByName("192.168.43.1"))));
+
+            HotspotNetworkUtils.notifyHotspotStateChanged(true);
+            HotspotNetworkUtils.notifyHotspotStateChanged(true);
+
+            assertThat(observer.connectedNetworks).hasSize(1);
+            assertThat(observer.connectedNetworks.get(0).name).isEqualTo("ap0");
+            assertThat(observer.connectionTypes)
+                    .containsExactly(NetworkChangeDetector.ConnectionType.CONNECTION_WIFI);
+
+            HotspotNetworkUtils.notifyHotspotStateChanged(false);
+
+            assertThat(observer.disconnectedHandles).containsExactly(0L);
+            assertThat(detector.getCurrentConnectionType())
+                    .isEqualTo(NetworkChangeDetector.ConnectionType.CONNECTION_NONE);
+            assertThat(observer.connectionTypes)
+                    .containsExactly(
+                            NetworkChangeDetector.ConnectionType.CONNECTION_WIFI,
+                            NetworkChangeDetector.ConnectionType.CONNECTION_NONE);
+        } finally {
+            detector.destroy();
+        }
+        assertThat(delegate.destroyed).isTrue();
+    }
+
+    @Test
+    public void preservesStaConnectionTypeDuringHotspotLifecycle() throws Exception {
+        AtomicReference<HotspotNetworkUtils.HotspotInterface> hotspot =
+                new AtomicReference<>(
+                        new HotspotNetworkUtils.HotspotInterface(
+                                "ap0", List.of(InetAddress.getByName("192.168.43.1"))));
+        RecordingObserver observer = new RecordingObserver();
+        FakeNetworkChangeDetector delegate =
+                new FakeNetworkChangeDetector(NetworkChangeDetector.ConnectionType.CONNECTION_WIFI);
+        HotspotAwareNetworkChangeDetector detector =
+                new HotspotAwareNetworkChangeDetector(observer, delegate, hotspot::get);
+        try {
+            detector.onHotspotStateChanged(true);
+            detector.onHotspotStateChanged(false);
+
+            assertThat(observer.connectedNetworks).hasSize(1);
+            assertThat(observer.disconnectedHandles).containsExactly(0L);
+            assertThat(observer.connectionTypes).isEmpty();
+        } finally {
+            detector.destroy();
+        }
+    }
+
     private static NetworkChangeDetector.NetworkInformation network(
             String name, long handle, String address) throws Exception {
         return new NetworkChangeDetector.NetworkInformation(
@@ -85,5 +147,60 @@ public class HotspotAwareNetworkChangeDetectorTest {
                 new NetworkChangeDetector.IPAddress[] {
                     new NetworkChangeDetector.IPAddress(InetAddress.getByName(address).getAddress())
                 });
+    }
+
+    private static final class RecordingObserver extends NetworkChangeDetector.Observer {
+        final List<NetworkChangeDetector.ConnectionType> connectionTypes = new ArrayList<>();
+        final List<NetworkChangeDetector.NetworkInformation> connectedNetworks = new ArrayList<>();
+        final List<Long> disconnectedHandles = new ArrayList<>();
+
+        @Override
+        public void onConnectionTypeChanged(
+                NetworkChangeDetector.ConnectionType newConnectionType) {
+            connectionTypes.add(newConnectionType);
+        }
+
+        @Override
+        public void onNetworkConnect(NetworkChangeDetector.NetworkInformation networkInfo) {
+            connectedNetworks.add(networkInfo);
+        }
+
+        @Override
+        public void onNetworkDisconnect(long networkHandle) {
+            disconnectedHandles.add(networkHandle);
+        }
+
+        @Override
+        public void onNetworkPreference(
+                List<NetworkChangeDetector.ConnectionType> types, int preference) {}
+    }
+
+    private static final class FakeNetworkChangeDetector implements NetworkChangeDetector {
+        private final ConnectionType connectionType;
+        boolean destroyed;
+
+        FakeNetworkChangeDetector(ConnectionType connectionType) {
+            this.connectionType = connectionType;
+        }
+
+        @Override
+        public ConnectionType getCurrentConnectionType() {
+            return connectionType;
+        }
+
+        @Override
+        public boolean supportNetworkCallback() {
+            return true;
+        }
+
+        @Override
+        public List<NetworkInformation> getActiveNetworkList() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+        }
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotAwareNetworkChangeDetectorTest.java
@@ -137,6 +137,43 @@ public class HotspotAwareNetworkChangeDetectorTest {
         }
     }
 
+    @Test
+    public void transientMissingInterfaceDoesNotDropPendingDisconnect() throws Exception {
+        HotspotNetworkUtils.HotspotInterface activeHotspot =
+                new HotspotNetworkUtils.HotspotInterface(
+                        "ap0", List.of(InetAddress.getByName("192.168.43.1")));
+        AtomicReference<HotspotNetworkUtils.HotspotInterface> hotspot =
+                new AtomicReference<>(activeHotspot);
+        RecordingObserver observer = new RecordingObserver();
+        FakeNetworkChangeDetector delegate =
+                new FakeNetworkChangeDetector(NetworkChangeDetector.ConnectionType.CONNECTION_NONE);
+        HotspotAwareNetworkChangeDetector detector =
+                new HotspotAwareNetworkChangeDetector(observer, delegate, hotspot::get);
+        try {
+            assertThat(detector.getActiveNetworkList())
+                    .extracting(network -> network.name)
+                    .containsExactly("ap0");
+
+            hotspot.set(null);
+            assertThat(detector.getActiveNetworkList()).isEmpty();
+
+            hotspot.set(activeHotspot);
+            assertThat(detector.getActiveNetworkList())
+                    .extracting(network -> network.name)
+                    .containsExactly("ap0");
+
+            hotspot.set(null);
+            assertThat(detector.getActiveNetworkList()).isEmpty();
+            HotspotNetworkUtils.notifyHotspotStateChanged(false);
+
+            assertThat(observer.disconnectedHandles).containsExactly(0L);
+            assertThat(detector.getCurrentConnectionType())
+                    .isEqualTo(NetworkChangeDetector.ConnectionType.CONNECTION_NONE);
+        } finally {
+            detector.destroy();
+        }
+    }
+
     private static NetworkChangeDetector.NetworkInformation network(
             String name, long handle, String address) throws Exception {
         return new NetworkChangeDetector.NetworkInformation(

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtilsTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/HotspotNetworkUtilsTest.java
@@ -1,0 +1,71 @@
+package com.mentra.asg_client.io.network.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import org.junit.Test;
+
+public class HotspotNetworkUtilsTest {
+    @Test
+    public void parsesIpv4StreamEndpoint() {
+        Inet4Address address =
+                HotspotNetworkUtils.parseIpv4Endpoint("http://192.168.43.207:8788/session/stream");
+
+        assertThat(address).isNotNull();
+        assertThat(address.getHostAddress()).isEqualTo("192.168.43.207");
+    }
+
+    @Test
+    public void rejectsHostnameAndInvalidIpv4Endpoint() {
+        assertThat(HotspotNetworkUtils.parseIpv4Endpoint("https://ingest.example.com/whip"))
+                .isNull();
+        assertThat(HotspotNetworkUtils.parseIpv4Endpoint("http://192.168.43.999/whip")).isNull();
+    }
+
+    @Test
+    public void matchesAddressUsingLiveInterfacePrefix() throws Exception {
+        Inet4Address local = ipv4("192.168.43.1");
+
+        assertThat(HotspotNetworkUtils.isAddressInSubnet(ipv4("192.168.43.207"), local, (short) 24))
+                .isTrue();
+        assertThat(HotspotNetworkUtils.isAddressInSubnet(ipv4("192.168.44.207"), local, (short) 24))
+                .isFalse();
+    }
+
+    @Test
+    public void supportsNonDefaultHotspotSubnetAndPrefix() throws Exception {
+        assertThat(
+                        HotspotNetworkUtils.isAddressInSubnet(
+                                ipv4("10.42.31.99"), ipv4("10.42.0.1"), (short) 16))
+                .isTrue();
+        assertThat(
+                        HotspotNetworkUtils.isAddressInSubnet(
+                                ipv4("10.43.0.2"), ipv4("10.42.0.1"), (short) 16))
+                .isFalse();
+    }
+
+    @Test
+    public void respectsNonOctetPrefixBoundaries() throws Exception {
+        Inet4Address local = ipv4("192.168.43.129");
+
+        assertThat(HotspotNetworkUtils.isAddressInSubnet(ipv4("192.168.43.254"), local, (short) 25))
+                .isTrue();
+        assertThat(HotspotNetworkUtils.isAddressInSubnet(ipv4("192.168.43.127"), local, (short) 25))
+                .isFalse();
+    }
+
+    @Test
+    public void rejectsInvalidPrefixLength() throws Exception {
+        Inet4Address local = ipv4("192.168.43.1");
+
+        assertThat(HotspotNetworkUtils.isAddressInSubnet(ipv4("192.168.43.2"), local, (short) -1))
+                .isFalse();
+        assertThat(HotspotNetworkUtils.isAddressInSubnet(ipv4("192.168.43.2"), local, (short) 33))
+                .isFalse();
+    }
+
+    private static Inet4Address ipv4(String address) throws Exception {
+        return (Inet4Address) InetAddress.getByName(address);
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/HotspotStreamActivityTrackerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/HotspotStreamActivityTrackerTest.java
@@ -1,0 +1,62 @@
+package com.mentra.asg_client.service.core.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
+
+import org.junit.Test;
+
+public class HotspotStreamActivityTrackerTest {
+    @Test
+    public void localStreamStartAndKeepAliveRefreshHotspotActivity() {
+        INetworkManager networkManager = mock(INetworkManager.class);
+        when(networkManager.isHotspotEnabled()).thenReturn(true);
+        HotspotStreamActivityTracker tracker = new HotspotStreamActivityTracker(networkManager);
+
+        tracker.onStreamStarted(true);
+        tracker.onKeepAlive();
+
+        verify(networkManager, times(2)).updateHttpActivity();
+    }
+
+    @Test
+    public void stoppedStreamNoLongerRefreshesHotspotActivity() {
+        INetworkManager networkManager = mock(INetworkManager.class);
+        when(networkManager.isHotspotEnabled()).thenReturn(true);
+        HotspotStreamActivityTracker tracker = new HotspotStreamActivityTracker(networkManager);
+
+        tracker.onStreamStarted(true);
+        tracker.onStreamStopped();
+        tracker.onKeepAlive();
+
+        verify(networkManager).updateHttpActivity();
+    }
+
+    @Test
+    public void staStreamDoesNotKeepUnrelatedHotspotAlive() {
+        INetworkManager networkManager = mock(INetworkManager.class);
+        when(networkManager.isHotspotEnabled()).thenReturn(true);
+        HotspotStreamActivityTracker tracker = new HotspotStreamActivityTracker(networkManager);
+
+        tracker.onStreamStarted(false);
+        tracker.onKeepAlive();
+
+        verify(networkManager, never()).updateHttpActivity();
+    }
+
+    @Test
+    public void localStreamDoesNotRefreshDisabledHotspot() {
+        INetworkManager networkManager = mock(INetworkManager.class);
+        when(networkManager.isHotspotEnabled()).thenReturn(false);
+        HotspotStreamActivityTracker tracker = new HotspotStreamActivityTracker(networkManager);
+
+        tracker.onStreamStarted(true);
+        tracker.onKeepAlive();
+
+        verify(networkManager, never()).updateHttpActivity();
+    }
+}

--- a/asg_client/docs/ASG_CLIENT_API.md
+++ b/asg_client/docs/ASG_CLIENT_API.md
@@ -313,7 +313,7 @@ See [features/rtmp-streaming.md](features/rtmp-streaming.md) for stream lifecycl
 | `flash`     | boolean | `true`   | Privacy LED during stream                                                                                                     |
 | `sound`     | boolean | `true`   | Start/stop tones                                                                                                              |
 
-**Constraints:** battery ≥ 10%, WiFi connected. WHIP streams whose requested resolution exceeds the camera's supported output are rejected (`WhipCameraFormatSelector`).
+**Constraints:** battery ≥ 10%, and either STA WiFi is connected or the stream endpoint is on the active glasses-hosted hotspot subnet. WHIP streams whose requested resolution exceeds the camera's supported output are rejected (`WhipCameraFormatSelector`).
 
 **Response wire type:** `stream_status` (new universal type from `MediaManager.sendStreamStatusResponse`). Legacy `rtmp_stream_status` is still produced by `ResponseBuilder` in some paths.
 

--- a/asg_client/docs/features/rtmp-streaming.md
+++ b/asg_client/docs/features/rtmp-streaming.md
@@ -71,7 +71,7 @@ If no stream is active, the response is `status: "error"` with `errorDetails: "n
 ## Resource constraints
 
 - **Battery** — start gated at `MIN_BATTERY_LEVEL`. The phone gets `BATTERY_LOW` and the user hears a low-battery audio cue.
-- **WiFi** — required for all three protocols. Mobile data is not used.
+- **Network** — requires either STA WiFi or an endpoint on the active glasses-hosted hotspot subnet. The glasses do not use cellular data.
 - **Camera contention** — only one stream at a time; starting a second stream stops the first. Buffer recording, photos, and video recording all share the same camera and yield to (or reject) streams.
 - **Thermal** — EIS is disabled while streaming.
 

--- a/asg_client/docs/features/rtmp-streaming.md
+++ b/asg_client/docs/features/rtmp-streaming.md
@@ -29,7 +29,7 @@ See the [API doc](../ASG_CLIENT_API.md#streaming-rtmp--srt--whip) for fields and
 
 1. **Validate URL.** The URL prefix selects the protocol; an unknown prefix is rejected with `Unknown stream URL protocol`.
 2. **Battery check.** Reject if battery is below `BatteryConstants.MIN_BATTERY_LEVEL` (currently 10%) — `BATTERY_LOW` error.
-3. **WiFi check.** All three protocols require WiFi.
+3. **Network check.** Require either a STA WiFi connection or an endpoint on the active glasses-hosted hotspot subnet.
 4. **Stop any existing stream** to avoid camera contention; brief pause so the camera HAL releases.
 5. **Resolution check (WHIP only).** Reject if requested resolution exceeds the camera's supported output (`WhipCameraFormatSelector`).
 6. **Disable EIS** during streaming to reduce camera HAL thermal load (`SysControl.setEisEnable(context, false)`). Re-enabled on stop.

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -108,6 +108,8 @@ Every camera-button press should still be forwarded to the phone as a `button_pr
 
 Mentra Live supports camera/microphone live streaming paths from `asg_client`, including RTMP, SRT, and WHIP services. Streaming behavior must coordinate camera ownership, microphone foreground-service requirements, reconnect/keep-alive handling, and privacy LED state.
 
+Streaming endpoints on the active Mentra Live hotspot subnet are reachable without a separate STA WiFi connection. `asg_client` derives that subnet from the live hotspot interface rather than assuming fixed client addresses. For WHIP, the WebRTC network inventory must also expose the hotspot interface so ICE can gather a directly reachable local candidate.
+
 ### Local media sync server
 
 `asg_client` runs an embedded HTTP server that lets the phone enumerate, download, ZIP, and delete captured media. This is used for gallery sync and avoids relying on cloud connectivity for local media transfer.

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -138,7 +138,7 @@ Camera and streaming features must leave LEDs in a safe state on stop, error, se
 
 The phone can configure WiFi behavior through `asg_client`. Mentra Live-specific network managers should be used when platform APIs are required; generic Android fallbacks exist for non-K900 paths.
 
-When the phone requests the Mentra Live hotspot, `asg_client` starts the K900 firmware hotspot through the SmartXY `ap_start` intent. It waits for the AP gateway and firmware-configured SSID/password before returning them to the phone over BLE. Clients must use the latest BLE status rather than assume fixed credentials. The hotspot remains active while the local HTTP server is receiving requests or streaming response data and automatically stops after 120 seconds of genuine HTTP inactivity.
+When the phone requests the Mentra Live hotspot, `asg_client` starts the K900 firmware hotspot through the SmartXY `ap_start` intent. It waits for the AP gateway and firmware-configured SSID/password before returning them to the phone over BLE. Clients must use the latest BLE status rather than assume fixed credentials. The hotspot remains active while the local HTTP server is receiving requests or streaming response data, or while a hotspot-local stream receives its standard stream keep-alives. It automatically stops after 120 seconds without any of those activity signals.
 
 ### OTA and updates
 


### PR DESCRIPTION
## Summary

- allow a stream to start without STA Wi-Fi when its IPv4 endpoint is directly reachable on the active glasses-hosted hotspot subnet
- derive the hotspot subnet from the live AP interface and prefix instead of hardcoding `192.168.43.0/24`
- add the tethering-side AP interface to WebRTC's network inventory so WHIP can gather a host candidate for hotspot clients
- preserve Android's normal network inventory, including `wlan0`, when the hotspot is inactive or AP+STA concurrency is active
- publish hotspot start/stop lifecycle changes so WebRTC adds and removes the local AP inventory entry dynamically
- keep hotspot-local streams alive through the standard `keep_stream_alive` heartbeat, including AP+STA sessions
- document hotspot-local streaming behavior and add focused route/network-inventory/activity tests

## Problem

The current stream preflight checks only STA Wi-Fi connectivity. A phone joined to the glasses-hosted hotspot can exchange local HTTP traffic with the glasses, but `start_stream` is rejected with `no_wifi_connection` when the glasses are not also joined to Wi-Fi.

With AP+STA concurrency, WHIP signaling can reach the phone over the hotspot, but Android's WebRTC network detector does not inventory the tethering-side `ap0` interface. ICE therefore lacks the directly reachable glasses-side hotspot candidate needed to pair with the phone's `192.168.43.x` answer candidate.

## Implementation

### Stream eligibility

`HotspotNetworkUtils`:

- discovers canonical `ap0`, with an `ap*` fallback for renamed platform interfaces
- reads the interface's actual IPv4 address and prefix
- parses the stream URL's numeric IPv4 host
- permits hotspot-only streaming only when that address belongs to the active AP subnet

Remote endpoints and hostnames continue to require STA Wi-Fi. This avoids treating an active hotspot as general Internet connectivity.

### WebRTC network inventory

`HotspotAwareNetworkChangeDetector` wraps WebRTC's stock `NetworkMonitorAutoDetect` and merges in the active hotspot interface. It preserves all Android-reported networks and uses local-only handle `0`, matching WebRTC's Wi-Fi Direct representation for an interface without an Android `Network` handle.

Expected matrix:

| Glasses networking | Expected behavior |
| --- | --- |
| STA only | Existing streaming path remains unchanged |
| Hotspot only + local endpoint | Stream preflight succeeds; ICE can gather the AP host candidate |
| STA + hotspot | Both `wlan0` and `ap0` remain available to ICE |
| No STA + remote endpoint | Rejected with `no_wifi_connection` as before |

## Firmware dependency

This is intended to ship with the Mentra Live MTK hotspot routing change in [mentra-live-mtk#1](https://github.com/Mentra-Community/mentra-live-mtk/pull/1), which stops advertising the glasses as the phone's IPv4 default router. That firmware change makes cellular Internet retention automatic; this PR supplies the separate ASG/WebRTC behavior needed to carry local video over the hotspot.

The combined experience should be released only after validation on the corrected firmware.

## Validation

- `./scripts/check-android-compile.sh asg`
- `cd asg_client && ./gradlew :app:testDebugUnitTest`
- focused hotspot route and WebRTC network-inventory tests
- `git diff --check origin/dev...HEAD`

All passed locally.

## Physical acceptance still required

- test on `MentraLive_20260816` or newer firmware containing the no-default-router change
- verify STA-only WHIP still streams
- verify hotspot-only WHIP reaches a phone-local endpoint and carries media
- verify AP+STA advertises both interfaces and completes ICE over the AP subnet
- verify a fresh iPhone retains system-wide cellular Internet without a prior per-SSID override
- verify stop/reconnect/keep-alive and hotspot teardown behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports starting and sustaining streams over the Mentra Live hotspot and exposes the hotspot interface to WebRTC ICE. Previously start_stream required STA Wi‑Fi and ICE omitted the tethering AP; now starts succeed when the endpoint is on the active AP subnet, ICE inventories the AP as a local‑only network, and hotspot lifecycle events are ordered and deduplicated so connect/disconnect deliver once and in order.

- Stream gating and activity: `StreamCommandHandler` uses `HotspotNetworkUtils.isEndpointOnActiveHotspot` to allow hotspot‑only starts; hostnames and remote endpoints still require STA Wi‑Fi. `HotspotStreamActivityTracker` refreshes the hotspot idle timer on start and valid keep‑alives only for hotspot‑local streams and no‑ops when the hotspot is disabled or on errors.
- WebRTC/ICE: `WhipStreamingService` installs `HotspotAwareNetworkChangeDetector` to add the AP (handle `0`) without duplicating Android‑reported networks. `BaseNetworkManager.notifyHotspotStateChanged` feeds `HotspotNetworkUtils` listeners; `HotspotNetworkUtils` now versions and serializes lifecycle notifications, replays the last known state to new listeners, and preserves disconnect notifications across transient interface gaps so ICE candidates add/remove correctly.
- Minor: `AsgConstants.MENTRA_LIVE_HOTSPOT_INTERFACE` names the AP; `K900NetworkManager` uses it to resolve the gateway. Docs and focused tests updated.

**Rollout**
- Requires Mentra Live MTK firmware that stops advertising the glasses as the phone’s IPv4 default router.
- Validate STA‑only, hotspot‑only to a phone‑local endpoint, and AP+STA concurrency to confirm ICE connect/disconnect and hotspot idle‑timer behavior.

<sup>Written for commit 46fc6e493da9b078bb28eff4033670b705485556. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream eligibility, WebRTC ICE network inventory, and hotspot idle-timeout bookkeeping. Incorrect routing or candidate handling could drop media or keep the AP up unexpectedly.
> 
> **Overview**
> Allows live streams when the endpoint is on the glasses-hosted hotspot, even if STA Wi‑Fi is down. Remote/hostname URLs still require STA Wi‑Fi.
> 
> `HotspotNetworkUtils` discovers `ap0` (with `ap*` fallback) and matches the stream host against the live AP subnet/prefix instead of a hardcoded `192.168.43.0/24`. Hotspot start/stop is published in-process so consumers see ordered connect/disconnect events.
> 
> WHIP now wraps WebRTC’s stock detector with `HotspotAwareNetworkChangeDetector`, injecting the tethering interface as a local-only Wi‑Fi network (handle `0`) so ICE can gather an AP host candidate without duplicating Android-reported nets like `wlan0`.
> 
> Hotspot-local streams refresh the AP idle timer on start and valid `keep_stream_alive` heartbeats so the hotspot does not tear down mid-stream. Docs and unit tests cover route matching, inventory merge, and activity tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46fc6e493da9b078bb28eff4033670b705485556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->