### PR TITLE
Report iOS Bluetooth SDK version in workspace builds

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
@@ -3,11 +3,14 @@ import Foundation
 /// Defaults for the public Bluetooth SDK surface.
 enum BluetoothSdkDefaults {
     static var sdkVersion: String? {
+        // Release exports replace the source placeholder; Expo builds stamp the host Info.plist.
         normalizedSdkVersion(swiftPackageSdkVersion)
+            ?? normalizedSdkVersion(Bundle.main.object(forInfoDictionaryKey: infoSdkVersionKey) as? String)
     }
 
     static let voiceActivityDetectionEnabled = false
     static let loudnessGateEnabled = true
+    private static let infoSdkVersionKey = "MentraBluetoothSdkVersion"
     private static let swiftPackageSdkVersion = "__MENTRA_BLUETOOTH_SDK_VERSION__"
     private static let swiftPackageSdkVersionPlaceholder = "__MENTRA" + "_BLUETOOTH_SDK_VERSION__"
 

--- a/mobile/modules/bluetooth-sdk/plugin/src/__tests__/withIos.test.ts
+++ b/mobile/modules/bluetooth-sdk/plugin/src/__tests__/withIos.test.ts
@@ -1,0 +1,27 @@
+const packageJson = require("../../../package.json")
+const {applyBluetoothSdkInfoPlist, INFO_SDK_VERSION} = require("../withIos")
+
+describe("Bluetooth SDK iOS config", () => {
+  it("stamps the package version into Info.plist for workspace builds", () => {
+    const infoPlist = applyBluetoothSdkInfoPlist({}, undefined)
+
+    expect(infoPlist[INFO_SDK_VERSION]).toBe(packageJson.version)
+  })
+
+  it("preserves analytics configuration while stamping the SDK version", () => {
+    const infoPlist = applyBluetoothSdkInfoPlist(
+      {
+        MentraBluetoothSdkPostHogApiKey: "stale-key",
+        MentraBluetoothSdkPostHogHost: "https://stale.example.com",
+      },
+      {analytics: false},
+    )
+
+    expect(infoPlist).toMatchObject({
+      [INFO_SDK_VERSION]: packageJson.version,
+      MentraBluetoothSdkAnalyticsDisabled: true,
+    })
+    expect(infoPlist).not.toHaveProperty("MentraBluetoothSdkPostHogApiKey")
+    expect(infoPlist).not.toHaveProperty("MentraBluetoothSdkPostHogHost")
+  })
+})

--- a/mobile/modules/bluetooth-sdk/plugin/src/withIos.ts
+++ b/mobile/modules/bluetooth-sdk/plugin/src/withIos.ts
@@ -2,13 +2,14 @@ import {execSync} from "child_process"
 import fs from "fs"
 import path from "path"
 
-import {type ConfigPlugin, withDangerousMod, withInfoPlist, withPodfile} from "expo/config-plugins"
+import {IOSConfig, type ConfigPlugin, withDangerousMod, withInfoPlist, withPodfile} from "expo/config-plugins"
 
 import {type BluetoothSdkPluginProps} from "./index"
 
 const BLUETOOTH_SDK_EXPO_ADAPTER_ENV = "MENTRA_BLUETOOTH_SDK_INCLUDE_EXPO_ADAPTER"
 const BLUETOOTH_SDK_EXPO_ADAPTER_LINE = `ENV['${BLUETOOTH_SDK_EXPO_ADAPTER_ENV}'] ||= '1'`
 const INFO_ANALYTICS_DISABLED = "MentraBluetoothSdkAnalyticsDisabled"
+export const INFO_SDK_VERSION = "MentraBluetoothSdkVersion"
 const STALE_INFO_POSTHOG_API_KEY = "MentraBluetoothSdkPostHogApiKey"
 const STALE_INFO_POSTHOG_HOST = "MentraBluetoothSdkPostHogHost"
 
@@ -75,18 +76,33 @@ function resolveAnalyticsProps(props: BluetoothSdkPluginProps | undefined) {
   }
 }
 
-function withAnalyticsInfoPlist(config: any, props: BluetoothSdkPluginProps | undefined) {
+export function applyBluetoothSdkInfoPlist(
+  infoPlist: IOSConfig.InfoPlist,
+  props: BluetoothSdkPluginProps | undefined,
+): IOSConfig.InfoPlist {
+  const packageJson = require("../../package.json") as {version?: unknown}
+  const sdkVersion = typeof packageJson.version === "string" ? packageJson.version.trim() : ""
+  if (!sdkVersion) {
+    throw new Error("@mentra/bluetooth-sdk package.json is missing a version")
+  }
+
+  const analytics = resolveAnalyticsProps(props)
+
+  delete infoPlist[INFO_ANALYTICS_DISABLED]
+  delete infoPlist[STALE_INFO_POSTHOG_API_KEY]
+  delete infoPlist[STALE_INFO_POSTHOG_HOST]
+
+  infoPlist[INFO_SDK_VERSION] = sdkVersion
+  if (analytics.disabled !== undefined) {
+    infoPlist[INFO_ANALYTICS_DISABLED] = analytics.disabled
+  }
+
+  return infoPlist
+}
+
+function withBluetoothSdkInfoPlist(config: any, props: BluetoothSdkPluginProps | undefined) {
   return withInfoPlist(config, (config) => {
-    const analytics = resolveAnalyticsProps(props)
-
-    delete config.modResults[INFO_ANALYTICS_DISABLED]
-    delete config.modResults[STALE_INFO_POSTHOG_API_KEY]
-    delete config.modResults[STALE_INFO_POSTHOG_HOST]
-
-    if (analytics.disabled !== undefined) {
-      config.modResults[INFO_ANALYTICS_DISABLED] = analytics.disabled
-    }
-
+    config.modResults = applyBluetoothSdkInfoPlist(config.modResults, props)
     return config
   })
 }
@@ -96,7 +112,7 @@ export const withIosConfiguration: ConfigPlugin<BluetoothSdkPluginProps> = (conf
     config.modResults.contents = ensureBluetoothSdkExpoAdapterPodEnv(config.modResults.contents)
     return config
   })
-  config = withAnalyticsInfoPlist(config, props)
+  config = withBluetoothSdkInfoPlist(config, props)
 
   if (props?.node) {
     config = withXcodeEnvLocal(config)


### PR DESCRIPTION
## Summary
- stamp the Bluetooth SDK package version into the iOS host Info.plist through the Expo config plugin
- fall back to that stamped value when the release-time Swift source placeholder is unresolved
- add regression coverage for version stamping and existing analytics configuration behavior

## Root cause
The iOS SDK only reported sdk_version when its Swift source placeholder had been replaced. npm packaging and the SwiftPM export replace that placeholder, but the Mentra App consumes the package directly from the monorepo workspace, so neither release step runs. The placeholder was rejected as invalid and sdk_version was omitted from PostHog events.

## Validation
- focused Jest suites: 18 tests passed
- mobile TypeScript compile
- ESLint on changed TypeScript files
- Swift typecheck and SwiftFormat lint
- Expo config introspection resolved MentraBluetoothSdkVersion to 0.1.21-dev.6
- npm prepack injection and restore path verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small iOS config-plugin and version-lookup change. It affects analytics/OTA version reporting, not auth or data handling.
> 
> **Overview**
> Fixes missing iOS `sdk_version` in monorepo/Expo workspace builds, where the Swift source placeholder is never replaced by npm/SwiftPM packaging.
> 
> The Expo iOS config plugin now writes `MentraBluetoothSdkVersion` from `package.json` into the host Info.plist (still applying existing analytics flags). `BluetoothSdkDefaults.sdkVersion` falls back to that plist value when the placeholder is invalid, so PostHog and OTA default-URL logic can see a real version.
> 
> Adds Jest coverage for version stamping and that analytics cleanup still runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e039f7c1a69f0fe96fcde6f5a3e5625975ba28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports the iOS Bluetooth SDK version in workspace builds by stamping `MentraBluetoothSdkVersion` into Info.plist via the Expo config plugin and reading it in Swift when the source placeholder is not replaced. Previously the SDK only reported a version when release steps replaced the Swift placeholder; now workspace builds report the version too.

- Extracts `applyBluetoothSdkInfoPlist` to set `MentraBluetoothSdkVersion` from the `@mentra/bluetooth-sdk` package version and to manage analytics keys; throws if the package version is missing.
- Swift falls back to Info.plist (`MentraBluetoothSdkVersion`) when the placeholder is unresolved.
- Removes stale `MentraBluetoothSdkPostHogApiKey` and `MentraBluetoothSdkPostHogHost`, and sets `MentraBluetoothSdkAnalyticsDisabled` when analytics are disabled.
- Adds tests covering version stamping and preserving analytics configuration.

<sup>Written for commit e7e039f7c1a69f0fe96fcde6f5a3e5625975ba28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

