### PR TITLE
Scope Miniapp SDK beta notice to Miniapp docs

### DIFF
--- a/mintlify-docs/app-devs/core-concepts/auth.mdx
+++ b/mintlify-docs/app-devs/core-concepts/auth.mdx
@@ -4,6 +4,10 @@ description: "Call your miniapp's backend as the signed-in Mentra user."
 icon: "key"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 If your miniapp has its own backend, `session.auth` lets you call it as the
 current Mentra user, with no login screen. The host hands your miniapp a signed
 token; your backend verifies it and gets the user's id. Two steps.

--- a/mintlify-docs/app-devs/core-concepts/blob.mdx
+++ b/mintlify-docs/app-devs/core-concepts/blob.mdx
@@ -4,6 +4,10 @@ description: "Persistent binary storage for files, images, and audio."
 icon: "box-archive"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.blob` stores arbitrary bytes (PDFs, EPUBs, audio, video, model files,
 caches) as files on the phone. It's scoped to the user and your miniapp, so your
 keys never collide with another miniapp's, and the files survive restarts. Where

--- a/mintlify-docs/app-devs/core-concepts/camera/photos.mdx
+++ b/mintlify-docs/app-devs/core-concepts/camera/photos.mdx
@@ -4,6 +4,10 @@ description: "Capture photos on camera glasses."
 icon: "camera"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.camera.takePhoto` captures a still on glasses that have a camera, like
 Mentra Live. It resolves after the photo is captured and uploaded, and hands you
 back a download URL.

--- a/mintlify-docs/app-devs/core-concepts/camera/videos.mdx
+++ b/mintlify-docs/app-devs/core-concepts/camera/videos.mdx
@@ -4,6 +4,10 @@ description: "Record video on camera glasses."
 icon: "video"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.camera` records video on glasses that have a camera, like Mentra Live.
 `startVideoRecording` returns a `recordingId`; pass it to `stopVideoRecording` to
 end the clip.

--- a/mintlify-docs/app-devs/core-concepts/cloud.mdx
+++ b/mintlify-docs/app-devs/core-concepts/cloud.mdx
@@ -4,6 +4,10 @@ description: "Read whether the phone is connected to MentraOS cloud."
 icon: "cloud"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.cloud` reports whether the phone currently has a connection to MentraOS
 cloud. The phone owns that connection. Your miniapp does not open, configure, or
 close it. This module only observes and reports the current state, so you can

--- a/mintlify-docs/app-devs/core-concepts/display/layouts.mdx
+++ b/mintlify-docs/app-devs/core-concepts/display/layouts.mdx
@@ -4,6 +4,10 @@ description: "Render scenes of positioned text, images, and shapes on the glasse
 icon: "display"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.display.render()` draws to the glasses HUD. Each call describes the
 whole frame: everything that should be on screen right now. The phone diffs it
 against the previous frame, so elements with a stable `id` update in place (no

--- a/mintlify-docs/app-devs/core-concepts/glasses.mdx
+++ b/mintlify-docs/app-devs/core-concepts/glasses.mdx
@@ -4,6 +4,10 @@ description: "Battery level and connection state of the glasses."
 icon: "glasses"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.glasses` reports on the glasses hardware: battery level plus charging
 state, and whether the glasses are connected. Both are subscriptions, so you get
 a callback whenever the value changes.

--- a/mintlify-docs/app-devs/core-concepts/heading.mdx
+++ b/mintlify-docs/app-devs/core-concepts/heading.mdx
@@ -4,6 +4,10 @@ description: "The phone's compass heading, as a continuous stream of degrees."
 icon: "compass"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.heading` reports the phone's compass heading. Subscribe with
 `onUpdate()` to get a `HeadingData` every time the heading changes.
 

--- a/mintlify-docs/app-devs/core-concepts/imu.mdx
+++ b/mintlify-docs/app-devs/core-concepts/imu.mdx
@@ -4,6 +4,10 @@ description: "Head-position events from the glasses inertial measurement unit."
 icon: "person-walking"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.imu` reports which way the wearer is looking. The glasses' inertial
 measurement unit resolves head pose into two states, `"up"` and `"down"`, and
 fires an event each time that state changes. Use it to wake content when someone

--- a/mintlify-docs/app-devs/core-concepts/input.mdx
+++ b/mintlify-docs/app-devs/core-concepts/input.mdx
@@ -4,6 +4,10 @@ description: "Glasses button presses and touchpad gestures."
 icon: "hand-pointer"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.input` delivers the physical controls on the glasses: button presses and
 touchpad gestures. The starter scaffold wires a button press to the display, so a
 short press shows a text wall.

--- a/mintlify-docs/app-devs/core-concepts/led/overview.mdx
+++ b/mintlify-docs/app-devs/core-concepts/led/overview.mdx
@@ -4,6 +4,10 @@ description: "Drive the indicator LED on glasses that have one."
 icon: "lightbulb"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.led` controls the indicator LED on supported glasses. You give it a
 color and a blink pattern, and it tells the LED to turn on or off.
 

--- a/mintlify-docs/app-devs/core-concepts/location.mdx
+++ b/mintlify-docs/app-devs/core-concepts/location.mdx
@@ -4,6 +4,10 @@ description: "The user's GPS position, as a one-shot fix or a continuous stream.
 icon: "location-dot"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.location` reports the phone's GPS position. Get a single fix with
 `getOnce()`, or subscribe to a stream with `onUpdate()`.
 

--- a/mintlify-docs/app-devs/core-concepts/microphone/audio-chunks.mdx
+++ b/mintlify-docs/app-devs/core-concepts/microphone/audio-chunks.mdx
@@ -4,6 +4,10 @@ description: "Raw audio frames and voice-activity detection from the glasses mic
 icon: "microphone"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.mic` is the low-level audio input: raw frames and a voice-activity
 signal. If you want text, use [`session.transcription`](/app-devs/core-concepts/microphone/speech-to-text)
 instead. Reach for `mic` when you need the audio itself, like recording a clip or

--- a/mintlify-docs/app-devs/core-concepts/microphone/speech-to-text.mdx
+++ b/mintlify-docs/app-devs/core-concepts/microphone/speech-to-text.mdx
@@ -4,6 +4,10 @@ description: "Real-time speech-to-text from the glasses microphone."
 icon: "message-captions"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.transcription` turns what the user says into text. Register a handler and
 you start getting results; the SDK handles the subscription for you.
 

--- a/mintlify-docs/app-devs/core-concepts/miniapp-interop.mdx
+++ b/mintlify-docs/app-devs/core-concepts/miniapp-interop.mdx
@@ -4,6 +4,10 @@ description: "Expose typed actions from your miniapp so Mentra AI can call them.
 icon: arrows-left-right
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 Your miniapp can expose **actions**: typed, described capabilities that Mentra AI
 can call to drive it. You declare each action in `miniapp.json` and handle it in
 your background layer. Mentra AI reads your declarations and decides when to call

--- a/mintlify-docs/app-devs/core-concepts/miniapp-manifest.mdx
+++ b/mintlify-docs/app-devs/core-concepts/miniapp-manifest.mdx
@@ -4,6 +4,10 @@ description: "Declare your miniapp's identity, entry points, permissions, and ha
 icon: "file-code"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 Every miniapp has a `miniapp.json` at its root. It declares who the miniapp is,
 where its two layers are built to, what permissions it needs, and what hardware
 it requires. The CLI validates it on every `dev`, `pack`, and `release`: bad

--- a/mintlify-docs/app-devs/core-concepts/navigation.mdx
+++ b/mintlify-docs/app-devs/core-concepts/navigation.mdx
@@ -4,6 +4,10 @@ description: "Turn-by-turn directions on the glasses, driven by the phone's GPS.
 icon: "route"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.navigation` runs a turn-by-turn trip. Call `start()` with a destination,
 then read live maneuvers from `onUpdate()` as the user moves. The phone owns the
 trip lifecycle; your miniapp starts it, listens, and stops it.

--- a/mintlify-docs/app-devs/core-concepts/permissions.mdx
+++ b/mintlify-docs/app-devs/core-concepts/permissions.mdx
@@ -4,6 +4,10 @@ description: "Query the permissions your miniapp declared, and react to changes.
 icon: "lock"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.permissions` tells you which permissions your miniapp declared in its
 [`miniapp.json`](/app-devs/core-concepts/miniapp-manifest). `has(type)` is a
 synchronous boolean, `getAll()` returns the full record, and `onUpdate` /

--- a/mintlify-docs/app-devs/core-concepts/phone.mdx
+++ b/mintlify-docs/app-devs/core-concepts/phone.mdx
@@ -4,6 +4,10 @@ description: "Phone notifications, calendar events, and phone battery."
 icon: "mobile"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.phone` reports state from the user's phone: notifications as they post,
 calendar events, and the phone's own battery. Each concern is its own sub-module.
 Register a handler and the events start arriving.

--- a/mintlify-docs/app-devs/core-concepts/session.mdx
+++ b/mintlify-docs/app-devs/core-concepts/session.mdx
@@ -4,6 +4,10 @@ description: "Your background-layer handle to everything on the glasses."
 icon: "plug"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 When your miniapp connects, the SDK hands your
 [`registerMiniapp`](/app-devs/core-concepts/two-layer-architecture#the-background-layer)
 handler a `session`. It lives in the **background layer**, and every capability

--- a/mintlify-docs/app-devs/core-concepts/speakers/text-to-speech.mdx
+++ b/mintlify-docs/app-devs/core-concepts/speakers/text-to-speech.mdx
@@ -4,6 +4,10 @@ description: "Play URLs, text-to-speech, and live PCM audio through the phone or
 icon: "volume"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.speaker` is audio output: play a URL, speak text, or stream live PCM.
 Playback follows the phone's media route, including connected Bluetooth audio
 glasses. For audio _input_ (mic frames, voice activity), use

--- a/mintlify-docs/app-devs/core-concepts/storage.mdx
+++ b/mintlify-docs/app-devs/core-concepts/storage.mdx
@@ -4,6 +4,10 @@ description: "Persistent key-value storage scoped to your miniapp."
 icon: "database"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.storage` is a phone-local key-value store. It's scoped to the user and
 your miniapp, so your keys never collide with another miniapp's, and the data
 survives restarts. Keys and values are both strings.

--- a/mintlify-docs/app-devs/core-concepts/stream.mdx
+++ b/mintlify-docs/app-devs/core-concepts/stream.mdx
@@ -4,6 +4,10 @@ description: "Live video streaming from camera glasses."
 icon: "tower-broadcast"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.stream` starts and stops a live video stream from camera glasses like
 Mentra Live. One method, `startStream`, covers both ways to stream: Mentra hosts
 it for you (the default), or you publish straight to a URL you own.

--- a/mintlify-docs/app-devs/core-concepts/system.mdx
+++ b/mintlify-docs/app-devs/core-concepts/system.mdx
@@ -4,6 +4,10 @@ description: "Phone-side OS actions: share sheet, downloads, clipboard, open URL
 icon: "share-nodes"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.system` runs OS-level actions on the phone: open the native share sheet,
 save a file through the system downloader, copy text to the clipboard, or open a
 URL in the phone browser. None of these need a permission or any hardware.

--- a/mintlify-docs/app-devs/core-concepts/translation.mdx
+++ b/mintlify-docs/app-devs/core-concepts/translation.mdx
@@ -4,6 +4,10 @@ description: "Real-time translation of speech from the glasses microphone."
 icon: "language"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `session.translation` turns spoken speech into translated text. Register a handler
 for the language pair you care about and results start arriving; the SDK handles
 the subscription for you.

--- a/mintlify-docs/app-devs/core-concepts/two-layer-architecture.mdx
+++ b/mintlify-docs/app-devs/core-concepts/two-layer-architecture.mdx
@@ -4,6 +4,10 @@ description: "How a miniapp's always-on background and on-demand UI layers work 
 icon: "layer-group"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 Every Mentra miniapp has two layers. Understanding the split is the key to the
 whole SDK: it determines where your code runs, what it can reach, and how the
 two halves communicate.

--- a/mintlify-docs/app-devs/core-concepts/webviews/react-webviews.mdx
+++ b/mintlify-docs/app-devs/core-concepts/webviews/react-webviews.mdx
@@ -4,6 +4,10 @@ description: "Build the miniapp's WebView UI with React, talking to the backgrou
 icon: "browser"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 The UI layer is the on-demand half of a [two-layer miniapp](/app-devs/core-concepts/two-layer-architecture). It is a normal React app that mounts when the user opens your tile and is destroyed when they leave. It has zero direct hardware access. To reach the glasses it sends messages to its own [background layer](/app-devs/core-concepts/session), which holds the `session` and translates those messages into `session.*` calls. The bridge is a single injected global named `mentra`.
 
 The entry point is small: create a React root, wrap it in `<MentraProvider>`, and call `mentra.ready()`.

--- a/mintlify-docs/app-devs/core-concepts/webviews/safe-areas.mdx
+++ b/mintlify-docs/app-devs/core-concepts/webviews/safe-areas.mdx
@@ -4,6 +4,10 @@ description: "Lay out your webview UI around the host chrome: notch insets and t
 icon: "crop"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 Your miniapp UI runs in a WebView inside the Mentra App, and the host draws its
 own chrome on top. Two things overlap your content: the device safe-area insets
 (notch, status bar, rounded corners) and a floating **capsule menu** the host

--- a/mintlify-docs/app-devs/getting-started/ai-ide-integration.mdx
+++ b/mintlify-docs/app-devs/getting-started/ai-ide-integration.mdx
@@ -4,6 +4,10 @@ description: "Connect your AI coding assistant to MentraOS docs for smarter deve
 icon: "robot"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 <Info>
 **TL;DR** - Get your AI coding assistant to understand MentraOS instantly. Works with Zed, Cursor, VS Code, Windsurf, Claude Code, and more.
 </Info>

--- a/mintlify-docs/app-devs/getting-started/distribution.mdx
+++ b/mintlify-docs/app-devs/getting-started/distribution.mdx
@@ -7,12 +7,12 @@ icon: "upload"
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'
 import BetaNote from '/snippets/beta-note.mdx'
 
+<BetaNote />
+
 A miniapp is a **bundle that runs on the user's phone**: there's no server to
 host, no domain, no uptime to manage. Distribution means producing that bundle
 and getting it installed. There are three ways to get a miniapp onto a device,
 from quickest to widest reach.
-
-<BetaNote />
 
 <LegacyCloudNote />
 

--- a/mintlify-docs/app-devs/getting-started/example-apps.mdx
+++ b/mintlify-docs/app-devs/getting-started/example-apps.mdx
@@ -3,6 +3,10 @@ title: Example miniapps
 description: "Working miniapps to start from: the scaffolder starter, the in-repo reference, and first-party apps shipped in this repo."
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 There are three ways to get working code in front of you: scaffold a fresh
 project, read the in-repo reference miniapp, or browse the first-party miniapps
 that ship in this repo.
@@ -48,9 +52,8 @@ bun dev
 ```
 
 `bun dev` validates the manifest, builds both layers, serves them over your LAN,
-and prints a QR code. Scan it from **Mentra App → Settings → Developer settings →
-Mini App Development → Scan Mini App QR Code** (phone and laptop on the same
-Wi-Fi).
+and prints a QR code. In the Mentra App, scan it from **Settings → Miniapp
+Developer Settings → Scan Miniapp QR Code** (phone and laptop on the same Wi-Fi).
 
 ## First-party miniapps in this repo
 

--- a/mintlify-docs/app-devs/getting-started/overview.mdx
+++ b/mintlify-docs/app-devs/getting-started/overview.mdx
@@ -6,6 +6,8 @@ description: "Build on-device apps for smart glasses with the Mentra Miniapp SDK
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'
 import BetaNote from '/snippets/beta-note.mdx'
 
+<BetaNote />
+
 MentraOS is the operating system for smart glasses. A **miniapp** is an app that
 runs on the user's phone, inside the Mentra App, and drives the glasses through the
 Mentra Miniapp SDK (`@mentra/miniapp`). You write a bundle, the user installs it
@@ -15,8 +17,6 @@ from the Mentra Miniapp Store, and it runs on their device.
 Building a mobile app that connects directly to glasses over Bluetooth? Use the
 [Bluetooth SDK docs](/mentra-live/overview) instead.
 </Info>
-
-<BetaNote />
 
 <LegacyCloudNote />
 

--- a/mintlify-docs/app-devs/getting-started/quickstart.mdx
+++ b/mintlify-docs/app-devs/getting-started/quickstart.mdx
@@ -6,6 +6,8 @@ description: Scaffold a Mentra miniapp and run it on your phone in a few minutes
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'
 import BetaNote from '/snippets/beta-note.mdx'
 
+<BetaNote />
+
 This Quickstart goes from zero to a miniapp running on your glasses. You need a
 phone, [Bun](https://bun.sh/docs/installation), and basic TypeScript. You can do
 the whole thing **without glasses**: the display just won't have anywhere to draw.
@@ -14,8 +16,6 @@ the whole thing **without glasses**: the display just won't have anywhere to dra
 Building a mobile app that connects directly to glasses over Bluetooth? Use the
 [Bluetooth SDK Quickstart](/mentra-live/quickstart) instead.
 </Info>
-
-<BetaNote />
 
 <LegacyCloudNote />
 

--- a/mintlify-docs/app-devs/reference/cli.mdx
+++ b/mintlify-docs/app-devs/reference/cli.mdx
@@ -4,6 +4,10 @@ description: "The author CLI for developing, packing, and releasing Mentra minia
 icon: "terminal"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 `@mentra/miniapp-cli` provides the `mentra-miniapp` command. It's installed as a
 dev dependency in every scaffolded project, so your `package.json` scripts call
 it directly (`"dev": "mentra-miniapp dev"`).
@@ -44,9 +48,9 @@ every 10 seconds and reprints the QR.
 The starting port comes from `"port"` in `miniapp.json` (default `3000`); if it or
 its sidecar neighbor is busy, the CLI scans upward for a free adjacent pair.
 
-**On the phone:** Mentra App → **Settings → Developer settings → Mini App
-Development → Scan Mini App QR Code**. Phone and laptop must share Wi-Fi. `Ctrl+C`
-stops everything.
+**On the phone:** In the Mentra App, open **Settings → Miniapp Developer Settings
+→ Scan Miniapp QR Code**. Phone and laptop must share Wi-Fi. `Ctrl+C` stops
+everything.
 
 <Warning>
 `dev` is live and temporary. Keep the CLI and computer running: the Mentra App

--- a/mintlify-docs/app-devs/reference/system-apis.mdx
+++ b/mintlify-docs/app-devs/reference/system-apis.mdx
@@ -4,6 +4,10 @@ description: "APIs restricted to system miniapps for discovering, launching, and
 icon: "shield-halved"
 ---
 
+import BetaNote from '/snippets/beta-note.mdx'
+
+<BetaNote />
+
 <Warning>
 These APIs are restricted to **system miniapps** (Mentra AI today). A regular
 miniapp that calls them gets `NOT_PERMITTED`. They're documented here for

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -2,10 +2,6 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
   "name": "MentraOS",
-  "banner": {
-    "content": "**Beta.** The Mentra Miniapp SDK and these docs are subject to change. Enable it at **Settings → Debug Settings → Miniapp Developer Settings** in the Mentra App. Send feedback with an in-app bug report, on [Discord](https://discord.gg/5ukNvkEAqT), or by [email](mailto:help@mentra.glass).",
-    "dismissible": false
-  },
   "colors": {
     "primary": "#00b869",
     "light": "#00b869",

--- a/mintlify-docs/mentra-live/overview.mdx
+++ b/mintlify-docs/mentra-live/overview.mdx
@@ -8,8 +8,6 @@ The Mentra Bluetooth SDK is the base SDK for building mobile apps that control M
 
 Use this SDK when your app owns the mobile experience and needs a direct phone-to-glasses connection.
 
-In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run on the phone. Learn more in the [MentraOS Roadmap June blogpost](https://mentraglass.com/blogs/blog/mentra-roadmap-update-moving-to-miniapps-on-the-phone).
-
 ## Packages
 
 | Platform | Package | Import |

--- a/mintlify-docs/snippets/beta-note.mdx
+++ b/mintlify-docs/snippets/beta-note.mdx
@@ -1,16 +1,14 @@
-<Warning>
-  **The Mentra Miniapp SDK is in beta.** It has not been thoroughly tested yet,
-  so it ships behind a developer toggle in the Mentra App rather than on by
-  default. Open **Settings → Debug Settings**, enable **Miniapp Developer
-  Settings**, then return to Settings and open **Miniapp Developer Settings**.
-  If Debug Settings is hidden, tap the version number at the bottom of Settings
-  ten times to reveal it.
+<Note>
+  **Mentra Miniapp SDK beta**
 
-  These docs describe the SDK as it stands today. Both the SDK and the docs are
-  subject to change, and some of it will change based on what beta testers run
-  into.
+  The SDK is in beta, so its APIs may change before general availability.
 
-  Please tell us what you hit. File a bug report from inside the Mentra App,
-  post on [Discord](https://discord.gg/5ukNvkEAqT), or email
+  To enable miniapp development, open **Settings** in the Mentra App and tap the
+  version number at the bottom ten times. Then open **Debug Settings**, turn on
+  **Miniapp Developer Settings**, return to **Settings**, and open **Miniapp
+  Developer Settings**.
+
+  Share feedback with an in-app bug report, on
+  [Discord](https://discord.gg/5ukNvkEAqT), or by email at
   [help@mentra.glass](mailto:help@mentra.glass).
-</Warning>
+</Note>


### PR DESCRIPTION
## Summary
- remove the site-wide beta banner so Mentra Live and other docs are no longer labeled beta
- show one reusable beta note at the top of every Miniapp Development page
- rewrite the notice with concise API-stability language and complete steps for revealing Debug Settings
- normalize Miniapp Developer Settings QR-code paths in the CLI and example docs
- remove the outdated MentraOS 3.0 roadmap callout from the Mentra Live overview

## Test plan
- npx --yes mint export --output /tmp/mentraos-docs-miniapp-beta.zip
- verified all 35 Miniapp Development pages render the note and no pages outside that section do
- searched the Mintlify docs for other dated roadmap and future-release callouts
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and navigation-path updates; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Stops labeling the whole docs site as beta. Mentra Live and other sections no longer inherit a global banner; Miniapp Development pages now show a reusable `<BetaNote />` at the top.
> 
> Rewrites `snippets/beta-note.mdx` from a Warning to a shorter Note: APIs may change, plus the full “tap version 10 times → Debug Settings → Miniapp Developer Settings” enable path. Aligns QR-scan instructions in the CLI and example-app docs to **Settings → Miniapp Developer Settings**. Drops the Summer 2026 MentraOS 3.0 teaser from the Mentra Live overview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea40a01f79193a5fa4ef2ee254255ec0b97db6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->