### PR TITLE
Differentiate documentation navigation icons

### DIFF
--- a/mintlify-docs/app-devs/core-concepts/camera/photos.mdx
+++ b/mintlify-docs/app-devs/core-concepts/camera/photos.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Photos"
 description: "Capture photos on camera glasses."
-icon: "camera"
+icon: "image"
 ---
 
 import BetaNote from '/snippets/beta-note.mdx'

--- a/mintlify-docs/app-devs/core-concepts/display/layouts.mdx
+++ b/mintlify-docs/app-devs/core-concepts/display/layouts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Display"
 description: "Render scenes of positioned text, images, and shapes on the glasses."
-icon: "display"
+icon: "layer-group"
 ---
 
 import BetaNote from '/snippets/beta-note.mdx'

--- a/mintlify-docs/app-devs/core-concepts/phone.mdx
+++ b/mintlify-docs/app-devs/core-concepts/phone.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Phone"
 description: "Phone notifications, calendar events, and phone battery."
-icon: "mobile"
+icon: "phone"
 ---
 
 import BetaNote from '/snippets/beta-note.mdx'

--- a/mintlify-docs/app-devs/core-concepts/storage.mdx
+++ b/mintlify-docs/app-devs/core-concepts/storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Storage"
 description: "Persistent key-value storage scoped to your miniapp."
-icon: "database"
+icon: "hard-drive"
 ---
 
 import BetaNote from '/snippets/beta-note.mdx'

--- a/mintlify-docs/app-devs/core-concepts/webviews/react-webviews.mdx
+++ b/mintlify-docs/app-devs/core-concepts/webviews/react-webviews.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The UI layer"
 description: "Build the miniapp's WebView UI with React, talking to the background over the injected mentra global."
-icon: "browser"
+icon: "code"
 ---
 
 import BetaNote from '/snippets/beta-note.mdx'

--- a/mintlify-docs/app-devs/getting-started/example-apps.mdx
+++ b/mintlify-docs/app-devs/getting-started/example-apps.mdx
@@ -1,6 +1,7 @@
 ---
 title: Example miniapps
 description: "Working miniapps to start from: the scaffolder starter, the in-repo reference, and first-party apps shipped in this repo."
+icon: "code"
 ---
 
 import BetaNote from '/snippets/beta-note.mdx'

--- a/mintlify-docs/app-devs/getting-started/overview.mdx
+++ b/mintlify-docs/app-devs/getting-started/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
 description: "Build on-device apps for smart glasses with the Mentra Miniapp SDK."
+icon: "compass"
 ---
 
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'

--- a/mintlify-docs/app-devs/getting-started/quickstart.mdx
+++ b/mintlify-docs/app-devs/getting-started/quickstart.mdx
@@ -1,6 +1,7 @@
 ---
 title: Quickstart
 description: Scaffold a Mentra miniapp and run it on your phone in a few minutes.
+icon: "rocket"
 ---
 
 import LegacyCloudNote from '/snippets/legacy-cloud-note.mdx'

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -119,7 +119,7 @@
         "groups": [
           {
             "group": "Getting Started",
-            "icon": "bluetooth",
+            "icon": "compass",
             "pages": [
               "bluetooth-sdk/overview",
               "bluetooth-sdk/quickstart",
@@ -130,7 +130,7 @@
           },
           {
             "group": "Platform Setup",
-            "icon": "mobile",
+            "icon": "gears",
             "pages": ["bluetooth-sdk/react-native-expo", "bluetooth-sdk/android", "bluetooth-sdk/ios"]
           },
           {


### PR DESCRIPTION
## Summary
- distinguish Bluetooth SDK Getting Started and Platform Setup group icons from their first pages
- add icons to the Miniapp SDK Overview, Quickstart, and Example miniapps pages
- distinguish the UI Layer, Display, Camera, Phone and System, and Data group icons from their first page icons

## Test plan
- npx --yes mint export --output /tmp/mentraos-docs-navigation-icons.zip
- verified all 56 pages export successfully
- validated docs.json as JSON
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic documentation icon changes only; no runtime, auth, or data-handling code.
> 
> **Overview**
> Makes Mintlify sidebar icons unique so nav **groups** no longer share the same glyph as their first page.
> 
> Bluetooth SDK groups switch to `compass` (Getting Started) and `gears` (Platform Setup). Miniapp SDK getting-started pages gain icons (`compass`, `rocket`, `code`), and first-page icons for Photos, Display, Phone, Storage, and the UI layer are retargeted so they no longer collide with their parent groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5e126c1c23534833f7c506b39e05bd2c0247d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Differentiate documentation navigation icons so groups no longer mirror their first page and add missing icons to key Miniapp SDK pages. This is a visual-only change that improves sidebar scanability.

- Group icons in `mintlify-docs/docs.json`: Bluetooth SDK “Getting Started” uses `compass` (was `bluetooth`); “Platform Setup” uses `gears` (was `mobile`).
- Added page icons: Getting Started Overview → `compass`; Quickstart → `rocket`; Example miniapps → `code`.
- Updated core concept page icons to avoid collisions and better reflect content: UI layer (React WebViews) → `code` (was `browser`); Display → `layer-group` (was `display`); Camera Photos → `image` (was `camera`); Phone → `phone` (was `mobile`); Storage → `hard-drive` (was `database`).
- Review: verify Mintlify recognizes the new icon slugs and the sidebar shows unique group/page icons; no content, routes, or links changed.

<sup>Written for commit 9a5e126c1c23534833f7c506b39e05bd2c0247d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

