### PR TITLE
Fix Android gallery performance for large libraries

### DIFF
--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -14,7 +14,9 @@ import {
   Animated,
   BackHandler,
   Dimensions,
+  FlatList,
   ImageStyle,
+  Platform,
   Pressable,
   TextStyle,
   TouchableOpacity,
@@ -25,6 +27,10 @@ import * as RNFS from "@dr.pogodin/react-native-fs"
 import {createShimmerPlaceholder} from "react-native-shimmer-placeholder"
 
 import {createMediaViewerSnapshot, MediaViewer} from "@/components/glasses/Gallery/MediaViewer"
+import {
+  createGalleryLoadCoordinator,
+  type GalleryLoadOptions,
+} from "@/components/glasses/Gallery/galleryLoadCoordinator"
 import {PhotoImage} from "@/components/glasses/Gallery/PhotoImage"
 import {ProgressRing} from "@/components/glasses/Gallery/ProgressRing"
 import {validateGalleryFiles} from "@/components/glasses/Gallery/validateGalleryFiles"
@@ -32,7 +38,7 @@ import {Header, Icon, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {useNavigationStore} from "@/stores/navigation"
-import {translate} from "@/i18n"
+import {isRTL, translate} from "@/i18n"
 import {engine, MediaLibraryPermissions, SETTINGS, useSetting} from "@mentra/engine"
 import {cameraRollExportCoordinator, localStorageService} from "@mentra/engine/internal"
 import {spacing, ThemedStyle} from "@/theme"
@@ -72,7 +78,6 @@ interface GalleryItem {
 
 const getGalleryItemType = (item: GalleryItem) => item.type
 const getGalleryItemKey = (item: GalleryItem) => item.id
-const GalleryItemSeparator = () => <View style={$itemSeparator} />
 
 export function GalleryScreen() {
   const {push} = useNavigationStore.getState()
@@ -110,7 +115,7 @@ export function GalleryScreen() {
   const [viewerPhotos, setViewerPhotos] = useState<PhotoInfo[]>([])
   const [viewerInitialIndex, setViewerInitialIndex] = useState(0)
   const galleryPhotosRef = useRef<GalleryItem[]>([])
-  const galleryLoadPromiseRef = useRef<Promise<void> | null>(null)
+  const galleryLoadCoordinator = useMemo(() => createGalleryLoadCoordinator(), [])
 
   // Photo sync states for UI (progress rings on thumbnails)
   const [photoSyncStates, setPhotoSyncStates] = useState<
@@ -347,18 +352,12 @@ export function GalleryScreen() {
     }
   }, [completedFiles])
 
-  // Mount and focus happen together when this route opens. Coalesce those callers
-  // so a large library is never scanned twice at the same time.
-  const loadDownloadedPhotos = useCallback(() => {
-    if (galleryLoadPromiseRef.current) return galleryLoadPromiseRef.current
-
-    const request = performGalleryLoad()
-    galleryLoadPromiseRef.current = request
-    void request.finally(() => {
-      if (galleryLoadPromiseRef.current === request) galleryLoadPromiseRef.current = null
-    })
-    return request
-  }, [performGalleryLoad])
+  // Mount and focus can share their lifecycle scan. Calls after a storage mutation
+  // (sync completion or deletion) queue one fresh pass if a scan is already active.
+  const loadDownloadedPhotos = useCallback(
+    (options?: GalleryLoadOptions) => galleryLoadCoordinator.run(performGalleryLoad, options),
+    [galleryLoadCoordinator, performGalleryLoad],
+  )
 
   // Initialize pending status for all files when sync starts
   useEffect(() => {
@@ -801,7 +800,7 @@ export function GalleryScreen() {
       setShowLoadingPlaceholders(true)
     }, 150) // Delay showing placeholders by 150ms
 
-    loadDownloadedPhotos().finally(() => {
+    loadDownloadedPhotos({refreshAfterCurrent: false}).finally(() => {
       const completeTime = Date.now()
       console.log(
         "[GalleryScreen] ⏱️ FINALLY BLOCK at",
@@ -840,7 +839,7 @@ export function GalleryScreen() {
   useFocusEffect(
     useCallback(() => {
       console.log("[GalleryScreen] Screen focused - refreshing downloaded photos")
-      loadDownloadedPhotos()
+      loadDownloadedPhotos({refreshAfterCurrent: false})
     }, []),
   )
 
@@ -1400,30 +1399,55 @@ export function GalleryScreen() {
             } else {
               return (
                 <Animated.View style={{flex: 1, opacity: fadeAnim}}>
-                  <FlashList
-                    data={displayItems}
-                    numColumns={numColumns}
-                    key={numColumns}
-                    renderItem={renderPhotoItem}
-                    keyExtractor={getGalleryItemKey}
-                    getItemType={getGalleryItemType}
-                    drawDistance={itemWidth * 2}
-                    maxItemsInRecyclePool={numColumns * 4}
-                    maintainVisibleContentPosition={{disabled: true}}
-                    contentContainerStyle={[
-                      themed($photoGridContent),
-                      {
-                        paddingBottom: shouldShowSyncButton
-                          ? 100 + insets.bottom + spacing.s6
-                          : spacing.s6 + insets.bottom,
-                      },
-                    ]}
-                    ItemSeparatorComponent={GalleryItemSeparator}
-                    scrollEventThrottle={16}
-                    bounces={false}
-                    overScrollMode="never"
-                    decelerationRate="fast"
-                  />
+                  {isRTL ? (
+                    <FlatList
+                      data={displayItems}
+                      numColumns={numColumns}
+                      key={numColumns}
+                      renderItem={renderPhotoItem}
+                      keyExtractor={getGalleryItemKey}
+                      contentContainerStyle={[
+                        themed($photoGridContent),
+                        {
+                          paddingBottom: shouldShowSyncButton
+                            ? 100 + insets.bottom + spacing.s6
+                            : spacing.s6 + insets.bottom,
+                        },
+                      ]}
+                      initialNumToRender={12}
+                      maxToRenderPerBatch={12}
+                      windowSize={5}
+                      removeClippedSubviews={Platform.OS === "android"}
+                      scrollEventThrottle={16}
+                      bounces={false}
+                      overScrollMode="never"
+                      decelerationRate="fast"
+                    />
+                  ) : (
+                    <FlashList
+                      data={displayItems}
+                      numColumns={numColumns}
+                      key={numColumns}
+                      renderItem={renderPhotoItem}
+                      keyExtractor={getGalleryItemKey}
+                      getItemType={getGalleryItemType}
+                      drawDistance={itemWidth * 2}
+                      maxItemsInRecyclePool={numColumns * 4}
+                      maintainVisibleContentPosition={{disabled: true}}
+                      contentContainerStyle={[
+                        themed($photoGridContent),
+                        {
+                          paddingBottom: shouldShowSyncButton
+                            ? 100 + insets.bottom + spacing.s6
+                            : spacing.s6 + insets.bottom,
+                        },
+                      ]}
+                      scrollEventThrottle={16}
+                      bounces={false}
+                      overScrollMode="never"
+                      decelerationRate="fast"
+                    />
+                  )}
                 </Animated.View>
               )
             }
@@ -1455,11 +1479,10 @@ const $screenContainer: ThemedStyle<ViewStyle> = ({spacing}) => ({
 })
 
 const $photoGridContent: ThemedStyle<ViewStyle> = ({spacing}) => ({
-  paddingHorizontal: spacing.s3, // Add padding on left and right edges
+  // Cell margins provide the inner half of the edge padding and both column gutters.
+  paddingHorizontal: spacing.s3 - ITEM_SPACING / 2,
   paddingTop: 0,
 })
-
-const $itemSeparator: ViewStyle = {height: ITEM_SPACING}
 
 const $loadingSpinnerContainer: ThemedStyle<ViewStyle> = () => ({
   flex: 1,
@@ -1500,7 +1523,8 @@ const $photoItem: ThemedStyle<ViewStyle> = () => ({
   borderRadius: 0,
   overflow: "hidden",
   backgroundColor: "rgba(0,0,0,0.05)",
-  // No marginBottom needed - ItemSeparatorComponent handles vertical spacing to match horizontal gap
+  marginHorizontal: ITEM_SPACING / 2,
+  marginBottom: ITEM_SPACING,
 })
 
 const $photoImage: ThemedStyle<ImageStyle> = () => ({

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -5,6 +5,7 @@
 
 import {getModelCapabilities} from "@/../../cloud/packages/types/src"
 import {MaterialCommunityIcons} from "@expo/vector-icons"
+import {FlashList} from "@shopify/flash-list"
 import LinearGradient from "expo-linear-gradient"
 import {useFocusEffect} from "expo-router"
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
@@ -13,7 +14,6 @@ import {
   Animated,
   BackHandler,
   Dimensions,
-  FlatList,
   ImageStyle,
   Pressable,
   TextStyle,
@@ -27,6 +27,7 @@ import {createShimmerPlaceholder} from "react-native-shimmer-placeholder"
 import {createMediaViewerSnapshot, MediaViewer} from "@/components/glasses/Gallery/MediaViewer"
 import {PhotoImage} from "@/components/glasses/Gallery/PhotoImage"
 import {ProgressRing} from "@/components/glasses/Gallery/ProgressRing"
+import {validateGalleryFiles} from "@/components/glasses/Gallery/validateGalleryFiles"
 import {Header, Icon, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
@@ -51,6 +52,7 @@ const TIMING = {
   PROGRESS_RING_DISPLAY_MS: 3000, // How long to show completed/failed progress rings
   ALERT_DELAY_MS: 100, // Delay before showing alerts to allow UI to settle
 } as const
+const ITEM_SPACING = 2
 
 /** Format video duration in milliseconds to m:ss display string */
 function formatDuration(ms: number): string {
@@ -68,6 +70,10 @@ interface GalleryItem {
   isOnServer?: boolean
 }
 
+const getGalleryItemType = (item: GalleryItem) => item.type
+const getGalleryItemKey = (item: GalleryItem) => item.id
+const GalleryItemSeparator = () => <View style={$itemSeparator} />
+
 export function GalleryScreen() {
   const {push} = useNavigationStore.getState()
   const {theme, themed} = useAppTheme()
@@ -75,7 +81,6 @@ export function GalleryScreen() {
 
   // Column calculation - 3 per row like Google Photos / Apple Photos
   const screenWidth = Dimensions.get("window").width
-  const ITEM_SPACING = 2 // Minimal spacing between items (1-2px hairline)
   const HORIZONTAL_PADDING = spacing.s3 * 2 // Padding on left and right edges (12px * 2 = 24px)
   const numColumns = screenWidth < 320 ? 2 : 3 // 2 columns for very small screens, otherwise 3
   const itemWidth = (screenWidth - HORIZONTAL_PADDING - ITEM_SPACING * (numColumns - 1)) / numColumns
@@ -105,6 +110,7 @@ export function GalleryScreen() {
   const [viewerPhotos, setViewerPhotos] = useState<PhotoInfo[]>([])
   const [viewerInitialIndex, setViewerInitialIndex] = useState(0)
   const galleryPhotosRef = useRef<GalleryItem[]>([])
+  const galleryLoadPromiseRef = useRef<Promise<void> | null>(null)
 
   // Photo sync states for UI (progress rings on thumbnails)
   const [photoSyncStates, setPhotoSyncStates] = useState<
@@ -234,7 +240,7 @@ export function GalleryScreen() {
   }, [downloadedPhotos.length])
 
   // Load downloaded photos (validates files exist and cleans up stale entries)
-  const loadDownloadedPhotos = useCallback(async () => {
+  const performGalleryLoad = useCallback(async () => {
     const loadStartTime = Date.now()
     console.log("[GalleryScreen] ⏱️ LOAD START at", loadStartTime)
     try {
@@ -267,45 +273,14 @@ export function GalleryScreen() {
       const validPhotoInfos: PhotoInfo[] = []
       const staleFileNames: string[] = []
 
-      // Check all files exist on disk in parallel (50-100x faster than sequential).
+      // Check all files with bounded concurrency. Scheduling thousands of native
+      // exists/stat calls together overwhelms the Android bridge on large galleries.
       // Returns one of three states per entry:
       //   "ok"           — keep the metadata, file is present and non-empty
       //   "stale"        — drop the metadata (file missing OR zero-byte)
       //   "unknown"      — keep the metadata (transient stat error; don't lose entries)
       // Zero-byte files also flag for disk unlink so they don't accumulate.
-      const validationPromises = Object.entries(downloadedFiles).map(async ([name, file]) => {
-        let status: "ok" | "stale" | "unknown" = "unknown"
-        let shouldUnlink = false
-        try {
-          const fileExists = await RNFS.exists(file.filePath)
-          if (!fileExists) {
-            status = "stale"
-          } else {
-            try {
-              const stat = await RNFS.stat(file.filePath)
-              if (stat.size > 0) {
-                status = "ok"
-              } else {
-                console.warn(`[GalleryScreen] Removing zero-byte local file from gallery index: ${name}`)
-                status = "stale"
-                shouldUnlink = true
-              }
-            } catch (statError) {
-              // Transient stat failure — keep the metadata so we don't permanently
-              // drop a still-valid entry on a one-off filesystem hiccup.
-              console.warn(`[GalleryScreen] Could not stat local file ${name}:`, statError)
-              status = "unknown"
-            }
-          }
-        } catch (existsError) {
-          console.warn(`[GalleryScreen] Could not check existence of local file ${name}:`, existsError)
-          status = "unknown"
-        }
-        return {name, file, status, shouldUnlink}
-      })
-
-      // Wait for all validations to complete (happens in parallel)
-      const validationResults = await Promise.all(validationPromises)
+      const validationResults = await validateGalleryFiles(Object.entries(downloadedFiles))
 
       // Process results
       const filesToUnlink: string[] = []
@@ -348,9 +323,6 @@ export function GalleryScreen() {
         "ms",
       )
       console.log(`[GalleryScreen] ✅ Loaded ${validPhotoInfos.length} valid photos`)
-      validPhotoInfos.forEach((photo, idx) => {
-        console.log(`[GalleryScreen]   ${idx + 1}. ${photo.name}`)
-      })
 
       // Add test data in development mode
       if (ENABLE_TEST_GALLERY_DATA) {
@@ -374,6 +346,19 @@ export function GalleryScreen() {
       setValidatingCount(0)
     }
   }, [completedFiles])
+
+  // Mount and focus happen together when this route opens. Coalesce those callers
+  // so a large library is never scanned twice at the same time.
+  const loadDownloadedPhotos = useCallback(() => {
+    if (galleryLoadPromiseRef.current) return galleryLoadPromiseRef.current
+
+    const request = performGalleryLoad()
+    galleryLoadPromiseRef.current = request
+    void request.finally(() => {
+      if (galleryLoadPromiseRef.current === request) galleryLoadPromiseRef.current = null
+    })
+    return request
+  }, [performGalleryLoad])
 
   // Initialize pending status for all files when sync starts
   useEffect(() => {
@@ -1206,9 +1191,9 @@ export function GalleryScreen() {
     )
   }
 
-  // Memoize renderPhotoItem to prevent FlatList scroll interruptions
+  // Memoize renderPhotoItem so recycled cells only update when their UI state changes.
   // CRITICAL: Without useCallback, this function is recreated on every render,
-  // causing FlatList to lose scroll momentum
+  // causing the virtualized grid to lose scroll momentum.
   const renderPhotoItem = useCallback(
     ({item}: {item: GalleryItem}) => {
       if (!item.photo) {
@@ -1415,12 +1400,16 @@ export function GalleryScreen() {
             } else {
               return (
                 <Animated.View style={{flex: 1, opacity: fadeAnim}}>
-                  <FlatList
+                  <FlashList
                     data={displayItems}
                     numColumns={numColumns}
                     key={numColumns}
                     renderItem={renderPhotoItem}
-                    keyExtractor={(item) => item.id}
+                    keyExtractor={getGalleryItemKey}
+                    getItemType={getGalleryItemType}
+                    drawDistance={itemWidth * 2}
+                    maxItemsInRecyclePool={numColumns * 4}
+                    maintainVisibleContentPosition={{disabled: true}}
                     contentContainerStyle={[
                       themed($photoGridContent),
                       {
@@ -1429,13 +1418,7 @@ export function GalleryScreen() {
                           : spacing.s6 + insets.bottom,
                       },
                     ]}
-                    columnWrapperStyle={numColumns > 1 ? themed($columnWrapper) : undefined}
-                    ItemSeparatorComponent={() => <View style={{height: ITEM_SPACING}} />}
-                    initialNumToRender={21}
-                    maxToRenderPerBatch={21}
-                    windowSize={7}
-                    removeClippedSubviews={false}
-                    updateCellsBatchingPeriod={50}
+                    ItemSeparatorComponent={GalleryItemSeparator}
                     scrollEventThrottle={16}
                     bounces={false}
                     overScrollMode="never"
@@ -1476,10 +1459,7 @@ const $photoGridContent: ThemedStyle<ViewStyle> = ({spacing}) => ({
   paddingTop: 0,
 })
 
-const $columnWrapper: ThemedStyle<ViewStyle> = () => ({
-  justifyContent: "flex-start",
-  gap: 2,
-})
+const $itemSeparator: ViewStyle = {height: ITEM_SPACING}
 
 const $loadingSpinnerContainer: ThemedStyle<ViewStyle> = () => ({
   flex: 1,

--- a/mobile/src/components/glasses/Gallery/PhotoImage.test.tsx
+++ b/mobile/src/components/glasses/Gallery/PhotoImage.test.tsx
@@ -1,0 +1,69 @@
+import {render} from "@testing-library/react-native"
+
+import {PhotoInfo} from "@/types/asg"
+
+import {PhotoImage} from "./PhotoImage"
+
+let mockImageProps: Record<string, unknown> = {}
+
+jest.mock("expo-image", () => {
+  const React = require("react")
+  const {View} = require("react-native")
+  return {
+    Image: (props: Record<string, unknown>) => {
+      mockImageProps = props
+      return React.createElement(View, {testID: "gallery-thumbnail"})
+    },
+  }
+})
+jest.mock("react-native-shimmer-placeholder", () => {
+  const React = require("react")
+  const {View} = require("react-native")
+  return {
+    createShimmerPlaceholder: () => (props: Record<string, unknown>) => React.createElement(View, props),
+  }
+})
+jest.mock("@/components/ignite", () => {
+  const {Text} = require("react-native")
+  return {Text}
+})
+jest.mock("@/contexts/ThemeContext", () => {
+  const colors = {
+    background: "white",
+    border: "gray",
+    primary: "blue",
+    textDim: "gray",
+    palette: {neutral200: "gray", primary500: "blue", secondary500: "purple"},
+  }
+  const spacing = {s2: 4, s3: 8}
+  return {
+    useAppTheme: () => ({
+      theme: {colors},
+      themed: (style: unknown) =>
+        typeof style === "function"
+          ? Reflect.apply(style, null, [{colors, spacing}])
+          : style,
+    }),
+  }
+})
+
+describe("PhotoImage", () => {
+  it("uses a downscaled, recyclable image view for gallery thumbnails", () => {
+    const photo = {
+      name: "photo.jpg",
+      thumbnailPath: "file:///gallery/photo-thumb.jpg",
+      is_video: false,
+    } as PhotoInfo
+
+    render(<PhotoImage photo={photo} style={{width: 120, height: 120}} />)
+
+    expect(mockImageProps).toMatchObject({
+      allowDownscaling: true,
+      cachePolicy: "disk",
+      contentFit: "cover",
+      recyclingKey: photo.thumbnailPath,
+      source: {uri: photo.thumbnailPath},
+      transition: 0,
+    })
+  })
+})

--- a/mobile/src/components/glasses/Gallery/PhotoImage.tsx
+++ b/mobile/src/components/glasses/Gallery/PhotoImage.tsx
@@ -127,7 +127,7 @@ export const PhotoImage = memo(function PhotoImage({photo, style, showPlaceholde
     }
 
     checkFileAndFormat()
-  }, [photo, imageUrl])
+  }, [imageUrl, photo.mime_type, photo.name])
 
   const handleLoadEnd = () => {
     setIsLoading(false)

--- a/mobile/src/components/glasses/Gallery/PhotoImage.tsx
+++ b/mobile/src/components/glasses/Gallery/PhotoImage.tsx
@@ -3,9 +3,10 @@
  * Shows a placeholder for AVIF files since React Native doesn't support them natively
  */
 
+import {Image} from "expo-image"
 import LinearGradient from "expo-linear-gradient"
-import {useState, useEffect} from "react"
-import {View, Image, ViewStyle, ImageStyle, TextStyle} from "react-native"
+import {memo, useEffect, useState} from "react"
+import {View, ViewStyle, ImageStyle, TextStyle} from "react-native"
 import {createShimmerPlaceholder} from "react-native-shimmer-placeholder"
 
 import {Text} from "@/components/ignite"
@@ -22,7 +23,7 @@ interface PhotoImageProps {
   showPlaceholder?: boolean
 }
 
-export function PhotoImage({photo, style, showPlaceholder = true}: PhotoImageProps) {
+export const PhotoImage = memo(function PhotoImage({photo, style, showPlaceholder = true}: PhotoImageProps) {
   const {theme, themed} = useAppTheme()
   const [isLoading, setIsLoading] = useState(true)
   const [hasError, setHasError] = useState(false)
@@ -67,6 +68,12 @@ export function PhotoImage({photo, style, showPlaceholder = true}: PhotoImagePro
 
   // ALL HOOKS MUST BE CALLED BEFORE ANY CONDITIONAL RETURNS
   useEffect(() => {
+    // FlashList reuses cell views. Clear state from the previous source before
+    // evaluating the media now occupying this cell.
+    setHasError(false)
+    setIsAvif(false)
+    setIsLoading(true)
+
     // If no imageUrl (e.g., video without thumbnail), skip validation
     if (!imageUrl) {
       setIsLoading(false)
@@ -128,7 +135,7 @@ export function PhotoImage({photo, style, showPlaceholder = true}: PhotoImagePro
 
   const handleError = (error: any) => {
     // Extract error message safely without passing complex circular objects
-    const errorMessage = error?.nativeEvent?.error || error?.message || String(error)
+    const errorMessage = error?.error || error?.nativeEvent?.error || error?.message || String(error)
     console.error("[PhotoImage] Error loading image:", {
       name: photo.name,
       url: imageUrl,
@@ -235,11 +242,15 @@ export function PhotoImage({photo, style, showPlaceholder = true}: PhotoImagePro
         style={[style, isLoading && {opacity: 0}]}
         onLoadEnd={handleLoadEnd}
         onError={handleError}
-        resizeMode="cover"
+        contentFit="cover"
+        cachePolicy="disk"
+        recyclingKey={imageUrl}
+        transition={0}
+        allowDownscaling
       />
     </View>
   )
-}
+})
 
 const $placeholderContainer: ThemedStyle<ViewStyle> = ({colors, spacing}) => ({
   backgroundColor: colors.palette.neutral200,

--- a/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.test.ts
+++ b/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.test.ts
@@ -1,0 +1,44 @@
+import {createGalleryLoadCoordinator} from "./galleryLoadCoordinator"
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((complete) => {
+    resolve = complete
+  })
+  return {promise, resolve}
+}
+
+describe("createGalleryLoadCoordinator", () => {
+  it("coalesces the duplicate mount and focus load", async () => {
+    const coordinator = createGalleryLoadCoordinator()
+    const pending = deferred()
+    const load = jest.fn(() => pending.promise)
+
+    const mountLoad = coordinator.run(load, {refreshAfterCurrent: false})
+    const focusLoad = coordinator.run(load, {refreshAfterCurrent: false})
+    expect(focusLoad).toBe(mountLoad)
+    expect(load).toHaveBeenCalledTimes(1)
+
+    pending.resolve()
+    await mountLoad
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs a fresh load after an in-flight scan when storage changed", async () => {
+    const coordinator = createGalleryLoadCoordinator()
+    const initial = deferred()
+    const refreshed = deferred()
+    const load = jest.fn().mockReturnValueOnce(initial.promise).mockReturnValueOnce(refreshed.promise)
+
+    const initialLoad = coordinator.run(load, {refreshAfterCurrent: false})
+    const postSyncLoad = coordinator.run(load)
+    expect(postSyncLoad).toBe(initialLoad)
+
+    initial.resolve()
+    await Promise.resolve()
+    expect(load).toHaveBeenCalledTimes(2)
+
+    refreshed.resolve()
+    await postSyncLoad
+  })
+})

--- a/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.test.ts
+++ b/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.test.ts
@@ -41,4 +41,25 @@ describe("createGalleryLoadCoordinator", () => {
     refreshed.resolve()
     await postSyncLoad
   })
+
+  it("does not let a lifecycle coalesce replace a queued storage refresh", async () => {
+    const coordinator = createGalleryLoadCoordinator()
+    const initial = deferred()
+    const refreshed = deferred()
+    const initialLoad = jest.fn(() => initial.promise)
+    const postSyncLoad = jest.fn(() => refreshed.promise)
+    const staleFocusLoad = jest.fn(() => Promise.resolve())
+
+    const request = coordinator.run(initialLoad, {refreshAfterCurrent: false})
+    coordinator.run(postSyncLoad)
+    coordinator.run(staleFocusLoad, {refreshAfterCurrent: false})
+
+    initial.resolve()
+    await Promise.resolve()
+    expect(postSyncLoad).toHaveBeenCalledTimes(1)
+    expect(staleFocusLoad).not.toHaveBeenCalled()
+
+    refreshed.resolve()
+    await request
+  })
 })

--- a/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.ts
+++ b/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.ts
@@ -1,0 +1,41 @@
+export interface GalleryLoadOptions {
+  refreshAfterCurrent?: boolean
+}
+
+export interface GalleryLoadCoordinator {
+  run(load: () => Promise<void>, options?: GalleryLoadOptions): Promise<void>
+}
+
+/**
+ * Coalesce duplicate lifecycle loads while preserving refreshes requested after
+ * storage mutations such as sync completion or deletion.
+ */
+export function createGalleryLoadCoordinator(): GalleryLoadCoordinator {
+  let inFlight: Promise<void> | null = null
+  let refreshRequested = false
+  let latestLoad: (() => Promise<void>) | null = null
+
+  return {
+    run(load, {refreshAfterCurrent = true} = {}) {
+      latestLoad = load
+      if (inFlight) {
+        if (refreshAfterCurrent) refreshRequested = true
+        return inFlight
+      }
+
+      const request = (async () => {
+        do {
+          refreshRequested = false
+          await latestLoad?.()
+        } while (refreshRequested)
+      })()
+
+      inFlight = request
+      const clearRequest = () => {
+        if (inFlight === request) inFlight = null
+      }
+      void request.then(clearRequest, clearRequest)
+      return request
+    },
+  }
+}

--- a/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.ts
+++ b/mobile/src/components/glasses/Gallery/galleryLoadCoordinator.ts
@@ -12,22 +12,24 @@ export interface GalleryLoadCoordinator {
  */
 export function createGalleryLoadCoordinator(): GalleryLoadCoordinator {
   let inFlight: Promise<void> | null = null
-  let refreshRequested = false
-  let latestLoad: (() => Promise<void>) | null = null
+  let queuedLoad: (() => Promise<void>) | null = null
 
   return {
     run(load, {refreshAfterCurrent = true} = {}) {
-      latestLoad = load
       if (inFlight) {
-        if (refreshAfterCurrent) refreshRequested = true
+        // Lifecycle calls may share the current request, but only a storage
+        // mutation is allowed to replace the queued refresh callback.
+        if (refreshAfterCurrent) queuedLoad = load
         return inFlight
       }
 
       const request = (async () => {
-        do {
-          refreshRequested = false
-          await latestLoad?.()
-        } while (refreshRequested)
+        let nextLoad: (() => Promise<void>) | null = load
+        while (nextLoad) {
+          await nextLoad()
+          nextLoad = queuedLoad
+          queuedLoad = null
+        }
       })()
 
       inFlight = request

--- a/mobile/src/components/glasses/Gallery/validateGalleryFiles.test.ts
+++ b/mobile/src/components/glasses/Gallery/validateGalleryFiles.test.ts
@@ -1,0 +1,66 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
+import {validateGalleryFiles} from "./validateGalleryFiles"
+
+jest.mock("@dr.pogodin/react-native-fs", () => ({
+  exists: jest.fn(),
+  stat: jest.fn(),
+}))
+
+const mockExists = RNFS.exists as jest.MockedFunction<typeof RNFS.exists>
+const mockStat = RNFS.stat as jest.MockedFunction<typeof RNFS.stat>
+
+describe("validateGalleryFiles", () => {
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it("bounds concurrent filesystem work for large galleries and preserves order", async () => {
+    let activeChecks = 0
+    let peakChecks = 0
+    mockExists.mockImplementation(async () => {
+      activeChecks += 1
+      peakChecks = Math.max(peakChecks, activeChecks)
+      await Promise.resolve()
+      activeChecks -= 1
+      return true
+    })
+    mockStat.mockResolvedValue({size: 128} as Awaited<ReturnType<typeof RNFS.stat>>)
+    const entries = Array.from(
+      {length: 40},
+      (_, index) => [`photo-${index}`, {filePath: `/gallery/photo-${index}.jpg`}] as const,
+    )
+
+    const results = await validateGalleryFiles(entries, 4)
+
+    expect(peakChecks).toBeLessThanOrEqual(4)
+    expect(results.map((result) => result.name)).toEqual(entries.map(([name]) => name))
+    expect(results.every((result) => result.status === "ok")).toBe(true)
+  })
+
+  it("drops missing and empty files but keeps entries after transient filesystem errors", async () => {
+    mockExists
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error("bridge unavailable"))
+    mockStat.mockResolvedValueOnce({size: 0} as Awaited<ReturnType<typeof RNFS.stat>>)
+    const entries: ReadonlyArray<readonly [string, {filePath: string}]> = [
+      ["missing", {filePath: "/gallery/missing.jpg"}],
+      ["empty", {filePath: "/gallery/empty.jpg"}],
+      ["unknown", {filePath: "/gallery/unknown.jpg"}],
+    ]
+
+    await expect(validateGalleryFiles(entries, 1)).resolves.toMatchObject([
+      {name: "missing", status: "stale", shouldUnlink: false},
+      {name: "empty", status: "stale", shouldUnlink: true},
+      {name: "unknown", status: "unknown", shouldUnlink: false},
+    ])
+  })
+})

--- a/mobile/src/components/glasses/Gallery/validateGalleryFiles.ts
+++ b/mobile/src/components/glasses/Gallery/validateGalleryFiles.ts
@@ -1,0 +1,62 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
+export const GALLERY_FILE_VALIDATION_CONCURRENCY = 12
+
+export interface GalleryFileValidationResult<TFile> {
+  name: string
+  file: TFile
+  status: "ok" | "stale" | "unknown"
+  shouldUnlink: boolean
+}
+
+/**
+ * Validate app-local gallery files without flooding the React Native bridge.
+ * Large galleries can contain thousands of entries, so an unbounded Promise.all
+ * here makes Android schedule every exists/stat operation at once.
+ */
+export async function validateGalleryFiles<TFile extends {filePath: string}>(
+  entries: ReadonlyArray<readonly [string, TFile]>,
+  concurrency = GALLERY_FILE_VALIDATION_CONCURRENCY,
+): Promise<GalleryFileValidationResult<TFile>[]> {
+  if (entries.length === 0) return []
+
+  const results = new Array<GalleryFileValidationResult<TFile>>(entries.length)
+  let nextIndex = 0
+
+  const validateNext = async () => {
+    while (nextIndex < entries.length) {
+      const index = nextIndex++
+      const [name, file] = entries[index]
+      let status: GalleryFileValidationResult<TFile>["status"] = "unknown"
+      let shouldUnlink = false
+
+      try {
+        const fileExists = await RNFS.exists(file.filePath)
+        if (!fileExists) {
+          status = "stale"
+        } else {
+          try {
+            const stat = await RNFS.stat(file.filePath)
+            if (stat.size > 0) {
+              status = "ok"
+            } else {
+              console.warn(`[GalleryScreen] Removing zero-byte local file from gallery index: ${name}`)
+              status = "stale"
+              shouldUnlink = true
+            }
+          } catch (statError) {
+            console.warn(`[GalleryScreen] Could not stat local file ${name}:`, statError)
+          }
+        }
+      } catch (existsError) {
+        console.warn(`[GalleryScreen] Could not check existence of local file ${name}:`, existsError)
+      }
+
+      results[index] = {name, file, status, shouldUnlink}
+    }
+  }
+
+  const workerCount = Math.min(Math.max(1, concurrency), entries.length)
+  await Promise.all(Array.from({length: workerCount}, validateNext))
+  return results
+}


### PR DESCRIPTION
## Summary
- replace the gallery grid FlatList with FlashList recycling and a bounded render/recycle window
- downscale thumbnails through expo-image and reset recycled image state between media items
- coalesce the duplicate mount/focus gallery scan and cap native file validation at 12 concurrent operations
- remove per-photo startup logging that amplified large-library stalls

## Root cause
Opening the gallery triggered both mount and focus loads. Each load scheduled exists/stat calls for every local media item at once. The grid also disabled clipped subviews and decoded images through the generic React Native image path, so large libraries produced heavy bridge traffic and bitmap pressure while scrolling.

## Test plan
- `bun run test -- --runInBand src/components/glasses/Gallery/PhotoImage.test.tsx src/components/glasses/Gallery/validateGalleryFiles.test.ts src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx src/components/glasses/Gallery/MediaViewer.test.ts`
- `bun run compile`
- targeted ESLint on all changed gallery files (passes with pre-existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gallery loading, native FS validation, and list recycling, so regressions could show as missing photos, stale cells, or RTL layout issues. No auth or data-integrity changes outside local gallery indexing.
> 
> **Overview**
> Makes the glasses gallery usable with large local libraries by cutting duplicate scans, unbounded filesystem checks, and heavy grid rendering.
> 
> The photo grid now uses `FlashList` recycling for LTR (FlatList remains for RTL). Thumbnails switch to memoized `expo-image` with disk cache, downscaling, and recycled-cell state reset.
> 
> Mount/focus loads are coalesced via `galleryLoadCoordinator`, while sync/delete still queue a fresh scan. File existence/stat work is bounded (12 concurrent) in `validateGalleryFiles` so Android is not flooded with native calls. Per-photo startup logging is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec29ac67ffb6823ce73ffa272701a770a488180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android gallery jank and stalls for large libraries by moving the grid to `@shopify/flash-list`, switching thumbnails to `expo-image`, and bounding filesystem validation. Previously mount and focus both triggered full loads and file checks ran unbounded; now lifecycle loads coalesce, storage changes queue exactly one refresh that cannot be replaced, and validation is limited to 12 concurrent ops.

- Gallery grid: use `FlashList` recycling for LTR; keep `FlatList` for RTL. Tuned draw distance and recycle pool, added stable key/type extractors, adjusted edge/gutter spacing, and preserved item spacing.
- Load coordination: `galleryLoadCoordinator` merges mount/focus scans; storage mutations (sync/delete) queue one fresh pass after the current scan and preserve any queued refresh. Covered by unit tests.
- File validation: extracted to `validateGalleryFiles` with bounded concurrency (12) using `@dr.pogodin/react-native-fs`; preserves order, classifies ok/stale/unknown, and flags zero-byte files for unlink. Unit tested for concurrency and behavior.
- Thumbnails: switch to `expo-image` with disk cache, allowDownscaling, `recyclingKey`, and no transition; reset recycled image state on source change and memoize component. Unit test verifies props.
- Noise reduction: remove per-photo startup logging that amplified stalls.

<sup>Written for commit 6ec29ac67ffb6823ce73ffa272701a770a488180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

