### PR TITLE
[TEST — do not merge] Live-validate Codex reviewer slot auth

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -24,11 +24,15 @@ When the PR agent orchestrator triggers this review, end with a top-level PR com
 3. JSON footer (same schema as the other reviewers):
 
 ```json
-{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"...","ref":"abc123"}]}
 ```
 
 - Use `blocking` only for issues that must be fixed before merge.
 - Use `nit` for style or optional suggestions.
+- `line` is required whenever the issue is anchored to code (line at current HEAD).
+- `ref` is only for re-confirming an existing entry from the orchestrator's
+  open findings: copy that entry's exact `id`. Omit `ref` for anything new.
+  Never invent ids.
 - The orchestrator's `<!-- pr-agent-orchestrator -->` state comment lists prior
   open findings. Treat each as a hypothesis, not a fact: check the current
   code at HEAD before repeating one. If it's already fixed, leave it out of

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -27,7 +27,6 @@ limits:
   maxNewBlockingPerCycle: 5
   maxFixAgentTurns: 80
   consecutiveNoNewReviewsForHandoff: 2
-  discoveryCycles: 1
 
 # External review-bot ingestion: live inline PR review comments from these bot
 # logins are normalized into ledger findings automatically, so the fixer

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -5,6 +5,10 @@ dryRun: false
 
 reviewModel: claude-opus-4-8
 fixModel: claude-opus-4-8
+# Codex CLI reviewer slot (third-vendor second opinion). Only scheduled when
+# the OPENAI_API_KEY repo secret exists; the rotation falls back to the
+# three-slot roster otherwise.
+codexModel: o4-mini
 
 authors:
   # allowlist | all | label_only

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -25,6 +25,20 @@ limits:
   consecutiveNoNewReviewsForHandoff: 2
   discoveryCycles: 1
 
+# External review-bot ingestion: live inline PR review comments from these bot
+# logins are normalized into ledger findings automatically, so the fixer
+# addresses them without a human copy/pasting them into the loop. A comment
+# counts as blocking when it matches the built-in severity patterns
+# ("High/Critical Severity", "blocking"); override per bot via blockingPatterns.
+externalReviewers:
+  enabled: true
+  bots:
+    - "cursor[bot]"
+    - "cubic-dev-ai[bot]"
+  # blockingPatterns:
+  #   "cubic-dev-ai[bot]":
+  #     - "\\bP0\\b"
+
 # Path-scoped required CI check names (must match workflow `name:` fields)
 ciGates:
   - paths:

--- a/.github/pr-agent/prompts/codex-review.md
+++ b/.github/pr-agent/prompts/codex-review.md
@@ -1,0 +1,65 @@
+# Codex review
+
+You are an independent reviewer for **MentraOS** pull requests, providing a
+second opinion alongside other automated reviewers. Focus on **logic,
+correctness, and integration risk** — review like a senior engineer on call
+for this code in production, not a linter skimming a diff.
+
+## How to review
+
+The diff shows only the changed lines, which is never enough on its own.
+Before judging any non-trivial change:
+
+- Open the changed files and read the surrounding code, not just the hunks.
+- Follow the symbols the change touches to their definitions — constructors
+  and factories of injected types, called methods, callers of changed
+  methods — and understand their side effects (I/O, threads, network,
+  file/device handles, shared state).
+- Reason about runtime ordering: initialization, lifecycle, concurrency,
+  error and cleanup paths. Are side effects correct and safe at that point?
+- Verify behavior against the implementation, never against names, comments,
+  or assumptions.
+
+Real defects often only become visible one or two hops beyond the diff.
+
+## What to look for
+
+- Bugs, race conditions, deadlocks, null/lifecycle issues, error-handling and
+  cleanup gaps.
+- Side effects running at the wrong time or in the wrong order.
+- Cross-file/module interactions with callers and callees.
+- Edge cases: disconnect, restart, offline, permission denied, partial
+  failure, and domain-specific ones (BLE, camera, pairing) when relevant.
+- Behavioral regressions implied by the change.
+
+## Context from orchestrator
+
+The orchestrator may provide current `openFindings` and `resolvedFindings`,
+PR number, base branch, and the changed file list.
+
+## Rules
+
+- **`openFindings` is not a checklist to restate — it is a hypothesis to
+  re-test.** For each entry, open the referenced file at the current HEAD and
+  verify it is still true. If the underlying issue is gone, do not include it
+  in your `findings` output — say so briefly in your prose and the
+  orchestrator resolves it automatically. Only repeat a prior finding if you
+  can point to the current line(s) that still exhibit it.
+- Do **not** re-raise resolved findings unless they regressed.
+- Only report: (a) new **blocking** issues, (b) regressions, or (c) **nits**.
+- Style-only issues are **nits**, not blocking.
+- If no blocking logic issues, **approve**.
+
+## Output
+
+1. Brief human-readable review (bullet points).
+2. End with a single JSON object on its own line (no markdown fence):
+
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"...","ref":"abc123"}]}
+
+- `line` is required whenever the issue is anchored to code: use the most
+  relevant line at the **current HEAD**.
+- `ref` is only for re-confirming an existing entry from `openFindings`: copy
+  that entry's exact `id`. Omit `ref` for anything new. Never invent ids.
+
+Use `changes_requested` if any **blocking** finding exists. Use `approve` otherwise.

--- a/.github/pr-agent/prompts/depth-review.md
+++ b/.github/pr-agent/prompts/depth-review.md
@@ -62,6 +62,11 @@ The orchestrator may provide:
 1. Brief human-readable review (bullet points).
 2. End with a single JSON object on its own line (no markdown fence):
 
-{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"...","ref":"abc123"}]}
+
+- `line` is required whenever the issue is anchored to code: use the most
+  relevant line at the **current HEAD**.
+- `ref` is only for re-confirming an existing entry from `openFindings`: copy
+  that entry's exact `id`. Omit `ref` for anything new. Never invent ids.
 
 Use `changes_requested` if any **blocking** finding exists. Use `approve` otherwise.

--- a/.github/pr-agent/prompts/standards-review.md
+++ b/.github/pr-agent/prompts/standards-review.md
@@ -38,6 +38,11 @@ The orchestrator may provide:
 1. Brief human-readable review (bullet points).
 2. End with a single JSON object on its own line (no markdown fence):
 
-{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"...","ref":"abc123"}]}
+
+- `line` is required whenever the issue is anchored to code: use the most
+  relevant line at the **current HEAD**.
+- `ref` is only for re-confirming an existing entry from `openFindings`: copy
+  that entry's exact `id`. Omit `ref` for anything new. Never invent ids.
 
 Use `changes_requested` if any **blocking** finding exists. Use `approve` otherwise.

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -49,6 +49,9 @@ permissions:
 
 env:
   FORCE_ROTATION: ${{ github.event.inputs.force_rotation || 'false' }}
+  # With a PAT the fixer's pushes trigger CI for real, so the CI gate stops
+  # conceding awaiting-approval workflow runs as green (see ci-gates.ts).
+  PR_AGENT_HAS_PAT: ${{ secrets.PR_AGENT_GITHUB_TOKEN != '' }}
 
 jobs:
   resolve-context:

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -180,6 +180,7 @@ jobs:
       run_bugbot: ${{ steps.plan.outputs.run_bugbot }}
       run_standards: ${{ steps.plan.outputs.run_standards }}
       run_depth: ${{ steps.plan.outputs.run_depth }}
+      run_codex: ${{ steps.plan.outputs.run_codex }}
       active_pair: ${{ steps.plan.outputs.active_pair }}
       is_dry_run: ${{ steps.plan.outputs.is_dry_run }}
       should_handoff: ${{ steps.plan.outputs.should_handoff }}
@@ -203,6 +204,7 @@ jobs:
           PR_AUTHOR: ${{ needs.resolve-context.outputs.pr_author }}
           PR_IS_FORK: ${{ needs.resolve-context.outputs.pr_is_fork }}
           CI_RECHECK_ONLY: ${{ needs.resolve-context.outputs.ci_recheck_only }}
+          HAS_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: bun run cli plan
         working-directory: scripts/pr-agent
@@ -292,6 +294,44 @@ jobs:
           path: .pr-agent/review-depth.txt
           if-no-files-found: ignore
 
+  review-codex:
+    name: Review (Codex)
+    needs: [resolve-context, plan]
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_codex == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-context.outputs.head_sha }}
+          fetch-depth: 0
+
+      - run: git fetch origin ${{ needs.resolve-context.outputs.base_ref }}
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Run codex review
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          BASE_REF: ${{ needs.resolve-context.outputs.base_ref }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: bun run cli review codex
+
+      - name: Upload review output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-agent-review-codex
+          path: .pr-agent/review-codex.txt
+          if-no-files-found: ignore
+
   review-bugbot:
     name: Review (Bugbot)
     needs: [resolve-context, plan]
@@ -330,6 +370,7 @@ jobs:
       - plan
       - review-standards
       - review-depth
+      - review-codex
       - review-bugbot
     # Require plan.result == success so a cancelled Plan (empty outputs) cannot
     # revive Aggregate — empty should_skip != 'true' used to pass after cancel.
@@ -372,6 +413,7 @@ jobs:
           BUGBOT_COMPLETED: ${{ needs.review-bugbot.outputs.bugbot_completed || 'false' }}
           BUGBOT_SUCCESS: ${{ needs.review-bugbot.outputs.bugbot_success || 'false' }}
           CI_TRIGGER_FAILED: ${{ needs.resolve-context.outputs.ci_trigger_failed }}
+          HAS_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run cli aggregate
 
@@ -509,6 +551,7 @@ jobs:
       - plan
       - review-standards
       - review-depth
+      - review-codex
       - review-bugbot
       - aggregate
       - fix

--- a/notes/pr-agent-codex-live-test.md
+++ b/notes/pr-agent-codex-live-test.md
@@ -1,0 +1,4 @@
+# PR agent codex live test
+
+Scratch note used to live-validate the Codex reviewer slot auth fix.
+This PR will be closed after the test.

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -14,6 +14,7 @@ import { frozenPairFromFindings } from './rotate.js';
 import { listAllIssueComments } from './state.js';
 import { MARKER_BUGBOT_VERDICT, type AggregateOutput, type PrAgentState, type ReviewSlot } from './types.js';
 import { isCiFailed, isCiGreen, type CiCheckStatus } from './ci-gates.js';
+import { isExternalSource, type ExternalFindings } from './external-reviews.js';
 
 export type ReviewOutputs = {
   standards?: string;
@@ -21,6 +22,8 @@ export type ReviewOutputs = {
   bugbot?: string;
   bugbotCheckCompleted?: boolean;
   bugbotCheckSuccess?: boolean;
+  /** Normalized live inline comments from allowlisted external bots. */
+  external?: ExternalFindings;
 };
 
 function slotReviewSucceeded(slot: ReviewSlot, reviews: ReviewOutputs): boolean {
@@ -100,6 +103,40 @@ export function aggregateCycle(
     }
   }
 
+  // External bot inline comments (Bugbot native, cubic, …) become findings so
+  // the fixer addresses them without a human copy/pasting them into the loop.
+  // They deliberately do NOT touch newBlockingFingerprints, allApproved, or
+  // stagnation counters: external bots re-review on their own schedule, so our
+  // convergence bookkeeping cannot key off their cadence. Their lifecycle is:
+  // live comment => open finding; comment outdated/deleted => resolved.
+  if (reviews.external) {
+    const extBlocking = reviews.external.current.filter(
+      (f) => f.severity === 'blocking' && !muted.has(f.fingerprint),
+    );
+    const extNits = reviews.external.current.filter(
+      (f) => f.severity === 'nit' && !muted.has(f.fingerprint),
+    );
+    openFindings = mergeFindings(openFindings, extBlocking, cycle).merged;
+    nitFindings = mergeFindings(nitFindings, extNits, cycle).merged;
+
+    const liveFingerprints = new Set(reviews.external.current.map((f) => f.fingerprint));
+    const extSources = new Set([
+      ...reviews.external.sources,
+      ...openFindings.map((f) => String(f.source)).filter(isExternalSource),
+    ]);
+    for (const source of extSources) {
+      const stale = resolveStaleFindingsFromSource(
+        openFindings,
+        resolvedFindings,
+        source,
+        liveFingerprints,
+        cycle,
+      );
+      openFindings = stale.open;
+      resolvedFindings = stale.resolved;
+    }
+  }
+
   const allSlotsSucceeded = activePair.every((slot) => slotReviewSucceeded(slot, reviews));
 
   const newBlockingCount = newBlockingFingerprints.length;
@@ -130,16 +167,22 @@ export function aggregateCycle(
   // Stagnation tracks the *fixer* failing to reduce open findings. It is only
   // meaningful when the fixer actually runs — never accumulate it in dry run,
   // where unchanged findings across review cycles are expected (no fixes land).
+  // External findings are excluded: their resolution depends on GitHub marking
+  // the underlying comment outdated, which lags our cycles and must not be
+  // read as the fixer stalling.
+  const internalOpenCount = openBlocking(openFindings).filter(
+    (f) => !isExternalSource(String(f.source)),
+  ).length;
   let stagnationFixRounds = state.stagnationFixRounds;
   if (config.dryRun) {
     stagnationFixRounds = 0;
   } else if (
     state.lastOpenCount !== undefined &&
-    openCount === state.lastOpenCount &&
-    openCount > 0
+    internalOpenCount === state.lastOpenCount &&
+    internalOpenCount > 0
   ) {
     stagnationFixRounds += 1;
-  } else if (openCount < (state.lastOpenCount ?? openCount)) {
+  } else if (internalOpenCount < (state.lastOpenCount ?? internalOpenCount)) {
     stagnationFixRounds = 0;
   }
 
@@ -161,7 +204,7 @@ export function aggregateCycle(
   } else if (newBlockingCount >= config.limits.maxNewBlockingPerCycle) {
     status = 'diverging';
     handoffReason = 'diverging';
-  } else if (stagnationFixRounds >= 2 && openCount > 0) {
+  } else if (stagnationFixRounds >= 2 && internalOpenCount > 0) {
     status = 'diverging';
     handoffReason = 'diverging';
   } else if (newBlockingCount >= 3 && state.fixRound >= 2) {
@@ -202,7 +245,7 @@ export function aggregateCycle(
     lastPair: activePair,
     status,
     stagnationFixRounds,
-    lastOpenCount: openCount,
+    lastOpenCount: internalOpenCount,
   };
 
   return {

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -61,7 +61,10 @@ export function aggregateCycle(
     const verdict = parseVerdictFromText(text);
     if (!verdict) return;
     if (verdict.verdict !== 'approve') allApproved = false;
-    const { blocking: rawBlocking, nits } = verdictToFindings(verdict, source, cycle);
+    const { blocking: rawBlocking, nits } = verdictToFindings(verdict, source, cycle, [
+      ...openFindings,
+      ...nitFindings,
+    ]);
     // Drop findings a human marked as false positive via `agent-resolve`.
     const blocking = rawBlocking.filter((b) => !muted.has(b.fingerprint));
     const mergedOpen = mergeFindings(openFindings, blocking, cycle);

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -19,6 +19,7 @@ import { isExternalSource, type ExternalFindings } from './external-reviews.js';
 export type ReviewOutputs = {
   standards?: string;
   depth?: string;
+  codex?: string;
   bugbot?: string;
   bugbotCheckCompleted?: boolean;
   bugbotCheckSuccess?: boolean;
@@ -27,8 +28,8 @@ export type ReviewOutputs = {
 };
 
 function slotReviewSucceeded(slot: ReviewSlot, reviews: ReviewOutputs): boolean {
-  if (slot === 'standards' || slot === 'depth') {
-    const text = slot === 'standards' ? reviews.standards : reviews.depth;
+  if (slot === 'standards' || slot === 'depth' || slot === 'codex') {
+    const text = reviews[slot];
     return !!text && !!parseVerdictFromText(text);
   }
   if (reviews.bugbotCheckCompleted !== true) return false;
@@ -95,6 +96,7 @@ export function aggregateCycle(
 
   if (activePair.includes('standards')) ingest(reviews.standards, 'standards');
   if (activePair.includes('depth')) ingest(reviews.depth, 'depth');
+  if (activePair.includes('codex')) ingest(reviews.codex, 'codex');
   if (activePair.includes('bugbot')) {
     if (reviews.bugbotCheckCompleted === true && reviews.bugbot) {
       ingest(reviews.bugbot, 'bugbot', {

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -171,6 +171,7 @@ export function aggregateCycle(
       handoffReason: undefined,
       ciFailed,
       newBlockingCount: 0,
+      newBlockingFindings: [],
       emptyCycle: true,
     };
   }
@@ -279,6 +280,11 @@ export function aggregateCycle(
     lastOpenCount: internalOpenCount,
   };
 
+  const newFingerprintSet = new Set(newBlockingFingerprints);
+  const newBlockingFindings = openFindings.filter(
+    (f) => newFingerprintSet.has(f.fingerprint) && f.status === 'open',
+  );
+
   return {
     state: nextState,
     shouldFix,
@@ -286,6 +292,7 @@ export function aggregateCycle(
     handoffReason,
     ciFailed,
     newBlockingCount,
+    newBlockingFindings,
   };
 }
 

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -147,6 +147,32 @@ export function aggregateCycle(
     isCiFailed(ciChecks) || process.env.CI_TRIGGER_FAILED === 'true';
   const ciGreen = isCiGreen(ciChecks);
 
+  // A cycle where reviewers were scheduled but none produced a usable verdict
+  // (agent run failed, artifact missing, Bugbot never completed) carries zero
+  // review signal. Consuming cycle budget or stagnation counters here produced
+  // false diverging/budget_exhausted exits (#3716 cycle 4: "No model reviews
+  // ran this cycle" still bumped both). Persist any external-comment ledger
+  // updates, but leave every convergence counter untouched and schedule
+  // nothing — the next genuine cycle re-runs the same pair.
+  const anyReviewIngested = activePair.some((slot) => slotReviewSucceeded(slot, reviews));
+  if (activePair.length > 0 && !anyReviewIngested) {
+    return {
+      state: {
+        ...state,
+        openFindings,
+        resolvedFindings,
+        nitFindings,
+        lastPair: activePair,
+      },
+      shouldFix: false,
+      shouldHandoff: false,
+      handoffReason: undefined,
+      ciFailed,
+      newBlockingCount: 0,
+      emptyCycle: true,
+    };
+  }
+
   let consecutiveNoNewReviews = state.consecutiveNoNewReviews;
   if (newBlockingCount === 0 && allApproved && allSlotsSucceeded) {
     consecutiveNoNewReviews += 1;

--- a/scripts/pr-agent/src/ci-gates.ts
+++ b/scripts/pr-agent/src/ci-gates.ts
@@ -77,9 +77,15 @@ function requiredChecks(checks: CiCheckStatus[]): CiCheckStatus[] {
 export function isCiGreen(checks: CiCheckStatus[]): boolean {
   const required = requiredChecks(checks);
   if (required.length === 0) return true;
+  // Without a PAT, fixer commits pushed via GITHUB_TOKEN never trigger CI
+  // (GitHub parks the runs as action_required), so awaiting-approval checks
+  // would block handoff forever — concede them as green and let the human
+  // reviewer approve the workflows. With PR_AGENT_GITHUB_TOKEN configured the
+  // fixer's pushes trigger CI for real, so the concession is dropped and the
+  // gate requires an actual green run.
+  const hasPat = process.env.PR_AGENT_HAS_PAT === 'true';
   return required.every((c) => {
-    // Awaiting approval means a human will trigger it when they review — treat as non-blocking.
-    if (c.awaitingApproval) return true;
+    if (c.awaitingApproval && !hasPat) return true;
     if (['in_progress', 'queued', 'waiting', 'pending'].includes(c.status)) {
       return false;
     }

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -19,6 +19,7 @@ import { buildHandoffComment } from './handoff.js';
 import { runPlan, writePlanOutputs } from './plan.js';
 import { recheckHandoff } from './recheck-handoff.js';
 import { buildReviewComment } from './review-comment.js';
+import { runCodexReview } from './review-codex.js';
 import { runReview } from './review.js';
 import {
   createOctokit,
@@ -45,8 +46,12 @@ async function cmdPlan() {
 
 async function cmdReview(slot: string) {
   const { state } = await loadOrCreateState(createOctokit(), owner, repo, prNumber);
+  if (slot === 'codex') {
+    await runCodexReview(repoRoot, prNumber, baseRef, state);
+    return;
+  }
   if (slot !== 'standards' && slot !== 'depth') {
-    throw new Error('slot must be standards or depth');
+    throw new Error('slot must be standards, depth, or codex');
   }
   await runReview(repoRoot, slot, prNumber, baseRef, state);
 }
@@ -104,6 +109,7 @@ async function cmdAggregate() {
   const reviews = {
     standards: loadReviewOutput(repoRoot, 'standards'),
     depth: loadReviewOutput(repoRoot, 'depth'),
+    codex: loadReviewOutput(repoRoot, 'codex'),
     bugbot: await loadBugbotVerdict(octokit, owner, repo, prNumber),
     bugbotCheckCompleted: process.env.BUGBOT_COMPLETED === 'true',
     bugbotCheckSuccess: process.env.BUGBOT_SUCCESS === 'true',
@@ -117,7 +123,12 @@ async function cmdAggregate() {
   // Always surface the human-readable review to the PR, regardless of verdict.
   const reviewComment = buildReviewComment(
     result.state,
-    { standards: reviews.standards, depth: reviews.depth, bugbot: reviews.bugbot },
+    {
+      standards: reviews.standards,
+      depth: reviews.depth,
+      codex: reviews.codex,
+      bugbot: reviews.bugbot,
+    },
     activePair,
   );
   await upsertMarkerComment(octokit, owner, repo, prNumber, MARKER_REVIEW, reviewComment);

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -13,6 +13,7 @@ import {
   requiredWorkflowsForPaths,
 } from './ci-gates.js';
 import { loadConfig } from './config.js';
+import { fetchExternalFindings, type ExternalFindings } from './external-reviews.js';
 import { runFix } from './fix.js';
 import { buildHandoffComment } from './handoff.js';
 import { runPlan, writePlanOutputs } from './plan.js';
@@ -84,12 +85,29 @@ async function cmdAggregate() {
   const ref = (await getPrHeadSha(octokit, owner, repo, prNumber)) || headSha;
   const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, ref, required);
 
+  // Ingestion of external bot inline comments must never take down the cycle:
+  // on API failure we proceed without them and pick them up next cycle.
+  let external: ExternalFindings | undefined;
+  try {
+    external = await fetchExternalFindings(
+      octokit,
+      owner,
+      repo,
+      prNumber,
+      repoRoot,
+      state.cycle,
+    );
+  } catch (err) {
+    console.warn('external review ingestion failed; continuing without:', err);
+  }
+
   const reviews = {
     standards: loadReviewOutput(repoRoot, 'standards'),
     depth: loadReviewOutput(repoRoot, 'depth'),
     bugbot: await loadBugbotVerdict(octokit, owner, repo, prNumber),
     bugbotCheckCompleted: process.env.BUGBOT_COMPLETED === 'true',
     bugbotCheckSuccess: process.env.BUGBOT_SUCCESS === 'true',
+    external,
   };
 
   const result = aggregateCycle(repoRoot, state, reviews, ciChecks, activePair);

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -15,6 +15,7 @@ import {
 import { loadConfig } from './config.js';
 import { fetchExternalFindings, type ExternalFindings } from './external-reviews.js';
 import { runFix } from './fix.js';
+import { postInlineFindings } from './inline-comments.js';
 import { buildHandoffComment } from './handoff.js';
 import { runPlan, writePlanOutputs } from './plan.js';
 import { recheckHandoff } from './recheck-handoff.js';
@@ -132,6 +133,15 @@ async function cmdAggregate() {
     activePair,
   );
   await upsertMarkerComment(octokit, owner, repo, prNumber, MARKER_REVIEW, reviewComment);
+
+  // Inline comments are best-effort: an anchor rejection must not fail the cycle.
+  if (result.newBlockingFindings.length > 0) {
+    try {
+      await postInlineFindings(octokit, owner, repo, prNumber, ref, result.newBlockingFindings);
+    } catch (err) {
+      console.warn('posting inline finding comments failed; continuing:', err);
+    }
+  }
 
   const out = process.env.GITHUB_OUTPUT;
   if (out) {

--- a/scripts/pr-agent/src/config.ts
+++ b/scripts/pr-agent/src/config.ts
@@ -7,6 +7,8 @@ const ConfigSchema = z.object({
   dryRun: z.boolean().default(true),
   reviewModel: z.string().default('claude-opus-4-8'),
   fixModel: z.string().default('claude-opus-4-8'),
+  /** Model for the Codex CLI reviewer slot (only used when OPENAI_API_KEY exists). */
+  codexModel: z.string().default('o4-mini'),
   authors: z
     .object({
       mode: z.enum(['allowlist', 'all', 'label_only']).default('label_only'),

--- a/scripts/pr-agent/src/config.ts
+++ b/scripts/pr-agent/src/config.ts
@@ -24,7 +24,6 @@ const ConfigSchema = z.object({
       maxNewBlockingPerCycle: z.number().default(5),
       maxFixAgentTurns: z.number().default(80),
       consecutiveNoNewReviewsForHandoff: z.number().default(2),
-      discoveryCycles: z.number().default(1),
     })
     .default({}),
   ciGates: z

--- a/scripts/pr-agent/src/config.ts
+++ b/scripts/pr-agent/src/config.ts
@@ -33,6 +33,22 @@ const ConfigSchema = z.object({
       }),
     )
     .default([]),
+  /**
+   * External review-bot ingestion: native inline PR review comments from these
+   * bot logins are normalized into ledger findings so the fixer addresses them
+   * without a human copy/pasting them into the loop.
+   */
+  externalReviewers: z
+    .object({
+      enabled: z.boolean().default(true),
+      bots: z.array(z.string()).default(['cursor[bot]', 'cubic-dev-ai[bot]']),
+      /**
+       * Per-bot regex overrides (case-insensitive) that classify a comment as
+       * blocking. Bots without an entry use the built-in defaults.
+       */
+      blockingPatterns: z.record(z.array(z.string())).default({}),
+    })
+    .default({}),
 });
 
 export type PrAgentConfig = z.infer<typeof ConfigSchema>;

--- a/scripts/pr-agent/src/external-reviews.ts
+++ b/scripts/pr-agent/src/external-reviews.ts
@@ -1,0 +1,117 @@
+import type { Octokit } from '@octokit/rest';
+import { loadConfig } from './config.js';
+import { shortId } from './findings.js';
+import type { Finding } from './types.js';
+
+/**
+ * External review ingestion: external bots (Bugbot, cubic, Codex, …) post
+ * native inline review comments on the PR, but those never reached the finding
+ * ledger — humans had to copy/paste them for the fixer to act. This module
+ * normalizes live inline comments from allowlisted bot logins into findings.
+ */
+
+export const EXTERNAL_SOURCE_PREFIX = 'external:';
+
+export function isExternalSource(source: string): boolean {
+  return source.startsWith(EXTERNAL_SOURCE_PREFIX);
+}
+
+/** Default patterns that mark an external comment as blocking (case-insensitive). */
+const DEFAULT_BLOCKING_PATTERNS = [
+  '(high|critical)\\s+severity',
+  '\\bseverity\\s*:\\s*(high|critical)\\b',
+  '\\bblocking\\b',
+];
+
+export type ExternalFindings = {
+  /** Findings whose underlying comments are live (still anchored to current code). */
+  current: Finding[];
+  /** Every external source encountered, for stale-resolution bookkeeping. */
+  sources: string[];
+};
+
+function stripHtmlComments(s: string): string {
+  return s
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export async function fetchExternalFindings(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  repoRoot: string,
+  cycle: number,
+): Promise<ExternalFindings> {
+  const ext = loadConfig(repoRoot).externalReviewers;
+  if (!ext.enabled || ext.bots.length === 0) {
+    return { current: [], sources: [] };
+  }
+
+  const comments: Awaited<
+    ReturnType<Octokit['pulls']['listReviewComments']>
+  >['data'] = [];
+  let page = 1;
+  for (;;) {
+    const { data } = await octokit.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+      page,
+    });
+    comments.push(...data);
+    if (data.length < 100) break;
+    page++;
+  }
+
+  const bots = new Set(ext.bots);
+  const current: Finding[] = [];
+  const sources = new Set<string>();
+
+  for (const c of comments) {
+    const login = c.user?.login ?? '';
+    if (!bots.has(login)) continue;
+    const source = `${EXTERNAL_SOURCE_PREFIX}${login}`;
+    sources.add(source);
+
+    // Thread replies are discussion, not findings.
+    if (c.in_reply_to_id) continue;
+    // line/position both null means GitHub marked the comment outdated: the
+    // code under it changed. Treat as resolved (handled by the stale pass).
+    const outdated = c.line == null && c.position == null;
+    if (outdated) continue;
+
+    const body = stripHtmlComments(c.body ?? '');
+    if (!body) continue;
+
+    const patterns = ext.blockingPatterns[login] ?? DEFAULT_BLOCKING_PATTERNS;
+    const blocking = patterns.some((p) => {
+      try {
+        return new RegExp(p, 'i').test(body);
+      } catch {
+        return false;
+      }
+    });
+
+    // The comment id is a stable identity: no rewording-forks-the-fingerprint
+    // failure mode, and the same comment maps to the same finding forever.
+    const fingerprint = `${EXTERNAL_SOURCE_PREFIX}${login}:${c.id}`;
+    current.push({
+      id: shortId(fingerprint),
+      fingerprint,
+      source,
+      severity: blocking ? 'blocking' : 'nit',
+      file: c.path,
+      line: c.line ?? c.original_line ?? undefined,
+      message: body.slice(0, 2000),
+      status: 'open',
+      introducedCycle: cycle,
+      lastSeenCycle: cycle,
+    });
+  }
+
+  return { current, sources: [...sources] };
+}

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -225,6 +225,7 @@ export function sourceCounts(findings: Finding[]): Record<ReviewSlot, number> {
     bugbot: 0,
     standards: 0,
     depth: 0,
+    codex: 0,
   };
   for (const f of openBlocking(findings)) {
     const s = f.source as ReviewSlot;

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -7,8 +7,21 @@ import {
   type Verdict,
 } from './types.js';
 
-export function fingerprintFinding(file: string, message: string): string {
+/**
+ * Finding identity. Message-hash fingerprints proved too fragile: reviewers
+ * routinely reword the same issue across cycles ("…confirmed against current
+ * API schema…") and the reworded report forked into a duplicate "new" finding
+ * that kept an already-fixed issue open and tripped false diverging exits
+ * (PR #3716). Prefer file + line-bucket (lines rounded to the nearest 10, so
+ * small drifts from surrounding edits still map to the same finding); fall
+ * back to the message hash only when the reviewer gave no usable line.
+ */
+export function fingerprintFinding(file: string, message: string, line?: number): string {
   const normalizedFile = file.replace(/\\/g, '/').toLowerCase();
+  if (typeof line === 'number' && line > 0) {
+    const bucket = Math.round(line / 10) * 10;
+    return `${normalizedFile}:L${bucket}`;
+  }
   const normalizedMessage = message
     .toLowerCase()
     .replace(/[`'"]/g, '')
@@ -30,12 +43,25 @@ export function verdictToFindings(
   verdict: Verdict,
   source: ReviewSlot | string,
   cycle: number,
+  /**
+   * Existing findings (open + nits) keyed for `ref` lookups: when a reviewer
+   * re-confirms a known finding by echoing its id, the report inherits that
+   * finding's fingerprint instead of minting a new identity from its own
+   * (possibly reworded) message.
+   */
+  existingFindings?: Finding[],
 ): { blocking: Finding[]; nits: Finding[] } {
   const blocking: Finding[] = [];
   const nits: Finding[] = [];
+  const byId = new Map(
+    (existingFindings ?? []).map((f) => [f.id.toLowerCase(), f]),
+  );
 
   for (const f of verdict.findings) {
-    const fp = fingerprintFinding(f.file || 'unknown', f.message);
+    const referenced = f.ref ? byId.get(f.ref.toLowerCase()) : undefined;
+    const fp =
+      referenced?.fingerprint ??
+      fingerprintFinding(f.file || 'unknown', f.message, f.line);
     const item: Finding = {
       id: shortId(fp),
       fingerprint: fp,

--- a/scripts/pr-agent/src/inline-comments.ts
+++ b/scripts/pr-agent/src/inline-comments.ts
@@ -1,0 +1,110 @@
+import type { Octokit } from '@octokit/rest';
+import type { Finding } from './types.js';
+
+/**
+ * Post blocking findings as inline PR review comments anchored at file/line,
+ * so humans act on them where they read code instead of cross-referencing the
+ * state-JSON ledger. Each comment carries a per-finding marker so re-reports
+ * across cycles never duplicate. Findings that GitHub rejects (line outside
+ * the diff) stay summary-only — the ledger comment already lists them.
+ */
+
+const FINDING_MARKER_PREFIX = '<!-- pr-agent-finding:';
+
+function findingMarker(id: string): string {
+  return `${FINDING_MARKER_PREFIX}${id} -->`;
+}
+
+function commentBody(finding: Finding): string {
+  return `${findingMarker(finding.id)}
+**PR Agent — blocking finding \`${finding.id}\`** (${finding.source})
+
+${finding.message}
+
+<sub>Reply \`agent-resolve ${finding.id}\` to dismiss as a false positive.</sub>`;
+}
+
+export async function postInlineFindings(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  findings: Finding[],
+): Promise<void> {
+  const candidates = findings.filter(
+    (f) => f.severity === 'blocking' && f.file && typeof f.line === 'number' && f.line > 0,
+  );
+  if (candidates.length === 0) return;
+
+  const existing: string[] = [];
+  let page = 1;
+  for (;;) {
+    const { data } = await octokit.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+      page,
+    });
+    existing.push(...data.map((c) => c.body ?? ''));
+    if (data.length < 100) break;
+    page++;
+  }
+
+  const fresh = candidates.filter(
+    (f) => !existing.some((body) => body.includes(findingMarker(f.id))),
+  );
+  if (fresh.length === 0) return;
+
+  const comments = fresh.map((f) => ({
+    path: f.file,
+    line: f.line!,
+    side: 'RIGHT' as const,
+    body: commentBody(f),
+  }));
+
+  try {
+    // One review containing every comment: a single notification for humans.
+    await octokit.pulls.createReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      commit_id: headSha,
+      event: 'COMMENT',
+      comments,
+    });
+    console.log(`Posted ${comments.length} inline finding comment(s)`);
+    return;
+  } catch (err) {
+    // GitHub 422s the whole review when any single anchor falls outside the
+    // diff. Retry per-comment so valid anchors still land.
+    console.warn(
+      'Batch inline review rejected; retrying per comment:',
+      (err as Error).message,
+    );
+  }
+
+  let posted = 0;
+  for (const c of comments) {
+    try {
+      await octokit.pulls.createReviewComment({
+        owner,
+        repo,
+        pull_number: prNumber,
+        commit_id: headSha,
+        path: c.path,
+        line: c.line,
+        side: c.side,
+        body: c.body,
+      });
+      posted++;
+    } catch (err) {
+      console.warn(
+        `Inline comment rejected for ${c.path}:${c.line} (likely outside diff):`,
+        (err as Error).message,
+      );
+    }
+  }
+  console.log(`Posted ${posted}/${comments.length} inline finding comment(s)`);
+}

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -159,6 +159,41 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
     openBlocking(state.openFindings).length === 0 &&
     state.consecutiveNoNewReviews >= config.limits.consecutiveNoNewReviewsForHandoff
   ) {
+    // Mirror the cycle-cap block: recheck-handoff no-ops on red CI, so routing a
+    // failed-CI workflow_run event to recheckOnly here strands the PR in_progress
+    // forever (fixer never runs, no handoff posted). When CI is failing and the
+    // fixer still has rounds left, skip model reviews but return the deferral
+    // shape (shouldSkip=false, no recheckOnly) so aggregate sets shouldFix and the
+    // fixer reacts to the CI failure.
+    let ciFailed = process.env.CI_TRIGGER_FAILED === 'true';
+    if (!ciFailed && state.fixRound < config.limits.maxFixRounds) {
+      try {
+        const ref = await getPrHeadSha(octokit, owner, repo, prNumber);
+        const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
+        const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
+        const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, ref, required);
+        ciFailed = isCiFailed(ciChecks);
+      } catch (err) {
+        console.warn('plan: failed to fetch CI status for reviews-clean deferral', err);
+      }
+    }
+
+    if (ciFailed && state.fixRound < config.limits.maxFixRounds) {
+      console.log(
+        `Reviews clean but CI failed with fixRound=${state.fixRound}; skipping model reviews, deferring to fixer`,
+      );
+      await saveState(octokit, owner, repo, prNumber, state, commentId);
+      return {
+        runBugbot: false,
+        runStandards: false,
+        runDepth: false,
+        activePair: [],
+        state,
+        shouldSkip: false,
+        skipReason: 'reviews clean; CI fix deferred',
+      };
+    }
+
     console.log(
       `Reviews clean (consecutiveNoNewReviews=${state.consecutiveNoNewReviews}); skipping model reviews, CI recheck only`,
     );

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from './config.js';
 import { resolveActivePair } from './rotate.js';
-import { applyResolvedIds, parseResolveIds } from './findings.js';
+import { applyResolvedIds, openBlocking, parseResolveIds } from './findings.js';
 import {
   createOctokit,
   listAllIssueComments,
@@ -147,6 +147,31 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
       state,
       shouldSkip: true,
       skipReason: `status ${state.status}`,
+    };
+  }
+
+  // Reviews already converged: no open blocking findings and enough clean
+  // cycles for handoff. The only thing left to wait for is CI, so re-running
+  // model reviews of an unchanged diff just burns credits (#3648 spent 8 full
+  // review cycles — ~16 model runs — reaching a handoff that needed 2). Route
+  // straight to the wait-ci -> recheck-handoff path instead.
+  if (
+    openBlocking(state.openFindings).length === 0 &&
+    state.consecutiveNoNewReviews >= config.limits.consecutiveNoNewReviewsForHandoff
+  ) {
+    console.log(
+      `Reviews clean (consecutiveNoNewReviews=${state.consecutiveNoNewReviews}); skipping model reviews, CI recheck only`,
+    );
+    await saveState(octokit, owner, repo, prNumber, state, commentId);
+    return {
+      runBugbot: false,
+      runStandards: false,
+      runDepth: false,
+      activePair: [],
+      state,
+      shouldSkip: false,
+      recheckOnly: true,
+      skipReason: 'reviews clean; awaiting CI',
     };
   }
 

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -273,6 +273,7 @@ export async function writePlanOutputs(repoRoot: string, plan: PlanOutput): Prom
   set('run_bugbot', String(plan.runBugbot));
   set('run_standards', String(plan.runStandards));
   set('run_depth', String(plan.runDepth));
+  set('run_codex', String(plan.activePair.includes('codex')));
   set('active_pair', plan.activePair.join(','));
   set('is_dry_run', String(loadConfig(repoRoot).dryRun));
   set('should_handoff', String(plan.shouldHandoff ?? false));

--- a/scripts/pr-agent/src/review-codex.ts
+++ b/scripts/pr-agent/src/review-codex.ts
@@ -19,9 +19,19 @@ export async function runCodexReview(
   state: PrAgentState,
 ): Promise<void> {
   const config = loadConfig(repoRoot);
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     throw new Error('OPENAI_API_KEY is required for the codex review slot');
   }
+
+  // Codex CLI (0.149+) does not read OPENAI_API_KEY from the environment for
+  // API auth — without an explicit login it sends no Authorization header at
+  // all ("401 Missing bearer or basic authentication"). Register the key via
+  // `codex login --with-api-key`, which reads it from stdin.
+  execFileSync('codex', ['login', '--with-api-key'], {
+    input: apiKey,
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
 
   const promptPath = join(repoRoot, '.github/pr-agent/prompts/codex-review.md');
   const basePrompt = readFileSync(promptPath, 'utf8');

--- a/scripts/pr-agent/src/review-codex.ts
+++ b/scripts/pr-agent/src/review-codex.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadConfig } from './config.js';
+import { buildReviewContext } from './review.js';
+import type { PrAgentState } from './types.js';
+
+/**
+ * Codex CLI reviewer: a true third-vendor slot (OpenAI, not Cursor-billed).
+ * Two prompts on one model are not two independent reviewers — Codex has
+ * previously caught bugs both Claude slots missed. Runs `codex exec` headless
+ * in read-only sandbox mode and writes the same review-<slot>.txt contract the
+ * aggregate step already consumes.
+ */
+export async function runCodexReview(
+  repoRoot: string,
+  prNumber: number,
+  baseRef: string,
+  state: PrAgentState,
+): Promise<void> {
+  const config = loadConfig(repoRoot);
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY is required for the codex review slot');
+  }
+
+  const promptPath = join(repoRoot, '.github/pr-agent/prompts/codex-review.md');
+  const basePrompt = readFileSync(promptPath, 'utf8');
+  const context = buildReviewContext(repoRoot, prNumber, baseRef, state);
+  const fullPrompt = `${basePrompt}\n\n---\n\n${context}`;
+
+  const outDir = join(repoRoot, '.pr-agent');
+  mkdirSync(outDir, { recursive: true });
+  const outPath = join(outDir, 'review-codex.txt');
+
+  const model = process.env.PR_AGENT_CODEX_MODEL ?? config.codexModel;
+
+  // Prompt goes via stdin ("-"): it embeds a full unified diff and can exceed
+  // the kernel's per-argument size limit as an argv entry.
+  execFileSync(
+    'codex',
+    [
+      'exec',
+      '--sandbox',
+      'read-only',
+      '--skip-git-repo-check',
+      '-m',
+      model,
+      '--output-last-message',
+      outPath,
+      '-',
+    ],
+    {
+      cwd: repoRoot,
+      input: fullPrompt,
+      stdio: ['pipe', 'inherit', 'inherit'],
+      timeout: 20 * 60_000,
+    },
+  );
+
+  if (!existsSync(outPath)) {
+    // Aggregate treats a missing artifact as "slot did not run"; an empty file
+    // means "ran but produced no verdict" — either way the cycle stays safe.
+    writeFileSync(outPath, '', 'utf8');
+  }
+  console.log('Review codex complete.');
+}

--- a/scripts/pr-agent/src/review-comment.ts
+++ b/scripts/pr-agent/src/review-comment.ts
@@ -50,10 +50,18 @@ export function buildReviewComment(
 
   const overall = blocking > 0 ? '⚠️ Changes requested' : '✅ No blocking findings';
   const reviewerList = activePair.length ? activePair.join(', ') : 'none';
-  const body =
-    sections.length > 0
-      ? sections.join('\n\n---\n\n')
-      : '_No model reviews ran this cycle._';
+
+  // No ingested review text: showing the ledger's blocking/nit counts next to
+  // "no reviews ran" reads as a contradiction. State plainly that this cycle
+  // carried no review signal and that counters did not move.
+  if (sections.length === 0) {
+    return `${MARKER_REVIEW}
+## 🤖 PR Agent Review — cycle ${state.cycle}
+
+_No model reviews were ingested this cycle (scheduled: ${reviewerList}); ledger and budget counters unchanged._
+
+<sub>Updated automatically by the PR Agent Orchestrator each review cycle. Nits do not block merge.</sub>`;
+  }
 
   return `${MARKER_REVIEW}
 ## 🤖 PR Agent Review — cycle ${state.cycle}
@@ -61,7 +69,7 @@ export function buildReviewComment(
 **${overall}** · ${blocking} blocking · ${nits} nit${nits === 1 ? '' : 's'}
 _Reviewers this cycle: ${reviewerList}_
 
-${body}
+${sections.join('\n\n---\n\n')}
 
 <sub>Updated automatically by the PR Agent Orchestrator each review cycle. Nits do not block merge.</sub>`;
 }

--- a/scripts/pr-agent/src/review-comment.ts
+++ b/scripts/pr-agent/src/review-comment.ts
@@ -4,12 +4,14 @@ import { MARKER_BUGBOT_VERDICT, MARKER_REVIEW, type PrAgentState, type ReviewSlo
 const SLOT_LABEL: Record<ReviewSlot, string> = {
   standards: 'Claude — standards',
   depth: 'Claude — depth',
+  codex: 'Codex — review',
   bugbot: 'Bugbot',
 };
 
 type ReviewTexts = {
   standards?: string;
   depth?: string;
+  codex?: string;
   bugbot?: string;
 };
 

--- a/scripts/pr-agent/src/review.ts
+++ b/scripts/pr-agent/src/review.ts
@@ -2,28 +2,25 @@ import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Agent, CursorAgentError } from '@cursor/sdk';
 import { loadConfig } from './config.js';
-import type { PrAgentState, ReviewSlot } from './types.js';
+import type { PrAgentState } from './types.js';
 import { execSync } from 'node:child_process';
 
-const SLOT_PROMPT: Record<Exclude<ReviewSlot, 'bugbot'>, string> = {
+const SLOT_PROMPT: Record<'standards' | 'depth', string> = {
   standards: 'standards-review.md',
   depth: 'depth-review.md',
 };
 
-export async function runReview(
+/**
+ * Shared review context (diff, changed files, orchestrator state, how-to)
+ * used by both the Cursor SDK reviewers and the Codex CLI reviewer so every
+ * slot judges the same evidence.
+ */
+export function buildReviewContext(
   repoRoot: string,
-  slot: Exclude<ReviewSlot, 'bugbot'>,
   prNumber: number,
   baseRef: string,
   state: PrAgentState,
-): Promise<void> {
-  const config = loadConfig(repoRoot);
-  const apiKey = process.env.CURSOR_API_KEY;
-  if (!apiKey) throw new Error('CURSOR_API_KEY is required');
-
-  const promptPath = join(repoRoot, '.github/pr-agent/prompts', SLOT_PROMPT[slot]);
-  const basePrompt = readFileSync(promptPath, 'utf8');
-
+): string {
   const diffStat = execSync(`git diff origin/${baseRef}...HEAD --stat`, {
     cwd: repoRoot,
     encoding: 'utf8',
@@ -51,7 +48,7 @@ export async function runReview(
     ? `${fullDiff.slice(0, MAX_DIFF_CHARS)}\n\n... [diff truncated at ${MAX_DIFF_CHARS} chars — open the changed files directly to review the rest] ...`
     : fullDiff || '(no diff)';
 
-  const context = `
+  return `
 PR #${prNumber}
 Base: ${baseRef}
 
@@ -87,7 +84,23 @@ ${diffStat || '(no diff)'}
 ${diffBody}
 \`\`\`
 `;
+}
 
+export async function runReview(
+  repoRoot: string,
+  slot: 'standards' | 'depth',
+  prNumber: number,
+  baseRef: string,
+  state: PrAgentState,
+): Promise<void> {
+  const config = loadConfig(repoRoot);
+  const apiKey = process.env.CURSOR_API_KEY;
+  if (!apiKey) throw new Error('CURSOR_API_KEY is required');
+
+  const promptPath = join(repoRoot, '.github/pr-agent/prompts', SLOT_PROMPT[slot]);
+  const basePrompt = readFileSync(promptPath, 'utf8');
+
+  const context = buildReviewContext(repoRoot, prNumber, baseRef, state);
   const fullPrompt = `${basePrompt}\n\n---\n\n${context}`;
 
   const reviewModel =

--- a/scripts/pr-agent/src/rotate.ts
+++ b/scripts/pr-agent/src/rotate.ts
@@ -1,30 +1,54 @@
 import type { ReviewSlot } from './types.js';
 
-const ROTATION_PAIRS: ReviewSlot[][] = [
+const ROTATION_PAIRS_3: ReviewSlot[][] = [
   ['bugbot', 'standards'],
   ['bugbot', 'depth'],
   ['standards', 'depth'],
 ];
 
-export function pairForCycle(cycle: number): ReviewSlot[] {
-  return ROTATION_PAIRS[((cycle % 3) + 3) % 3]!;
+// Codex-enabled rotation (4 choose 2), ordered so consecutive cycles swap both
+// slots and the codex slot appears every other cycle for vendor diversity.
+const ROTATION_PAIRS_4: ReviewSlot[][] = [
+  ['bugbot', 'standards'],
+  ['codex', 'depth'],
+  ['bugbot', 'codex'],
+  ['standards', 'depth'],
+  ['bugbot', 'depth'],
+  ['codex', 'standards'],
+];
+
+/** The codex slot only runs when the OPENAI_API_KEY secret is configured. */
+export function codexSlotAvailable(): boolean {
+  return process.env.HAS_OPENAI_API_KEY === 'true';
+}
+
+function rotationPairs(codexAvailable: boolean): ReviewSlot[][] {
+  return codexAvailable ? ROTATION_PAIRS_4 : ROTATION_PAIRS_3;
+}
+
+export function pairForCycle(cycle: number, codexAvailable = codexSlotAvailable()): ReviewSlot[] {
+  const pairs = rotationPairs(codexAvailable);
+  const n = pairs.length;
+  return pairs[((cycle % n) + n) % n]!;
 }
 
 export function frozenPairFromFindings(
   counts: Record<ReviewSlot, number>,
+  codexAvailable = codexSlotAvailable(),
 ): ReviewSlot[] {
+  const available = new Set(rotationPairs(codexAvailable).flat());
   const entries = (Object.entries(counts) as [ReviewSlot, number][]).filter(
-    ([, n]) => n > 0,
+    ([slot, n]) => n > 0 && available.has(slot),
   );
   entries.sort((a, b) => b[1] - a[1]);
   if (entries.length >= 2) {
     return [entries[0]![0], entries[1]![0]];
   }
   if (entries.length === 1) {
-    const other = ROTATION_PAIRS.flat().find((s) => s !== entries[0]![0]);
-    return other ? [entries[0]![0], other] : pairForCycle(0);
+    const other = [...available].find((s) => s !== entries[0]![0]);
+    return other ? [entries[0]![0], other] : pairForCycle(0, codexAvailable);
   }
-  return pairForCycle(0);
+  return pairForCycle(0, codexAvailable);
 }
 
 export function resolveActivePair(
@@ -36,9 +60,10 @@ export function resolveActivePair(
     openFindings: { source: string }[];
   },
   forceRotation: boolean,
+  codexAvailable = codexSlotAvailable(),
 ): ReviewSlot[] {
   if (forceRotation) {
-    return pairForCycle(state.cycle);
+    return pairForCycle(state.cycle, codexAvailable);
   }
   const inConvergence =
     state.phase === 'convergence' ||
@@ -46,7 +71,11 @@ export function resolveActivePair(
     state.openFindings.length > 0;
 
   if (inConvergence && state.frozenPair?.length === 2) {
-    return state.frozenPair;
+    // A frozen pair minted while codex was available must not schedule the
+    // codex slot after the OPENAI_API_KEY secret is removed.
+    if (codexAvailable || !state.frozenPair.includes('codex')) {
+      return state.frozenPair;
+    }
   }
-  return pairForCycle(state.cycle);
+  return pairForCycle(state.cycle, codexAvailable);
 }

--- a/scripts/pr-agent/src/state.ts
+++ b/scripts/pr-agent/src/state.ts
@@ -68,14 +68,46 @@ export async function loadOrCreateState(
   repo: string,
   issueNumber: number,
 ): Promise<{ state: PrAgentState; commentId?: number }> {
-  const comments = await listAllIssueComments(octokit, owner, repo, issueNumber);
+  // Races between concurrent orchestrator runs (e.g. a workflow_run-triggered
+  // run on the default branch overlapping a pull_request-triggered run on the
+  // PR branch) have produced duplicate state comments: a transient list/parse
+  // failure made one run fall back to a default state, whose save then created
+  // a second marker comment. Recover deterministically: parse every marker
+  // comment, adopt the highest revision, and best-effort delete the rest so
+  // the ledger converges back to a single source of truth.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const comments = await listAllIssueComments(octokit, owner, repo, issueNumber);
+    const markers = comments.filter((c) => c.body?.includes(MARKER_ORCHESTRATOR));
 
-  const markerComment = comments.find((c) => c.body?.includes(MARKER_ORCHESTRATOR));
-  if (markerComment?.body) {
-    const parsed = parseStateFromComment(markerComment.body);
-    if (parsed) {
-      return { state: parsed, commentId: markerComment.id };
+    const parsed = markers
+      .map((c) => ({ id: c.id, state: c.body ? parseStateFromComment(c.body) : null }))
+      .filter((x): x is { id: number; state: PrAgentState } => x.state != null);
+
+    if (parsed.length > 0) {
+      parsed.sort((a, b) => (b.state.revision ?? 0) - (a.state.revision ?? 0));
+      const winner = parsed[0]!;
+      for (const dup of parsed.slice(1)) {
+        try {
+          await octokit.issues.deleteComment({ owner, repo, comment_id: dup.id });
+          console.log(
+            `Deleted duplicate state comment ${dup.id} (revision ${dup.state.revision ?? 0} < ${winner.state.revision ?? 0})`,
+          );
+        } catch {
+          // Best-effort: a leftover duplicate is inert as long as the winner sorts first.
+        }
+      }
+      return { state: winner.state, commentId: winner.id };
     }
+
+    if (markers.length > 0 && attempt === 0) {
+      // Marker comments exist but none parsed — likely a transient mid-edit
+      // read. Retry once before falling back: proceeding with a default state
+      // silently resets the ledger and budget counters.
+      console.warn('State comment present but unparseable; retrying once before default');
+      await new Promise((r) => setTimeout(r, 5000));
+      continue;
+    }
+    break;
   }
   return { state: defaultState() };
 }

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const ReviewSlotSchema = z.enum(['bugbot', 'standards', 'depth']);
+export const ReviewSlotSchema = z.enum(['bugbot', 'standards', 'depth', 'codex']);
 export type ReviewSlot = z.infer<typeof ReviewSlotSchema>;
 
 export const FindingSchema = z.object({

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -55,6 +55,12 @@ export const VerdictSchema = z.object({
         file: z.string(),
         line: z.number().optional(),
         message: z.string(),
+        /**
+         * Id of an existing open finding the reviewer is re-confirming. The
+         * report then inherits that finding's fingerprint so rewording the
+         * same issue cannot fork it into a duplicate identity.
+         */
+        ref: z.string().optional(),
       }),
     )
     .default([]),

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -94,6 +94,12 @@ export type AggregateOutput = {
   ciFailed: boolean;
   newBlockingCount: number;
   /**
+   * Blocking findings first introduced this cycle by model reviewers (external
+   * bot findings excluded — those already exist as inline comments). Used to
+   * post inline PR review comments anchored at file/line.
+   */
+  newBlockingFindings: Finding[];
+  /**
    * True when reviewers were scheduled but none produced a usable verdict.
    * The cycle carried no review signal, so no convergence counters moved.
    */

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -93,4 +93,9 @@ export type AggregateOutput = {
   handoffReason?: 'human_handoff' | 'budget_exhausted' | 'diverging';
   ciFailed: boolean;
   newBlockingCount: number;
+  /**
+   * True when reviewers were scheduled but none produced a usable verdict.
+   * The cycle carried no review signal, so no convergence counters moved.
+   */
+  emptyCycle?: boolean;
 };

--- a/scripts/pr-agent/tests/overhaul.test.ts
+++ b/scripts/pr-agent/tests/overhaul.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Unit tests for the orchestrator overhaul: external ingestion, stable
+ * fingerprints, empty-cycle guard, codex rotation, PAT CI gate, inline
+ * comments, and review-comment rendering. Run with `bun test`.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { aggregateCycle } from '../src/aggregate.js';
+import { isCiGreen, type CiCheckStatus } from '../src/ci-gates.js';
+import { resetConfigCache } from '../src/config.js';
+import { fetchExternalFindings } from '../src/external-reviews.js';
+import {
+  fingerprintFinding,
+  sourceCounts,
+  verdictToFindings,
+} from '../src/findings.js';
+import { postInlineFindings } from '../src/inline-comments.js';
+import { buildReviewComment } from '../src/review-comment.js';
+import { frozenPairFromFindings, pairForCycle, resolveActivePair } from '../src/rotate.js';
+import { PrAgentStateSchema, type Finding } from '../src/types.js';
+
+const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? '/workspace';
+
+function finding(partial: Partial<Finding>): Finding {
+  return {
+    id: 'aaaaaa',
+    fingerprint: 'file.ts:L10',
+    source: 'standards',
+    severity: 'blocking',
+    file: 'file.ts',
+    line: 10,
+    message: 'msg',
+    status: 'open',
+    introducedCycle: 0,
+    lastSeenCycle: 0,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  resetConfigCache();
+  delete process.env.HAS_OPENAI_API_KEY;
+  delete process.env.PR_AGENT_HAS_PAT;
+  process.env.CI_TRIGGER_FAILED = 'false';
+});
+
+describe('fingerprintFinding', () => {
+  test('same line bucket, different wording => same fingerprint', () => {
+    const a = fingerprintFinding('Foo.java', 'issue below minimum', 101);
+    const b = fingerprintFinding('Foo.java', 'totally reworded description', 104);
+    expect(a).toBe(b);
+    expect(a).toBe('foo.java:L100');
+  });
+
+  test('distant lines differ', () => {
+    expect(fingerprintFinding('Foo.java', 'x', 101)).not.toBe(
+      fingerprintFinding('Foo.java', 'x', 401),
+    );
+  });
+
+  test('no line falls back to normalized message hash', () => {
+    const a = fingerprintFinding('Foo.java', 'Value 42 is `bad`');
+    const b = fingerprintFinding('Foo.java', 'value 99 is bad');
+    expect(a).toBe(b); // numbers masked, quotes stripped, case-folded
+    expect(a).not.toContain(':L');
+  });
+});
+
+describe('verdictToFindings ref echo', () => {
+  test('ref inherits the existing fingerprint case-insensitively', () => {
+    const existing = finding({ id: 'AbC123', fingerprint: 'foo.java:L100' });
+    const { blocking } = verdictToFindings(
+      {
+        verdict: 'changes_requested',
+        findings: [
+          { severity: 'blocking', file: 'Other.java', line: 999, message: 'reworded', ref: 'abc123' },
+        ],
+      },
+      'depth',
+      3,
+      [existing],
+    );
+    expect(blocking[0]!.fingerprint).toBe('foo.java:L100');
+  });
+
+  test('unknown ref mints a fresh identity', () => {
+    const { blocking } = verdictToFindings(
+      {
+        verdict: 'changes_requested',
+        findings: [
+          { severity: 'blocking', file: 'A.java', line: 55, message: 'new', ref: 'zzzzzz' },
+        ],
+      },
+      'depth',
+      3,
+      [finding({})],
+    );
+    expect(blocking[0]!.fingerprint).toBe('a.java:L60');
+  });
+});
+
+describe('rotation', () => {
+  test('3-slot roster never schedules codex', () => {
+    for (let i = 0; i < 6; i++) {
+      expect(pairForCycle(i, false)).not.toContain('codex');
+    }
+  });
+
+  test('4-slot roster schedules codex regularly and covers all slots', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 6; i++) for (const s of pairForCycle(i, true)) seen.add(s);
+    expect([...seen].sort()).toEqual(['bugbot', 'codex', 'depth', 'standards']);
+  });
+
+  test('frozen pair containing codex is remapped when codex unavailable', () => {
+    const pair = resolveActivePair(
+      {
+        cycle: 3,
+        fixRound: 1,
+        phase: 'convergence',
+        frozenPair: ['codex', 'depth'],
+        openFindings: [{ source: 'codex' }],
+      },
+      false,
+      false,
+    );
+    expect(pair).not.toContain('codex');
+    expect(pair.length).toBe(2);
+  });
+
+  test('frozen pair kept verbatim when codex available', () => {
+    const pair = resolveActivePair(
+      {
+        cycle: 3,
+        fixRound: 1,
+        phase: 'convergence',
+        frozenPair: ['codex', 'depth'],
+        openFindings: [{ source: 'codex' }],
+      },
+      false,
+      true,
+    );
+    expect(pair).toEqual(['codex', 'depth']);
+  });
+
+  test('sourceCounts has a codex bucket and frozenPairFromFindings uses counts', () => {
+    const counts = sourceCounts([
+      finding({ source: 'codex', fingerprint: 'a:L10' }),
+      finding({ source: 'codex', fingerprint: 'b:L10' }),
+      finding({ source: 'depth', fingerprint: 'c:L10' }),
+    ]);
+    expect(counts.codex).toBe(2);
+    expect(frozenPairFromFindings(counts, true)).toEqual(['codex', 'depth']);
+  });
+});
+
+describe('aggregateCycle', () => {
+  const cleanApprove =
+    'clean\n{"verdict":"approve","findings":[]}';
+  const oneBlocking =
+    'found\n{"verdict":"changes_requested","findings":[{"severity":"blocking","file":"Bar.java","line":42,"message":"bad"}]}';
+
+  test('empty cycle freezes all counters and schedules nothing', () => {
+    const st = PrAgentStateSchema.parse({
+      cycle: 3,
+      stagnationFixRounds: 1,
+      consecutiveNoNewReviews: 1,
+      lastOpenCount: 2,
+    });
+    const out = aggregateCycle(REPO_ROOT, st, {}, [], ['standards', 'bugbot']);
+    expect(out.emptyCycle).toBe(true);
+    expect(out.state.cycle).toBe(3);
+    expect(out.state.stagnationFixRounds).toBe(1);
+    expect(out.state.consecutiveNoNewReviews).toBe(1);
+    expect(out.shouldFix).toBe(false);
+    expect(out.shouldHandoff).toBe(false);
+  });
+
+  test('bugbot incomplete alone (single-slot pair) is an empty cycle', () => {
+    const st = PrAgentStateSchema.parse({ cycle: 2 });
+    const out = aggregateCycle(
+      REPO_ROOT,
+      st,
+      { bugbotCheckCompleted: false },
+      [],
+      ['bugbot'],
+    );
+    expect(out.emptyCycle).toBe(true);
+    expect(out.state.cycle).toBe(2);
+  });
+
+  test('codex slot text is ingested like standards/depth', () => {
+    const st = PrAgentStateSchema.parse({ cycle: 0 });
+    const out = aggregateCycle(
+      REPO_ROOT,
+      st,
+      { codex: oneBlocking, standards: cleanApprove },
+      [],
+      ['codex', 'standards'],
+    );
+    expect(out.emptyCycle).toBeUndefined();
+    expect(out.state.openFindings.some((f) => f.source === 'codex')).toBe(true);
+    expect(out.shouldFix).toBe(true);
+  });
+
+  test('external blocking finding drives shouldFix but not new-blocking or divergence counters', () => {
+    const ext = finding({
+      source: 'external:cursor[bot]',
+      fingerprint: 'external:cursor[bot]:1',
+      severity: 'blocking',
+    });
+    const st = PrAgentStateSchema.parse({ cycle: 0 });
+    const out = aggregateCycle(
+      REPO_ROOT,
+      st,
+      {
+        standards: cleanApprove,
+        external: { current: [ext], sources: ['external:cursor[bot]'] },
+      },
+      [],
+      ['standards'],
+    );
+    expect(out.shouldFix).toBe(true);
+    expect(out.newBlockingCount).toBe(0);
+    // consecutive still increments: model reviews were clean
+    expect(out.state.consecutiveNoNewReviews).toBe(1);
+    // external excluded from stagnation baseline
+    expect(out.state.lastOpenCount).toBe(0);
+    // external excluded from inline-comment candidates
+    expect(out.newBlockingFindings.length).toBe(0);
+  });
+
+  test('external finding whose comment disappeared is resolved', () => {
+    const ext = finding({
+      source: 'external:cursor[bot]',
+      fingerprint: 'external:cursor[bot]:1',
+    });
+    const st = PrAgentStateSchema.parse({ cycle: 1, openFindings: [ext] });
+    const out = aggregateCycle(
+      REPO_ROOT,
+      st,
+      {
+        standards: cleanApprove,
+        external: { current: [], sources: ['external:cursor[bot]'] },
+      },
+      [],
+      ['standards'],
+    );
+    expect(out.state.openFindings.length).toBe(0);
+    expect(
+      out.state.resolvedFindings.some((f) => f.fingerprint === 'external:cursor[bot]:1'),
+    ).toBe(true);
+  });
+
+  test('muted external fingerprints are not re-ingested', () => {
+    const ext = finding({
+      source: 'external:cursor[bot]',
+      fingerprint: 'external:cursor[bot]:1',
+    });
+    const st = PrAgentStateSchema.parse({
+      cycle: 1,
+      mutedFingerprints: ['external:cursor[bot]:1'],
+    });
+    const out = aggregateCycle(
+      REPO_ROOT,
+      st,
+      {
+        standards: cleanApprove,
+        external: { current: [ext], sources: ['external:cursor[bot]'] },
+      },
+      [],
+      ['standards'],
+    );
+    expect(out.state.openFindings.length).toBe(0);
+    expect(out.shouldFix).toBe(false);
+  });
+
+  test('stagnation counts only internal findings', () => {
+    const internal = finding({ fingerprint: 'a.ts:L10' });
+    const ext = finding({
+      source: 'external:cursor[bot]',
+      fingerprint: 'external:cursor[bot]:9',
+    });
+    // lastOpenCount=1 (internal), and this cycle internal count is still 1 =>
+    // stagnation increments regardless of the external finding coming and going.
+    const st = PrAgentStateSchema.parse({
+      cycle: 2,
+      lastOpenCount: 1,
+      openFindings: [internal],
+    });
+    const out = aggregateCycle(
+      REPO_ROOT,
+      st,
+      {
+        standards:
+          'still there\n{"verdict":"changes_requested","findings":[{"severity":"blocking","file":"a.ts","line":10,"message":"still bad"}]}',
+        external: { current: [ext], sources: ['external:cursor[bot]'] },
+      },
+      [],
+      ['standards'],
+    );
+    expect(out.state.stagnationFixRounds).toBe(1);
+    expect(out.state.lastOpenCount).toBe(1);
+  });
+});
+
+describe('isCiGreen PAT gate', () => {
+  const awaiting: CiCheckStatus[] = [
+    { name: 'Build', status: 'pending', conclusion: null, required: true, awaitingApproval: true },
+  ];
+
+  test('without PAT, awaiting-approval checks are conceded as green', () => {
+    process.env.PR_AGENT_HAS_PAT = 'false';
+    expect(isCiGreen(awaiting)).toBe(true);
+  });
+
+  test('with PAT, awaiting-approval checks block the gate', () => {
+    process.env.PR_AGENT_HAS_PAT = 'true';
+    expect(isCiGreen(awaiting)).toBe(false);
+  });
+
+  test('with PAT, genuinely green checks still pass', () => {
+    process.env.PR_AGENT_HAS_PAT = 'true';
+    expect(
+      isCiGreen([{ name: 'Build', status: 'completed', conclusion: 'success', required: true }]),
+    ).toBe(true);
+  });
+});
+
+describe('fetchExternalFindings', () => {
+  type Comment = {
+    id: number;
+    user?: { login: string };
+    path: string;
+    line: number | null;
+    original_line?: number | null;
+    position?: number | null;
+    body?: string;
+    in_reply_to_id?: number;
+  };
+
+  function octokitWith(comments: Comment[]) {
+    return {
+      pulls: {
+        listReviewComments: async ({ page }: { page: number }) => ({
+          data: page === 1 ? comments : [],
+        }),
+      },
+    } as never;
+  }
+
+  test('classifies severity, skips replies/outdated/non-allowlisted, strips HTML', async () => {
+    const comments: Comment[] = [
+      {
+        id: 1,
+        user: { login: 'cursor[bot]' },
+        path: 'a.ts',
+        line: 12,
+        position: 3,
+        body: '### Bug\n\n**High Severity**\n\n<!-- meta -->details here',
+      },
+      { id: 2, user: { login: 'cursor[bot]' }, path: 'b.ts', line: 5, position: 1, body: 'minor style note' },
+      { id: 3, user: { login: 'cursor[bot]' }, path: 'c.ts', line: null, position: null, body: '**High Severity** outdated' },
+      { id: 4, user: { login: 'cursor[bot]' }, path: 'a.ts', line: 12, position: 3, body: 'reply', in_reply_to_id: 1 },
+      { id: 5, user: { login: 'random-user' }, path: 'd.ts', line: 9, position: 2, body: '**High Severity** not allowlisted' },
+    ];
+    const res = await fetchExternalFindings(
+      octokitWith(comments),
+      'o',
+      'r',
+      1,
+      REPO_ROOT,
+      7,
+    );
+    expect(res.current.length).toBe(2);
+    const blocking = res.current.find((f) => f.fingerprint.endsWith(':1'))!;
+    expect(blocking.severity).toBe('blocking');
+    expect(blocking.message).not.toContain('<!--');
+    expect(blocking.file).toBe('a.ts');
+    expect(blocking.line).toBe(12);
+    const nit = res.current.find((f) => f.fingerprint.endsWith(':2'))!;
+    expect(nit.severity).toBe('nit');
+    expect(res.sources).toEqual(['external:cursor[bot]']);
+  });
+});
+
+describe('postInlineFindings', () => {
+  function mockOctokit(opts: { existingBodies?: string[]; failBatch?: boolean; failPaths?: string[] }) {
+    const calls = { reviews: [] as unknown[], comments: [] as Array<{ path: string }> };
+    const octokit = {
+      pulls: {
+        listReviewComments: async ({ page }: { page: number }) => ({
+          data: page === 1 ? (opts.existingBodies ?? []).map((b, i) => ({ id: i, body: b })) : [],
+        }),
+        createReview: async (args: unknown) => {
+          if (opts.failBatch) throw new Error('422 line outside diff');
+          calls.reviews.push(args);
+          return {};
+        },
+        createReviewComment: async (args: { path: string }) => {
+          if ((opts.failPaths ?? []).includes(args.path)) throw new Error('422');
+          calls.comments.push(args);
+          return {};
+        },
+      },
+    } as never;
+    return { octokit, calls };
+  }
+
+  test('posts one batch review for fresh blocking findings with lines', async () => {
+    const { octokit, calls } = mockOctokit({});
+    await postInlineFindings(octokit, 'o', 'r', 1, 'sha', [
+      finding({ id: 'f1', line: 10 }),
+      finding({ id: 'f2', line: 0 }), // no usable line: skipped
+      finding({ id: 'f3', line: 20, severity: 'nit' }), // nit: skipped
+    ]);
+    expect(calls.reviews.length).toBe(1);
+    const review = calls.reviews[0] as { comments: Array<{ body: string }> };
+    expect(review.comments.length).toBe(1);
+    expect(review.comments[0]!.body).toContain('pr-agent-finding:f1');
+    expect(review.comments[0]!.body).toContain('agent-resolve f1');
+  });
+
+  test('marker dedupe suppresses already-posted findings', async () => {
+    const { octokit, calls } = mockOctokit({
+      existingBodies: ['<!-- pr-agent-finding:f1 --> already here'],
+    });
+    await postInlineFindings(octokit, 'o', 'r', 1, 'sha', [finding({ id: 'f1', line: 10 })]);
+    expect(calls.reviews.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+
+  test('batch rejection falls back to per-comment posting and skips bad anchors', async () => {
+    const { octokit, calls } = mockOctokit({ failBatch: true, failPaths: ['bad.ts'] });
+    await postInlineFindings(octokit, 'o', 'r', 1, 'sha', [
+      finding({ id: 'f1', file: 'good.ts', fingerprint: 'good.ts:L10', line: 10 }),
+      finding({ id: 'f2', file: 'bad.ts', fingerprint: 'bad.ts:L20', line: 20 }),
+    ]);
+    expect(calls.comments.map((c) => c.path)).toEqual(['good.ts']);
+  });
+});
+
+describe('buildReviewComment', () => {
+  test('no ingested reviews renders the counters-unchanged banner without counts', () => {
+    const st = PrAgentStateSchema.parse({
+      cycle: 4,
+      openFindings: [finding({})],
+      nitFindings: [finding({ severity: 'nit' })],
+    });
+    const body = buildReviewComment(st, {}, ['standards', 'bugbot']);
+    expect(body).toContain('No model reviews were ingested');
+    expect(body).toContain('counters unchanged');
+    expect(body).not.toContain('blocking ·');
+  });
+
+  test('codex section renders with its own label', () => {
+    const st = PrAgentStateSchema.parse({ cycle: 1 });
+    const body = buildReviewComment(
+      st,
+      { codex: 'all good\n{"verdict":"approve","findings":[]}' },
+      ['codex'],
+    );
+    expect(body).toContain('Codex — review');
+    expect(body).toContain('✅ approve');
+  });
+});

--- a/scripts/pr-agent/tests/state.test.ts
+++ b/scripts/pr-agent/tests/state.test.ts
@@ -1,10 +1,61 @@
 import { describe, expect, test } from 'bun:test';
 import {
   formatStateComment,
+  loadOrCreateState,
   parseStateFromComment,
   saveState,
 } from '../src/state.js';
 import { makeState } from './helpers.js';
+
+describe('loadOrCreateState duplicate recovery', () => {
+  test('adopts the highest-revision state comment and deletes duplicates', async () => {
+    const real = formatStateComment(makeState({ cycle: 3, revision: 12 }));
+    const rogue = formatStateComment(makeState({ cycle: 0, revision: 1 }));
+    const deleted: number[] = [];
+    const octokit = {
+      issues: {
+        listComments: async ({ page }: { page: number }) => ({
+          data:
+            page === 1
+              ? [
+                  { id: 1, body: 'unrelated' },
+                  { id: 2, body: real },
+                  { id: 3, body: rogue },
+                ]
+              : [],
+        }),
+        deleteComment: async ({ comment_id }: { comment_id: number }) => {
+          deleted.push(comment_id);
+        },
+      },
+    } as any;
+
+    const { state, commentId } = await loadOrCreateState(octokit, 'o', 'r', 1);
+    expect(state.cycle).toBe(3);
+    expect(state.revision).toBe(12);
+    expect(commentId).toBe(2);
+    expect(deleted).toEqual([3]);
+  });
+
+  test('unparseable marker comment falls back to default only after a retry', async () => {
+    let listCalls = 0;
+    const octokit = {
+      issues: {
+        listComments: async () => {
+          listCalls++;
+          return {
+            data: [{ id: 5, body: '<!-- pr-agent-orchestrator -->\n```json\n{corrupted' }],
+          };
+        },
+      },
+    } as any;
+
+    const { state, commentId } = await loadOrCreateState(octokit, 'o', 'r', 1);
+    expect(listCalls).toBe(2);
+    expect(state.cycle).toBe(0);
+    expect(commentId).toBeUndefined();
+  }, 15_000);
+});
 
 describe('saveState revision CAS', () => {
   test('refuses to overwrite a newer remote revision', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Scratch PR to live-validate the Codex CLI auth fix in the PR agent orchestrator (`codex login --with-api-key` before `codex exec`). Branched off `cursor/pr-agent-overhaul-7075` so the new orchestrator code runs here.

Cycle 0 runs bugbot + standards; cycle 1 runs codex + depth, which exercises the fixed auth path against the real `OPENAI_API_KEY` secret.

Will be closed after the test completes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b38a621b-68d2-4f6c-b324-980eb5dc7075?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b38a621b-68d2-4f6c-b324-980eb5dc7075&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

