### PR TITLE
OS-1891 Fix rapid video recording restart

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1565,11 +1565,17 @@ public class CameraNeoService extends LifecycleService {
             stopSelf();
         } catch (InterruptedException e) {
             Log.e(TAG, "Interrupted while trying to lock camera", e);
-            photoSession.notifyHostPhotoError("Camera operation interrupted");
+            if (forVideo)
+                notifyVideoError(videoSession.currentVideoId(), "Camera operation interrupted");
+            else photoSession.notifyHostPhotoError("Camera operation interrupted");
             stopSelf();
         } catch (Exception e) {
             Log.e(TAG, "Error setting up camera", e);
-            photoSession.notifyHostPhotoError("Error setting up camera: " + e.getMessage());
+            if (forVideo)
+                notifyVideoError(
+                        videoSession.currentVideoId(),
+                        "Error setting up camera: " + e.getMessage());
+            else photoSession.notifyHostPhotoError("Error setting up camera: " + e.getMessage());
             stopSelf();
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -97,7 +97,7 @@ public class MediaCaptureService {
     private final MlKitTextRoiDetector textRoiDetector;
 
     // Track current video recording
-    private boolean isRecordingVideo = false;
+    private volatile boolean isRecordingVideo = false;
     private String currentVideoId = null;
     // volatile: read in the stop prologue (BLE worker / main looper) to derive the upload-target
     // captureId key, while written on the start/callback threads — needs cross-thread visibility.
@@ -140,6 +140,7 @@ public class MediaCaptureService {
     }
 
     private StopReason mCurrentStopReason = null;
+    private final VideoRecordingLifecycle videoRecordingLifecycle = new VideoRecordingLifecycle();
 
     /**
      * Stop-time upload target bound to a specific recording. Empty/null webhook = keep on device.
@@ -1000,36 +1001,42 @@ public class MediaCaptureService {
                     "⚠️ StateManager not initialized - skipping battery check for video recording");
         }
 
-        if (isRecordingVideo) {
+        if (isRecordingVideo && !videoRecordingLifecycle.isStopping()) {
             Log.d(TAG, "Stopping video recording");
             stopVideoRecording();
         } else {
-            Log.d(
-                    TAG,
-                    "Starting video recording with settings: "
-                            + settings
-                            + ", max time: "
-                            + maxRecordingTimeMinutes
-                            + " minutes, battery: "
-                            + initialBatteryLevel
-                            + "%");
-            // Generate IDs for local recording
-            String timeStamp =
-                    new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(new Date());
-            int randomSuffix = (int) (Math.random() * 1000);
-            String requestId = "local_video_" + timeStamp + "_" + randomSuffix;
-            String captureDir = "VID_" + timeStamp + "_" + randomSuffix;
-            File captureDirFile = new File(fileManager.getDefaultMediaDirectory(), captureDir);
-            captureDirFile.mkdirs();
-            String videoFilePath = new File(captureDirFile, "base.mp4").getAbsolutePath();
-            startVideoRecording(
-                    videoFilePath,
-                    requestId,
-                    settings,
-                    enableFlash,
-                    true,
-                    maxRecordingTimeMinutes,
-                    false);
+            Runnable startAction =
+                    () -> {
+                        Log.d(
+                                TAG,
+                                "Starting video recording with settings: "
+                                        + settings
+                                        + ", max time: "
+                                        + maxRecordingTimeMinutes
+                                        + " minutes, battery: "
+                                        + initialBatteryLevel
+                                        + "%");
+                        String timeStamp =
+                                new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US)
+                                        .format(new Date());
+                        int randomSuffix = (int) (Math.random() * 1000);
+                        String requestId = "local_video_" + timeStamp + "_" + randomSuffix;
+                        String captureDir = "VID_" + timeStamp + "_" + randomSuffix;
+                        File captureDirFile =
+                                new File(fileManager.getDefaultMediaDirectory(), captureDir);
+                        captureDirFile.mkdirs();
+                        String videoFilePath =
+                                new File(captureDirFile, "base.mp4").getAbsolutePath();
+                        startVideoRecording(
+                                videoFilePath,
+                                requestId,
+                                settings,
+                                enableFlash,
+                                true,
+                                maxRecordingTimeMinutes,
+                                false);
+                    };
+            requestVideoStart(startAction);
         }
     }
 
@@ -1038,10 +1045,11 @@ public class MediaCaptureService {
      *
      * @param requestId Unique request ID for tracking
      * @param save Whether to keep the video on device after upload
+     * @return true when the start was accepted immediately or queued behind recorder teardown
      */
-    public void handleStartVideoCommand(
+    public boolean handleStartVideoCommand(
             String requestId, boolean save, boolean enableFlash, boolean enableSound) {
-        handleStartVideoCommand(requestId, save, null, enableFlash, enableSound);
+        return handleStartVideoCommand(requestId, save, null, enableFlash, enableSound);
     }
 
     /**
@@ -1050,14 +1058,15 @@ public class MediaCaptureService {
      * @param requestId Unique request ID for tracking
      * @param save Whether to keep the video on device after upload
      * @param settings Video settings (resolution, fps) or null for defaults
+     * @return true when the start was accepted immediately or queued behind recorder teardown
      */
-    public void handleStartVideoCommand(
+    public boolean handleStartVideoCommand(
             String requestId,
             boolean save,
             VideoSettings settings,
             boolean enableFlash,
             boolean enableSound) {
-        handleStartVideoCommand(requestId, save, settings, enableFlash, enableSound, 0);
+        return handleStartVideoCommand(requestId, save, settings, enableFlash, enableSound, 0);
     }
 
     /**
@@ -1067,8 +1076,9 @@ public class MediaCaptureService {
      * @param save Whether to keep the video on device after upload
      * @param settings Video settings (resolution, fps) or null for defaults
      * @param maxRecordingTimeMinutes Maximum recording time in minutes (0 = no limit)
+     * @return true when the start was accepted immediately or queued behind recorder teardown
      */
-    public void handleStartVideoCommand(
+    public boolean handleStartVideoCommand(
             String requestId,
             boolean save,
             VideoSettings settings,
@@ -1090,40 +1100,50 @@ public class MediaCaptureService {
                         + ", maxRecordingTimeMinutes: "
                         + maxRecordingTimeMinutes);
 
-        // Check if already recording
-        if (isRecordingVideo) {
-            Log.w(TAG, "Already recording video, ignoring start command");
-            if (mMediaCaptureListener != null) {
-                mMediaCaptureListener.onMediaError(
-                        requestId, "Already recording", MediaUploadQueueManager.MEDIA_TYPE_VIDEO);
-            }
-            return;
+        Runnable startAction =
+                () -> {
+                    String timeStamp =
+                            new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US)
+                                    .format(new Date());
+                    int randomSuffix = (int) (Math.random() * 1000);
+                    String embeddedRequestId = CaptureRequestId.sanitizeForDirName(requestId);
+                    String captureDir =
+                            "VID_"
+                                    + timeStamp
+                                    + "_"
+                                    + randomSuffix
+                                    + (embeddedRequestId.isEmpty() ? "" : "_" + embeddedRequestId);
+                    File captureDirFile =
+                            new File(fileManager.getDefaultMediaDirectory(), captureDir);
+                    captureDirFile.mkdirs();
+                    String videoFilePath = new File(captureDirFile, "base.mp4").getAbsolutePath();
+
+                    startVideoRecording(
+                            videoFilePath,
+                            requestId,
+                            settings,
+                            enableFlash,
+                            enableSound,
+                            maxRecordingTimeMinutes,
+                            save);
+                };
+        return requestVideoStart(startAction);
+    }
+
+    private boolean requestVideoStart(Runnable startAction) {
+        VideoRecordingLifecycle.StartResult result =
+                videoRecordingLifecycle.requestStart(startAction);
+        if (result == VideoRecordingLifecycle.StartResult.START_NOW) {
+            startAction.run();
+            return true;
+        }
+        if (result == VideoRecordingLifecycle.StartResult.QUEUED) {
+            Log.i(TAG, "Queued video start until the active recording finishes stopping");
+            return true;
         }
 
-        // Generate filename with requestId
-        String timeStamp =
-                new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(new Date());
-        int randomSuffix = (int) (Math.random() * 1000);
-        String embeddedRequestId = CaptureRequestId.sanitizeForDirName(requestId);
-        String captureDir =
-                "VID_"
-                        + timeStamp
-                        + "_"
-                        + randomSuffix
-                        + (embeddedRequestId.isEmpty() ? "" : "_" + embeddedRequestId);
-        File captureDirFile = new File(fileManager.getDefaultMediaDirectory(), captureDir);
-        captureDirFile.mkdirs();
-        String videoFilePath = new File(captureDirFile, "base.mp4").getAbsolutePath();
-
-        // Start video recording with the provided requestId and settings (or null for defaults)
-        startVideoRecording(
-                videoFilePath,
-                requestId,
-                settings,
-                enableFlash,
-                enableSound,
-                maxRecordingTimeMinutes,
-                save);
+        Log.w(TAG, "Video start rejected because another recording or queued start is active");
+        return false;
     }
 
     /**
@@ -1201,6 +1221,7 @@ public class MediaCaptureService {
                 || SrtStreamingService.isStreaming()
                 || WhipStreamingService.isStreaming()) {
             Log.e(TAG, "Cannot start video - streaming active");
+            videoRecordingLifecycle.startFailed();
             if (mMediaCaptureListener != null) {
                 mMediaCaptureListener.onMediaError(
                         requestId,
@@ -1213,6 +1234,7 @@ public class MediaCaptureService {
         // Check if camera is actively in use (this will return false for kept-alive idle camera)
         if (CameraNeoService.isCameraInUse()) {
             Log.e(TAG, "Cannot start video - camera actively in use");
+            videoRecordingLifecycle.startFailed();
             if (mMediaCaptureListener != null) {
                 mMediaCaptureListener.onMediaError(
                         requestId, "Camera busy", MediaUploadQueueManager.MEDIA_TYPE_VIDEO);
@@ -1223,6 +1245,7 @@ public class MediaCaptureService {
         // Check storage availability before recording
         if (!isExternalStorageAvailable()) {
             Log.e(TAG, "External storage is not available for video capture");
+            videoRecordingLifecycle.startFailed();
             if (mMediaCaptureListener != null) {
                 mMediaCaptureListener.onMediaError(
                         requestId,
@@ -1265,6 +1288,7 @@ public class MediaCaptureService {
                         @Override
                         public void onRecordingStarted(String videoId) {
                             Log.d(TAG, "Video recording started with ID: " + videoId);
+                            videoRecordingLifecycle.recordingStarted();
                             isRecordingVideo = true;
                             recordingStartTime = System.currentTimeMillis();
 
@@ -1397,6 +1421,7 @@ public class MediaCaptureService {
                             isRecordingVideo = false;
                             currentVideoId = null;
                             currentVideoPath = null;
+                            completeVideoTermination();
 
                             if (filePath == null || captureIdFromCallback == null) {
                                 Log.e(
@@ -1614,6 +1639,7 @@ public class MediaCaptureService {
                             // Reset state
                             currentVideoId = null;
                             currentVideoPath = null;
+                            completeVideoTermination();
                         }
 
                         @Override
@@ -1646,6 +1672,34 @@ public class MediaCaptureService {
             clearVideoCaptureSyncBlocks(videoFilePath);
             currentVideoId = null;
             currentVideoPath = null;
+            videoRecordingLifecycle.startFailed();
+        }
+    }
+
+    /** Release one start queued behind MediaRecorder teardown onto the main looper. */
+    private void completeVideoTermination() {
+        final Runnable pendingStart;
+        synchronized (mStopLock) {
+            mCurrentStopReason = null;
+            pendingStart = videoRecordingLifecycle.recordingTerminated();
+        }
+        if (pendingStart == null) {
+            return;
+        }
+
+        boolean posted =
+                mainHandler.post(
+                        () -> {
+                            if (isCleaningUp.get()) {
+                                videoRecordingLifecycle.startFailed();
+                                return;
+                            }
+                            Log.i(TAG, "Starting video queued behind recorder teardown");
+                            pendingStart.run();
+                        });
+        if (!posted) {
+            videoRecordingLifecycle.startFailed();
+            Log.e(TAG, "Could not post video start queued behind recorder teardown");
         }
     }
 
@@ -1688,6 +1742,14 @@ public class MediaCaptureService {
                 return;
             }
 
+            if (!isRecordingVideo || currentVideoId == null) {
+                Log.w(TAG, "⚠️ Not currently recording, nothing to stop");
+                return;
+            }
+            if (!videoRecordingLifecycle.beginStop()) {
+                Log.w(TAG, "⚠️ Video lifecycle is not ready to stop");
+                return;
+            }
             mCurrentStopReason = reason;
         }
         Log.d(TAG, "🛑 Stopping video recording - Reason: " + reason);
@@ -1700,13 +1762,6 @@ public class MediaCaptureService {
         try {
             // Stop battery monitoring first
             stopBatteryMonitoring();
-
-            if (!isRecordingVideo || currentVideoId == null) {
-                Log.w(TAG, "⚠️ Not currently recording, nothing to stop");
-                // No dispatch → no camera callback → nothing was registered for this stop, so
-                // there is nothing to leak (registration happens below, only on dispatch).
-                return;
-            }
 
             // Handle based on reason
             switch (reason) {
@@ -1784,10 +1839,7 @@ public class MediaCaptureService {
                 hardwareManager.setRecordingLedOff();
                 Log.d(TAG, "Recording LED turned OFF (stop error recovery)");
             }
-        } finally {
-            synchronized (mStopLock) {
-                mCurrentStopReason = null; // Reset for next recording
-            }
+            completeVideoTermination();
         }
     }
 
@@ -7004,6 +7056,7 @@ public class MediaCaptureService {
         assertMainThread();
         Log.d(TAG, "🧹 MediaCaptureService cleanup() called");
         isCleaningUp.set(true);
+        videoRecordingLifecycle.cancelPendingStart();
 
         try {
             photoFeedbackController.cleanup();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/VideoRecordingLifecycle.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/VideoRecordingLifecycle.java
@@ -1,0 +1,79 @@
+package com.mentra.asg_client.io.media.core;
+
+/**
+ * Serializes video recording starts with asynchronous recorder teardown.
+ *
+ * <p>The camera remains occupied after a stop request is dispatched, until MediaRecorder finishes
+ * finalizing the file and the terminal callback runs. One start received during that interval is
+ * retained and released only after termination; additional starts are rejected.
+ */
+final class VideoRecordingLifecycle {
+    enum StartResult {
+        START_NOW,
+        QUEUED,
+        REJECTED
+    }
+
+    private enum Phase {
+        IDLE,
+        STARTING,
+        RECORDING,
+        STOPPING
+    }
+
+    private Phase phase = Phase.IDLE;
+    private Runnable pendingStart;
+
+    synchronized StartResult requestStart(Runnable startAction) {
+        if (phase == Phase.IDLE) {
+            phase = Phase.STARTING;
+            return StartResult.START_NOW;
+        }
+        if (phase == Phase.STOPPING && pendingStart == null) {
+            pendingStart = startAction;
+            return StartResult.QUEUED;
+        }
+        return StartResult.REJECTED;
+    }
+
+    synchronized void recordingStarted() {
+        if (phase == Phase.STARTING) {
+            phase = Phase.RECORDING;
+        }
+    }
+
+    synchronized boolean beginStop() {
+        if (phase != Phase.RECORDING) {
+            return false;
+        }
+        phase = Phase.STOPPING;
+        return true;
+    }
+
+    /**
+     * Completes the active lifecycle and returns the queued start, if any.
+     *
+     * <p>When a start is returned, the phase is already STARTING so no later request can overtake
+     * it before its posted action runs.
+     */
+    synchronized Runnable recordingTerminated() {
+        Runnable next = pendingStart;
+        pendingStart = null;
+        phase = next == null ? Phase.IDLE : Phase.STARTING;
+        return next;
+    }
+
+    synchronized void startFailed() {
+        if (phase == Phase.STARTING) {
+            phase = Phase.IDLE;
+        }
+    }
+
+    synchronized boolean isStopping() {
+        return phase == Phase.STOPPING;
+    }
+
+    synchronized void cancelPendingStart() {
+        pendingStart = null;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/VideoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/VideoCommandHandler.java
@@ -127,13 +127,6 @@ public class VideoCommandHandler extends BaseMediaCommandHandler {
                 Log.w(TAG, "⚠️ StateManager not available - skipping battery check");
             }
 
-            if (captureService.isRecordingVideo()) {
-                logCommandResult("start_video_recording", false, "Already recording video");
-                streamingManager.sendVideoRecordingStatusResponse(
-                        requestId, false, "already_recording", "Already recording video");
-                return false;
-            }
-
             // Parse video settings if provided. Any field that is missing or <= 0
             // falls back to the saved button-video default rather than being
             // dropped, so partial overrides (e.g. an fps-only request from a
@@ -217,8 +210,15 @@ public class VideoCommandHandler extends BaseMediaCommandHandler {
                 maxRecordingTimeMinutes = MAX_RECORDING_TIME_MINUTES;
             }
 
-            captureService.handleStartVideoCommand(
-                    requestId, save, videoSettings, flash, sound, maxRecordingTimeMinutes);
+            boolean accepted =
+                    captureService.handleStartVideoCommand(
+                            requestId, save, videoSettings, flash, sound, maxRecordingTimeMinutes);
+            if (!accepted) {
+                logCommandResult("start_video_recording", false, "Already recording video");
+                streamingManager.sendVideoRecordingStatusResponse(
+                        requestId, false, "already_recording", "Already recording video");
+                return false;
+            }
 
             logCommandResult("start_video_recording", true, null);
             return true;

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/VideoRecordingLifecycleTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/VideoRecordingLifecycleTest.java
@@ -1,0 +1,71 @@
+package com.mentra.asg_client.io.media.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class VideoRecordingLifecycleTest {
+
+    @Test
+    public void startDuringStop_runsAfterRecordingTerminates() {
+        VideoRecordingLifecycle lifecycle = new VideoRecordingLifecycle();
+        AtomicInteger starts = new AtomicInteger();
+
+        assertThat(lifecycle.requestStart(starts::incrementAndGet))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.START_NOW);
+        lifecycle.recordingStarted();
+        assertThat(lifecycle.beginStop()).isTrue();
+
+        assertThat(lifecycle.requestStart(starts::incrementAndGet))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.QUEUED);
+        assertThat(starts).hasValue(0);
+
+        Runnable queuedStart = lifecycle.recordingTerminated();
+
+        assertThat(queuedStart).isNotNull();
+        queuedStart.run();
+        assertThat(starts).hasValue(1);
+    }
+
+    @Test
+    public void secondStartDuringStop_isRejected() {
+        VideoRecordingLifecycle lifecycle = recordingLifecycle();
+
+        assertThat(lifecycle.requestStart(() -> {}))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.QUEUED);
+        assertThat(lifecycle.requestStart(() -> {}))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.REJECTED);
+    }
+
+    @Test
+    public void queuedStart_cannotBeOvertakenAfterTermination() {
+        VideoRecordingLifecycle lifecycle = recordingLifecycle();
+        lifecycle.requestStart(() -> {});
+
+        assertThat(lifecycle.recordingTerminated()).isNotNull();
+
+        assertThat(lifecycle.requestStart(() -> {}))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.REJECTED);
+    }
+
+    @Test
+    public void failedStart_returnsToIdle() {
+        VideoRecordingLifecycle lifecycle = new VideoRecordingLifecycle();
+        assertThat(lifecycle.requestStart(() -> {}))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.START_NOW);
+
+        lifecycle.startFailed();
+
+        assertThat(lifecycle.requestStart(() -> {}))
+                .isEqualTo(VideoRecordingLifecycle.StartResult.START_NOW);
+    }
+
+    private VideoRecordingLifecycle recordingLifecycle() {
+        VideoRecordingLifecycle lifecycle = new VideoRecordingLifecycle();
+        lifecycle.requestStart(() -> {});
+        lifecycle.recordingStarted();
+        assertThat(lifecycle.beginStop()).isTrue();
+        return lifecycle;
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/VideoCommandHandlerStartValidationTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/VideoCommandHandlerStartValidationTest.java
@@ -2,6 +2,8 @@ package com.mentra.asg_client.service.core.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -33,17 +35,20 @@ public class VideoCommandHandlerStartValidationTest {
     private static final int MAX_RECORDING_TIME_MINUTES = 24 * 60;
 
     private MediaCaptureService captureService;
+    private IMediaManager streamingManager;
     private VideoCommandHandler handler;
 
     @Before
     public void setUp() {
         AsgClientServiceManager serviceManager = mock(AsgClientServiceManager.class);
-        IMediaManager streamingManager = mock(IMediaManager.class);
+        streamingManager = mock(IMediaManager.class);
         IStateManager stateManager = mock(IStateManager.class);
         captureService = mock(MediaCaptureService.class);
 
         when(serviceManager.getMediaCaptureService()).thenReturn(captureService);
-        when(captureService.isRecordingVideo()).thenReturn(false);
+        when(captureService.handleStartVideoCommand(
+                        anyString(), anyBoolean(), isNull(), anyBoolean(), anyBoolean(), anyInt()))
+                .thenReturn(true);
         // -1 → battery unknown, skip the low-battery rejection so the start path runs.
         when(stateManager.getBatteryLevel()).thenReturn(-1);
 
@@ -105,5 +110,19 @@ public class VideoCommandHandlerStartValidationTest {
                         anyBoolean(),
                         anyBoolean(),
                         eq(5));
+    }
+
+    @Test
+    public void start_whenServiceRejects_returnsAlreadyRecording() throws Exception {
+        when(captureService.handleStartVideoCommand(
+                        anyString(), anyBoolean(), isNull(), anyBoolean(), anyBoolean(), anyInt()))
+                .thenReturn(false);
+
+        boolean handled = handler.handleCommand("start_video_recording", startData(0));
+
+        assertThat(handled).isFalse();
+        verify(streamingManager)
+                .sendVideoRecordingStatusResponse(
+                        "req-1", false, "already_recording", "Already recording video");
     }
 }

--- a/asg_client/docs/ASG_CLIENT_API.md
+++ b/asg_client/docs/ASG_CLIENT_API.md
@@ -254,6 +254,10 @@ Wire response type for all video commands: `video_recording_status`.
 
 Same battery constraint as photo. `recording_started` is the successful start status. `already_recording`, `battery_low`, `service_unavailable`, `missing_request_id`, and `error` are emitted with `success: false`.
 
+If a start arrives after a stop has been requested but before the recorder has finished finalizing
+the previous file, ASG queues that start and begins it as soon as camera teardown completes. One
+start may wait behind the active stop; further starts are rejected as `already_recording`.
+
 ```json
 {"type": "video_recording_status", "success": true, "status": "recording_started", "timestamp": 1708963201234}
 ```


### PR DESCRIPTION
## Summary

- serialize video recording through starting, recording, stopping, and idle phases
- queue one start received while MediaRecorder finalizes the previous capture
- keep duplicate starts rejected and preserve existing status responses
- document rapid stop/start behavior

## Test evidence

- `./gradlew :app:testDebugUnitTest --tests "com.mentra.asg_client.io.media.core.VideoRecordingLifecycleTest" --tests "com.mentra.asg_client.service.core.handlers.VideoCommandHandlerStartValidationTest"`
- `./gradlew :app:testDebugUnitTest --tests "*Camera*" --tests "*Video*"`
- `./scripts/check-android-compile.sh asg`
- `git diff --check`

## Device validation

- Physical Mentra Live rapid stop/start validation remains recommended for the real MediaRecorder and camera HAL timing.

Linear: OS-1891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threading and state around camera/MediaRecorder teardown; incorrect lifecycle transitions could drop starts, double-record, or mis-report status, though behavior is covered by new unit tests.
> 
> **Overview**
> Fixes **rapid stop/start video** by gating recording through a new **`VideoRecordingLifecycle`** (idle → starting → recording → stopping). While MediaRecorder is still finalizing after a stop, **one** incoming start is **queued** and run on the main looper when teardown completes; any further start is **rejected** as before.
> 
> **`MediaCaptureService`** routes all starts through `requestVideoStart`, returns a **boolean** from `handleStartVideoCommand` (immediate, queued, or rejected), and calls `completeVideoTermination` from stop/error paths so queued work is not dropped. Toggle/stop logic treats **stopping** separately from active recording so a start during teardown can be accepted instead of flipping to stop. **`VideoCommandHandler`** drops the early `isRecordingVideo` check and maps a `false` return to the existing **`already_recording`** status.
> 
> **`CameraNeoService`** now reports camera setup/interrupt failures via **`notifyVideoError`** when opening for video, not only photo errors. Docs describe the queued-start behavior; unit tests cover the lifecycle and handler rejection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6678c11d9f48f2147cd046f77e7cbc01d2686ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rapid video restart by serializing the recording lifecycle and queuing one start issued while a stop finalizes; additional starts are rejected as already_recording. Also reports camera setup failures during video open as video errors so senders get a clear failure instead of a silent drop. Addresses Linear OS-1891.

- Introduces `VideoRecordingLifecycle` (IDLE → STARTING → RECORDING → STOPPING) to allow one pending start while stopping; failed starts reset to IDLE.
- Updates `MediaCaptureService` to route starts through a gated `requestVideoStart`, post the queued start after terminal callbacks via `completeVideoTermination`, and return a boolean from `handleStartVideoCommand` indicating accepted/queued vs rejected; integrates failure paths, makes `isRecordingVideo` volatile, and cancels a pending start on cleanup.
- Updates `VideoCommandHandler` to use the service’s boolean result and preserve existing status responses (already_recording, etc.).
- `CameraNeoService` now calls `notifyVideoError` with the current video ID on camera open interruptions/errors (previously only photo errors were surfaced).
- Adds unit tests and docs for the queued-start behavior; no API/protocol changes for senders beyond improved video error reporting and accepting one start received while stopping.

<sup>Written for commit 6678c11d9f48f2147cd046f77e7cbc01d2686ceb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

