### PR TITLE
Upgrade Android foreground service types

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1,7 +1,10 @@
 package com.mentra.bluetoothsdk
 
+import android.app.Activity
+import android.app.Application
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import com.mentra.bluetoothsdk.utils.ControllerTypes
@@ -30,6 +33,23 @@ class MentraBluetoothSdk private constructor(
     private val discoveredDeviceNames = mutableSetOf<String>()
     private val bridgeEventSinkId: String
     private val storeListenerId: String
+    private val activityLifecycleCallbacks =
+        object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityResumed(activity: Activity) {
+                // Match the Mentra App's OnActivityEntersForeground hook. This runs after
+                // runtime permission dialogs in native host apps, allowing the service to
+                // replace its temporary dataSync type with connectedDevice/microphone/location.
+                deviceManager.refreshForegroundServiceTypes()
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+            override fun onActivityStarted(activity: Activity) = Unit
+            override fun onActivityPaused(activity: Activity) = Unit
+            override fun onActivityStopped(activity: Activity) = Unit
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+            override fun onActivityDestroyed(activity: Activity) = Unit
+        }
+    private var activityLifecycleCallbacksRegistered = false
     private var suppressDefaultDeviceEvents = false
     private val streamKeepAliveLock = Any()
     private var activeStreamKeepAlive: ActiveStreamKeepAlive? = null
@@ -57,6 +77,10 @@ class MentraBluetoothSdk private constructor(
         listeners.add(listener)
         Bridge.initialize(appContext)
         deviceManager = DeviceManager.getInstance()
+        (appContext as? Application)?.let { application ->
+            application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+            activityLifecycleCallbacksRegistered = true
+        }
         bridgeEventSinkId = Bridge.addEventSink { eventName, data -> dispatchBridgeEvent(eventName, data) }
         // Baseline the analytics connection state before subscribing to the store:
         // store updates invoke listeners synchronously on the updating thread, so a
@@ -1359,6 +1383,12 @@ class MentraBluetoothSdk private constructor(
 
     override fun close() {
         stopStreamKeepAliveMonitor()
+        if (activityLifecycleCallbacksRegistered) {
+            (appContext as? Application)?.unregisterActivityLifecycleCallbacks(
+                activityLifecycleCallbacks,
+            )
+            activityLifecycleCallbacksRegistered = false
+        }
         Bridge.removeEventSink(bridgeEventSinkId)
         DeviceStore.store.removeListener(storeListenerId)
         analytics.shutdown()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
@@ -20,6 +20,35 @@ class ForegroundService : Service() {
         const val NOTIFICATION_ID = 1001
         const val ACTION_REFRESH_TYPES =
                 "com.mentra.bluetoothsdk.services.action.REFRESH_FOREGROUND_SERVICE_TYPES"
+
+        internal fun bootstrapServiceType(): Int =
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+
+        internal fun preferredServiceType(
+                hasConnectedDeviceAccess: Boolean,
+                hasMicrophoneAccess: Boolean,
+                hasLocationAccess: Boolean,
+                includeMediaPlayback: Boolean = true,
+        ): Int {
+            var serviceType = 0
+
+            if (includeMediaPlayback) {
+                serviceType =
+                        serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            }
+            if (hasConnectedDeviceAccess) {
+                serviceType =
+                        serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+            }
+            if (hasMicrophoneAccess) {
+                serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            }
+            if (hasLocationAccess) {
+                serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            }
+
+            return if (serviceType == 0) bootstrapServiceType() else serviceType
+        }
     }
 
     private var locationTypeRequested = false
@@ -28,7 +57,11 @@ class ForegroundService : Service() {
         super.onCreate()
         Bridge.log("ForegroundService: onCreate() called")
         BleTraceLogger.logLifecycle(this, "ForegroundService", "service_create")
-        startForegroundWithAutoDetectedType()
+        // Enter the foreground immediately with a type that has no runtime
+        // prerequisites. onStartCommand() replaces this bootstrap type with the
+        // eligible long-running types, deliberately omitting dataSync so Android 15's
+        // six-hour dataSync timer no longer applies.
+        startForegroundWithType(bootstrapServiceType())
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -50,8 +83,10 @@ class ForegroundService : Service() {
     }
 
     private fun startForegroundWithAutoDetectedType() {
-        val serviceType = detectServiceType()
+        startForegroundWithType(detectServiceType())
+    }
 
+    private fun startForegroundWithType(serviceType: Int) {
         createNotificationChannel()
 
         val notification =
@@ -65,7 +100,7 @@ class ForegroundService : Service() {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             Bridge.log(
-                    "ForegroundService: Starting with auto-detected type: ${getServiceTypeName(serviceType)}"
+                    "ForegroundService: Starting with type: ${getServiceTypeName(serviceType)}"
             )
             startForeground(NOTIFICATION_ID, notification, serviceType)
         } else {
@@ -79,14 +114,11 @@ class ForegroundService : Service() {
             return 0 // No service types before Android Q
         }
 
-        var serviceType = 0
-
         // Audio prompts can be initiated by glasses while the host Activity is
         // backgrounded. mediaPlayback has no runtime prerequisite, so keep it
         // active on the existing Mentra service for the entire connected
         // session rather than trying to launch a second service after a wake
         // phrase arrives.
-        serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
         Bridge.log("ForegroundService: Added mediaPlayback (supports background audio)")
 
         // Check Bluetooth permissions
@@ -106,28 +138,32 @@ class ForegroundService : Service() {
                     }
                 }
 
-        // Check CHANGE_NETWORK_STATE permission - this is a "normal" permission that is
-        // auto-granted at install time, but we check it defensively in case this changes.
-        // This permission can satisfy the connectedDevice FGS requirement without needing
-        // BLUETOOTH_CONNECT, which is a "dangerous" permission that users can deny.
-        val hasNetworkStatePermission =
+        // These normal permissions satisfy the connectedDevice FGS prerequisite without
+        // waiting for a runtime Bluetooth grant. CHANGE_WIFI_STATE is declared by the SDK;
+        // CHANGE_NETWORK_STATE is also accepted when a host app already declares it.
+        val hasConnectedDeviceManifestPermission =
                 ContextCompat.checkSelfPermission(
                         this,
                         android.Manifest.permission.CHANGE_NETWORK_STATE
-                ) == PackageManager.PERMISSION_GRANTED
+                ) == PackageManager.PERMISSION_GRANTED ||
+                        ContextCompat.checkSelfPermission(
+                                this,
+                                android.Manifest.permission.CHANGE_WIFI_STATE
+                        ) == PackageManager.PERMISSION_GRANTED
 
-        // Use connectedDevice if we have EITHER Bluetooth OR network state permission.
-        // This avoids falling back to dataSync (which has a 6-hour timeout on Android 14+)
+        // Use connectedDevice if we have either Bluetooth or a qualifying normal permission.
+        // This avoids falling back to dataSync (which has a six-hour timeout on Android 15+)
         // when users deny Bluetooth permissions.
-        if (hasBluetoothPermission || hasNetworkStatePermission) {
-            serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+        val hasConnectedDeviceAccess =
+                hasBluetoothPermission || hasConnectedDeviceManifestPermission
+        if (hasConnectedDeviceAccess) {
             if (hasBluetoothPermission) {
                 Bridge.log("ForegroundService: Added connectedDevice (has Bluetooth permission)")
             } else {
-                Bridge.log("ForegroundService: Added connectedDevice (has CHANGE_NETWORK_STATE permission)")
+                Bridge.log("ForegroundService: Added connectedDevice (has network control permission)")
             }
         } else {
-            Bridge.log("ForegroundService: No Bluetooth or network state permission for connectedDevice")
+            Bridge.log("ForegroundService: No qualifying permission for connectedDevice")
         }
 
         // Check microphone permission
@@ -136,7 +172,6 @@ class ForegroundService : Service() {
                         PackageManager.PERMISSION_GRANTED
 
         if (hasMicPermission) {
-            serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
             Bridge.log("ForegroundService: Added microphone (has RECORD_AUDIO permission)")
         } else {
             Bridge.log("ForegroundService: No microphone permission")
@@ -154,8 +189,8 @@ class ForegroundService : Service() {
         val locationManager = getSystemService(LocationManager::class.java)
         val isLocationEnabled = locationManager?.isLocationEnabled == true
 
-        if (locationTypeRequested && hasLocationPermission && isLocationEnabled) {
-            serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+        val hasLocationAccess = locationTypeRequested && hasLocationPermission && isLocationEnabled
+        if (hasLocationAccess) {
             Bridge.log("ForegroundService: Added location (has foreground location permission)")
         } else {
             Bridge.log(
@@ -164,15 +199,11 @@ class ForegroundService : Service() {
             )
         }
 
-        // Only use dataSync as absolute last resort fallback if no other types were added.
-        // WARNING: dataSync has a 6-hour timeout on Android 14+ which will crash the app.
-        // This should rarely happen since CHANGE_NETWORK_STATE is a normal permission.
-        if (serviceType == 0) {
-            serviceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            Bridge.log("ForegroundService: WARNING - Using dataSync as fallback (6-hour timeout on Android 14+)")
-        }
-
-        return serviceType
+        return preferredServiceType(
+                hasConnectedDeviceAccess = hasConnectedDeviceAccess,
+                hasMicrophoneAccess = hasMicPermission,
+                hasLocationAccess = hasLocationAccess,
+        )
     }
 
     private fun getNotificationText(serviceType: Int): String {

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/services/ForegroundServiceTypeTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/services/ForegroundServiceTypeTest.kt
@@ -1,0 +1,69 @@
+package com.mentra.bluetoothsdk.services
+
+import android.content.pm.ServiceInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForegroundServiceTypeTest {
+    @Test
+    fun `bootstrap starts as dataSync`() {
+        assertEquals(
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            ForegroundService.bootstrapServiceType(),
+        )
+    }
+
+    @Test
+    fun `preferred types remove dataSync once connectedDevice is available`() {
+        val serviceType =
+            ForegroundService.preferredServiceType(
+                hasConnectedDeviceAccess = true,
+                hasMicrophoneAccess = false,
+                hasLocationAccess = false,
+                includeMediaPlayback = false,
+            )
+
+        assertTrue(
+            serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE != 0,
+        )
+        assertEquals(
+            0,
+            serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        )
+    }
+
+    @Test
+    fun `preferred types retain dataSync only when no better type is available`() {
+        val serviceType =
+            ForegroundService.preferredServiceType(
+                hasConnectedDeviceAccess = false,
+                hasMicrophoneAccess = false,
+                hasLocationAccess = false,
+                includeMediaPlayback = false,
+            )
+
+        assertEquals(
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            serviceType,
+        )
+    }
+
+    @Test
+    fun `production mask never carries dataSync with media playback`() {
+        val serviceType =
+            ForegroundService.preferredServiceType(
+                hasConnectedDeviceAccess = true,
+                hasMicrophoneAccess = true,
+                hasLocationAccess = true,
+            )
+
+        assertEquals(
+            0,
+            serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        )
+        assertTrue(
+            serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK != 0,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- bootstrap the Android foreground service with `dataSync` so it can enter the foreground before runtime permissions are available
- replace that bootstrap mask with eligible long-running types such as `connectedDevice`, deliberately omitting `dataSync` so the Android 15 timeout no longer applies
- mirror the Mentra App's Activity-foreground refresh inside the native SDK so permission changes upgrade the running service
- recognize the SDK-declared `CHANGE_WIFI_STATE` permission as a valid `connectedDevice` prerequisite

## Tests

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `cd mobile/android && ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.services.ForegroundServiceTypeTest -PmentraPublicSdk=true --no-daemon`

Fixes [OS-1719](https://linear.app/mentralabs/issue/OS-1719/native-android-example-app-crash-report-in-the-background)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Android 15 background crashes (OS-1719) by avoiding long-lived `dataSync` foreground service usage. The service now bootstraps with `dataSync` only to enter the foreground, then switches to connectedDevice/microphone/location/mediaPlayback when eligible; permission changes trigger an immediate refresh.

- Selects types via `preferredServiceType(...)`; once any eligible type exists, it excludes `dataSync`.
- Starts with `bootstrapServiceType()` in `onCreate`, then replaces the type in `onStartCommand`; logging reflects the chosen type.
- Accepts `CHANGE_WIFI_STATE` and `CHANGE_NETWORK_STATE` as `connectedDevice` prerequisites, so normal permissions can avoid `dataSync` even if Bluetooth is denied.
- Registers `Application.ActivityLifecycleCallbacks` to refresh types on `onActivityResumed`; unregisters in `close()`.
- Adds unit tests for bootstrap and preferred-type masks.

<sup>Written for commit debe3eb9c75e1204ebe5366ffddaa88137fe017d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Android foreground service type selection and lifecycle refresh paths, which are sensitive to OS version rules and permission timing; mistakes could cause FGS start failures or renewed timeout crashes.
> 
> **Overview**
> Reworks how the Bluetooth SDK’s Android **foreground service** declares its type so long-running glasses sessions avoid Android 15’s **six-hour `dataSync` limit** (fixes background crash reports).
> 
> **`ForegroundService`** now calls `startForeground` immediately with **`dataSync`** (no runtime permissions needed), then **`onStartCommand`** recomputes and replaces the mask via new helpers **`bootstrapServiceType()`** and **`preferredServiceType()`**, using **`connectedDevice`**, **`mediaPlayback`**, **`microphone`**, and **`location`** when eligible and **dropping `dataSync`** once any of those apply. **`connectedDevice`** can be satisfied by **`CHANGE_WIFI_STATE`** (SDK-declared) in addition to **`CHANGE_NETWORK_STATE`**.
> 
> **`MentraBluetoothSdk`** registers **`Application.ActivityLifecycleCallbacks`** and on **`onActivityResumed`** calls **`deviceManager.refreshForegroundServiceTypes()`** so native host apps refresh types after permission dialogs, matching the main Mentra app; callbacks are unregistered in **`close()`**.
> 
> Adds **`ForegroundServiceTypeTest`** for bootstrap vs preferred type masks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit debe3eb9c75e1204ebe5366ffddaa88137fe017d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->