### PR TITLE
Allow Android Mentra Live connections without LC3

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -77,6 +77,11 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
+internal fun hasRequiredMentraLiveCoreCharacteristics(
+        hasRxCharacteristic: Boolean,
+        hasTxCharacteristic: Boolean,
+): Boolean = hasRxCharacteristic && hasTxCharacteristic
+
 /**
  * Smart Glasses Communicator for Mentra Live (K900) glasses Uses BLE to communicate with the
  * glasses
@@ -2329,21 +2334,32 @@ class MentraLive : SGCManager() {
                             txCharacteristic = service.getCharacteristic(TX_CHAR_UUID)
                             rxCharacteristic = service.getCharacteristic(RX_CHAR_UUID)
 
-                            // Get LC3 characteristics (always supported)
+                            // LC3 audio is optional. Older firmware can still run the core session
+                            // and receive an OTA without these characteristics.
                             lc3ReadCharacteristic = service.getCharacteristic(LC3_READ_UUID)
                             lc3WriteCharacteristic = service.getCharacteristic(LC3_WRITE_UUID)
 
-                            // Check if we have required characteristics
+                            // Match iOS: only the core transport pair is required for readiness.
                             val hasRequiredCharacteristics =
-                                    (rxCharacteristic != null && txCharacteristic != null) &&
-                                            (lc3ReadCharacteristic != null &&
-                                                    lc3WriteCharacteristic != null)
+                                    hasRequiredMentraLiveCoreCharacteristics(
+                                            hasRxCharacteristic = rxCharacteristic != null,
+                                            hasTxCharacteristic = txCharacteristic != null,
+                                    )
+                            val hasLc3AudioCharacteristics =
+                                    lc3ReadCharacteristic != null && lc3WriteCharacteristic != null
 
                             if (hasRequiredCharacteristics) {
+                                if (!hasLc3AudioCharacteristics) {
+                                    Bridge.log(
+                                            "LIVE: ⚠️ LC3 audio characteristics unavailable - continuing with core BLE transport"
+                                    )
+                                }
                                 // BLE connection established, but we still need to wait for glasses
                                 // SOC
                                 Bridge.log(
-                                        "LIVE: 🔌 ✅ BLE reconnection fully ready (Core TX/RX + LC3 TX/RX characteristics verified)"
+                                        "LIVE: 🔌 ✅ BLE reconnection fully ready (Core TX/RX verified, LC3 audio available: " +
+                                                hasLc3AudioCharacteristics +
+                                                ")"
                                 )
                                 markPairingTiming("ble_chars_ready")
                                 Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...")
@@ -2398,13 +2414,6 @@ class MentraLive : SGCManager() {
                                 }
                                 if (txCharacteristic == null) {
                                     Log.e(TAG, "TX characteristic (peripheral's RX) not found")
-                                }
-                                // Log LC3 characteristic errors
-                                if (lc3ReadCharacteristic == null) {
-                                    Log.e(TAG, "LC3_READ characteristic not found")
-                                }
-                                if (lc3WriteCharacteristic == null) {
-                                    Log.e(TAG, "LC3_WRITE characteristic not found")
                                 }
                                 gatt.disconnect()
                             }

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattCharacteristicsTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattCharacteristicsTest.kt
@@ -1,0 +1,39 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MentraLiveGattCharacteristicsTest {
+    @Test
+    fun `accepts the core characteristic pair without requiring optional characteristics`() {
+        assertTrue(
+            hasRequiredMentraLiveCoreCharacteristics(
+                hasRxCharacteristic = true,
+                hasTxCharacteristic = true,
+            )
+        )
+    }
+
+    @Test
+    fun `rejects an incomplete core characteristic pair`() {
+        assertFalse(
+            hasRequiredMentraLiveCoreCharacteristics(
+                hasRxCharacteristic = false,
+                hasTxCharacteristic = true,
+            )
+        )
+        assertFalse(
+            hasRequiredMentraLiveCoreCharacteristics(
+                hasRxCharacteristic = true,
+                hasTxCharacteristic = false,
+            )
+        )
+        assertFalse(
+            hasRequiredMentraLiveCoreCharacteristics(
+                hasRxCharacteristic = false,
+                hasTxCharacteristic = false,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- require only the core Mentra Live TX/RX characteristics before starting an Android BLE session
- treat the LC3 read/write pair as an optional audio capability, matching iOS behavior
- log whether LC3 is available while allowing older firmware to connect for recovery and OTA
- add regression coverage for the core-characteristic readiness policy

## Context

PR #3723 identified that a Mentra Live unit without LC3 characteristics connects on iOS but Android repeatedly disconnects with “Required BLE characteristics not found.” The Android implementation included the optional LC3 pair in its mandatory readiness check; iOS requires only core TX/RX.

This PR intentionally includes only that remaining compatibility fix. The CTKD/service-discovery sequencing from #3723 is superseded by the safer BLE-first sequencing merged in #3224, and the unrelated legacy Wi-Fi parser change is excluded.

## Test evidence

- ./scripts/check-android-compile.sh bluetooth-sdk
- MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/Users/alexisraelov/conductor/workspaces/AugmentOS/belmopan/mobile/modules/bluetooth-sdk ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.sgcs.MentraLiveGattCharacteristicsTest --no-daemon -PmentraPublicSdk=true


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Android Mentra Live BLE sessions without LC3 by requiring only the core TX/RX characteristics. Previously Android disconnected when LC3 was missing; now it matches iOS, continues the session, and logs LC3 availability so older firmware can connect for recovery and OTA.

- Updates `com.mentra.bluetoothsdk.sgcs.MentraLive` readiness to require only RX/TX; treats LC3 read/write as optional and logs availability; disconnects only when the core pair is missing.
- Adds unit tests for the core-characteristic policy in `MentraLiveGattCharacteristicsTest`.
- Leaves CTKD and service discovery unchanged; sequencing remains BLE-first.

<sup>Written for commit 516e35f6624a3d4ce8462986b26985c69debcb4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BLE connection gating for Mentra Live; devices without LC3 will connect where they previously failed, which may affect audio paths that assumed LC3 was always present.
> 
> **Overview**
> **Android Mentra Live BLE readiness now matches iOS** by requiring only the core TX/RX GATT pair before treating a session as ready, instead of also mandating LC3 read/write.
> 
> When LC3 characteristics are missing (e.g. older firmware), the stack **logs a warning and continues** with core transport so devices can still connect for recovery and OTA. Missing LC3 no longer triggers disconnect or error logs that blocked connection. Readiness logging now reports whether LC3 audio is available.
> 
> A small **`hasRequiredMentraLiveCoreCharacteristics`** helper encapsulates the policy, with unit tests covering complete vs incomplete core pairs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516e35f6624a3d4ce8462986b26985c69debcb4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->