### PR TITLE
Show Miniapp Store coming-soon page

### DIFF
--- a/cloud/websites/store/index.html
+++ b/cloud/websites/store/index.html
@@ -5,28 +5,26 @@
     <link rel="icon" type="image/svg+xml" href="/logo_new.svg" />
     <link rel="preload" href="/logo_new.svg" as="image" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Smart Glasses App Store | MentraOS</title>
+    <title>Mentra Miniapp Store | Coming Soon</title>
     <meta
       name="description"
-      content="Browse and install apps for your smart glasses. AI notetaking, live captions, translation, teleprompter, and more on MentraOS." />
+      content="Mentra Miniapp Store for Mentra 3.0 is coming soon." />
 
     <!-- Default Open Graph / Social Media Preview -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://apps.mentraglass.com" />
-    <meta property="og:title" content="Smart Glasses App Store | MentraOS" />
+    <meta property="og:title" content="Mentra Miniapp Store | Coming Soon" />
     <meta
       property="og:description"
-      content="Browse and install apps for your smart glasses. AI notetaking, live captions, translation, teleprompter, and more." />
-    <meta property="og:image" content="https://apps.mentraglass.com/app-store-preview.png" />
+      content="Mentra Miniapp Store for Mentra 3.0 is coming soon." />
 
     <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:url" content="https://apps.mentraglass.com" />
-    <meta name="twitter:title" content="Smart Glasses App Store | MentraOS" />
+    <meta name="twitter:title" content="Mentra Miniapp Store | Coming Soon" />
     <meta
       name="twitter:description"
-      content="Browse and install apps for your smart glasses. AI notetaking, live captions, translation, teleprompter, and more." />
-    <meta name="twitter:image" content="https://apps.mentraglass.com/app-store-preview.png" />
+      content="Mentra Miniapp Store for Mentra 3.0 is coming soon." />
   </head>
   <body>
     <div id="root"></div>

--- a/cloud/websites/store/src/App.css
+++ b/cloud/websites/store/src/App.css
@@ -1,0 +1,47 @@
+.coming-soon {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  color: #111411;
+  background: #f7f8f6;
+}
+
+.coming-soon__content {
+  width: 100%;
+  max-width: 720px;
+  text-align: center;
+}
+
+.coming-soon__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 32px;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.coming-soon__brand img {
+  width: 50px;
+  height: auto;
+}
+
+.coming-soon h1 {
+  margin: 0;
+  font-size: clamp(36px, 7vw, 68px);
+  font-weight: 600;
+  line-height: 1.05;
+}
+
+@media (max-width: 480px) {
+  .coming-soon {
+    padding: 24px;
+  }
+
+  .coming-soon__brand {
+    margin-bottom: 24px;
+    font-size: 20px;
+  }
+}

--- a/cloud/websites/store/src/App.tsx
+++ b/cloud/websites/store/src/App.tsx
@@ -1,84 +1,19 @@
-import { Suspense, lazy, type ReactNode, type FC } from "react";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { AuthProvider, useAuth } from "@mentra/shared";
-import { PlatformProvider } from "./hooks/usePlatform";
-import { SearchProvider } from "./contexts/SearchContext";
-import { ProfileDropdownProvider } from "./contexts/ProfileDropdownContext";
-import { ToastProvider } from "./components/ui/MuiToast";
+import type {FC} from 'react';
 
-// Lazy load pages for better performance
-const AppStore = lazy(() => import("./pages/AppStore"));
-// const AppDetails = lazy(() => import('./pages/AppDetails'));
-const AppDetailsV2 = lazy(() => import("./pages/AppDetailsV2"));
-const LoginPage = lazy(() => import("./pages/LoginPage"));
-const ForgotPasswordPage = lazy(() => import("@mentra/shared").then((m) => ({ default: m.ForgotPasswordPage })));
-const ResetPasswordPage = lazy(() => import("@mentra/shared").then((m) => ({ default: m.ResetPasswordPage })));
-const NotFound = lazy(() => import("./pages/NotFound"));
+import './App.css';
 
-// Loading spinner component (simplified)
-const LoadingSpinner: FC = () => (
-  <div className="flex items-center justify-center min-h-screen">
-    <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
-  </div>
-);
-
-// Protected route component
-const ProtectedRoute: FC<{ children: ReactNode }> = ({ children }) => {
-  const { isAuthenticated, isLoading } = useAuth();
-
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-
-  return <>{children}</>;
-};
-
-// Main routes component
-const AppRoutes: FC = () => {
-  return (
-    <Suspense fallback={<LoadingSpinner />}>
-      <Routes>
-        <Route path="/" element={<AppStore />} />
-        <Route path="/package/:packageName" element={<AppDetailsV2 />} />
-        <Route path="/package/:packageName/start" element={<AppDetailsV2 />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-        <Route path="/reset-password" element={<ResetPasswordPage redirectUrl="/" />} />
-        <Route
-          path="/webview"
-          element={
-            <ProtectedRoute>
-              <AppStore />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </Suspense>
-  );
-};
-
-// Main App component
 const App: FC = () => {
   return (
-    <PlatformProvider>
-      <AuthProvider enableWebViewAuth={true}>
-        <SearchProvider>
-          <ProfileDropdownProvider>
-            <BrowserRouter>
-              <ToastProvider>
-                <AppRoutes />
-              </ToastProvider>
-            </BrowserRouter>
-          </ProfileDropdownProvider>
-        </SearchProvider>
-      </AuthProvider>
-    </PlatformProvider>
-  );
+    <main className="coming-soon">
+      <div className="coming-soon__content">
+        <div className="coming-soon__brand" aria-label="Mentra">
+          <img src="/logo_new.svg" alt="" />
+          <span>Mentra</span>
+        </div>
+        <h1>Mentra Miniapp Store for Mentra 3.0 is coming soon.</h1>
+      </div>
+    </main>
+  )
 };
 
 export default App;


### PR DESCRIPTION
## Summary

- replace the legacy public miniapp catalog with a simple Mentra 3.0 coming-soon page
- keep the existing store implementation in the repository but remove it from the public route tree
- update page and social metadata to match the placeholder

## Test evidence

- `bun run build` in `cloud/websites/store`
- verified `/`, `/package/com.example.app`, and `/webview` return the coming-soon page in the production preview

## Deployment

This PR targets `main` because the `mentra-store-prod` Cloudflare Pages project deploys `apps.mentraglass.com` from that branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public-facing copy and UI swap only; no auth, API, or data-path changes in this diff.
> 
> **Overview**
> The **apps.mentraglass.com** store site no longer mounts the full miniapp catalog, routing, auth, or webview flows. **`App.tsx`** now renders a single centered **coming-soon** screen (Mentra branding + “Mentra Miniapp Store for Mentra 3.0 is coming soon”), backed by new **`App.css`** layout styles.
> 
> **`index.html`** metadata is aligned with that placeholder: title and descriptions switch to the Miniapp Store / coming-soon messaging, Open Graph and Twitter text match, large preview images are removed, and Twitter uses **`summary`** instead of **`summary_large_image`**.
> 
> The previous store pages and components are still in the tree but are **not** wired into the public app entrypoint, so production builds show the placeholder on **`/`**, package URLs, and **`/webview`** (per PR testing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c9cb8be445b400f2ca9509c0e3d842812bbbb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the public Miniapp Store with a static coming-soon page for Mentra 3.0. Previously the site served the React store with routing and auth; now all routes render the placeholder.

- Keep the existing store code in the repo but remove it from the public route tree (no router/auth at runtime).
- Update HTML title/description and Open Graph/Twitter metadata (Twitter card set to summary; remove image).
- Add minimal layout styles in `App.css` and static markup in `App.tsx`; drop runtime dependency on `@mentra/shared`.
- Deep links to `/package/:packageName` and `/webview` now show the coming-soon page; check for any external links relying on the old pages.
- Deploy from `main` to Cloudflare Pages project `mentra-store-prod` for `apps.mentraglass.com`.

<sup>Written for commit f7c9cb8be445b400f2ca9509c0e3d842812bbbb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

