### PR TITLE
Remove 0709-to-0820.2 MTK patch

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -41,12 +41,6 @@
       "end_firmware": "MentraLive_20260709",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
       "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
-    },
-    {
-      "start_firmware": "MentraLive_20260709",
-      "end_firmware": "MentraLive_20260820.2",
-      "url": "https://mtkfirmware.mentraglass.com/mtk_ota_update_20260709_20260820.2.zip",
-      "sha256": "d3b9c7c4b4205703568ed73f9ab3deabcc6a815f57d352fdac66b7755632cc9b"
     }
   ],
   "bes_firmware": {


### PR DESCRIPTION
## Summary

- remove only the MentraLive_20260709 to MentraLive_20260820.2 MTK patch from the live firmware manifest
- preserve the other MTK patch entries and BES firmware configuration

## Validation

- jq empty asg_client/ota_manifests/firmware_live.json
- git diff --check
- verified seven MTK patch entries remain
- verified the BES firmware object matches origin/dev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which MTK OTA upgrades are offered in production; devices stuck on 20260709 lose this specific path to 20260820.2 until another manifest entry is added.
> 
> **Overview**
> Removes the **live OTA manifest** entry that offered an MTK patch from `MentraLive_20260709` to `MentraLive_20260820.2` (hosted at `mtkfirmware.mentraglass.com`). All other `mtk_patches` rows and the `bes_firmware` block are unchanged.
> 
> Devices on `20260709` will no longer see that upgrade path when the client matches patches from `firmware_live.json`; remaining patches still target `20260709` as the end firmware from earlier start versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3a1dde0965a78a7bdb31c250acff5015507c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->