### PR TITLE
Engine: expose the public Bluetooth SDK facade

### DIFF
--- a/mobile/modules/engine/README.md
+++ b/mobile/modules/engine/README.md
@@ -21,7 +21,8 @@ npm install @mentra/engine
 
 ## Entry points
 
-The package exposes four entry points (declared in `package.json` `exports`,
+The package exposes its Engine entry points and a supported Bluetooth SDK
+facade (declared in `package.json` `exports`,
 with the `react-native` condition pointing at `src/` so Metro, tsc and jest
 resolve live TypeScript source):
 
@@ -45,6 +46,11 @@ resolve live TypeScript source):
   Native experiences. `MentraLiveOtaFlow` owns the complete check, hotspot or
   Wi-Fi install, APK/MTK/BES progress, reboot, retry, and final verification
   flow so hosts do not implement their own OTA state machines.
+- **`@mentra/engine/bluetooth-sdk`** (`src/bluetooth-sdk/index.ts`) — the
+  complete public Bluetooth SDK surface, re-exported without a wrapper so it
+  has the same singleton identity as `@mentra/bluetooth-sdk`. The supported
+  SDK `react`, `types`, `photo-receiver`, and `debug` subpaths are mirrored
+  below this path. The SDK's `internal` entrypoint is deliberately not exposed.
 
 See `cloud-v2/docs/issues/020-glasses-status-boundary/integration-review.md`
 §D for the burn-down plan.
@@ -63,6 +69,7 @@ sockets.
 
 ```ts
 import {engine, decideDevLaunchRoute} from "@mentra/engine"
+import BluetoothSdk from "@mentra/engine/bluetooth-sdk"
 import {webviewBridge, buildMiniappGlobalsScript} from "@mentra/engine/internal"
 import {miniappRunningRegistry} from "@mentra/engine/devtools"
 ```
@@ -84,10 +91,7 @@ the authenticated cloud/miniapp runtime:
 ```tsx
 import {MentraLiveOtaFlow} from "@mentra/engine/ota"
 
-<MentraLiveOtaFlow
-  onFinished={() => setShowOta(false)}
-  onOpenWifiSetup={() => setShowWifiSetup(true)}
-/>
+;<MentraLiveOtaFlow onFinished={() => setShowOta(false)} onOpenWifiSetup={() => setShowWifiSetup(true)} />
 ```
 
 The component starts only the glasses-status and OTA projections. A host that
@@ -117,4 +121,4 @@ combined run. Per-file processes give every suite an isolated registry.
 
 The same rule applies when writing tests: it is fine to `mock.module` any
 specifier your suite needs, but never rely on a mock installed by a
-*different* test file — each file must set up everything it imports.
+_different_ test file — each file must set up everything it imports.

--- a/mobile/modules/engine/package.json
+++ b/mobile/modules/engine/package.json
@@ -26,6 +26,31 @@
       "react-native": "./src/react/index.ts",
       "default": "./build/react/index.js"
     },
+    "./bluetooth-sdk": {
+      "types": "./build/bluetooth-sdk/index.d.ts",
+      "react-native": "./src/bluetooth-sdk/index.ts",
+      "default": "./build/bluetooth-sdk/index.js"
+    },
+    "./bluetooth-sdk/react": {
+      "types": "./build/bluetooth-sdk/react.d.ts",
+      "react-native": "./src/bluetooth-sdk/react.ts",
+      "default": "./build/bluetooth-sdk/react.js"
+    },
+    "./bluetooth-sdk/types": {
+      "types": "./build/bluetooth-sdk/types.d.ts",
+      "react-native": "./src/bluetooth-sdk/types.ts",
+      "default": "./build/bluetooth-sdk/types.js"
+    },
+    "./bluetooth-sdk/photo-receiver": {
+      "types": "./build/bluetooth-sdk/photo-receiver.d.ts",
+      "react-native": "./src/bluetooth-sdk/photo-receiver.ts",
+      "default": "./build/bluetooth-sdk/photo-receiver.js"
+    },
+    "./bluetooth-sdk/debug": {
+      "types": "./build/bluetooth-sdk/debug.d.ts",
+      "react-native": "./src/bluetooth-sdk/debug.ts",
+      "default": "./build/bluetooth-sdk/debug.js"
+    },
     "./build/*": null,
     "./src/*": null,
     "./package.json": "./package.json"
@@ -42,6 +67,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "./scripts/test.sh",
+    "test:public-api": "bun test src/bluetooth-sdk/__tests__/publicApi.test.ts",
     "build:module": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"

--- a/mobile/modules/engine/src/bluetooth-sdk/__tests__/publicApi.test.ts
+++ b/mobile/modules/engine/src/bluetooth-sdk/__tests__/publicApi.test.ts
@@ -1,0 +1,58 @@
+import {afterAll, beforeAll, describe, expect, mock, test} from "bun:test"
+import {readFileSync} from "node:fs"
+import path from "node:path"
+
+const sdkSingleton = Object.freeze({name: "sdk-singleton"})
+const photoReceiverSingleton = Object.freeze({name: "photo-receiver-singleton"})
+
+beforeAll(() => {
+  mock.module("@mentra/bluetooth-sdk", () => ({
+    default: sdkSingleton,
+    BluetoothSdk: sdkSingleton,
+  }))
+  mock.module("@mentra/bluetooth-sdk/photo-receiver", () => ({
+    default: photoReceiverSingleton,
+  }))
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+describe("@mentra/engine/bluetooth-sdk", () => {
+  test("preserves the direct SDK singleton identity", async () => {
+    const facade = await import("../index")
+
+    expect(facade.default).toBe(sdkSingleton)
+    expect(facade.BluetoothSdk).toBe(sdkSingleton)
+    expect(facade.default).toBe(facade.BluetoothSdk)
+  })
+
+  test("preserves the photo receiver default export", async () => {
+    const facade = await import("../photo-receiver")
+
+    expect(facade.default).toBe(photoReceiverSingleton)
+  })
+
+  test("publishes every supported SDK facade with source, declaration, and default conditions", () => {
+    const packagePath = path.resolve(import.meta.dir, "../../../package.json")
+    const packageManifest = JSON.parse(readFileSync(packagePath, "utf8"))
+    const expected = {
+      "./bluetooth-sdk": "index",
+      "./bluetooth-sdk/react": "react",
+      "./bluetooth-sdk/types": "types",
+      "./bluetooth-sdk/photo-receiver": "photo-receiver",
+      "./bluetooth-sdk/debug": "debug",
+    }
+
+    for (const [subpath, file] of Object.entries(expected)) {
+      expect(packageManifest.exports[subpath]).toEqual({
+        "types": `./build/bluetooth-sdk/${file}.d.ts`,
+        "react-native": `./src/bluetooth-sdk/${file}.ts`,
+        "default": `./build/bluetooth-sdk/${file}.js`,
+      })
+    }
+
+    expect(packageManifest.exports["./bluetooth-sdk/internal"]).toBeUndefined()
+  })
+})

--- a/mobile/modules/engine/src/bluetooth-sdk/debug.ts
+++ b/mobile/modules/engine/src/bluetooth-sdk/debug.ts
@@ -1,0 +1,1 @@
+export * from "@mentra/bluetooth-sdk/debug"

--- a/mobile/modules/engine/src/bluetooth-sdk/index.ts
+++ b/mobile/modules/engine/src/bluetooth-sdk/index.ts
@@ -1,0 +1,2 @@
+export {default} from "@mentra/bluetooth-sdk"
+export * from "@mentra/bluetooth-sdk"

--- a/mobile/modules/engine/src/bluetooth-sdk/photo-receiver.ts
+++ b/mobile/modules/engine/src/bluetooth-sdk/photo-receiver.ts
@@ -1,0 +1,2 @@
+export {default} from "@mentra/bluetooth-sdk/photo-receiver"
+export * from "@mentra/bluetooth-sdk/photo-receiver"

--- a/mobile/modules/engine/src/bluetooth-sdk/react.ts
+++ b/mobile/modules/engine/src/bluetooth-sdk/react.ts
@@ -1,0 +1,1 @@
+export * from "@mentra/bluetooth-sdk/react"

--- a/mobile/modules/engine/src/bluetooth-sdk/types.ts
+++ b/mobile/modules/engine/src/bluetooth-sdk/types.ts
@@ -1,0 +1,1 @@
+export * from "@mentra/bluetooth-sdk/types"


### PR DESCRIPTION
## Why

Mentra Engine reuses the Bluetooth SDK internally and is intended to expose it as part of the coordinated product family. Consumers need a supported public import path that preserves the SDK singleton and never turns the SDK internal surface into an Engine API.

## What changes

- Adds `@mentra/engine/bluetooth-sdk`.
- Mirrors the public SDK `react`, `types`, `photo-receiver`, and `debug` subpaths.
- Re-exports the SDK directly with no wrapper, copied object, or second singleton.
- Deliberately does not expose `@mentra/engine/bluetooth-sdk/internal`.
- Documents the facade and its ownership boundary.
- Adds tests for singleton identity and every package export condition.

The existing migration-era `@mentra/engine/internal` export remains unchanged in this focused layer. Removing it requires migrating current MentraOS imports and is tracked separately by the accepted design.

## Verification

- Clean builds of Bluetooth SDK, JSpolyfill, Crust, Miniapp, and Engine
- Full Engine test suite, per-file isolation
- `npm pack --dry-run --json`, including all new source, JS, and declaration entrypoints
- Generated declarations reference only public Bluetooth SDK subpaths

## Stack

Layer 2, based on #3754.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive package exports and pass-through re-exports with no runtime logic changes; risk is mainly consumers adopting a new import path.
> 
> **Overview**
> Adds a **supported public import path** for the Bluetooth SDK under `@mentra/engine`, so OEM apps can use Engine as the coordinated entry point without pulling in SDK `internal` APIs.
> 
> New **`@mentra/engine/bluetooth-sdk`** entry points mirror the SDK’s public surface (`react`, `types`, `photo-receiver`, `debug`) via **thin re-exports**—no wrapper—so `default` / `BluetoothSdk` keep the **same singleton identity** as `@mentra/bluetooth-sdk`. **`./bluetooth-sdk/internal` is intentionally omitted** from `package.json` `exports`.
> 
> Documentation in the Engine README describes the facade and shows `import BluetoothSdk from "@mentra/engine/bluetooth-sdk"`. **`publicApi.test.ts`** asserts singleton preservation, photo-receiver default export, and that every subpath has `types` / `react-native` / `default` conditions; **`test:public-api`** runs that suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b032a0a814a9e38113214c6e19916f73b974523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->