### PR TITLE
Release records: generate immutable intent and verified completion

### DIFF
--- a/.github/scripts/collect-ota-release-inputs.mjs
+++ b/.github/scripts/collect-ota-release-inputs.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+const input = path.resolve(process.argv[2] || "asg_client/ota_manifests/firmware_live.json")
+const output = path.resolve(process.argv[3] || "ota-release-inputs.json")
+const bytes = readFileSync(input)
+const manifest = JSON.parse(bytes.toString("utf8"))
+
+if (!Array.isArray(manifest.mtk_patches) || !manifest.bes_firmware) {
+  throw new Error(`${input} must contain mtk_patches and bes_firmware`)
+}
+
+const result = {
+  firmwareManifest: {
+    path: path.relative(process.cwd(), input),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+  },
+  mtkPatches: manifest.mtk_patches,
+  besFirmware: manifest.bes_firmware,
+}
+
+writeFileSync(output, serializeReleaseRecord(result))
+console.log(`Wrote OTA release inputs to ${output}`)

--- a/.github/scripts/create-release-plan.mjs
+++ b/.github/scripts/create-release-plan.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+
+import {channelForBranch, createReleasePlan, loadReleaseFamily, serializeReleaseRecord} from "./release-family.mjs"
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    const name = option.slice(2)
+    if (values[name] !== undefined) throw new Error(`Duplicate option --${name}`)
+    values[name] = value
+  }
+  return values
+}
+
+const args = parseArgs(process.argv.slice(2))
+const channel = args.channel || channelForBranch(args.branch)
+const sequence = channel === "production" ? undefined : Number(args.sequence)
+const otaInputs = args["ota-inputs"] ? JSON.parse(readFileSync(path.resolve(args["ota-inputs"]), "utf8")) : {}
+const family = loadReleaseFamily({requireVersionMirrors: args["require-version-mirrors"] === "true"})
+const plan = createReleasePlan({
+  family,
+  channel,
+  sequence,
+  sourceCommit: args["source-commit"],
+  nativeBuildNumber: Number(args["native-build-number"]),
+  otaInputs,
+})
+const output = path.resolve(args.output || "release-plan.json")
+writeFileSync(output, serializeReleaseRecord(plan))
+console.log(`Wrote ${plan.releaseSetId} plan to ${output}`)

--- a/.github/scripts/finalize-release-manifest.mjs
+++ b/.github/scripts/finalize-release-manifest.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+
+import {finalizeReleaseManifest, serializeReleaseRecord} from "./release-family.mjs"
+
+function option(name) {
+  const index = process.argv.indexOf(`--${name}`)
+  if (index < 0 || !process.argv[index + 1]) throw new Error(`Missing --${name}`)
+  return process.argv[index + 1]
+}
+
+const plan = JSON.parse(readFileSync(path.resolve(option("plan")), "utf8"))
+const results = JSON.parse(readFileSync(path.resolve(option("results")), "utf8"))
+const manifest = finalizeReleaseManifest({plan, results, completedAt: option("completed-at")})
+const output = path.resolve(option("output"))
+writeFileSync(output, serializeReleaseRecord(manifest))
+console.log(`Wrote completed ${manifest.releaseSetId} manifest to ${output}`)

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -1,4 +1,5 @@
 import {readFileSync} from "node:fs"
+import {createHash} from "node:crypto"
 import path from "node:path"
 
 const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
@@ -6,6 +7,8 @@ const COMMIT_PATTERN = /^[0-9a-f]{40}$/
 const CHANNELS = new Set(["dev", "beta", "production"])
 const KINDS = new Set(["package", "product"])
 const PUBLISH_TARGETS = new Set(["app-store-connect", "google-play", "maven-central", "npm", "swift-package-manager"])
+const PUBLICATION_STATUSES = new Set(["promoted", "published", "reused"])
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
 
 function fail(message) {
   throw new Error(`Invalid release family: ${message}`)
@@ -173,11 +176,16 @@ export function createReleasePlan({family, channel, sequence, sourceCommit, nati
   }
 
   const releaseIdentity = deriveReleaseIdentity(family.familyBaseVersion, channel, sequence)
-  const products = Object.fromEntries(family.members.map((member) => [member.name, releaseIdentity]))
-  const dependencies = Object.fromEntries(
+  const members = Object.fromEntries(
     family.members.map((member) => [
       member.name,
-      Object.fromEntries(member.dependencies.map((dependency) => [dependency, releaseIdentity])),
+      {
+        version: releaseIdentity,
+        kind: member.kind,
+        manifest: member.manifest,
+        publishTargets: member.publishTargets,
+        dependencies: Object.fromEntries(member.dependencies.map((dependency) => [dependency, releaseIdentity])),
+      },
     ]),
   )
 
@@ -193,9 +201,170 @@ export function createReleasePlan({family, channel, sequence, sourceCommit, nati
       marketingVersion: family.familyBaseVersion,
       buildNumber: nativeBuildNumber,
     },
-    products,
-    dependencies,
+    products: Object.fromEntries(family.products.map((product) => [product, releaseIdentity])),
+    members,
     publicationOrder: family.publicationOrder,
+    artifactNames: {
+      releasePlan: `mentra-release-plan-${releaseIdentity}.json`,
+      releaseManifest: `mentra-release-${releaseIdentity}.json`,
+      otaManifest: `mentra-live-ota-${releaseIdentity}.json`,
+      asgSelection: `mentra-live-asg-selection-${releaseIdentity}.json`,
+      androidApp: `mentraos-${releaseIdentity}-android.apk`,
+      androidStoreApp: `mentraos-${releaseIdentity}-android.aab`,
+      iosApp: `mentraos-${releaseIdentity}-ios.ipa`,
+      iosSdkArchive: `mentra-bluetooth-sdk-ios-${releaseIdentity}.tar`,
+      enginePackage: `mentra-engine-${releaseIdentity}.tgz`,
+    },
     otaInputs,
+  }
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    )
+  }
+  return value
+}
+
+export function serializeReleaseRecord(record) {
+  return `${JSON.stringify(canonicalize(record), null, 2)}\n`
+}
+
+export function releaseRecordSha256(record) {
+  return createHash("sha256").update(serializeReleaseRecord(record)).digest("hex")
+}
+
+export function requirePublicHttpsUrl(value, label) {
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error(`${label} must be a valid URL`)
+  }
+  if (parsed.protocol !== "https:") throw new Error(`${label} must use HTTPS`)
+  if (parsed.username || parsed.password || parsed.hash) {
+    throw new Error(`${label} must be credential-free HTTPS without a fragment`)
+  }
+  return parsed.toString()
+}
+
+function validatePublication(publication, label) {
+  if (!publication || typeof publication !== "object") throw new Error(`${label} is missing`)
+  if (!PUBLICATION_STATUSES.has(publication.status)) {
+    throw new Error(`${label}.status must be promoted, published, or reused`)
+  }
+  requireString(publication.coordinate, `${label}.coordinate`)
+  requirePublicHttpsUrl(publication.url, `${label}.url`)
+  requirePublicHttpsUrl(publication.provenanceUrl, `${label}.provenanceUrl`)
+  if (!SHA256_PATTERN.test(publication.sha256)) {
+    throw new Error(`${label}.sha256 must be a lowercase SHA-256 digest`)
+  }
+  return publication
+}
+
+function expectedPublicationCoordinate(plan, memberName, target) {
+  const version = plan.members[memberName].version
+  if (target === "npm") return `${memberName}@${version}`
+  if (target === "maven-central") return `com.mentraglass:bluetooth-sdk:${version}`
+  if (target === "swift-package-manager") return `Mentra-Community/mentra-bluetooth-sdk-ios@${version}`
+  const channels = {
+    dev: {play: "internal", appStore: "Dev"},
+    beta: {play: "beta", appStore: "Beta"},
+    production: {play: "production", appStore: "App Store"},
+  }
+  const selected = channels[plan.channel]
+  if (!selected) throw new Error(`Unknown release channel ${JSON.stringify(plan.channel)}`)
+  if (target === "google-play") return `com.mentra.mentra:${plan.native.buildNumber}:${selected.play}`
+  if (target === "app-store-connect") {
+    return `com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:${selected.appStore}`
+  }
+  throw new Error(`Unknown publication target ${JSON.stringify(target)}`)
+}
+
+function requiredArtifactCoordinates(plan) {
+  const keys =
+    plan.channel === "production"
+      ? ["enginePackage"]
+      : ["asgSelection", "androidApp", "androidStoreApp", "iosApp", "enginePackage"]
+  return keys.map((key) => {
+    const coordinate = plan.artifactNames?.[key]
+    if (typeof coordinate !== "string" || coordinate.length === 0) {
+      throw new Error(`Release plan is missing required artifact name ${key}`)
+    }
+    return coordinate
+  })
+}
+
+export function finalizeReleaseManifest({plan, results, completedAt}) {
+  if (!plan?.releaseSetId || !plan?.members) throw new Error("A generated release plan is required")
+  if (results?.releaseSetId !== plan.releaseSetId) throw new Error("Publication results do not match the release set")
+  const completed = new Date(completedAt)
+  if (!completedAt || Number.isNaN(completed.valueOf()) || completed.toISOString() !== completedAt) {
+    throw new Error("completedAt must be an ISO-8601 UTC timestamp")
+  }
+  if (
+    plan.native?.marketingVersion !== plan.familyBaseVersion ||
+    !Number.isSafeInteger(plan.native?.buildNumber) ||
+    plan.native.buildNumber < 1
+  ) {
+    throw new Error("Release plan has invalid native build identity")
+  }
+
+  const publications = {}
+  for (const [memberName, member] of Object.entries(plan.members)) {
+    const memberResults = results.publications?.[memberName]
+    if (!memberResults || typeof memberResults !== "object") {
+      throw new Error(`Missing publication results for ${memberName}`)
+    }
+    publications[memberName] = {}
+    for (const target of member.publishTargets) {
+      const label = `publications.${memberName}.${target}`
+      const publication = validatePublication(memberResults[target], label)
+      const expected = expectedPublicationCoordinate(plan, memberName, target)
+      if (publication.coordinate !== expected) {
+        throw new Error(`${label}.coordinate must be ${expected}`)
+      }
+      publications[memberName][target] = publication
+    }
+  }
+
+  const otaManifest = validatePublication(results.otaManifest, "otaManifest")
+  if (plan.channel === "production" && otaManifest.status !== "promoted") {
+    throw new Error("Production OTA manifest must be promoted from the selected beta")
+  }
+  if (plan.channel !== "production" && otaManifest.coordinate !== plan.artifactNames.otaManifest) {
+    throw new Error(`otaManifest.coordinate must be ${plan.artifactNames.otaManifest}`)
+  }
+  if (!Array.isArray(results.artifacts)) throw new Error("artifacts must be an array")
+  const artifacts = results.artifacts.map((artifact, index) => validatePublication(artifact, `artifacts[${index}]`))
+  const artifactCoordinates = new Set()
+  for (const artifact of artifacts) {
+    if (artifactCoordinates.has(artifact.coordinate)) {
+      throw new Error(`artifacts contains duplicate coordinate ${artifact.coordinate}`)
+    }
+    artifactCoordinates.add(artifact.coordinate)
+  }
+  for (const coordinate of requiredArtifactCoordinates(plan)) {
+    if (!artifactCoordinates.has(coordinate)) throw new Error(`Missing required artifact ${coordinate}`)
+  }
+
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    familyBaseVersion: plan.familyBaseVersion,
+    releaseIdentity: plan.releaseIdentity,
+    channel: plan.channel,
+    sourceCommit: plan.sourceCommit,
+    native: plan.native,
+    completedAt,
+    releasePlanSha256: releaseRecordSha256(plan),
+    publications,
+    otaManifest,
+    artifacts,
   }
 }

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -10,10 +10,27 @@ import {
   createReleasePlan,
   dependencyOrder,
   deriveReleaseIdentity,
+  finalizeReleaseManifest,
   loadReleaseFamily,
+  releaseRecordSha256,
+  requirePublicHttpsUrl,
+  serializeReleaseRecord,
 } from "./release-family.mjs"
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+
+test("accepts only credential-free public HTTPS URLs without fragments", () => {
+  assert.equal(requirePublicHttpsUrl("https://artifacts.example.com/file?q=1", "artifact"), "https://artifacts.example.com/file?q=1")
+  assert.throws(() => requirePublicHttpsUrl("http://artifacts.example.com/file", "artifact"), /must use HTTPS/)
+  assert.throws(
+    () => requirePublicHttpsUrl("https://token@artifacts.example.com/file", "artifact"),
+    /credential-free HTTPS/,
+  )
+  assert.throws(
+    () => requirePublicHttpsUrl("https://artifacts.example.com/file#sha256", "artifact"),
+    /without a fragment/,
+  )
+})
 
 test("loads the repository release family and derives dependency-first publication order", () => {
   const family = loadReleaseFamily({rootDir: repositoryRoot})
@@ -55,8 +72,99 @@ test("creates a deterministic release plan with exact dependency versions", () =
   assert.equal(plan.native.marketingVersion, "3.1.0")
   assert.equal(plan.native.buildNumber, 3100057)
   assert.equal(plan.products["@mentra/engine"], "3.1.0-beta.57")
-  assert.equal(plan.dependencies["@mentra/engine"]["@mentra/bluetooth-sdk"], "3.1.0-beta.57")
+  assert.equal(plan.members["@mentra/engine"].dependencies["@mentra/bluetooth-sdk"], "3.1.0-beta.57")
+  assert.equal(plan.members["@mentra/bluetooth-sdk"].publishTargets.length, 3)
+  assert.equal(plan.artifactNames.otaManifest, "mentra-live-ota-3.1.0-beta.57.json")
+  assert.equal(plan.artifactNames.asgSelection, "mentra-live-asg-selection-3.1.0-beta.57.json")
+  assert.equal(plan.artifactNames.androidStoreApp, "mentraos-3.1.0-beta.57-android.aab")
   assert.equal(plan.otaInputs.firmwareManifest, "firmware_live.json")
+})
+
+test("serializes records canonically and finalizes only complete release results", () => {
+  const family = loadReleaseFamily({rootDir: repositoryRoot})
+  const plan = createReleasePlan({
+    family,
+    channel: "beta",
+    sequence: 57,
+    sourceCommit: "a".repeat(40),
+    nativeBuildNumber: 3100057,
+  })
+  const publication = (coordinate) => ({
+    status: "published",
+    coordinate,
+    url: `https://artifacts.example.com/${encodeURIComponent(coordinate)}`,
+    sha256: "b".repeat(64),
+    provenanceUrl: "https://github.com/Mentra-Community/MentraOS/attestations/123",
+  })
+  const expectedCoordinates = {
+    "npm": (name) => `${name}@${plan.releaseIdentity}`,
+    "maven-central": () => `com.mentraglass:bluetooth-sdk:${plan.releaseIdentity}`,
+    "swift-package-manager": () => `Mentra-Community/mentra-bluetooth-sdk-ios@${plan.releaseIdentity}`,
+    "google-play": () => `com.mentra.mentra:${plan.native.buildNumber}:beta`,
+    "app-store-connect": () => `com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:Beta`,
+  }
+  const publications = Object.fromEntries(
+    Object.entries(plan.members).map(([name, member]) => [
+      name,
+      Object.fromEntries(
+        member.publishTargets.map((target) => [target, publication(expectedCoordinates[target](name))]),
+      ),
+    ]),
+  )
+  const results = {
+    releaseSetId: plan.releaseSetId,
+    publications,
+    otaManifest: publication(plan.artifactNames.otaManifest),
+    artifacts: [
+      publication(plan.artifactNames.asgSelection),
+      publication(plan.artifactNames.androidApp),
+      publication(plan.artifactNames.androidStoreApp),
+      publication(plan.artifactNames.iosApp),
+      publication(plan.artifactNames.enginePackage),
+    ],
+  }
+
+  const manifest = finalizeReleaseManifest({plan, results, completedAt: "2026-08-24T20:00:00.000Z"})
+  assert.equal(manifest.releasePlanSha256, releaseRecordSha256(plan))
+  assert.equal(manifest.publications["@mentra/engine"].npm.coordinate, "@mentra/engine@3.1.0-beta.57")
+  assert.deepEqual(manifest.native, plan.native)
+  assert.equal(serializeReleaseRecord({z: 1, a: 2}), '{\n  "a": 2,\n  "z": 1\n}\n')
+
+  const incompletePlan = structuredClone(plan)
+  delete incompletePlan.artifactNames.androidStoreApp
+  assert.throws(
+    () => finalizeReleaseManifest({plan: incompletePlan, results, completedAt: "2026-08-24T20:00:00.000Z"}),
+    /missing required artifact name androidStoreApp/,
+  )
+
+  delete results.publications["@mentra/bluetooth-sdk"]["maven-central"]
+  assert.throws(
+    () => finalizeReleaseManifest({plan, results, completedAt: "2026-08-24T20:00:00.000Z"}),
+    /publications\.@mentra\/bluetooth-sdk\.maven-central is missing/,
+  )
+
+  results.publications["@mentra/bluetooth-sdk"]["maven-central"] = publication(
+    "com.mentraglass:bluetooth-sdk:3.1.0-beta.56",
+  )
+  assert.throws(
+    () => finalizeReleaseManifest({plan, results, completedAt: "2026-08-24T20:00:00.000Z"}),
+    /coordinate must be com\.mentraglass:bluetooth-sdk:3\.1\.0-beta\.57/,
+  )
+
+  results.publications["@mentra/bluetooth-sdk"]["maven-central"] = publication(
+    "com.mentraglass:bluetooth-sdk:3.1.0-beta.57",
+  )
+  results.artifacts = results.artifacts.filter((artifact) => artifact.coordinate !== plan.artifactNames.iosApp)
+  assert.throws(
+    () => finalizeReleaseManifest({plan, results, completedAt: "2026-08-24T20:00:00.000Z"}),
+    new RegExp(`Missing required artifact ${plan.artifactNames.iosApp}`),
+  )
+
+  results.artifacts.push(publication(plan.artifactNames.iosApp), publication(plan.artifactNames.iosApp))
+  assert.throws(
+    () => finalizeReleaseManifest({plan, results, completedAt: "2026-08-24T20:00:00.000Z"}),
+    new RegExp(`artifacts contains duplicate coordinate ${plan.artifactNames.iosApp}`),
+  )
 })
 
 test("rejects unknown dependencies and dependency cycles", () => {

--- a/.github/workflows/release-family-checks.yml
+++ b/.github/workflows/release-family-checks.yml
@@ -5,13 +5,18 @@ on:
     branches: [dev, staging, main]
     paths:
       - ".github/release-family.json"
-      - ".github/scripts/release-family*.mjs"
+      - ".github/scripts/*.mjs"
+      - ".github/workflows/coordinated-*.yml"
       - ".github/workflows/release-family-checks.yml"
+      - ".github/workflows/reusable-coordinated-*.yml"
+      - "asg_client/ota_manifests/firmware_live.json"
       - "package.json"
       - "mobile/package.json"
       - "mobile/modules/bluetooth-sdk/package.json"
+      - "mobile/modules/bluetooth-sdk/scripts/*.mjs"
       - "mobile/modules/crust/package.json"
       - "mobile/modules/engine/package.json"
+      - "mobile/modules/engine/scripts/*.mjs"
       - "mobile/modules/jspolyfill/package.json"
       - "mobile/modules/miniapp/package.json"
       - "cloud-v2/packages/cloud-client/package.json"
@@ -27,7 +32,30 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Test release-family contract
-        run: node --test .github/scripts/release-family.test.mjs
+      - name: Test coordinated release tooling
+        run: |
+          set -euo pipefail
+          mapfile -t tests < <(find \
+            .github/scripts \
+            mobile/modules/bluetooth-sdk/scripts \
+            mobile/modules/engine/scripts \
+            -maxdepth 1 -name '*.test.mjs' -print | sort)
+          test "${#tests[@]}" -gt 0
+          node --test "${tests[@]}"
       - name: Validate repository definition
         run: node .github/scripts/release-family-cli.mjs validate
+      - name: Validate release plan inputs
+        run: |
+          set -euo pipefail
+          ota_inputs="$RUNNER_TEMP/ota-release-inputs.json"
+          release_plan="$RUNNER_TEMP/release-plan.json"
+          node .github/scripts/collect-ota-release-inputs.mjs \
+            asg_client/ota_manifests/firmware_live.json \
+            "$ota_inputs"
+          node .github/scripts/create-release-plan.mjs \
+            --branch dev \
+            --sequence 1 \
+            --source-commit "$(git rev-parse HEAD)" \
+            --native-build-number 310000001 \
+            --ota-inputs "$ota_inputs" \
+            --output "$release_plan"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "prepare": "husky",
     "release:validate-family": "node .github/scripts/release-family-cli.mjs validate",
     "release:test-family": "node --test .github/scripts/release-family.test.mjs",
+    "release:create-plan": "node .github/scripts/create-release-plan.mjs",
+    "release:finalize-manifest": "node .github/scripts/finalize-release-manifest.mjs",
     "generate-licenses": "bun mintlify-docs/generate-licenses.ts",
     "build:miniapp": "cd mobile/modules/miniapp && bun run build",
     "sync-miniapp": "bun scripts/sync-miniapp.mjs",


### PR DESCRIPTION
## Why

A coordinated release needs a durable distinction between what CI intends to publish and what actually finished. A partial run must never look like a completed release, and a retry must reconcile the same identity instead of silently allocating or mutating another one.

## What changes

- Expands `release-plan.json` to record every family member, exact dependency version, target registry/store, publication order, native build representation, normalized artifact name, and promoted MTK/BES input.
- Serializes release records canonically and computes a SHA-256 over the exact plan bytes.
- Adds `release-manifest.json` finalization that fails unless every declared member-target pair has a terminal status, coordinate, immutable HTTPS URL, SHA-256, and provenance URL.
- Captures the full promoted `firmware_live.json` MTK/BES inputs plus the source file digest.
- Adds CLI entrypoints for creating plans and finalizing manifests.
- Adds a PR/manual preview workflow that generates the same plan twice and byte-compares it before uploading the preview artifact.

The preview workflow does not publish anything. Live branch triggers and publisher migration remain in higher stack layers so the release-record contract can be reviewed independently.

## Verification

- Six release-family and release-record tests
- Real plan generation for `mentra-3.1.0-beta.57` against the current promoted firmware manifest
- Deterministic byte comparison
- YAML parse, Prettier, and `git diff --check`

## Stack

Layer 4, based on #3756. GitHub stack: #3758.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the coordinated release data model and strict completion gates for store, registry, and OTA artifacts; mistakes could block or mis-validate releases but do not directly publish or touch runtime auth.
> 
> **Overview**
> Introduces a **release-record contract** that separates immutable publish intent from verified completion: CI can record what it meant to ship, and only emit a finished manifest when every target and artifact checks out.
> 
> **Release plans** are expanded: per-member version, kind, manifest path, publish targets, dependency pins, fixed **artifact filenames**, and **OTA inputs** (MTK/BES from `firmware_live.json` plus source path and SHA-256). Plans are written via **canonical JSON** and a **SHA-256 over plan bytes** for stable identity on retries.
> 
> **`finalizeReleaseManifest`** validates publication results against the plan—terminal status, credential-free HTTPS URLs, digests, provenance, expected store/registry **coordinates** (npm, Maven, SPM, Play, App Store), required artifacts (channel-dependent), and production OTA **promoted** status—then produces a completed manifest that embeds `releasePlanSha256`.
> 
> New CLIs: **`collect-ota-release-inputs`**, **`create-release-plan`**, **`finalize-release-manifest`**, plus root **`release:create-plan`** / **`release:finalize-manifest`** scripts. **Coordinated Release Family Checks** now runs all coordinated `*.test.mjs` files and smoke-generates a dev release plan from the live firmware manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b34b592ffc68677bd2d5f7d36352283678ad51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->