### PR TITLE
Release family: activate the shared 3.1.0 source base

### DIFF
--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -107,6 +107,7 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
   const members = []
   const names = new Set()
   const manifests = new Set()
+  const packageManifests = new Map()
 
   for (const [index, rawMember] of definition.members.entries()) {
     const label = `members[${index}]`
@@ -131,6 +132,7 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
     if (requireVersionMirrors && packageManifest.version !== familyBaseVersion) {
       fail(`${manifest} version ${JSON.stringify(packageManifest.version)} does not mirror ${familyBaseVersion}`)
     }
+    packageManifests.set(name, packageManifest)
     members.push({name, manifest, kind, publishTargets, dependencies, sourceVersion: packageManifest.version})
   }
 
@@ -138,6 +140,31 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
     for (const dependency of member.dependencies) {
       if (!names.has(dependency)) fail(`${member.name} depends on unknown family member ${dependency}`)
       if (dependency === member.name) fail(`${member.name} cannot depend on itself`)
+    }
+  }
+
+  if (requireVersionMirrors) {
+    for (const member of members) {
+      const packageManifest = packageManifests.get(member.name)
+      const configuredDependencies = new Set(member.dependencies)
+      const expectedRange = member.name === "mentraos" ? "workspace:*" : familyBaseVersion
+
+      for (const dependency of member.dependencies) {
+        const actualRange = packageManifest.dependencies?.[dependency]
+        if (actualRange !== expectedRange) {
+          fail(
+            `${member.manifest} dependencies.${dependency} is ${JSON.stringify(actualRange)}, expected ${JSON.stringify(expectedRange)}`,
+          )
+        }
+      }
+      for (const dependency of names) {
+        if (packageManifest.peerDependencies?.[dependency] !== undefined) {
+          fail(`${member.manifest} must not declare family member ${dependency} as a peerDependency`)
+        }
+        if (packageManifest.dependencies?.[dependency] !== undefined && !configuredDependencies.has(dependency)) {
+          fail(`${member.manifest} depends on ${dependency}, but the release-family graph is missing that edge`)
+        }
+      }
     }
   }
 

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -209,3 +209,103 @@ test("can require package manifests to mirror the family base during activation"
 
   assert.throws(() => loadReleaseFamily({rootDir: root, requireVersionMirrors: true}), /does not mirror 3.1.0/)
 })
+
+test("requires exact regular dependencies between activated public family packages", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-release-family-"))
+  mkdirSync(path.join(root, ".github"), {recursive: true})
+  mkdirSync(path.join(root, "packages/base"), {recursive: true})
+  mkdirSync(path.join(root, "packages/product"), {recursive: true})
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.1.0"}))
+  writeFileSync(path.join(root, "packages/base/package.json"), JSON.stringify({name: "base", version: "3.1.0"}))
+  writeFileSync(
+    path.join(root, "packages/product/package.json"),
+    JSON.stringify({name: "product", version: "3.1.0", dependencies: {base: "^3.1.0"}}),
+  )
+  writeFileSync(
+    path.join(root, ".github/release-family.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      family: "mentra",
+      versionSource: "package.json",
+      products: ["product"],
+      members: [
+        {
+          name: "base",
+          manifest: "packages/base/package.json",
+          kind: "package",
+          publishTargets: ["npm"],
+          dependencies: [],
+        },
+        {
+          name: "product",
+          manifest: "packages/product/package.json",
+          kind: "product",
+          publishTargets: ["npm"],
+          dependencies: ["base"],
+        },
+      ],
+    }),
+  )
+
+  assert.throws(
+    () => loadReleaseFamily({rootDir: root, requireVersionMirrors: true}),
+    /dependencies\.base is "\^3\.1\.0", expected "3\.1\.0"/,
+  )
+})
+
+test("rejects family dependencies hidden from the configured graph or declared as peers", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-release-family-"))
+  mkdirSync(path.join(root, ".github"), {recursive: true})
+  mkdirSync(path.join(root, "packages/base"), {recursive: true})
+  mkdirSync(path.join(root, "packages/product"), {recursive: true})
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.1.0"}))
+  writeFileSync(path.join(root, "packages/base/package.json"), JSON.stringify({name: "base", version: "3.1.0"}))
+  writeFileSync(
+    path.join(root, "packages/product/package.json"),
+    JSON.stringify({name: "product", version: "3.1.0", dependencies: {base: "3.1.0"}}),
+  )
+  const familyDefinition = {
+    schemaVersion: 1,
+    family: "mentra",
+    versionSource: "package.json",
+    products: ["product"],
+    members: [
+      {
+        name: "base",
+        manifest: "packages/base/package.json",
+        kind: "package",
+        publishTargets: ["npm"],
+        dependencies: [],
+      },
+      {
+        name: "product",
+        manifest: "packages/product/package.json",
+        kind: "product",
+        publishTargets: ["npm"],
+        dependencies: [],
+      },
+    ],
+  }
+  writeFileSync(path.join(root, ".github/release-family.json"), JSON.stringify(familyDefinition))
+
+  assert.throws(
+    () => loadReleaseFamily({rootDir: root, requireVersionMirrors: true}),
+    /depends on base, but the release-family graph is missing that edge/,
+  )
+
+  familyDefinition.members[1].dependencies = ["base"]
+  writeFileSync(path.join(root, ".github/release-family.json"), JSON.stringify(familyDefinition))
+  writeFileSync(
+    path.join(root, "packages/product/package.json"),
+    JSON.stringify({
+      name: "product",
+      version: "3.1.0",
+      dependencies: {base: "3.1.0"},
+      peerDependencies: {base: "3.1.0"},
+    }),
+  )
+  assert.throws(
+    () => loadReleaseFamily({rootDir: root, requireVersionMirrors: true}),
+    /must not declare family member base as a peerDependency/,
+  )
+})

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -9,6 +9,7 @@ on:
       - "mobile/package.json"
       - "mobile/bun.lock"
       - "mobile/modules/**/package.json"
+      - "cloud-v2/bun.lock"
       - "cloud-v2/packages/**/package.json"
       - "miniapps/**/package.json"
       - "sdk/bun.lock"
@@ -23,6 +24,7 @@ on:
       - "mobile/package.json"
       - "mobile/bun.lock"
       - "mobile/modules/**/package.json"
+      - "cloud-v2/bun.lock"
       - "cloud-v2/packages/**/package.json"
       - "miniapps/**/package.json"
       - "sdk/bun.lock"
@@ -52,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-lockfiles-${{ hashFiles('bun.lock', 'mobile/bun.lock', 'sdk/bun.lock') }}
+          key: ${{ runner.os }}-bun-lockfiles-${{ hashFiles('bun.lock', 'mobile/bun.lock', 'cloud-v2/bun.lock', 'sdk/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-lockfiles-
 
@@ -61,6 +63,10 @@ jobs:
 
       - name: Validate mobile Bun lockfile
         working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate Cloud V2 Bun lockfile
+        working-directory: cloud-v2
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Validate SDK Bun lockfile

--- a/.github/workflows/release-family-checks.yml
+++ b/.github/workflows/release-family-checks.yml
@@ -43,7 +43,7 @@ jobs:
           test "${#tests[@]}" -gt 0
           node --test "${tests[@]}"
       - name: Validate repository definition
-        run: node .github/scripts/release-family-cli.mjs validate
+        run: node .github/scripts/release-family-cli.mjs validate --require-version-mirrors
       - name: Validate release plan inputs
         run: |
           set -euo pipefail
@@ -58,4 +58,5 @@ jobs:
             --source-commit "$(git rev-parse HEAD)" \
             --native-build-number 310000001 \
             --ota-inputs "$ota_inputs" \
+            --require-version-mirrors true \
             --output "$release_plan"

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "cloud-v2/packages/cloud-client": {
       "name": "@mentra/cloud-client",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
         "@mentra/cloud-protocol": "^0.1.0-dev.0",
         "tweetnacl": "^1.0.3",
@@ -84,7 +84,7 @@
     },
     "cloud-v2/packages/protocol": {
       "name": "@mentra/cloud-protocol",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
         "zod": "^3.24.1",
       },
@@ -100,7 +100,7 @@
       "name": "@mentra/cloud-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "^3.1.0",
         "@mentra/cloud-shared": "workspace:*",
         "@soniox/node": "^2.1.0",
         "hono": "^4.11.1",
@@ -288,9 +288,9 @@
     },
     "mobile/modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "workspace:*",
+        "@mentra/cloud-protocol": "3.1.0",
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
       },

--- a/cloud-v2/bun.lock
+++ b/cloud-v2/bun.lock
@@ -34,9 +34,9 @@
     },
     "packages/cloud-client": {
       "name": "@mentra/cloud-client",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "3.1.0",
         "tweetnacl": "^1.0.3",
       },
       "devDependencies": {
@@ -65,7 +65,7 @@
     },
     "packages/protocol": {
       "name": "@mentra/cloud-protocol",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
         "zod": "^3.24.1",
       },
@@ -81,7 +81,7 @@
       "name": "@mentra/cloud-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "^3.1.0",
         "@mentra/cloud-shared": "workspace:*",
         "@soniox/node": "^2.1.0",
         "hono": "^4.11.1",

--- a/cloud-v2/packages/cloud-client/package.json
+++ b/cloud-v2/packages/cloud-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/cloud-client",
-  "version": "0.1.0-dev.0",
+  "version": "3.1.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
@@ -12,7 +12,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@mentra/cloud-protocol": "^0.1.0-dev.0",
+    "@mentra/cloud-protocol": "3.1.0",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/cloud-v2/packages/protocol/package.json
+++ b/cloud-v2/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/cloud-protocol",
-  "version": "0.1.0-dev.0",
+  "version": "3.1.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/cloud-v2/packages/runtime/package.json
+++ b/cloud-v2/packages/runtime/package.json
@@ -13,7 +13,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@mentra/cloud-protocol": "^0.1.0-dev.0",
+    "@mentra/cloud-protocol": "^3.1.0",
     "@mentra/cloud-shared": "workspace:*",
     "@soniox/node": "^2.1.0",
     "hono": "^4.11.1",

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -167,15 +167,15 @@
         "qrcode": "^1.5.4",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "1.3.14",
         "@types/qrcode": "^1.5.5",
       },
     },
     "../cloud-v2/packages/cloud-client": {
       "name": "@mentra/cloud-client",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "3.1.0",
         "tweetnacl": "^1.0.3",
       },
       "devDependencies": {
@@ -204,7 +204,7 @@
     },
     "../cloud-v2/packages/protocol": {
       "name": "@mentra/cloud-protocol",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
         "zod": "^3.24.1",
       },
@@ -220,7 +220,7 @@
       "name": "@mentra/cloud-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "^3.1.0",
         "@mentra/cloud-shared": "workspace:*",
         "@soniox/node": "^2.1.0",
         "hono": "^4.11.1",
@@ -244,7 +244,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.6",
+      "version": "3.1.0",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",
@@ -260,9 +260,9 @@
     },
     "modules/crust": {
       "name": "@mentra/crust",
-      "version": "0.1.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/jspolyfill": "^0.1.0-dev.0",
+        "@mentra/jspolyfill": "3.1.0",
       },
       "devDependencies": {
         "@expo/config-plugins": ">=8.0.0",
@@ -278,18 +278,19 @@
     },
     "modules/engine": {
       "name": "@mentra/engine",
-      "version": "0.1.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
+        "@mentra/bluetooth-sdk": "3.1.0",
+        "@mentra/cloud-client": "3.1.0",
+        "@mentra/cloud-protocol": "3.1.0",
+        "@mentra/crust": "3.1.0",
+        "@mentra/miniapp": "3.1.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
         "semver": "^7.7.4",
         "typesafe-ts": "^1.7.1",
       },
       "devDependencies": {
-        "@mentra/bluetooth-sdk": "workspace:*",
-        "@mentra/cloud-client": "workspace:*",
-        "@mentra/cloud-protocol": "workspace:*",
-        "@mentra/miniapp": "workspace:*",
         "@types/semver": "^7.7.1",
         "expo-module-scripts": "^55.0.2",
         "expo-modules-core": "55.0.25",
@@ -299,11 +300,6 @@
       "peerDependencies": {
         "@craftzdog/react-native-buffer": "*",
         "@dr.pogodin/react-native-fs": "*",
-        "@mentra/bluetooth-sdk": "*",
-        "@mentra/cloud-client": "^0.1.0-dev.0",
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
-        "@mentra/crust": "^0.1.0-dev.0",
-        "@mentra/miniapp": "^0.3.0-dev.0",
         "@react-native-community/netinfo": "*",
         "@types/react": "*",
         "axios": "*",
@@ -340,16 +336,16 @@
     },
     "modules/jspolyfill": {
       "name": "@mentra/jspolyfill",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "devDependencies": {
         "esbuild": "^0.23.0",
       },
     },
     "modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "workspace:*",
+        "@mentra/cloud-protocol": "3.1.0",
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
       },
@@ -3215,7 +3211,7 @@
 
     "@livekit/react-native-webrtc/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
-    "@mentra/cli/@mentra/miniapp-cli": ["@mentra/miniapp-cli@file:../sdk/miniapp-cli", { "dependencies": { "@clack/prompts": "^1.2.0", "jszip": "^3.10.1", "qrcode": "^1.5.4", "typescript": "^5.0.0" }, "devDependencies": { "@types/qrcode": "^1.5.5", "bun-types": "^1.3.14" }, "bin": { "mentra-miniapp": "./src/index.ts" } }],
+    "@mentra/cli/@mentra/miniapp-cli": ["@mentra/miniapp-cli@file:../sdk/miniapp-cli", { "dependencies": { "@clack/prompts": "^1.2.0", "jszip": "^3.10.1", "qrcode": "^1.5.4", "typescript": "^5.0.0" }, "devDependencies": { "@types/qrcode": "^1.5.5", "bun-types": "1.3.14" }, "bin": { "mentra-miniapp": "./src/index.ts" } }],
 
     "@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.21-dev.6",
+  "version": "3.1.0",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/mobile/modules/crust/package.json
+++ b/mobile/modules/crust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/crust",
-  "version": "0.1.0-dev.1",
+  "version": "3.1.0",
   "description": "Mentra Native Module",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://github.com/fossephate/crust#readme",
   "dependencies": {
-    "@mentra/jspolyfill": "^0.1.0-dev.0"
+    "@mentra/jspolyfill": "3.1.0"
   },
   "devDependencies": {
     "@expo/config-plugins": ">=8.0.0",

--- a/mobile/modules/engine/package.json
+++ b/mobile/modules/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/engine",
-  "version": "0.1.0-dev.1",
+  "version": "3.1.0",
   "description": "Mentra Engine — miniapp registry, WebView bridge, and miniapp store",
   "main": "build/index.js",
   "react-native": "src/index.ts",
@@ -97,16 +97,17 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@mentra/bluetooth-sdk": "3.1.0",
+    "@mentra/cloud-client": "3.1.0",
+    "@mentra/cloud-protocol": "3.1.0",
+    "@mentra/crust": "3.1.0",
+    "@mentra/miniapp": "3.1.0",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "semver": "^7.7.4",
     "typesafe-ts": "^1.7.1"
   },
   "devDependencies": {
-    "@mentra/bluetooth-sdk": "workspace:*",
-    "@mentra/cloud-client": "workspace:*",
-    "@mentra/cloud-protocol": "workspace:*",
-    "@mentra/miniapp": "workspace:*",
     "@types/semver": "^7.7.1",
     "expo-module-scripts": "^55.0.2",
     "expo-modules-core": "55.0.25",
@@ -147,11 +148,6 @@
     "@react-native-community/netinfo": "*",
     "@dr.pogodin/react-native-fs": "*",
     "@craftzdog/react-native-buffer": "*",
-    "axios": "*",
-    "@mentra/bluetooth-sdk": "*",
-    "@mentra/crust": "^0.1.0-dev.0",
-    "@mentra/cloud-client": "^0.1.0-dev.0",
-    "@mentra/miniapp": "^0.3.0-dev.0",
-    "@mentra/cloud-protocol": "^0.1.0-dev.0"
+    "axios": "*"
   }
 }

--- a/mobile/modules/jspolyfill/package.json
+++ b/mobile/modules/jspolyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/jspolyfill",
-  "version": "0.1.0-dev.0",
+  "version": "3.1.0",
   "description": "MentraJS polyfill bundle \u2014 installed into each per-miniapp JSContext (iOS-JSC, Android-QuickJS) at spawn time. Provides browser-like globals (console, timers, fetch, WebSocket, localStorage, crypto.subtle) over a single __dispatch native bridge, plus the __deliver / signalReady plumbing the host runtime relies on.",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/mobile/modules/miniapp/package.json
+++ b/mobile/modules/miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/miniapp",
-  "version": "0.3.0-dev.1",
+  "version": "3.1.0",
   "description": "SDK for building MentraOS local miniapps (browser/WebView)",
   "author": "Mentra Labs",
   "license": "MIT",
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@mentra/cloud-protocol": "workspace:*",
+    "@mentra/cloud-protocol": "3.1.0",
     "@mentra/types": "1.0.0-beta.2",
     "eventemitter3": "^5.0.1"
   },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentraos",
-  "version": "0.0.1",
+  "version": "3.1.0",
   "private": true,
   "main": "expo-router/entry",
   "workspaces": [

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -28,9 +28,9 @@
     },
     "../cloud-v2/packages/cloud-client": {
       "name": "@mentra/cloud-client",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "3.1.0",
         "tweetnacl": "^1.0.3",
       },
       "devDependencies": {
@@ -59,7 +59,7 @@
     },
     "../cloud-v2/packages/protocol": {
       "name": "@mentra/cloud-protocol",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "dependencies": {
         "zod": "^3.24.1",
       },
@@ -75,7 +75,7 @@
       "name": "@mentra/cloud-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
+        "@mentra/cloud-protocol": "^3.1.0",
         "@mentra/cloud-shared": "workspace:*",
         "@soniox/node": "^2.1.0",
         "hono": "^4.11.1",
@@ -263,7 +263,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.6",
+      "version": "3.1.0",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",
@@ -279,9 +279,9 @@
     },
     "../mobile/modules/crust": {
       "name": "@mentra/crust",
-      "version": "0.1.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/jspolyfill": "^0.1.0-dev.0",
+        "@mentra/jspolyfill": "3.1.0",
       },
       "devDependencies": {
         "@expo/config-plugins": ">=8.0.0",
@@ -297,18 +297,19 @@
     },
     "../mobile/modules/engine": {
       "name": "@mentra/engine",
-      "version": "0.1.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
+        "@mentra/bluetooth-sdk": "3.1.0",
+        "@mentra/cloud-client": "3.1.0",
+        "@mentra/cloud-protocol": "3.1.0",
+        "@mentra/crust": "3.1.0",
+        "@mentra/miniapp": "3.1.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
         "semver": "^7.7.4",
         "typesafe-ts": "^1.7.1",
       },
       "devDependencies": {
-        "@mentra/bluetooth-sdk": "workspace:*",
-        "@mentra/cloud-client": "workspace:*",
-        "@mentra/cloud-protocol": "workspace:*",
-        "@mentra/miniapp": "workspace:*",
         "@types/semver": "^7.7.1",
         "expo-module-scripts": "^55.0.2",
         "expo-modules-core": "55.0.25",
@@ -318,11 +319,6 @@
       "peerDependencies": {
         "@craftzdog/react-native-buffer": "*",
         "@dr.pogodin/react-native-fs": "*",
-        "@mentra/bluetooth-sdk": "*",
-        "@mentra/cloud-client": "^0.1.0-dev.0",
-        "@mentra/cloud-protocol": "^0.1.0-dev.0",
-        "@mentra/crust": "^0.1.0-dev.0",
-        "@mentra/miniapp": "^0.3.0-dev.0",
         "@react-native-community/netinfo": "*",
         "@types/react": "*",
         "axios": "*",
@@ -359,16 +355,16 @@
     },
     "../mobile/modules/jspolyfill": {
       "name": "@mentra/jspolyfill",
-      "version": "0.1.0-dev.0",
+      "version": "3.1.0",
       "devDependencies": {
         "esbuild": "^0.23.0",
       },
     },
     "../mobile/modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0-dev.1",
+      "version": "3.1.0",
       "dependencies": {
-        "@mentra/cloud-protocol": "workspace:*",
+        "@mentra/cloud-protocol": "3.1.0",
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
       },
@@ -1087,10 +1083,6 @@
     "@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.83.6", "", {}, "sha512-5prXv7WWR1RgZ/kWGZP+mi7/y/IE2ymfOHIZO5Pv14tMOmRAcQSgSYogcRmOiWw5mJs2K0UFeMiQD49ZO9oCug=="],
 
     "@react-native/js-polyfills": ["@react-native/js-polyfills@0.83.6", "", {}, "sha512-VSev0LV2i5X0ibduHBSLqKj0YU2F+waCgjl2uvaGHMGCSV1ZRKNFX/vJFqvLwjvdzLbkAZoFT1Rg7k7jDv44UA=="],
-
-    "@react-native/metro-babel-transformer": ["@react-native/metro-babel-transformer@0.86.0", "", { "dependencies": { "@babel/core": "^7.25.2", "@react-native/babel-preset": "0.86.0", "hermes-parser": "0.36.0", "nullthrows": "^1.1.1" } }, "sha512-SjKej3E5qIahqo/G+rSOrmJUQM44RyKtWtO+VfmKAAMoJWkBFomM22hTLKCIS5cdbIAJ9COAmU+KAi2wVSO0wQ=="],
-
-    "@react-native/metro-config": ["@react-native/metro-config@0.86.0", "", { "dependencies": { "@react-native/js-polyfills": "0.86.0", "@react-native/metro-babel-transformer": "0.86.0", "metro-config": "^0.84.3", "metro-runtime": "^0.84.3" } }, "sha512-7v+xbTeEci9ZcQ/Z1OqI4RXcqN69wSMDYL5BAMvOReZ7U04+aDQ0/SQhClYPn6x2/RxM4WzMKSAuNyLKqvYVtw=="],
 
     "@react-native/normalize-colors": ["@react-native/normalize-colors@0.83.6", "", {}, "sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw=="],
 
@@ -3122,16 +3114,6 @@
 
     "@react-native/dev-middleware/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
-    "@react-native/metro-babel-transformer/@react-native/babel-preset": ["@react-native/babel-preset@0.86.0", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.25.2", "@babel/plugin-transform-react-jsx-self": "^7.24.7", "@babel/plugin-transform-react-jsx-source": "^7.24.7", "@babel/plugin-transform-regenerator": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@react-native/babel-plugin-codegen": "0.86.0", "babel-plugin-syntax-hermes-parser": "0.36.0", "babel-plugin-transform-flow-enums": "^0.0.2", "react-refresh": "^0.14.0" } }, "sha512-bYQcWiPySNvF4dns9Ls9gMmwgq66ohvM9Fwc/Kn8r85t66UNHxch3p1QwPiSorDelFauZwJbgo9+ReibTgvpbA=="],
-
-    "@react-native/metro-babel-transformer/hermes-parser": ["hermes-parser@0.36.0", "", { "dependencies": { "hermes-estree": "0.36.0" } }, "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w=="],
-
-    "@react-native/metro-config/@react-native/js-polyfills": ["@react-native/js-polyfills@0.86.0", "", {}, "sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ=="],
-
-    "@react-native/metro-config/metro-config": ["metro-config@0.84.4", "", { "dependencies": { "connect": "^3.6.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.84.4", "metro-cache": "0.84.4", "metro-core": "0.84.4", "metro-runtime": "0.84.4", "yaml": "^2.6.1" } }, "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q=="],
-
-    "@react-native/metro-config/metro-runtime": ["metro-runtime@0.84.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q=="],
-
     "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "@testing-library/react-native/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
@@ -3406,28 +3388,6 @@
 
     "@react-native/codegen/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-class-properties": ["@babel/plugin-transform-class-properties@7.29.7", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-classes": ["@babel/plugin-transform-classes@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-replace-supers": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-nullish-coalescing-operator": ["@babel/plugin-transform-nullish-coalescing-operator@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-optional-chaining": ["@babel/plugin-transform-optional-chaining@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-unicode-regex": ["@babel/plugin-transform-unicode-regex@7.29.7", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.86.0", "", { "dependencies": { "@babel/traverse": "^7.29.0", "@react-native/codegen": "0.86.0" } }, "sha512-qdsABWNW7uTll90l4Vh03gjeyu3WVDi2CyiiyvYGMRDcoYbjbQi6df3BMAm9lQI2yslZ1T14LlDDAsgTwNxplA=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/babel-plugin-syntax-hermes-parser": ["babel-plugin-syntax-hermes-parser@0.36.0", "", { "dependencies": { "hermes-parser": "0.36.0" } }, "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q=="],
-
-    "@react-native/metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.36.0", "", {}, "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w=="],
-
-    "@react-native/metro-config/metro-config/metro": ["metro@0.84.4", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "accepts": "^2.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.35.0", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.84.4", "metro-cache": "0.84.4", "metro-cache-key": "0.84.4", "metro-config": "0.84.4", "metro-core": "0.84.4", "metro-file-map": "0.84.4", "metro-resolver": "0.84.4", "metro-runtime": "0.84.4", "metro-source-map": "0.84.4", "metro-symbolicate": "0.84.4", "metro-transform-plugins": "0.84.4", "metro-transform-worker": "0.84.4", "mime-types": "^3.0.1", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA=="],
-
-    "@react-native/metro-config/metro-config/metro-cache": ["metro-cache@0.84.4", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.84.4" } }, "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg=="],
-
-    "@react-native/metro-config/metro-config/metro-core": ["metro-core@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.84.4" } }, "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ=="],
-
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -3540,38 +3500,6 @@
 
     "@react-native/codegen/glob/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@react-native/babel-plugin-codegen/@react-native/codegen": ["@react-native/codegen@0.86.0", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.29.0", "hermes-parser": "0.36.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "tinyglobby": "^0.2.15", "yargs": "^17.6.2" } }, "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA=="],
-
-    "@react-native/metro-config/metro-config/metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "@react-native/metro-config/metro-config/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
-
-    "@react-native/metro-config/metro-config/metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-babel-transformer": ["metro-babel-transformer@0.84.4", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.35.0", "metro-cache-key": "0.84.4", "nullthrows": "^1.1.1" } }, "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-cache-key": ["metro-cache-key@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-file-map": ["metro-file-map@0.84.4", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-resolver": ["metro-resolver@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-source-map": ["metro-source-map@0.84.4", "", { "dependencies": { "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.84.4", "nullthrows": "^1.1.1", "ob1": "0.84.4", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-symbolicate": ["metro-symbolicate@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.84.4", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-transform-plugins": ["metro-transform-plugins@0.84.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-transform-worker": ["metro-transform-worker@0.84.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "flow-enums-runtime": "^0.0.6", "metro": "0.84.4", "metro-babel-transformer": "0.84.4", "metro-cache": "0.84.4", "metro-cache-key": "0.84.4", "metro-minify-terser": "0.84.4", "metro-source-map": "0.84.4", "metro-transform-plugins": "0.84.4", "nullthrows": "^1.1.1" } }, "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg=="],
-
-    "@react-native/metro-config/metro-config/metro/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "@react-native/metro-config/metro-config/metro/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
-
-    "@react-native/metro-config/metro-config/metro-cache/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "@react-native/metro-config/metro-config/metro-core/metro-resolver": ["metro-resolver@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A=="],
-
     "@testing-library/react-native/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "eslint-plugin-import/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -3615,18 +3543,6 @@
     "@jest/reporters/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@react-native/codegen/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@react-native/metro-config/metro-config/metro-cache/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "@react-native/metro-config/metro-config/metro/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "@react-native/metro-config/metro-config/metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-source-map/ob1": ["ob1@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA=="],
-
-    "@react-native/metro-config/metro-config/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ=="],
-
-    "@react-native/metro-config/metro-config/metro/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "jest-config/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 


### PR DESCRIPTION
## Why

The coordinated release system needs one future-production base version in source and exact ownership of every first-party runtime dependency. Without that contract, MentraOS, Engine, the Bluetooth SDK, and Engine's supporting packages can silently publish incompatible prerelease combinations even when the top-level product versions look aligned.

This PR activates the release-family definition introduced lower in the stack. It intentionally keeps source manifests at the stable future-production base, `3.1.0`; the release coordinator will derive immutable `3.1.0-dev.N` and `3.1.0-beta.N` identities in isolated publication staging directories rather than making developers churn package manifests on every commit.

## What changes

- Sets the release-family source manifests to the shared `3.1.0` base:
  - MentraOS
  - Mentra Engine
  - Bluetooth SDK
  - Crust
  - JSpolyfill
  - Miniapp SDK
  - Cloud Client
  - Cloud Protocol
- Moves Engine's first-party runtime closure into exact regular dependencies instead of peer/dev dependencies.
- Uses exact `3.1.0` family edges for public packages, while MentraOS continues to consume the local workspace through `workspace:*`.
- Extends release-family validation to reject:
  - source-version drift from the root base version
  - semver ranges between published family packages
  - family dependencies declared as peers
  - package dependency edges omitted from the release graph
- Enables the strict activation validation in PR CI.
- Updates the root, mobile, and SDK Bun lockfiles with Bun 1.4.0.

## Contract established

For a source checkout at base `3.1.0`:

- all family manifests say `3.1.0`;
- every published family package owns exact `3.1.0` runtime dependencies;
- MentraOS uses local workspaces while building from source;
- the release coordinator may stage the whole closure as one exact `3.1.0-dev.N`, `3.1.0-beta.N`, or `3.1.0` set;
- consumers do not need to reason about unrelated Engine and Bluetooth SDK version families.

## Verification

- `node --test .github/scripts/release-family.test.mjs`
- `node .github/scripts/release-family-cli.mjs validate --require-version-mirrors`
- frozen Bun 1.4.0 installs in the root, `mobile`, and `sdk` workspaces
- package builds for JSpolyfill, Crust, Bluetooth SDK, Miniapp SDK, and Engine
- Engine Bluetooth SDK public-facade identity tests
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide version and dependency-graph changes across mobile and cloud packages affect install resolution and publish compatibility; mistakes could break coordinated releases or consumer version alignment.
> 
> **Overview**
> Activates the coordinated **3.1.0** release-family base in source and tightens what CI can accept before a release.
> 
> **Manifests and dependencies:** Family packages (MentraOS, Engine, Bluetooth SDK, Crust, JSpolyfill, Miniapp, Cloud Client/Protocol) are set to version **3.1.0**. Inter-family runtime edges use **exact** `3.1.0` (not semver ranges or `workspace:*` on publishable packages). **Engine** now lists its first-party closure (`bluetooth-sdk`, `cloud-client`, `cloud-protocol`, `crust`, `miniapp`) as regular **dependencies** instead of dev/peer deps. Lockfiles for root, mobile, sdk, and **cloud-v2** reflect those changes.
> 
> **Validation:** When `requireVersionMirrors` is on, `loadReleaseFamily` also enforces matching `dependencies.*` ranges, forbids family members as **peerDependencies**, and requires every such dependency to appear in `.github/release-family.json`. New unit tests cover those failures. PR workflows run `validate --require-version-mirrors` and pass the same flag into release-plan generation.
> 
> **CI:** Bun lockfile checks now validate **cloud-v2** (`bun install --frozen-lockfile` in `cloud-v2`) and include `cloud-v2/bun.lock` in path filters and cache keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85895c14a36c75065d588d153e971cb597895e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->