### PR TITLE
Release staging: stamp one exact coordinated identity

### DIFF
--- a/.github/scripts/stage-release-family.mjs
+++ b/.github/scripts/stage-release-family.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {loadReleaseFamily} from "./release-family.mjs"
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"))
+}
+
+export function stageReleaseFamily({rootDir = process.cwd(), plan}) {
+  const family = loadReleaseFamily({rootDir, requireVersionMirrors: true})
+  if (plan.familyBaseVersion !== family.familyBaseVersion) {
+    throw new Error(
+      `Release plan base ${JSON.stringify(plan.familyBaseVersion)} does not match source ${family.familyBaseVersion}`,
+    )
+  }
+  if (!plan.releaseIdentity || plan.releaseSetId !== `mentra-${plan.releaseIdentity}`) {
+    throw new Error("Release plan has an invalid release identity")
+  }
+
+  const planMembers = Object.keys(plan.members || {}).sort()
+  const familyMembers = family.members.map(({name}) => name).sort()
+  if (JSON.stringify(planMembers) !== JSON.stringify(familyMembers)) {
+    throw new Error("Release plan members do not match the configured release family")
+  }
+
+  const changes = []
+  for (const member of family.members) {
+    const planned = plan.members[member.name]
+    if (planned.version !== plan.releaseIdentity) {
+      throw new Error(`${member.name} plan version does not match ${plan.releaseIdentity}`)
+    }
+    const manifestPath = path.join(rootDir, member.manifest)
+    const manifest = readJson(manifestPath)
+    manifest.version = plan.releaseIdentity
+
+    for (const dependency of member.dependencies) {
+      const expected = member.name === "mentraos" ? "workspace:*" : plan.releaseIdentity
+      if (!manifest.dependencies || manifest.dependencies[dependency] === undefined) {
+        throw new Error(`${member.manifest} is missing dependencies.${dependency}`)
+      }
+      manifest.dependencies[dependency] = expected
+    }
+
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    changes.push({name: member.name, manifest: member.manifest, version: plan.releaseIdentity})
+  }
+  return changes
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : ""
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.plan) throw new Error("Missing --plan")
+  const rootDir = path.resolve(args.root || process.cwd())
+  const plan = readJson(path.resolve(args.plan))
+  const changes = stageReleaseFamily({rootDir, plan})
+  console.log(`Staged ${changes.length} release-family manifests at ${plan.releaseIdentity}`)
+}

--- a/.github/scripts/stage-release-family.test.mjs
+++ b/.github/scripts/stage-release-family.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import {cpSync, mkdirSync, mkdtempSync, readFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+import {fileURLToPath} from "node:url"
+
+import {createReleasePlan, loadReleaseFamily} from "./release-family.mjs"
+import {stageReleaseFamily} from "./stage-release-family.mjs"
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-release-stage-"))
+  mkdirSync(path.join(root, ".github"), {recursive: true})
+  cpSync(path.join(repositoryRoot, ".github/release-family.json"), path.join(root, ".github/release-family.json"), {
+    recursive: true,
+  })
+  cpSync(path.join(repositoryRoot, "package.json"), path.join(root, "package.json"))
+  const family = loadReleaseFamily({rootDir: repositoryRoot, requireVersionMirrors: true})
+  for (const member of family.members) {
+    const source = path.join(repositoryRoot, member.manifest)
+    const destination = path.join(root, member.manifest)
+    mkdirSync(path.dirname(destination), {recursive: true})
+    cpSync(source, destination, {recursive: true})
+  }
+  return {root, family}
+}
+
+test("stages one exact prerelease identity without changing MentraOS workspace edges", () => {
+  const {root, family} = fixture()
+  const plan = createReleasePlan({
+    family,
+    channel: "beta",
+    sequence: 57,
+    sourceCommit: "a".repeat(40),
+    nativeBuildNumber: 310000057,
+  })
+
+  stageReleaseFamily({rootDir: root, plan})
+
+  for (const member of family.members) {
+    const manifest = JSON.parse(readFileSync(path.join(root, member.manifest), "utf8"))
+    assert.equal(manifest.version, "3.1.0-beta.57")
+    for (const dependency of member.dependencies) {
+      assert.equal(manifest.dependencies[dependency], member.name === "mentraos" ? "workspace:*" : "3.1.0-beta.57")
+    }
+  }
+})
+
+test("rejects a plan from another family base", () => {
+  const {root, family} = fixture()
+  const plan = createReleasePlan({
+    family,
+    channel: "dev",
+    sequence: 4,
+    sourceCommit: "b".repeat(40),
+    nativeBuildNumber: 310000004,
+  })
+  plan.familyBaseVersion = "3.2.0"
+
+  assert.throws(() => stageReleaseFamily({rootDir: root, plan}), /does not match source/)
+})


### PR DESCRIPTION
## Why

Source manifests deliberately carry only the future stable family base (`3.1.0`). A coordinated run still needs to build and publish every member as one exact identity such as `3.1.0-dev.184` or `3.1.0-beta.57`, without committing version churn or letting individual workflows derive different suffixes.

## What changes

- Adds a release-staging command that consumes an immutable `release-plan.json`.
- Revalidates the clean source checkout against the activated release-family contract before changing anything.
- Refuses plans with a mismatched family base, release-set identity, member set, or member version.
- Stamps every family manifest to the one planned release identity.
- Rewrites every public first-party dependency to the same exact version.
- Preserves MentraOS `workspace:*` edges because the mobile app builds the local workspace rather than installing registry packages.
- Runs only against the ephemeral CI checkout; no generated prerelease versions are committed.
- Adds the staging regression suite to release-family PR CI.

This is intentionally a separate stack layer from branch-trigger activation. It gives the reusable package and product workflows one tested staging primitive before any old publisher is replaced.

## Verification

- `node --test .github/scripts/release-family.test.mjs .github/scripts/stage-release-family.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New release automation that mutates manifests only in ephemeral CI checkouts, with strict plan validation and no runtime or auth impact.
> 
> **Overview**
> Adds **`stageReleaseFamily`**, a CI-only primitive that reads an immutable **`release-plan.json`**, re-validates it against **`.github/release-family.json`** (family base, `releaseSetId`, member set, per-member versions), then rewrites each member manifest’s **`version`** and first-party **`dependencies`** to the single planned **`releaseIdentity`**.
> 
> **MentraOS** keeps **`workspace:*`** on its configured dependency edges; other members get the exact prerelease identity (e.g. `3.1.0-beta.57`). A small CLI (`--plan`, optional `--root`) applies staging on the ephemeral checkout without committing churn.
> 
> **Tests** copy the real release-family fixture into a temp tree, assert coordinated stamping and workspace preservation, and assert rejection when **`familyBaseVersion`** does not match source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79ede6615389edf703372ac153f8d45e4ab9f09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->