### PR TITLE
Release family: publish the exact npm dependency closure

### DIFF
--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {execFileSync} from "node:child_process"
+import {mkdirSync, readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {loadReleaseFamily, serializeReleaseRecord} from "./release-family.mjs"
+
+export function npmReleaseTag(channel) {
+  if (channel === "dev") return "dev"
+  if (channel === "beta") return "beta"
+  if (channel === "production") throw new Error("Production npm publication requires an explicit candidate dist-tag")
+  throw new Error(`Unsupported npm release channel ${JSON.stringify(channel)}`)
+}
+
+export function sha512Integrity(bytes) {
+  return `sha512-${createHash("sha512").update(bytes).digest("base64")}`
+}
+
+export function requirePlanSourceCommit(rootDir, expectedCommit) {
+  const actualCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: rootDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim()
+  if (actualCommit !== expectedCommit) {
+    throw new Error(`Release source checkout is ${actualCommit}, expected ${expectedCommit}`)
+  }
+  return actualCommit
+}
+
+export function requireNpmProvenanceSource(packageJson, manifest) {
+  const expectedDirectory = path.dirname(manifest)
+  if (
+    packageJson.repository?.type !== "git" ||
+    packageJson.repository?.url !== "git+https://github.com/Mentra-Community/MentraOS.git" ||
+    packageJson.repository?.directory !== expectedDirectory
+  ) {
+    throw new Error(`${packageJson.name} repository metadata does not identify ${expectedDirectory} in MentraOS`)
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function run(command, args, options = {}) {
+  console.log(`$ ${command} ${args.join(" ")}`)
+  return execFileSync(command, args, {stdio: "inherit", ...options})
+}
+
+function npmView(spec, field) {
+  try {
+    return execFileSync("npm", ["view", spec, field, "--json", "--registry=https://registry.npmjs.org"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim()
+  } catch (error) {
+    const output = `${error.stdout || ""}${error.stderr || ""}`
+    if (/"code":\s*"E404"/.test(output) || /code E404/.test(output)) return null
+    throw new Error(`npm view ${spec} failed with a non-404 error:\n${output}`)
+  }
+}
+
+function parseViewValue(output) {
+  if (output === null) return null
+  try {
+    return JSON.parse(output)
+  } catch {
+    return output
+  }
+}
+
+function npmViewPublished(spec, field) {
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    const value = parseViewValue(npmView(spec, field))
+    if (value !== null) return value
+    if (attempt < 12) execFileSync("sleep", ["5"])
+  }
+  return null
+}
+
+export function npmMembersInOrder(family, selectedNames) {
+  const selected = new Set(selectedNames)
+  for (const name of selected) {
+    const member = family.members.find((candidate) => candidate.name === name)
+    if (!member) throw new Error(`Unknown release-family member ${name}`)
+    if (!member.publishTargets.includes("npm")) throw new Error(`${name} is not configured for npm publication`)
+  }
+  return family.publicationOrder.filter((name) => selected.has(name))
+}
+
+export function publishReleaseNpm({rootDir, plan, memberNames, outputDir, dryRun}) {
+  requirePlanSourceCommit(rootDir, plan.sourceCommit)
+  const family = loadReleaseFamily({rootDir})
+  if (plan.familyBaseVersion !== family.familyBaseVersion)
+    throw new Error("Release plan does not match source family base")
+  const orderedNames = npmMembersInOrder(family, memberNames)
+  const tag = npmReleaseTag(plan.channel)
+  const publications = {}
+  mkdirSync(outputDir, {recursive: true})
+
+  for (const name of orderedNames) {
+    const member = family.members.find((candidate) => candidate.name === name)
+    const packageDir = path.dirname(path.join(rootDir, member.manifest))
+    const packageJson = JSON.parse(readFileSync(path.join(rootDir, member.manifest), "utf8"))
+    requireNpmProvenanceSource(packageJson, member.manifest)
+    if (packageJson.version !== plan.releaseIdentity) {
+      throw new Error(`${name} is ${packageJson.version}, expected staged version ${plan.releaseIdentity}`)
+    }
+    for (const dependency of member.dependencies) {
+      if (packageJson.dependencies?.[dependency] !== plan.releaseIdentity) {
+        throw new Error(`${name} does not pin ${dependency} to ${plan.releaseIdentity}`)
+      }
+    }
+
+    if (packageJson.scripts?.build) run("bun", ["run", "build"], {cwd: packageDir})
+    const packageOutput = path.join(outputDir, name.replace(/^@/, "").replaceAll("/", "-"))
+    mkdirSync(packageOutput, {recursive: true})
+    run("npm", ["pack", "--pack-destination", packageOutput], {cwd: packageDir})
+    const packed = execFileSync("find", [packageOutput, "-maxdepth", "1", "-name", "*.tgz", "-print"], {
+      encoding: "utf8",
+    })
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+    if (packed.length !== 1) throw new Error(`${name} produced ${packed.length} npm tarballs`)
+    const tarball = packed[0]
+    const bytes = readFileSync(tarball)
+    const integrity = sha512Integrity(bytes)
+    const sha256 = createHash("sha256").update(bytes).digest("hex")
+    const coordinate = `${name}@${plan.releaseIdentity}`
+    const registryIntegrity = parseViewValue(npmView(coordinate, "dist.integrity"))
+    let status = "built"
+
+    if (registryIntegrity !== null) {
+      if (registryIntegrity !== integrity) {
+        throw new Error(`${coordinate} already exists on npm with different bytes`)
+      }
+      status = "reused"
+    } else if (!dryRun) {
+      run("npm", ["publish", tarball, "--tag", tag, "--access", "public", "--provenance"], {cwd: rootDir})
+      status = "published"
+    }
+
+    let url = `https://registry.npmjs.org/${encodeURIComponent(name)}`
+    if (!dryRun) {
+      const registryUrl = npmViewPublished(coordinate, "dist.tarball")
+      if (typeof registryUrl !== "string" || !registryUrl.startsWith("https://")) {
+        throw new Error(`${coordinate} was published but has no HTTPS registry tarball URL`)
+      }
+      url = registryUrl
+    }
+    publications[name] = {
+      npm: {
+        status,
+        coordinate,
+        url,
+        sha256,
+        integrity,
+        provenanceUrl: `https://github.com/${process.env.GITHUB_REPOSITORY || "Mentra-Community/MentraOS"}/actions/runs/${process.env.GITHUB_RUN_ID || "0"}`,
+      },
+    }
+  }
+
+  const result = {releaseSetId: plan.releaseSetId, publications}
+  writeFileSync(path.join(outputDir, "npm-publications.json"), serializeReleaseRecord(result))
+  return result
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  for (const required of ["plan", "members", "output-dir"]) {
+    if (!args[required]) throw new Error(`Missing --${required}`)
+  }
+  const rootDir = path.resolve(args.root || process.cwd())
+  const plan = JSON.parse(readFileSync(path.resolve(args.plan), "utf8"))
+  publishReleaseNpm({
+    rootDir,
+    plan,
+    memberNames: args.members.split(",").filter(Boolean),
+    outputDir: path.resolve(args["output-dir"]),
+    dryRun: args["dry-run"] === "true",
+  })
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import {execFileSync} from "node:child_process"
+import {readFileSync} from "node:fs"
+import path from "node:path"
+import test from "node:test"
+import {fileURLToPath} from "node:url"
+
+import {loadReleaseFamily} from "./release-family.mjs"
+import {
+  npmMembersInOrder,
+  npmReleaseTag,
+  requireNpmProvenanceSource,
+  requirePlanSourceCommit,
+  sha512Integrity,
+} from "./publish-release-npm.mjs"
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+
+test("maps coordinated channels to npm tags", () => {
+  assert.equal(npmReleaseTag("dev"), "dev")
+  assert.equal(npmReleaseTag("beta"), "beta")
+  assert.throws(() => npmReleaseTag("production"), /explicit candidate dist-tag/)
+  assert.throws(() => npmReleaseTag("nightly"), /Unsupported/)
+})
+
+test("selects npm packages in dependency order", () => {
+  const family = loadReleaseFamily()
+  const names = npmMembersInOrder(family, [
+    "@mentra/miniapp",
+    "@mentra/crust",
+    "@mentra/cloud-client",
+    "@mentra/cloud-protocol",
+    "@mentra/jspolyfill",
+  ])
+  assert.deepEqual(names, [
+    "@mentra/jspolyfill",
+    "@mentra/cloud-protocol",
+    "@mentra/crust",
+    "@mentra/cloud-client",
+    "@mentra/miniapp",
+  ])
+})
+
+test("creates npm-compatible SHA-512 integrity values", () => {
+  assert.match(sha512Integrity(Buffer.from("mentra")), /^sha512-[A-Za-z0-9+/]+=*$/)
+})
+
+test("requires the package checkout to match the immutable release plan", () => {
+  const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {cwd: repositoryRoot, encoding: "utf8"}).trim()
+  assert.equal(requirePlanSourceCommit(repositoryRoot, sourceCommit), sourceCommit)
+  assert.throws(() => requirePlanSourceCommit(repositoryRoot, "a".repeat(40)), /expected a{40}/)
+})
+
+test("requires every npm member to identify its exact MentraOS source directory", () => {
+  const family = loadReleaseFamily({rootDir: repositoryRoot})
+  for (const member of family.members.filter((candidate) => candidate.publishTargets.includes("npm"))) {
+    const packageJson = JSON.parse(readFileSync(path.join(repositoryRoot, member.manifest), "utf8"))
+    assert.doesNotThrow(() => requireNpmProvenanceSource(packageJson, member.manifest))
+  }
+  assert.throws(
+    () =>
+      requireNpmProvenanceSource(
+        {name: "@mentra/crust", repository: "https://github.com/fossephate/crust"},
+        "mobile/modules/crust/package.json",
+      ),
+    /does not identify mobile\/modules\/crust in MentraOS/,
+  )
+})

--- a/.github/workflows/release-family-checks.yml
+++ b/.github/workflows/release-family-checks.yml
@@ -32,6 +32,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - name: Reject unresolved conflict markers
+        run: |
+          if git grep -nE '^(<<<<<<< |\|\|\|\|\|\|\| parent of |>>>>>>> )'; then
+            exit 1
+          fi
       - name: Test coordinated release tooling
         run: |
           set -euo pipefail

--- a/.github/workflows/reusable-coordinated-npm.yml
+++ b/.github/workflows/reusable-coordinated-npm.yml
@@ -1,0 +1,84 @@
+name: Reusable Coordinated npm Release
+
+on:
+  workflow_call:
+    inputs:
+      source_commit:
+        required: true
+        type: string
+      release_plan_artifact:
+        required: true
+        type: string
+      members:
+        description: Comma-separated release-family member names.
+        required: true
+        type: string
+      result_artifact:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish exact npm family closure
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - name: Download immutable release plan
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install exact root workspace dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Install exact mobile workspace dependencies
+        working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Stage coordinated package identities
+        run: node .github/scripts/stage-release-family.mjs --plan release-intent/release-plan.json
+
+      - name: Test npm release tooling
+        run: node --test .github/scripts/publish-release-npm.test.mjs
+
+      - name: Build, pack, reconcile, and publish in dependency order
+        run: >-
+          node .github/scripts/publish-release-npm.mjs
+          --plan release-intent/release-plan.json
+          --members "${{ inputs.members }}"
+          --output-dir release-output
+          --dry-run "${{ inputs.dry_run }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Upload exact npm artifacts and publication records
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.result_artifact }}
+          path: release-output
+          if-no-files-found: error
+          retention-days: 90

--- a/mobile/modules/crust/package.json
+++ b/mobile/modules/crust/package.json
@@ -23,7 +23,11 @@
     "crust",
     "Crust"
   ],
-  "repository": "https://github.com/fossephate/crust",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "mobile/modules/crust"
+  },
   "bugs": {
     "url": "https://github.com/fossephate/crust/issues"
   },


### PR DESCRIPTION
## Why

Mentra Engine cannot be a coherent standalone product if its first-party runtime dependencies are released by unrelated workflows with independently derived versions. The release family needs one dependency-ordered npm operation that consumes the coordinator's immutable plan and either publishes or verifies the exact bytes at every coordinate.

## What changes

- Adds a reusable, caller-only npm release workflow. It has no branch trigger and cannot publish independently.
- Checks out the coordinator's exact source commit and downloads its immutable `release-plan.json` artifact.
- Installs the root and mobile lock domains with Bun 1.4.0 before staging any versions.
- Stamps the whole family to the one planned identity after frozen installation.
- Builds and packs selected npm members in release-DAG order.
- Validates every staged package version and exact first-party dependency before packing.
- Publishes the already inspected tarball with the channel tag and npm provenance.
- Reconciles retries:
  - an absent coordinate is published;
  - an existing coordinate is reused only when its SHA-512 integrity matches the locally rebuilt tarball;
  - different bytes at an immutable coordinate fail the release.
- Emits exact SHA-256, SHA-512 integrity, registry URL, coordinate, status, and workflow provenance in `npm-publications.json`.
- Uploads both the tarballs and publication record as one named result artifact for final release-manifest assembly.

The initial dependency-closure call is intended for:

1. `@mentra/jspolyfill`
2. `@mentra/cloud-protocol`
3. `@mentra/crust`
4. `@mentra/cloud-client`
5. `@mentra/miniapp`

Bluetooth SDK and Engine use the same primitive in later coordinated jobs because they have additional OTA/native verification requirements.

## Verification

- 13 release-family, staging, and npm-tooling tests
- `actionlint` on both modified workflows
- complete disposable-checkout dry run at `3.1.0-beta.999`
- root and mobile frozen installs with Bun 1.4.0
- successful builds and npm packs for all five closure packages
- generated publication record with a distinct tarball SHA-256 for every package
- disposable worktree removed after verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces automated npm publication with registry side effects; mitigations include plan/commit pinning, integrity reconciliation, and dry-run, but a misconfigured coordinator or token could still publish wrong artifacts.
> 
> **Overview**
> Adds **dependency-ordered npm publishing** driven by the coordinator’s immutable `release-plan.json`, so the first-party closure (`jspolyfill` → `cloud-protocol` → `crust` → `cloud-client` → `miniapp`) ships as one operation instead of unrelated workflows.
> 
> New **`publish-release-npm.mjs`** checks out match `sourceCommit`, validates staged versions and pinned first-party deps, builds/packs each member, then **publishes or reuses** registry coordinates: missing versions are published with channel tags (`dev`/`beta`) and `--provenance`; existing versions are accepted only when SHA-512 integrity matches the rebuilt tarball, otherwise the job fails. It writes **`npm-publications.json`** (status, hashes, URLs, provenance) plus tarballs for downstream manifest assembly.
> 
> A **`workflow_call`-only** `reusable-coordinated-npm.yml` wires this up: exact commit checkout, plan artifact download, frozen Bun installs, `stage-release-family`, tests, publish (optional dry-run), and result artifact upload.
> 
> **`release-family-checks`** now fails on unresolved git conflict markers. **`@mentra/crust`** `package.json` **`repository`** is updated to the monorepo git URL + `directory` so npm provenance checks pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6beedfc26fb309babd268622f8c347989c9a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->