### PR TITLE
Engine release: verify one exact SDK and OTA package pair

### DIFF
--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -98,7 +98,166 @@ export function npmMembersInOrder(family, selectedNames) {
   return family.publicationOrder.filter((name) => selected.has(name))
 }
 
-export function publishReleaseNpm({rootDir, plan, memberNames, outputDir, dryRun}) {
+function requireReleaseMetadata(options) {
+  if (!options.otaManifestUrl || !options.otaManifestSha256) {
+    throw new Error("SDK and Engine publication requires the coordinated OTA manifest URL and SHA-256")
+  }
+}
+
+export function releaseMetadataArgs({plan, otaManifestUrl, otaManifestSha256}) {
+  return [
+    "--family-base-version",
+    plan.familyBaseVersion,
+    "--release-identity",
+    plan.releaseIdentity,
+    "--release-set-id",
+    plan.releaseSetId,
+    "--source-commit",
+    plan.sourceCommit,
+    "--ota-manifest-url",
+    otaManifestUrl,
+    "--ota-manifest-sha256",
+    otaManifestSha256,
+  ]
+}
+
+function transitiveDependencies(family, memberName) {
+  const selected = new Set()
+  function visit(name) {
+    const member = family.members.find((candidate) => candidate.name === name)
+    if (!member) throw new Error(`Unknown release-family dependency ${name}`)
+    for (const dependency of member.dependencies) {
+      selected.add(dependency)
+      visit(dependency)
+    }
+  }
+  visit(memberName)
+  return family.publicationOrder.filter((name) => selected.has(name))
+}
+
+function prepareBluetoothSdkBuild({rootDir, plan, otaManifestUrl, otaManifestSha256}) {
+  requireReleaseMetadata({otaManifestUrl, otaManifestSha256})
+  run("node", ["scripts/write-release-metadata.mjs", ...releaseMetadataArgs({plan, otaManifestUrl, otaManifestSha256})], {
+    cwd: path.join(rootDir, "mobile/modules/bluetooth-sdk"),
+  })
+}
+
+function prepareEngineBuild({rootDir, family, plan, otaManifestUrl, otaManifestSha256}) {
+  requireReleaseMetadata({otaManifestUrl, otaManifestSha256})
+  const metadataArgs = releaseMetadataArgs({plan, otaManifestUrl, otaManifestSha256})
+  prepareBluetoothSdkBuild({rootDir, plan, otaManifestUrl, otaManifestSha256})
+
+  for (const dependencyName of transitiveDependencies(family, "@mentra/engine")) {
+    const dependency = family.members.find((candidate) => candidate.name === dependencyName)
+    const packageDir = path.dirname(path.join(rootDir, dependency.manifest))
+    const packageJson = JSON.parse(readFileSync(path.join(rootDir, dependency.manifest), "utf8"))
+    if (packageJson.scripts?.build) run("bun", ["run", "build"], {cwd: packageDir})
+  }
+
+  run("node", ["scripts/write-release-metadata.mjs", ...metadataArgs], {
+    cwd: path.join(rootDir, "mobile/modules/engine"),
+  })
+}
+
+function verifyBluetoothSdkPackage({rootDir, plan, tarball, outputDir, otaManifestUrl, otaManifestSha256}) {
+  requireReleaseMetadata({otaManifestUrl, otaManifestSha256})
+  const unpacked = path.join(outputDir, "sdk-unpacked")
+  mkdirSync(unpacked, {recursive: true})
+  run("tar", ["-xzf", tarball, "-C", unpacked])
+  run(
+    "node",
+    [
+      "scripts/verify-release-package.mjs",
+      "--package-root",
+      path.join(unpacked, "package"),
+      "--release-identity",
+      plan.releaseIdentity,
+      "--ota-manifest-url",
+      otaManifestUrl,
+      "--ota-manifest-sha256",
+      otaManifestSha256,
+    ],
+    {cwd: path.join(rootDir, "mobile/modules/bluetooth-sdk")},
+  )
+}
+
+function verifyEngineAndSdkPackages({
+  rootDir,
+  plan,
+  engineTarball,
+  outputDir,
+  otaManifestUrl,
+  otaManifestSha256,
+  sdkTarball,
+}) {
+  requireReleaseMetadata({otaManifestUrl, otaManifestSha256})
+  const engineRoot = path.join(outputDir, "engine-unpacked")
+  mkdirSync(engineRoot, {recursive: true})
+  run("tar", ["-xzf", engineTarball, "-C", engineRoot])
+  const common = [
+    "--family-base-version",
+    plan.familyBaseVersion,
+    "--release-identity",
+    plan.releaseIdentity,
+    "--release-set-id",
+    plan.releaseSetId,
+    "--source-commit",
+    plan.sourceCommit,
+    "--ota-manifest-url",
+    otaManifestUrl,
+    "--ota-manifest-sha256",
+    otaManifestSha256,
+  ]
+  run("node", ["scripts/verify-release-package.mjs", "--package-root", path.join(engineRoot, "package"), ...common], {
+    cwd: path.join(rootDir, "mobile/modules/engine"),
+  })
+
+  const sdkOutput = path.join(outputDir, "sdk-registry-verification")
+  mkdirSync(sdkOutput, {recursive: true})
+  let selectedSdkTarball = sdkTarball ? path.resolve(sdkTarball) : null
+  if (!selectedSdkTarball) {
+    run("npm", ["pack", `@mentra/bluetooth-sdk@${plan.releaseIdentity}`, "--pack-destination", sdkOutput], {
+      cwd: rootDir,
+    })
+    const sdkTarballs = execFileSync("find", [sdkOutput, "-maxdepth", "1", "-name", "*.tgz", "-print"], {
+      encoding: "utf8",
+    })
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+    if (sdkTarballs.length !== 1) throw new Error(`SDK verification produced ${sdkTarballs.length} tarballs`)
+    selectedSdkTarball = sdkTarballs[0]
+  }
+  const sdkRoot = path.join(sdkOutput, "unpacked")
+  mkdirSync(sdkRoot, {recursive: true})
+  run("tar", ["-xzf", selectedSdkTarball, "-C", sdkRoot])
+  run(
+    "node",
+    [
+      "scripts/verify-release-package.mjs",
+      "--package-root",
+      path.join(sdkRoot, "package"),
+      "--release-identity",
+      plan.releaseIdentity,
+      "--ota-manifest-url",
+      otaManifestUrl,
+      "--ota-manifest-sha256",
+      otaManifestSha256,
+    ],
+    {cwd: path.join(rootDir, "mobile/modules/bluetooth-sdk")},
+  )
+}
+
+export function publishReleaseNpm({
+  rootDir,
+  plan,
+  memberNames,
+  outputDir,
+  dryRun,
+  otaManifestUrl,
+  otaManifestSha256,
+  sdkTarball,
+}) {
   requirePlanSourceCommit(rootDir, plan.sourceCommit)
   const family = loadReleaseFamily({rootDir})
   if (plan.familyBaseVersion !== family.familyBaseVersion)
@@ -106,6 +265,7 @@ export function publishReleaseNpm({rootDir, plan, memberNames, outputDir, dryRun
   const orderedNames = npmMembersInOrder(family, memberNames)
   const tag = npmReleaseTag(plan.channel)
   const publications = {}
+  let selectedSdkTarball = sdkTarball
   mkdirSync(outputDir, {recursive: true})
 
   for (const name of orderedNames) {
@@ -122,6 +282,11 @@ export function publishReleaseNpm({rootDir, plan, memberNames, outputDir, dryRun
       }
     }
 
+    if (name === "@mentra/bluetooth-sdk") {
+      prepareBluetoothSdkBuild({rootDir, plan, otaManifestUrl, otaManifestSha256})
+    } else if (name === "@mentra/engine") {
+      prepareEngineBuild({rootDir, family, plan, otaManifestUrl, otaManifestSha256})
+    }
     if (packageJson.scripts?.build) run("bun", ["run", "build"], {cwd: packageDir})
     const packageOutput = path.join(outputDir, name.replace(/^@/, "").replaceAll("/", "-"))
     mkdirSync(packageOutput, {recursive: true})
@@ -140,6 +305,28 @@ export function publishReleaseNpm({rootDir, plan, memberNames, outputDir, dryRun
     const coordinate = `${name}@${plan.releaseIdentity}`
     const registryIntegrity = parseViewValue(npmView(coordinate, "dist.integrity"))
     let status = "built"
+
+    if (name === "@mentra/bluetooth-sdk") {
+      verifyBluetoothSdkPackage({
+        rootDir,
+        plan,
+        tarball,
+        outputDir: packageOutput,
+        otaManifestUrl,
+        otaManifestSha256,
+      })
+      selectedSdkTarball = tarball
+    } else if (name === "@mentra/engine") {
+      verifyEngineAndSdkPackages({
+        rootDir,
+        plan,
+        engineTarball: tarball,
+        outputDir: packageOutput,
+        otaManifestUrl,
+        otaManifestSha256,
+        sdkTarball: selectedSdkTarball,
+      })
+    }
 
     if (registryIntegrity !== null) {
       if (registryIntegrity !== integrity) {
@@ -189,6 +376,9 @@ function main() {
     memberNames: args.members.split(",").filter(Boolean),
     outputDir: path.resolve(args["output-dir"]),
     dryRun: args["dry-run"] === "true",
+    otaManifestUrl: args["ota-manifest-url"],
+    otaManifestSha256: args["ota-manifest-sha256"],
+    sdkTarball: args["sdk-tarball"],
   })
 }
 

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -9,6 +9,7 @@ import {loadReleaseFamily} from "./release-family.mjs"
 import {
   npmMembersInOrder,
   npmReleaseTag,
+  releaseMetadataArgs,
   requireNpmProvenanceSource,
   requirePlanSourceCommit,
   sha512Integrity,
@@ -41,6 +42,12 @@ test("selects npm packages in dependency order", () => {
   ])
 })
 
+test("admits Engine only as the final selected npm package", () => {
+  const family = loadReleaseFamily()
+  const names = npmMembersInOrder(family, ["@mentra/engine", "@mentra/bluetooth-sdk"])
+  assert.deepEqual(names, ["@mentra/bluetooth-sdk", "@mentra/engine"])
+})
+
 test("creates npm-compatible SHA-512 integrity values", () => {
   assert.match(sha512Integrity(Buffer.from("mentra")), /^sha512-[A-Za-z0-9+/]+=*$/)
 })
@@ -64,5 +71,34 @@ test("requires every npm member to identify its exact MentraOS source directory"
         "mobile/modules/crust/package.json",
       ),
     /does not identify mobile\/modules\/crust in MentraOS/,
+  )
+})
+
+test("stamps SDK and Engine packages from the same immutable release metadata", () => {
+  assert.deepEqual(
+    releaseMetadataArgs({
+      plan: {
+        familyBaseVersion: "3.1.0",
+        releaseIdentity: "3.1.0-beta.57",
+        releaseSetId: "mentra-3.1.0-beta.57",
+        sourceCommit: "a".repeat(40),
+      },
+      otaManifestUrl: "https://example.com/ota.json",
+      otaManifestSha256: "b".repeat(64),
+    }),
+    [
+      "--family-base-version",
+      "3.1.0",
+      "--release-identity",
+      "3.1.0-beta.57",
+      "--release-set-id",
+      "mentra-3.1.0-beta.57",
+      "--source-commit",
+      "a".repeat(40),
+      "--ota-manifest-url",
+      "https://example.com/ota.json",
+      "--ota-manifest-sha256",
+      "b".repeat(64),
+    ],
   )
 })

--- a/.github/workflows/reusable-coordinated-npm.yml
+++ b/.github/workflows/reusable-coordinated-npm.yml
@@ -16,6 +16,15 @@ on:
       result_artifact:
         required: true
         type: string
+      ota_manifest_url:
+        required: false
+        type: string
+      ota_manifest_sha256:
+        required: false
+        type: string
+      sdk_package_artifact:
+        required: false
+        type: string
       dry_run:
         required: false
         default: false
@@ -40,6 +49,13 @@ jobs:
         with:
           name: ${{ inputs.release_plan_artifact }}
           path: release-intent
+
+      - name: Download coordinated SDK package for offline verification
+        if: inputs.sdk_package_artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.sdk_package_artifact }}
+          path: sdk-package
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -66,14 +82,32 @@ jobs:
         run: node --test .github/scripts/publish-release-npm.test.mjs
 
       - name: Build, pack, reconcile, and publish in dependency order
-        run: >-
-          node .github/scripts/publish-release-npm.mjs
-          --plan release-intent/release-plan.json
-          --members "${{ inputs.members }}"
-          --output-dir release-output
-          --dry-run "${{ inputs.dry_run }}"
+        run: |
+          args=(
+            --plan release-intent/release-plan.json
+            --members "$RELEASE_MEMBERS"
+            --output-dir release-output
+            --dry-run "$DRY_RUN"
+          )
+          if [[ -n "$OTA_MANIFEST_URL" || -n "$OTA_MANIFEST_SHA256" ]]; then
+            args+=(--ota-manifest-url "$OTA_MANIFEST_URL" --ota-manifest-sha256 "$OTA_MANIFEST_SHA256")
+          fi
+          if [[ -n "$SDK_PACKAGE_ARTIFACT" ]]; then
+            mapfile -t sdk_tarballs < <(find sdk-package -type f -name '*.tgz' -print)
+            if (( ${#sdk_tarballs[@]} != 1 )); then
+              echo "::error::SDK package artifact must contain exactly one npm tarball; found ${#sdk_tarballs[@]}"
+              exit 1
+            fi
+            args+=(--sdk-tarball "${sdk_tarballs[0]}")
+          fi
+          node .github/scripts/publish-release-npm.mjs "${args[@]}"
         env:
+          DRY_RUN: ${{ inputs.dry_run }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          OTA_MANIFEST_SHA256: ${{ inputs.ota_manifest_sha256 }}
+          OTA_MANIFEST_URL: ${{ inputs.ota_manifest_url }}
+          RELEASE_MEMBERS: ${{ inputs.members }}
+          SDK_PACKAGE_ARTIFACT: ${{ inputs.sdk_package_artifact }}
 
       - name: Upload exact npm artifacts and publication records
         uses: actions/upload-artifact@v4

--- a/mobile/modules/engine/scripts/verify-release-package.mjs
+++ b/mobile/modules/engine/scripts/verify-release-package.mjs
@@ -6,6 +6,13 @@ import {fileURLToPath} from "node:url"
 import {validateReleaseMetadata} from "./write-release-metadata.mjs"
 
 const METADATA_FILES = ["src/generated/releaseMetadata.ts", "build/generated/releaseMetadata.js"]
+const EXACT_FAMILY_DEPENDENCIES = [
+  "@mentra/bluetooth-sdk",
+  "@mentra/cloud-client",
+  "@mentra/cloud-protocol",
+  "@mentra/crust",
+  "@mentra/miniapp",
+]
 
 export function verifyReleasePackage({packageRoot, expected}) {
   const metadata = validateReleaseMetadata(expected)
@@ -17,6 +24,14 @@ export function verifyReleasePackage({packageRoot, expected}) {
   }
   if (packageManifest.version !== metadata.releaseIdentity) {
     throw new Error(`Engine version ${packageManifest.version} does not match ${metadata.releaseIdentity}`)
+  }
+  for (const dependency of EXACT_FAMILY_DEPENDENCIES) {
+    if (packageManifest.dependencies?.[dependency] !== metadata.releaseIdentity) {
+      throw new Error(`Engine dependency ${dependency} must be exactly ${metadata.releaseIdentity}`)
+    }
+    if (packageManifest.peerDependencies?.[dependency] !== undefined) {
+      throw new Error(`Engine dependency ${dependency} must not be published as a peer`)
+    }
   }
 
   for (const relativePath of METADATA_FILES) {

--- a/mobile/modules/engine/scripts/verify-release-package.test.mjs
+++ b/mobile/modules/engine/scripts/verify-release-package.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import {mkdirSync, mkdtempSync, writeFileSync} from "node:fs"
+import {mkdirSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs"
 import {tmpdir} from "node:os"
 import path from "node:path"
 import test from "node:test"
@@ -22,7 +22,17 @@ function fixture() {
   mkdirSync(path.join(root, "build/generated"), {recursive: true})
   writeFileSync(
     path.join(root, "package.json"),
-    JSON.stringify({name: "@mentra/engine", version: expected.releaseIdentity}),
+    JSON.stringify({
+      name: "@mentra/engine",
+      version: expected.releaseIdentity,
+      dependencies: {
+        "@mentra/bluetooth-sdk": expected.releaseIdentity,
+        "@mentra/cloud-client": expected.releaseIdentity,
+        "@mentra/cloud-protocol": expected.releaseIdentity,
+        "@mentra/crust": expected.releaseIdentity,
+        "@mentra/miniapp": expected.releaseIdentity,
+      },
+    }),
   )
   const source = renderReleaseMetadata(expected)
   writeFileSync(path.join(root, "src/generated/releaseMetadata.ts"), source)
@@ -44,4 +54,14 @@ test("rejects a package whose built metadata drifted", () => {
     () => verifyReleasePackage({packageRoot: root, expected}),
     /does not contain expected familyBaseVersion/,
   )
+})
+
+test("rejects a packed Engine with a drifting family dependency", () => {
+  const root = fixture()
+  const manifestPath = path.join(root, "package.json")
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  manifest.dependencies["@mentra/bluetooth-sdk"] = "^3.1.0-beta.57"
+  writeFileSync(manifestPath, JSON.stringify(manifest))
+
+  assert.throws(() => verifyReleasePackage({packageRoot: root, expected}), /must be exactly/)
 })


### PR DESCRIPTION
## Why

Engine re-exports and runs Bluetooth SDK, so publishing both under matching version strings is not enough. The Engine tarball must carry the same immutable OTA pin as the exact SDK package it depends on, and a clean release checkout must regenerate all dependency outputs before compiling Engine.

## What changes

- Extends the reusable npm publisher with an Engine-specific verification path.
- Requires the coordinator's immutable OTA manifest URL and SHA-256 for any Engine publication.
- Generates matching SDK and Engine release metadata from the same plan.
- Rebuilds Engine's transitive local dependency closure in DAG order before compiling Engine, so a clean checkout never relies on stale `build/` or `dist/` output:
  - JSpolyfill
  - Cloud Protocol
  - Crust
  - Cloud Client
  - Bluetooth SDK
  - Miniapp SDK
- Packs Engine only after that clean dependency build.
- Unpacks and verifies Engine's source and generated JavaScript metadata.
- Requires every first-party Engine runtime dependency to be an exact regular dependency at the release identity; ranges and peer leakage fail.
- Downloads the exact coordinated SDK package from npm for live releases, or accepts the SDK tarball artifact from an earlier dry-run job.
- Unpacks that SDK and verifies its TypeScript, generated JavaScript, Kotlin, and Swift release metadata against the same URL, digest, identity, and source release.
- Publishes Engine only after both packages pass.

## Failure modes closed

- Engine and SDK versions match but select different OTA bundles.
- Engine silently consumes a broad SDK range.
- a clean release compiles only because a developer checkout left generated files behind.
- a dry run verifies workspace SDK source while the published SDK tarball differs.
- first-party runtime dependencies escape back into peers.

## Verification

- 9 npm, Engine metadata, and unpacked-package tests
- `actionlint` for the reusable workflow
- clean disposable-checkout pair dry run at `3.1.0-beta.999`
- generated and packed a 64.6 MB SDK tarball carrying the fixture OTA pin on JS, Android, and iOS
- rebuilt Engine's complete transitive local dependency closure
- generated and packed Engine with exact `3.1.0-beta.999` dependencies
- unpacked and independently verified both tarballs against the same manifest URL and SHA-256
- disposable worktree removed after verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and publish gates for critical mobile packages; mistakes could block releases or allow mismatched OTA/SDK pairs if inputs are wrong.
> 
> **Overview**
> Coordinated npm publishing now treats **@mentra/bluetooth-sdk** and **@mentra/engine** as a matched pair: both require the coordinator’s **OTA manifest URL and SHA-256**, stamp release metadata from the same plan, and are **verified from unpacked tarballs** before publish proceeds.
> 
> For Engine, the publisher **rebuilds the full transitive local dependency closure** (in family order) before compile/pack, writes Engine metadata, then checks the Engine tarball plus either the **SDK tarball from the same run** or an **optional CI SDK artifact** (or `npm pack` of the published SDK). Engine verification also enforces **exact `dependencies` pins** at the release identity and rejects those packages as **peers**.
> 
> The reusable **coordinated npm workflow** gains optional `ota_manifest_*` and `sdk_package_artifact` inputs and passes them through to `publish-release-npm.mjs`; tests cover metadata args and publication ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10911ced55366d5de5e47c524ec725f8dfc49a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->