### PR TITLE
ci(release): publish immutable coordinated ota bundles

### DIFF
--- a/.github/scripts/allocate-asg-version.mjs
+++ b/.github/scripts/allocate-asg-version.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+const ASSET_PATTERN = /^mentra-live-asg-(\d+)-([0-9a-f]{64})\.(apk|json)$/
+// The legacy publisher allocated seconds since 2025-01-01 and had already crossed
+// 50 million before this allocator replaced it. Keep the coordinated namespace
+// permanently above that range so the first cutover build is always an upgrade.
+const COORDINATED_VERSION_CODE_BASELINE = 100_000_000
+
+export function allocateAsgVersion({assets, fingerprint, runNumber}) {
+  if (!Array.isArray(assets)) throw new Error("GitHub release assets must be an array")
+  if (!/^[0-9a-f]{64}$/.test(fingerprint)) throw new Error("Invalid ASG fingerprint")
+  if (!Number.isSafeInteger(runNumber) || runNumber <= 0) throw new Error("runNumber must be a positive integer")
+
+  const recognized = assets.flatMap((asset) => {
+    const match = ASSET_PATTERN.exec(asset.name ?? "")
+    if (!match) return []
+    return [{id: asset.id, name: asset.name, versionCode: Number(match[1]), fingerprint: match[2], type: match[3]}]
+  })
+  const matching = recognized.filter((asset) => asset.fingerprint === fingerprint)
+  const apks = matching.filter((asset) => asset.type === "apk")
+  const provenance = matching.filter((asset) => asset.type === "json")
+  if (apks.length > 1 || provenance.length > 1) throw new Error("Duplicate immutable ASG release assets found")
+
+  if (apks.length === 1 && provenance.length === 1) {
+    if (apks[0].versionCode !== provenance[0].versionCode) {
+      throw new Error("ASG artifact and provenance use different version codes")
+    }
+    return {
+      exists: true,
+      versionCode: apks[0].versionCode,
+      apkAsset: apks[0].name,
+      provenanceAsset: provenance[0].name,
+      orphanAssetIds: [],
+    }
+  }
+
+  const maxRecordedVersionCode = recognized.reduce((maximum, asset) => Math.max(maximum, asset.versionCode), 0)
+  const versionCode = Math.max(COORDINATED_VERSION_CODE_BASELINE + runNumber, maxRecordedVersionCode + 1)
+  if (versionCode > 2_100_000_000) throw new Error("Allocated ASG versionCode exceeds the Android-safe range")
+  return {
+    exists: false,
+    versionCode,
+    apkAsset: `mentra-live-asg-${versionCode}-${fingerprint}.apk`,
+    provenanceAsset: `mentra-live-asg-${versionCode}-${fingerprint}.json`,
+    orphanAssetIds: matching.map((asset) => asset.id),
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const result = allocateAsgVersion({
+    assets: JSON.parse(readFileSync(path.resolve(args.assets), "utf8")),
+    fingerprint: args.fingerprint,
+    runNumber: Number(args["run-number"]),
+  })
+  writeFileSync(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/allocate-asg-version.test.mjs
+++ b/.github/scripts/allocate-asg-version.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {allocateAsgVersion} from "./allocate-asg-version.mjs"
+
+const fingerprint = "a".repeat(64)
+
+function asset(id, versionCode, selectedFingerprint, extension) {
+  return {id, name: `mentra-live-asg-${versionCode}-${selectedFingerprint}.${extension}`}
+}
+
+test("allocates from the monotonic workflow run number for a new fingerprint", () => {
+  const result = allocateAsgVersion({assets: [], fingerprint, runNumber: 57})
+  assert.equal(result.exists, false)
+  assert.equal(result.versionCode, 100_000_057)
+  assert.deepEqual(result.orphanAssetIds, [])
+})
+
+test("allocates above the complete legacy timestamp namespace at cutover", () => {
+  const result = allocateAsgVersion({
+    assets: [asset(1, 52_000_000, "b".repeat(64), "apk"), asset(2, 52_000_000, "b".repeat(64), "json")],
+    fingerprint,
+    runNumber: 1,
+  })
+  assert.equal(result.versionCode, 100_000_001)
+})
+
+test("reuses the recorded code for an existing complete fingerprint", () => {
+  const result = allocateAsgVersion({
+    assets: [asset(1, 100_000_042, fingerprint, "apk"), asset(2, 100_000_042, fingerprint, "json")],
+    fingerprint,
+    runNumber: 99,
+  })
+  assert.equal(result.exists, true)
+  assert.equal(result.versionCode, 100_000_042)
+})
+
+test("allocates above all published codes when retrying an older workflow run", () => {
+  const result = allocateAsgVersion({
+    assets: [asset(1, 100_000_120, "b".repeat(64), "apk"), asset(2, 100_000_120, "b".repeat(64), "json")],
+    fingerprint,
+    runNumber: 57,
+  })
+  assert.equal(result.versionCode, 100_000_121)
+})
+
+test("marks an interrupted asset pair for removal before rebuilding", () => {
+  const result = allocateAsgVersion({
+    assets: [asset(7, 100_000_057, fingerprint, "apk")],
+    fingerprint,
+    runNumber: 57,
+  })
+  assert.equal(result.exists, false)
+  assert.equal(result.versionCode, 100_000_058)
+  assert.deepEqual(result.orphanAssetIds, [7])
+})
+
+test("rejects duplicate and mismatched complete pairs", () => {
+  assert.throws(
+    () =>
+      allocateAsgVersion({
+        assets: [asset(1, 100_000_057, fingerprint, "apk"), asset(2, 100_000_057, fingerprint, "apk")],
+        fingerprint,
+        runNumber: 57,
+      }),
+    /Duplicate/,
+  )
+  assert.throws(
+    () =>
+      allocateAsgVersion({
+        assets: [asset(1, 100_000_057, fingerprint, "apk"), asset(2, 100_000_058, fingerprint, "json")],
+        fingerprint,
+        runNumber: 57,
+      }),
+    /different version codes/,
+  )
+})

--- a/.github/scripts/compute-asg-build-identity.mjs
+++ b/.github/scripts/compute-asg-build-identity.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {execFileSync} from "node:child_process"
+import {mkdirSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+const BUILD_INPUT_PATHS = [
+  "asg_client",
+  ".github/scripts/compute-asg-build-identity.mjs",
+  ".github/workflows/reusable-coordinated-ota.yml",
+]
+const EXCLUDED_PREFIXES = ["asg_client/ota_manifests/"]
+const BUILD_CONTRACT = {
+  androidBuildVariant: "release",
+  javaVersion: "17",
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    )
+  }
+  return value
+}
+
+export function computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, contract = BUILD_CONTRACT}) {
+  if (!Array.isArray(entries) || entries.length === 0) throw new Error("ASG build inputs must not be empty")
+  if (!Number.isSafeInteger(latestInputCommitTimestamp) || latestInputCommitTimestamp <= 0) {
+    throw new Error("latestInputCommitTimestamp must be a positive integer")
+  }
+  const normalizedEntries = entries
+    .map(({mode, object, path: entryPath}) => {
+      if (!/^\d{6}$/.test(mode) || !/^[0-9a-f]{40,64}$/.test(object) || !entryPath) {
+        throw new Error(`Invalid ASG build input entry: ${JSON.stringify({mode, object, path: entryPath})}`)
+      }
+      return {mode, object, path: entryPath}
+    })
+    .sort((left, right) => left.path.localeCompare(right.path))
+  const payload = canonicalize({schemaVersion: 1, contract, entries: normalizedEntries})
+  const fingerprint = createHash("sha256")
+    .update(`${JSON.stringify(payload)}\n`)
+    .digest("hex")
+  return {
+    schemaVersion: 1,
+    fingerprint,
+    latestInputCommitTimestamp,
+    contract,
+    entries: normalizedEntries,
+  }
+}
+
+export function finalizeAsgBuildIdentity({buildFingerprint, versionCode}) {
+  const {fingerprint} = buildFingerprint
+  if (!/^[0-9a-f]{64}$/.test(fingerprint)) throw new Error("Invalid ASG build fingerprint")
+  if (!Number.isSafeInteger(versionCode) || versionCode <= 0 || versionCode > 2_100_000_000) {
+    throw new Error(`Allocated ASG versionCode ${versionCode} is outside the Android-safe range`)
+  }
+  const versionName = `asg.${versionCode}.${fingerprint.slice(0, 12)}`
+  return {
+    ...buildFingerprint,
+    versionCode,
+    versionName,
+    apkAsset: `mentra-live-asg-${versionCode}-${fingerprint}.apk`,
+    provenanceAsset: `mentra-live-asg-${versionCode}-${fingerprint}.json`,
+  }
+}
+
+export function computeAsgBuildIdentity({entries, latestInputCommitTimestamp, versionCode, contract = BUILD_CONTRACT}) {
+  return finalizeAsgBuildIdentity({
+    buildFingerprint: computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, contract}),
+    versionCode,
+  })
+}
+
+function git(repoRoot, args) {
+  return execFileSync("git", args, {cwd: repoRoot, encoding: "utf8"}).trim()
+}
+
+export function computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit}) {
+  if (!/^[0-9a-f]{40}$/.test(sourceCommit)) throw new Error("sourceCommit must be a full lowercase Git SHA")
+  const tree = git(repoRoot, ["ls-tree", "-r", sourceCommit, "--", ...BUILD_INPUT_PATHS])
+  const entries = tree
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const match = /^(\d{6})\s+\S+\s+([0-9a-f]+)\t(.+)$/.exec(line)
+      if (!match) throw new Error(`Unexpected git ls-tree row: ${line}`)
+      return {mode: match[1], object: match[2], path: match[3]}
+    })
+    .filter((entry) => !EXCLUDED_PREFIXES.some((prefix) => entry.path.startsWith(prefix)))
+  const latestInputCommitTimestamp = Number(
+    git(repoRoot, [
+      "log",
+      "-1",
+      "--format=%ct",
+      sourceCommit,
+      "--",
+      ...BUILD_INPUT_PATHS,
+      ...EXCLUDED_PREFIXES.map((prefix) => `:(exclude)${prefix}**`),
+    ]),
+  )
+  return computeAsgBuildFingerprint({entries, latestInputCommitTimestamp})
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const repoRoot = path.resolve(args["repo-root"] || process.cwd())
+  const sourceCommit = args["source-commit"] || git(repoRoot, ["rev-parse", "HEAD"])
+  const output = path.resolve(repoRoot, args.output || "asg-build-identity.json")
+  const buildFingerprint = computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit})
+  const identity = args["version-code"]
+    ? finalizeAsgBuildIdentity({buildFingerprint, versionCode: Number(args["version-code"])})
+    : buildFingerprint
+  mkdirSync(path.dirname(output), {recursive: true})
+  writeFileSync(output, `${JSON.stringify(identity, null, 2)}\n`)
+  if (process.env.GITHUB_OUTPUT) {
+    const lines = [
+      `fingerprint=${identity.fingerprint}`,
+      `version_code=${identity.versionCode ?? ""}`,
+      `version_name=${identity.versionName ?? ""}`,
+      `apk_asset=${identity.apkAsset ?? ""}`,
+      `provenance_asset=${identity.provenanceAsset ?? ""}`,
+    ]
+    writeFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`, {flag: "a"})
+  }
+  console.log(
+    identity.versionName
+      ? `Wrote ASG build identity ${identity.versionName} to ${output}`
+      : `Wrote ASG build fingerprint ${identity.fingerprint} to ${output}`,
+  )
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/compute-asg-build-identity.test.mjs
+++ b/.github/scripts/compute-asg-build-identity.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  computeAsgBuildFingerprint,
+  computeAsgBuildIdentity,
+  finalizeAsgBuildIdentity,
+} from "./compute-asg-build-identity.mjs"
+
+const entries = [
+  {mode: "100644", object: "a".repeat(40), path: "asg_client/app/build.gradle"},
+  {mode: "160000", object: "b".repeat(40), path: "asg_client/StreamPackLite"},
+]
+
+test("derives a deterministic content-addressed ASG identity", () => {
+  const first = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057})
+  const reordered = computeAsgBuildIdentity({
+    entries: [...entries].reverse(),
+    latestInputCommitTimestamp: 1_782_000_000,
+    versionCode: 100_057,
+  })
+
+  assert.deepEqual(first, reordered)
+  assert.match(first.fingerprint, /^[0-9a-f]{64}$/)
+  assert.equal(first.versionCode, 100_057)
+  assert.equal(first.versionName, `asg.100057.${first.fingerprint.slice(0, 12)}`)
+  assert.equal(first.apkAsset, `mentra-live-asg-${first.versionCode}-${first.fingerprint}.apk`)
+})
+
+test("changes identity when an effective source or build contract changes", () => {
+  const baseline = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057})
+  const sourceChange = computeAsgBuildIdentity({
+    entries: [{...entries[0], object: "c".repeat(40)}, entries[1]],
+    latestInputCommitTimestamp: 1_782_000_100,
+    versionCode: 100_058,
+  })
+  const contractChange = computeAsgBuildIdentity({
+    entries,
+    latestInputCommitTimestamp: 1_782_000_000,
+    versionCode: 100_057,
+    contract: {androidBuildVariant: "release", javaVersion: "21"},
+  })
+
+  assert.notEqual(sourceChange.fingerprint, baseline.fingerprint)
+  assert.notEqual(sourceChange.versionCode, baseline.versionCode)
+  assert.notEqual(contractChange.fingerprint, baseline.fingerprint)
+})
+
+test("allocates the externally selected version code without changing the content fingerprint", () => {
+  const fingerprint = computeAsgBuildFingerprint({entries, latestInputCommitTimestamp: 1_782_000_000})
+  const first = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_057})
+  const later = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_099})
+
+  assert.equal(first.fingerprint, later.fingerprint)
+  assert.equal(first.versionCode, 100_057)
+  assert.equal(later.versionCode, 100_099)
+})
+
+test("rejects malformed input entries, timestamps, and version codes", () => {
+  assert.throws(
+    () => computeAsgBuildIdentity({entries: [], latestInputCommitTimestamp: 1, versionCode: 100_001}),
+    /must not be empty/,
+  )
+  assert.throws(
+    () =>
+      computeAsgBuildIdentity({
+        entries: [{mode: "bad", object: "x", path: "asg"}],
+        latestInputCommitTimestamp: 1,
+        versionCode: 100_001,
+      }),
+    /Invalid ASG build input/,
+  )
+  assert.throws(
+    () => computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1, versionCode: 0}),
+    /outside the Android-safe range/,
+  )
+})

--- a/.github/scripts/coordinated-ota-records.mjs
+++ b/.github/scripts/coordinated-ota-records.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {requirePublicHttpsUrl, serializeReleaseRecord} from "./release-family.mjs"
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+const PUBLICATION_STATUSES = new Set(["built", "published", "reused"])
+
+function canonicalJson(value) {
+  return serializeReleaseRecord(value).trimEnd()
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"))
+}
+
+function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex")
+}
+
+function normalizeCertificateSha256(value) {
+  const normalized = value.replaceAll(":", "").toLowerCase()
+  if (!SHA256_PATTERN.test(normalized)) throw new Error("signingCertificateSha256 must be a SHA-256 digest")
+  return normalized
+}
+
+function validateIdentity(identity) {
+  if (!identity || identity.schemaVersion !== 1 || !SHA256_PATTERN.test(identity.fingerprint)) {
+    throw new Error("Invalid ASG build identity")
+  }
+  if (!Number.isSafeInteger(identity.versionCode) || identity.versionCode <= 0 || !identity.versionName) {
+    throw new Error("Invalid ASG build version metadata")
+  }
+  return identity
+}
+
+export function createAsgProvenance({identity, releasePlan, apkPath, apkUrl, signingCertificateSha256}) {
+  validateIdentity(identity)
+  if (releasePlan.releaseSetId !== `mentra-${releasePlan.releaseIdentity}` || !releasePlan.sourceCommit) {
+    throw new Error("Invalid release plan for ASG provenance")
+  }
+  return {
+    schemaVersion: 1,
+    fingerprint: identity.fingerprint,
+    versionCode: identity.versionCode,
+    versionName: identity.versionName,
+    buildIdentity: identity,
+    apk: {
+      asset: identity.apkAsset,
+      url: requirePublicHttpsUrl(apkUrl, "ASG APK URL"),
+      sha256: sha256File(apkPath),
+      size: statSync(apkPath).size,
+      signingCertificateSha256: normalizeCertificateSha256(signingCertificateSha256),
+    },
+    originatingReleaseSetId: releasePlan.releaseSetId,
+    originatingReleaseIdentity: releasePlan.releaseIdentity,
+    sourceCommit: releasePlan.sourceCommit,
+  }
+}
+
+export function verifyAsgProvenance({identity, provenance, apkPath, signingCertificateSha256}) {
+  validateIdentity(identity)
+  if (provenance.schemaVersion !== 1 || provenance.fingerprint !== identity.fingerprint) {
+    throw new Error("ASG provenance fingerprint does not match selected build identity")
+  }
+  for (const field of ["versionCode", "versionName"]) {
+    if (provenance[field] !== identity[field]) throw new Error(`ASG provenance ${field} does not match`)
+  }
+  if (provenance.apk?.asset !== identity.apkAsset) throw new Error("ASG provenance APK asset does not match")
+  if (provenance.apk?.sha256 !== sha256File(apkPath)) throw new Error("ASG APK SHA-256 does not match provenance")
+  if (provenance.apk?.size !== statSync(apkPath).size) throw new Error("ASG APK size does not match provenance")
+  if (
+    normalizeCertificateSha256(provenance.apk?.signingCertificateSha256 ?? "") !==
+    normalizeCertificateSha256(signingCertificateSha256)
+  ) {
+    throw new Error("ASG signing certificate does not match provenance")
+  }
+  requirePublicHttpsUrl(provenance.apk.url, "ASG provenance APK URL")
+  if (!provenance.originatingReleaseSetId || !provenance.sourceCommit) {
+    throw new Error("ASG provenance is missing its origin")
+  }
+  return provenance
+}
+
+export function createAsgSelection({releasePlan, identity, provenance}) {
+  validateIdentity(identity)
+  if (releasePlan.artifactNames?.asgSelection !== `mentra-live-asg-selection-${releasePlan.releaseIdentity}.json`) {
+    throw new Error("Release plan has an invalid ASG selection artifact name")
+  }
+  return {
+    schemaVersion: 1,
+    releaseSetId: releasePlan.releaseSetId,
+    releaseIdentity: releasePlan.releaseIdentity,
+    sourceCommit: releasePlan.sourceCommit,
+    fingerprint: identity.fingerprint,
+    versionCode: identity.versionCode,
+    versionName: identity.versionName,
+    originatingReleaseSetId: provenance.originatingReleaseSetId,
+    apk: provenance.apk,
+    provenanceAsset: identity.provenanceAsset,
+  }
+}
+
+export function createOtaReleaseResult({
+  releasePlan,
+  identity,
+  provenance,
+  selectionPath,
+  selectionUrl,
+  selectionStatus,
+  manifestPath,
+  manifestUrl,
+  bundlePath,
+  bundleUrl,
+  bundleStatus,
+  manifestStatus,
+  reused,
+  workflow,
+}) {
+  if (
+    !PUBLICATION_STATUSES.has(selectionStatus) ||
+    !PUBLICATION_STATUSES.has(manifestStatus) ||
+    !PUBLICATION_STATUSES.has(bundleStatus)
+  ) {
+    throw new Error("ASG selection, OTA manifest, and bundle must have valid publication statuses")
+  }
+  verifyAsgProvenance({
+    identity,
+    provenance,
+    apkPath: workflow.apkPath,
+    signingCertificateSha256: workflow.signingCertificateSha256,
+  })
+  const manifest = readJson(manifestPath)
+  const asg = manifest.apps?.["com.mentra.asg_client"]
+  if (
+    asg?.versionCode !== identity.versionCode ||
+    asg?.versionName !== identity.versionName ||
+    asg?.apkUrl !== provenance.apk.url ||
+    asg?.sha256 !== provenance.apk.sha256 ||
+    asg?.apkSize !== provenance.apk.size
+  ) {
+    throw new Error("OTA manifest does not pin the selected ASG artifact exactly")
+  }
+  if (canonicalJson(manifest.mtk_patches) !== canonicalJson(releasePlan.otaInputs.mtkPatches)) {
+    throw new Error("OTA manifest MTK inputs differ from the release plan")
+  }
+  if (canonicalJson(manifest.bes_firmware) !== canonicalJson(releasePlan.otaInputs.besFirmware)) {
+    throw new Error("OTA manifest BES input differs from the release plan")
+  }
+  const selection = readJson(selectionPath)
+  const expectedSelection = createAsgSelection({releasePlan, identity, provenance})
+  if (canonicalJson(selection) !== canonicalJson(expectedSelection)) {
+    throw new Error("ASG selection record does not match the selected build")
+  }
+  const result = {
+    schemaVersion: 1,
+    releaseSetId: releasePlan.releaseSetId,
+    releaseIdentity: releasePlan.releaseIdentity,
+    sourceCommit: releasePlan.sourceCommit,
+    firmwareManifestSha256: releasePlan.otaInputs.firmwareManifest.sha256,
+    selection: {
+      status: selectionStatus,
+      asset: releasePlan.artifactNames.asgSelection,
+      url: requirePublicHttpsUrl(selectionUrl, "ASG selection URL"),
+      sha256: sha256File(selectionPath),
+      size: statSync(selectionPath).size,
+    },
+    manifest: {
+      status: manifestStatus,
+      asset: releasePlan.artifactNames.otaManifest,
+      url: requirePublicHttpsUrl(manifestUrl, "OTA manifest URL"),
+      sha256: sha256File(manifestPath),
+      size: statSync(manifestPath).size,
+    },
+    bundle: {
+      status: bundleStatus,
+      asset: path.basename(bundlePath),
+      url: requirePublicHttpsUrl(bundleUrl, "OTA bundle URL"),
+      sha256: sha256File(bundlePath),
+      size: statSync(bundlePath).size,
+    },
+    asg: {
+      fingerprint: identity.fingerprint,
+      versionCode: identity.versionCode,
+      versionName: identity.versionName,
+      reused: Boolean(reused),
+      originatingReleaseSetId: provenance.originatingReleaseSetId,
+      artifact: provenance.apk,
+      provenanceAsset: identity.provenanceAsset,
+    },
+    workflow: {
+      repository: workflow.repository,
+      runId: String(workflow.runId),
+      runAttempt: Number(workflow.runAttempt),
+    },
+  }
+  if (!result.workflow.repository || !result.workflow.runId || !Number.isSafeInteger(result.workflow.runAttempt)) {
+    throw new Error("OTA workflow provenance is incomplete")
+  }
+  return result
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const command = process.argv[2]
+  const args = parseArgs(process.argv.slice(3))
+  const identity = readJson(args.identity)
+  const apkPath = path.resolve(args.apk)
+  const signingCertificateSha256 = args["signing-certificate-sha256"]
+  if (command === "create-provenance") {
+    const record = createAsgProvenance({
+      identity,
+      releasePlan: readJson(args.plan),
+      apkPath,
+      apkUrl: args["apk-url"],
+      signingCertificateSha256,
+    })
+    writeFileSync(args.output, serializeReleaseRecord(record))
+    return
+  }
+  if (command === "verify-provenance") {
+    verifyAsgProvenance({
+      identity,
+      provenance: readJson(args.provenance),
+      apkPath,
+      signingCertificateSha256,
+    })
+    return
+  }
+  if (command === "create-selection") {
+    const record = createAsgSelection({
+      releasePlan: readJson(args.plan),
+      identity,
+      provenance: readJson(args.provenance),
+    })
+    writeFileSync(args.output, serializeReleaseRecord(record))
+    return
+  }
+  if (command === "create-result") {
+    const record = createOtaReleaseResult({
+      releasePlan: readJson(args.plan),
+      identity,
+      provenance: readJson(args.provenance),
+      selectionPath: path.resolve(args.selection),
+      selectionUrl: args["selection-url"],
+      selectionStatus: args["selection-status"],
+      manifestPath: path.resolve(args.manifest),
+      manifestUrl: args["manifest-url"],
+      bundlePath: path.resolve(args.bundle),
+      bundleUrl: args["bundle-url"],
+      bundleStatus: args["bundle-status"],
+      manifestStatus: args["manifest-status"],
+      reused: args.reused === "true",
+      workflow: {
+        apkPath,
+        signingCertificateSha256,
+        repository: args.repository,
+        runId: args["run-id"],
+        runAttempt: Number(args["run-attempt"]),
+      },
+    })
+    writeFileSync(args.output, serializeReleaseRecord(record))
+    return
+  }
+  throw new Error(`Unknown command ${JSON.stringify(command)}`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/coordinated-ota-records.test.mjs
+++ b/.github/scripts/coordinated-ota-records.test.mjs
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict"
+import {mkdirSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {
+  createAsgProvenance,
+  createAsgSelection,
+  createOtaReleaseResult,
+  verifyAsgProvenance,
+} from "./coordinated-ota-records.mjs"
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+const signingCertificateSha256 = "e8f49381d6324f0703d464328a46eaba1f40422be3b39085d521e38885677387"
+const identity = {
+  schemaVersion: 1,
+  fingerprint: "a".repeat(64),
+  versionCode: 46_410_400,
+  versionName: "asg.46410400.aaaaaaaaaaaa",
+  apkAsset: `mentra-live-asg-46410400-${"a".repeat(64)}.apk`,
+  provenanceAsset: `mentra-live-asg-46410400-${"a".repeat(64)}.json`,
+  latestInputCommitTimestamp: 1_782_000_000,
+  contract: {androidBuildVariant: "release"},
+  entries: [{mode: "100644", object: "b".repeat(40), path: "asg_client/app/build.gradle"}],
+}
+const releasePlan = {
+  releaseSetId: "mentra-3.1.0-beta.57",
+  releaseIdentity: "3.1.0-beta.57",
+  sourceCommit: "c".repeat(40),
+  artifactNames: {
+    otaManifest: "mentra-live-ota-3.1.0-beta.57.json",
+    asgSelection: "mentra-live-asg-selection-3.1.0-beta.57.json",
+  },
+  otaInputs: {
+    firmwareManifest: {path: "asg_client/ota_manifests/firmware_live.json", sha256: "d".repeat(64)},
+    mtkPatches: [{start_firmware: "20260709", end_firmware: "20260730", url: "https://example.com/mtk.zip"}],
+    besFirmware: {version: "26.8.1", url: "https://example.com/bes.bin"},
+  },
+}
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "coordinated-ota-records-"))
+  mkdirSync(path.join(root, "artifacts"))
+  const apkPath = path.join(root, "artifacts", identity.apkAsset)
+  const bundlePath = path.join(root, "artifacts", "mentra-live-ota-bundle-3.1.0-beta.57.zip")
+  const manifestPath = path.join(root, "artifacts", releasePlan.artifactNames.otaManifest)
+  const selectionPath = path.join(root, "artifacts", releasePlan.artifactNames.asgSelection)
+  writeFileSync(apkPath, "signed apk fixture")
+  writeFileSync(bundlePath, "portable OTA bundle fixture")
+  const provenance = createAsgProvenance({
+    identity,
+    releasePlan,
+    apkPath,
+    apkUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-coordinated-ota/${identity.apkAsset}`,
+    signingCertificateSha256,
+  })
+  writeFileSync(selectionPath, serializeReleaseRecord(createAsgSelection({releasePlan, identity, provenance})))
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        apps: {
+          "com.mentra.asg_client": {
+            versionCode: identity.versionCode,
+            versionName: identity.versionName,
+            apkUrl: provenance.apk.url,
+            apkSize: provenance.apk.size,
+            sha256: provenance.apk.sha256,
+          },
+        },
+        mtk_patches: releasePlan.otaInputs.mtkPatches,
+        bes_firmware: releasePlan.otaInputs.besFirmware,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  return {apkPath, bundlePath, manifestPath, selectionPath, provenance}
+}
+
+test("creates and verifies immutable ASG provenance", () => {
+  const fixtureData = fixture()
+  assert.equal(
+    verifyAsgProvenance({
+      identity,
+      provenance: fixtureData.provenance,
+      apkPath: fixtureData.apkPath,
+      signingCertificateSha256: signingCertificateSha256.toUpperCase().match(/../g).join(":"),
+    }),
+    fixtureData.provenance,
+  )
+})
+
+test("creates a retry-stable ASG selection record", () => {
+  const fixtureData = fixture()
+  const selection = createAsgSelection({releasePlan, identity, provenance: fixtureData.provenance})
+
+  assert.equal(selection.releaseSetId, releasePlan.releaseSetId)
+  assert.equal(selection.fingerprint, identity.fingerprint)
+  assert.equal(selection.originatingReleaseSetId, releasePlan.releaseSetId)
+  assert.equal(Object.hasOwn(selection, "reused"), false)
+})
+
+test("rejects ASG bytes that differ from recorded provenance", () => {
+  const fixtureData = fixture()
+  writeFileSync(fixtureData.apkPath, "different bytes")
+  assert.throws(
+    () =>
+      verifyAsgProvenance({
+        identity,
+        provenance: fixtureData.provenance,
+        apkPath: fixtureData.apkPath,
+        signingCertificateSha256,
+      }),
+    /SHA-256 does not match/,
+  )
+})
+
+test("creates a release result only for an exact ASG, MTK, and BES selection", () => {
+  const fixtureData = fixture()
+  const result = createOtaReleaseResult({
+    releasePlan,
+    identity,
+    provenance: fixtureData.provenance,
+    selectionPath: fixtureData.selectionPath,
+    selectionUrl: "https://example.com/asg-selection.json",
+    selectionStatus: "published",
+    manifestPath: fixtureData.manifestPath,
+    manifestUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-coordinated-ota/${releasePlan.artifactNames.otaManifest}`,
+    bundlePath: fixtureData.bundlePath,
+    bundleUrl:
+      "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-coordinated-ota/mentra-live-ota-bundle-3.1.0-beta.57.zip",
+    bundleStatus: "published",
+    manifestStatus: "reused",
+    reused: true,
+    workflow: {
+      apkPath: fixtureData.apkPath,
+      signingCertificateSha256,
+      repository: "Mentra-Community/MentraOS",
+      runId: "123",
+      runAttempt: 2,
+    },
+  })
+
+  assert.equal(result.asg.reused, true)
+  assert.equal(result.selection.asset, releasePlan.artifactNames.asgSelection)
+  assert.equal(result.manifest.status, "reused")
+  assert.equal(result.bundle.status, "published")
+  assert.equal(result.asg.originatingReleaseSetId, releasePlan.releaseSetId)
+  assert.equal(result.firmwareManifestSha256, releasePlan.otaInputs.firmwareManifest.sha256)
+  assert.match(result.manifest.sha256, /^[0-9a-f]{64}$/)
+})
+
+test("rejects a substituted ASG selection record", () => {
+  const fixtureData = fixture()
+  const selection = JSON.parse(readFileSync(fixtureData.selectionPath, "utf8"))
+  selection.versionCode += 1
+  writeFileSync(fixtureData.selectionPath, JSON.stringify(selection))
+
+  assert.throws(
+    () =>
+      createOtaReleaseResult({
+        releasePlan,
+        identity,
+        provenance: fixtureData.provenance,
+        selectionPath: fixtureData.selectionPath,
+        selectionUrl: "https://example.com/asg-selection.json",
+        selectionStatus: "published",
+        manifestPath: fixtureData.manifestPath,
+        manifestUrl: "https://example.com/version.json",
+        bundlePath: fixtureData.bundlePath,
+        bundleUrl: "https://example.com/bundle.zip",
+        bundleStatus: "published",
+        manifestStatus: "published",
+        reused: false,
+        workflow: {
+          apkPath: fixtureData.apkPath,
+          signingCertificateSha256,
+          repository: "Mentra-Community/MentraOS",
+          runId: "123",
+          runAttempt: 1,
+        },
+      }),
+    /selection record does not match/,
+  )
+})
+
+test("compares promoted firmware semantically instead of by object key order", () => {
+  const fixtureData = fixture()
+  const manifest = JSON.parse(readFileSync(fixtureData.manifestPath, "utf8"))
+  manifest.mtk_patches = manifest.mtk_patches.map((patch) => ({
+    url: patch.url,
+    end_firmware: patch.end_firmware,
+    start_firmware: patch.start_firmware,
+  }))
+  manifest.bes_firmware = {url: manifest.bes_firmware.url, version: manifest.bes_firmware.version}
+  writeFileSync(fixtureData.manifestPath, JSON.stringify(manifest))
+
+  assert.doesNotThrow(() =>
+    createOtaReleaseResult({
+      releasePlan,
+      identity,
+      provenance: fixtureData.provenance,
+      selectionPath: fixtureData.selectionPath,
+      selectionUrl: "https://example.com/asg-selection.json",
+      selectionStatus: "published",
+      manifestPath: fixtureData.manifestPath,
+      manifestUrl: "https://example.com/version.json",
+      bundlePath: fixtureData.bundlePath,
+      bundleUrl: "https://example.com/bundle.zip",
+      bundleStatus: "published",
+      manifestStatus: "published",
+      reused: false,
+      workflow: {
+        apkPath: fixtureData.apkPath,
+        signingCertificateSha256,
+        repository: "Mentra-Community/MentraOS",
+        runId: "123",
+        runAttempt: 1,
+      },
+    }),
+  )
+})
+
+test("rejects a manifest whose promoted firmware differs from release intent", () => {
+  const fixtureData = fixture()
+  const manifest = JSON.parse(readFileSync(fixtureData.manifestPath, "utf8"))
+  manifest.bes_firmware.version = "unexpected"
+  writeFileSync(fixtureData.manifestPath, JSON.stringify(manifest))
+
+  assert.throws(
+    () =>
+      createOtaReleaseResult({
+        releasePlan,
+        identity,
+        provenance: fixtureData.provenance,
+        selectionPath: fixtureData.selectionPath,
+        selectionUrl: "https://example.com/asg-selection.json",
+        selectionStatus: "published",
+        manifestPath: fixtureData.manifestPath,
+        manifestUrl: "https://example.com/version.json",
+        bundlePath: fixtureData.bundlePath,
+        bundleUrl: "https://example.com/bundle.zip",
+        bundleStatus: "published",
+        manifestStatus: "published",
+        reused: false,
+        workflow: {
+          apkPath: fixtureData.apkPath,
+          signingCertificateSha256,
+          repository: "Mentra-Community/MentraOS",
+          runId: "123",
+          runAttempt: 1,
+        },
+      }),
+    /BES input differs/,
+  )
+})

--- a/.github/scripts/verify-public-release-asset.mjs
+++ b/.github/scripts/verify-public-release-asset.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import {readFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {requirePublicHttpsUrl} from "./release-family.mjs"
+
+const DEFAULT_ATTEMPTS = 12
+const DEFAULT_DELAY_MS = 10_000
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+export async function verifyPublicReleaseAsset({
+  file,
+  url,
+  attempts = DEFAULT_ATTEMPTS,
+  delayMs = DEFAULT_DELAY_MS,
+  fetchImpl = fetch,
+  sleepImpl = sleep,
+}) {
+  if (!Number.isInteger(attempts) || attempts < 1) throw new Error("attempts must be a positive integer")
+  if (!Number.isFinite(delayMs) || delayMs < 0) throw new Error("delayMs must be non-negative")
+  const publicUrl = requirePublicHttpsUrl(url, "Public release asset URL")
+
+  const expected = readFileSync(path.resolve(file))
+  let lastFailure = "not requested"
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    console.log(`Verifying public release asset (attempt ${attempt}/${attempts})`)
+    try {
+      const response = await fetchImpl(publicUrl, {cache: "no-store", redirect: "follow"})
+      if (!response.ok) {
+        lastFailure = `HTTP ${response.status}`
+      } else {
+        const actual = Buffer.from(await response.arrayBuffer())
+        if (expected.equals(actual)) return
+        lastFailure = "public bytes differ from the immutable source"
+      }
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error)
+    }
+
+    if (attempt < attempts) await sleepImpl(delayMs)
+  }
+
+  throw new Error(`Public release asset did not converge after ${attempts} attempts: ${lastFailure}`)
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.file || !args.url) throw new Error("--file and --url are required")
+  await verifyPublicReleaseAsset({file: args.file, url: args.url})
+  console.log(`Verified public release asset ${args.url}`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main()

--- a/.github/scripts/verify-public-release-asset.test.mjs
+++ b/.github/scripts/verify-public-release-asset.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {verifyPublicReleaseAsset} from "./verify-public-release-asset.mjs"
+
+function fixture(context, contents = "immutable release bytes") {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "mentra-release-asset-"))
+  context.after(() => rmSync(directory, {force: true, recursive: true}))
+  const file = path.join(directory, "asset.json")
+  writeFileSync(file, contents)
+  return file
+}
+
+test("waits for the public release asset to serve the immutable bytes", async (context) => {
+  const file = fixture(context)
+  const responses = [
+    {ok: false, status: 404},
+    {ok: true, status: 200, arrayBuffer: async () => Buffer.from("immutable release bytes")},
+  ]
+  const delays = []
+
+  await verifyPublicReleaseAsset({
+    file,
+    url: "https://github.com/Mentra-Community/MentraOS/releases/download/test/asset.json",
+    attempts: 2,
+    delayMs: 7,
+    fetchImpl: async () => responses.shift(),
+    sleepImpl: async (delay) => delays.push(delay),
+  })
+
+  assert.deepEqual(delays, [7])
+})
+
+test("fails after bounded attempts when the public bytes never match", async (context) => {
+  const file = fixture(context)
+  let requests = 0
+
+  await assert.rejects(
+    verifyPublicReleaseAsset({
+      file,
+      url: "https://github.com/Mentra-Community/MentraOS/releases/download/test/asset.json",
+      attempts: 2,
+      delayMs: 0,
+      fetchImpl: async () => {
+        requests += 1
+        return {ok: true, status: 200, arrayBuffer: async () => Buffer.from("stale bytes")}
+      },
+      sleepImpl: async () => {},
+    }),
+    /public bytes differ.*after 2 attempts|after 2 attempts.*public bytes differ/,
+  )
+  assert.equal(requests, 2)
+})

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -1,0 +1,456 @@
+name: Reusable Coordinated OTA Release
+
+on:
+  workflow_call:
+    inputs:
+      release_plan_artifact:
+        description: Actions artifact containing release-plan.json and ota-release-inputs.json
+        required: true
+        type: string
+      dry_run:
+        description: Build and verify without publishing GitHub release assets
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      manifest_url:
+        description: Immutable OTA manifest URL selected by every product in the release set
+        value: ${{ jobs.ota.outputs.manifest_url }}
+      manifest_sha256:
+        description: SHA-256 of the immutable OTA manifest
+        value: ${{ jobs.ota.outputs.manifest_sha256 }}
+      result_artifact:
+        description: Actions artifact containing the verified OTA result record
+        value: ${{ jobs.ota.outputs.result_artifact }}
+      asg_fingerprint:
+        description: Effective ASG build-input fingerprint
+        value: ${{ jobs.ota.outputs.asg_fingerprint }}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: coordinated-ota-publication
+  cancel-in-progress: false
+
+env:
+  OTA_RELEASE_TAG: mentra-coordinated-ota
+  ASG_SIGNING_CERT_SHA256: e8f49381d6324f0703d464328a46eaba1f40422be3b39085d521e38885677387
+
+jobs:
+  ota:
+    name: Select ASG and publish immutable OTA bundle
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 90
+    outputs:
+      manifest_url: ${{ steps.names.outputs.manifest_url }}
+      manifest_sha256: ${{ steps.result.outputs.manifest_sha256 }}
+      result_artifact: ${{ steps.names.outputs.result_artifact }}
+      asg_fingerprint: ${{ steps.asg-identity.outputs.fingerprint }}
+    steps:
+      - name: Clean persistent-runner build outputs
+        run: rm -rf asg_client/app/build asg_client/.gradle asg_client/StreamPackLite coordinated-ota-work
+
+      - name: Checkout exact source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Download immutable release intent
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - name: Validate release intent against checkout and promoted firmware
+        env:
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: |
+          node --input-type=module <<'EOF'
+          import {createHash} from "node:crypto"
+          import {readFileSync} from "node:fs"
+
+          const plan = JSON.parse(readFileSync("release-intent/release-plan.json", "utf8"))
+          const firmware = readFileSync("asg_client/ota_manifests/firmware_live.json")
+          const firmwareSha256 = createHash("sha256").update(firmware).digest("hex")
+          if (plan.sourceCommit !== process.env.SOURCE_COMMIT) throw new Error("Release plan source does not match checkout")
+          if (plan.releaseSetId !== `mentra-${plan.releaseIdentity}`) throw new Error("Invalid release-set identity")
+          if (plan.otaInputs?.firmwareManifest?.sha256 !== firmwareSha256) {
+            throw new Error("Promoted firmware manifest differs from immutable release intent")
+          }
+          if (!plan.artifactNames?.otaManifest || !plan.artifactNames?.asgSelection) {
+            throw new Error("Release plan is missing coordinated OTA artifact names")
+          }
+          EOF
+
+      - name: Compute effective ASG build fingerprint
+        id: asg-fingerprint
+        run: >-
+          node .github/scripts/compute-asg-build-identity.mjs
+          --source-commit "${{ github.sha }}"
+          --output coordinated-ota-work/asg-build-fingerprint.json
+
+      - name: Allocate or reuse the ASG version code
+        id: existing-asg
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASG_FINGERPRINT: ${{ steps.asg-fingerprint.outputs.fingerprint }}
+          WORKFLOW_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          mkdir -p coordinated-ota-work
+          releases=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq 'add')
+          matches=$(jq --arg tag "$OTA_RELEASE_TAG" '[.[] | select(.tag_name == $tag)]' <<< "$releases")
+          if [[ "$(jq 'length' <<< "$matches")" -gt 1 ]]; then
+            echo "Found more than one GitHub release for tag $OTA_RELEASE_TAG" >&2
+            exit 1
+          fi
+          release_id=$(jq -r '.[0].id // empty' <<< "$matches")
+          assets='[]'
+          if [[ -n "$release_id" ]]; then
+            assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" | jq 'add')
+          fi
+          printf '%s\n' "$assets" > coordinated-ota-work/release-assets.json
+          node .github/scripts/allocate-asg-version.mjs \
+            --assets coordinated-ota-work/release-assets.json \
+            --fingerprint "$ASG_FINGERPRINT" \
+            --run-number "$WORKFLOW_RUN_NUMBER" \
+            --output coordinated-ota-work/asg-allocation.json
+
+          if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+            while IFS= read -r asset_id; do
+              [[ -z "$asset_id" ]] && continue
+              echo "Removing incomplete ASG release asset ${asset_id} before rebuilding its pair."
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+            done < <(jq -r '.orphanAssetIds[]' coordinated-ota-work/asg-allocation.json)
+          fi
+
+          {
+            echo "exists=$(jq -r .exists coordinated-ota-work/asg-allocation.json)"
+            echo "version_code=$(jq -r .versionCode coordinated-ota-work/asg-allocation.json)"
+            echo "apk_asset=$(jq -r .apkAsset coordinated-ota-work/asg-allocation.json)"
+            echo "provenance_asset=$(jq -r .provenanceAsset coordinated-ota-work/asg-allocation.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Finalize effective ASG build identity
+        id: asg-identity
+        run: >-
+          node .github/scripts/compute-asg-build-identity.mjs
+          --source-commit "${{ github.sha }}"
+          --version-code "${{ steps.existing-asg.outputs.version_code }}"
+          --output coordinated-ota-work/asg-build-identity.json
+
+      - name: Prepare immutable asset names
+        id: names
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p coordinated-ota-work/release-assets coordinated-ota-work/bundle
+          release_identity=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          release_set_id=$(jq -er .releaseSetId release-intent/release-plan.json)
+          manifest_asset=$(jq -er .artifactNames.otaManifest release-intent/release-plan.json)
+          selection_asset=$(jq -er .artifactNames.asgSelection release-intent/release-plan.json)
+          apk_asset=$(jq -er .apkAsset coordinated-ota-work/asg-build-identity.json)
+          provenance_asset=$(jq -er .provenanceAsset coordinated-ota-work/asg-build-identity.json)
+          [[ "$apk_asset" == "${{ steps.existing-asg.outputs.apk_asset }}" ]]
+          [[ "$provenance_asset" == "${{ steps.existing-asg.outputs.provenance_asset }}" ]]
+          bundle_asset="mentra-live-ota-bundle-${release_identity}.zip"
+          release_base="https://github.com/${REPOSITORY}/releases/download/${OTA_RELEASE_TAG}"
+
+          {
+            echo "release_identity=${release_identity}"
+            echo "release_set_id=${release_set_id}"
+            echo "apk_asset=${apk_asset}"
+            echo "provenance_asset=${provenance_asset}"
+            echo "manifest_asset=${manifest_asset}"
+            echo "selection_asset=${selection_asset}"
+            echo "bundle_asset=${bundle_asset}"
+            echo "apk_url=${release_base}/${apk_asset}"
+            echo "manifest_url=${release_base}/${manifest_asset}"
+            echo "selection_url=${release_base}/${selection_asset}"
+            echo "bundle_url=${release_base}/${bundle_asset}"
+            echo "result_artifact=coordinated-ota-${release_set_id}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download reusable ASG artifact and provenance
+        if: steps.existing-asg.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APK_ASSET: ${{ steps.names.outputs.apk_asset }}
+          PROVENANCE_ASSET: ${{ steps.names.outputs.provenance_asset }}
+        run: |
+          gh release download "$OTA_RELEASE_TAG" --pattern "$APK_ASSET" --pattern "$PROVENANCE_ASSET" --dir coordinated-ota-work
+          mv "coordinated-ota-work/$APK_ASSET" coordinated-ota-work/asg.apk
+          mv "coordinated-ota-work/$PROVENANCE_ASSET" coordinated-ota-work/asg-provenance.json
+
+      - name: Setup Java for ASG build and APK verification
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Setup Android SDK for APK verification
+        uses: android-actions/setup-android@v3
+
+      - name: Initialize ASG build inputs
+        if: steps.existing-asg.outputs.exists != 'true'
+        run: |
+          cp asg_client/.env.example asg_client/.env
+          git submodule update --init asg_client/StreamPackLite
+          chmod +x asg_client/recovery_worker/build_and_deploy.sh
+          (cd asg_client/recovery_worker && ./build_and_deploy.sh)
+          test -f asg_client/app/src/main/assets/recovery_worker.apk
+
+      - name: Build signed ASG APK once
+        id: asg-build
+        if: steps.existing-asg.outputs.exists != 'true'
+        working-directory: asg_client
+        continue-on-error: true
+        run: >-
+          ./gradlew
+          -PASG_VERSION_CODE="${{ steps.asg-identity.outputs.version_code }}"
+          -PASG_VERSION_NAME="${{ steps.asg-identity.outputs.version_name }}"
+          assembleRelease --build-cache --parallel
+
+      - name: Retry failed ASG build from a clean Gradle cache
+        if: steps.existing-asg.outputs.exists != 'true' && steps.asg-build.outcome == 'failure'
+        working-directory: asg_client
+        run: |
+          ./gradlew --stop || true
+          rm -rf ~/.gradle/caches ~/.gradle/wrapper
+          ./gradlew \
+            -PASG_VERSION_CODE="${{ steps.asg-identity.outputs.version_code }}" \
+            -PASG_VERSION_NAME="${{ steps.asg-identity.outputs.version_name }}" \
+            assembleRelease --build-cache --parallel
+
+      - name: Stage newly built ASG APK
+        if: steps.existing-asg.outputs.exists != 'true'
+        run: cp asg_client/app/build/outputs/apk/release/app-release.apk coordinated-ota-work/asg.apk
+
+      - name: Verify ASG signature and embedded version
+        id: verify-asg
+        env:
+          EXPECTED_VERSION_CODE: ${{ steps.asg-identity.outputs.version_code }}
+          EXPECTED_VERSION_NAME: ${{ steps.asg-identity.outputs.version_name }}
+        run: |
+          set -euo pipefail
+          apksigner=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -perm +111 | LC_ALL=C sort | tail -1)
+          aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm +111 | LC_ALL=C sort | tail -1)
+          test -n "$apksigner"
+          test -n "$aapt"
+          $apksigner verify --print-certs coordinated-ota-work/asg.apk > coordinated-ota-work/apksigner-output.txt
+          signer=$(sed -n 's/^Signer #1 certificate SHA-256 digest: //p' coordinated-ota-work/apksigner-output.txt)
+          signer=${signer%%$'\n'*}
+          signer=$(tr '[:upper:]' '[:lower:]' <<< "$signer" | tr -d ':')
+          if [[ "$signer" != "$ASG_SIGNING_CERT_SHA256" ]]; then
+            echo "ASG APK signing certificate ${signer:-<missing>} is not the production certificate." >&2
+            exit 1
+          fi
+          $aapt dump badging coordinated-ota-work/asg.apk > coordinated-ota-work/aapt-badging.txt
+          badging=$(sed -n '1p' coordinated-ota-work/aapt-badging.txt)
+          version_code=$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<< "$badging")
+          version_name=$(sed -n "s/.*versionName='\([^']*\)'.*/\1/p" <<< "$badging")
+          [[ "$version_code" == "$EXPECTED_VERSION_CODE" ]]
+          [[ "$version_name" == "$EXPECTED_VERSION_NAME" ]]
+          echo "signing_certificate_sha256=${signer}" >> "$GITHUB_OUTPUT"
+
+      - name: Create provenance for a new ASG artifact
+        if: steps.existing-asg.outputs.exists != 'true'
+        run: >-
+          node .github/scripts/coordinated-ota-records.mjs create-provenance
+          --identity coordinated-ota-work/asg-build-identity.json
+          --plan release-intent/release-plan.json
+          --apk coordinated-ota-work/asg.apk
+          --apk-url "${{ steps.names.outputs.apk_url }}"
+          --signing-certificate-sha256 "${{ steps.verify-asg.outputs.signing_certificate_sha256 }}"
+          --output coordinated-ota-work/asg-provenance.json
+
+      - name: Verify selected ASG provenance
+        run: >-
+          node .github/scripts/coordinated-ota-records.mjs verify-provenance
+          --identity coordinated-ota-work/asg-build-identity.json
+          --provenance coordinated-ota-work/asg-provenance.json
+          --apk coordinated-ota-work/asg.apk
+          --signing-certificate-sha256 "${{ steps.verify-asg.outputs.signing_certificate_sha256 }}"
+
+      - name: Generate immutable OTA manifest
+        env:
+          ASG_APK_URL: ${{ steps.names.outputs.apk_url }}
+          ASG_VERSION_CODE: ${{ steps.asg-identity.outputs.version_code }}
+          ASG_VERSION_NAME: ${{ steps.asg-identity.outputs.version_name }}
+          FIRMWARE_MANIFEST: asg_client/ota_manifests/firmware_live.json
+          OUTPUT_PATH: coordinated-ota-work/release-assets/${{ steps.names.outputs.manifest_asset }}
+          SDK_VERSION: ${{ steps.names.outputs.release_identity }}
+        run: |
+          ASG_APK_SHA256=$(jq -er .apk.sha256 coordinated-ota-work/asg-provenance.json)
+          ASG_APK_SIZE=$(jq -er .apk.size coordinated-ota-work/asg-provenance.json)
+          export ASG_APK_SHA256 ASG_APK_SIZE
+          node .github/scripts/build-bluetooth-sdk-ota-manifest.mjs
+
+      - name: Build deterministic portable OTA bundle
+        env:
+          MANIFEST_SOURCE: coordinated-ota-work/release-assets/${{ steps.names.outputs.manifest_asset }}
+          OUTPUT_DIRECTORY: coordinated-ota-work/bundle/root
+          APK_URL: ${{ steps.names.outputs.apk_url }}
+          BUNDLE_ASSET: ${{ steps.names.outputs.bundle_asset }}
+        run: |
+          set -euo pipefail
+          LOCAL_ARTIFACTS_JSON=$(jq -cn --arg url "$APK_URL" --arg path coordinated-ota-work/asg.apk '{($url): $path}')
+          export LOCAL_ARTIFACTS_JSON
+          node .github/scripts/build-bluetooth-sdk-ota-bundle.mjs
+          node coordinated-ota-work/bundle/root/configure.mjs https://updates.example.invalid/mentra/version.json
+          test -f coordinated-ota-work/bundle/root/version.json
+          rm coordinated-ota-work/bundle/root/version.json
+          find coordinated-ota-work/bundle/root -exec touch -t 198001010000 {} +
+          (
+            cd coordinated-ota-work/bundle/root
+            find . -type f -print | LC_ALL=C sort | sed 's#^\./##' | zip -X -q "../../release-assets/$BUNDLE_ASSET" -@
+          )
+          unzip -t "coordinated-ota-work/release-assets/$BUNDLE_ASSET"
+
+      - name: Create immutable ASG selection record
+        run: >-
+          node .github/scripts/coordinated-ota-records.mjs create-selection
+          --identity coordinated-ota-work/asg-build-identity.json
+          --plan release-intent/release-plan.json
+          --provenance coordinated-ota-work/asg-provenance.json
+          --apk coordinated-ota-work/asg.apk
+          --signing-certificate-sha256 "${{ steps.verify-asg.outputs.signing_certificate_sha256 }}"
+          --output coordinated-ota-work/release-assets/${{ steps.names.outputs.selection_asset }}
+
+      - name: Inspect immutable OTA asset state
+        id: asset-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            {
+              echo "manifest_status=built"
+              echo "selection_status=built"
+              echo "bundle_status=built"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          manifest_status=published
+          selection_status=published
+          bundle_status=published
+          if gh release view "$OTA_RELEASE_TAG" >/dev/null 2>&1; then
+            release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${OTA_RELEASE_TAG}" --jq .id)
+            assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" | jq 'add')
+            if jq -e --arg name "${{ steps.names.outputs.manifest_asset }}" '.[] | select(.name == $name)' <<< "$assets" >/dev/null; then
+              manifest_status=reused
+            fi
+            if jq -e --arg name "${{ steps.names.outputs.selection_asset }}" '.[] | select(.name == $name)' <<< "$assets" >/dev/null; then
+              selection_status=reused
+            fi
+            if jq -e --arg name "${{ steps.names.outputs.bundle_asset }}" '.[] | select(.name == $name)' <<< "$assets" >/dev/null; then
+              bundle_status=reused
+            fi
+          fi
+          {
+            echo "manifest_status=$manifest_status"
+            echo "selection_status=$selection_status"
+            echo "bundle_status=$bundle_status"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create verified OTA result record
+        run: >-
+          node .github/scripts/coordinated-ota-records.mjs create-result
+          --identity coordinated-ota-work/asg-build-identity.json
+          --plan release-intent/release-plan.json
+          --provenance coordinated-ota-work/asg-provenance.json
+          --selection coordinated-ota-work/release-assets/${{ steps.names.outputs.selection_asset }}
+          --selection-url "${{ steps.names.outputs.selection_url }}"
+          --selection-status "${{ steps.asset-state.outputs.selection_status }}"
+          --apk coordinated-ota-work/asg.apk
+          --signing-certificate-sha256 "${{ steps.verify-asg.outputs.signing_certificate_sha256 }}"
+          --manifest coordinated-ota-work/release-assets/${{ steps.names.outputs.manifest_asset }}
+          --manifest-url "${{ steps.names.outputs.manifest_url }}"
+          --bundle coordinated-ota-work/release-assets/${{ steps.names.outputs.bundle_asset }}
+          --bundle-url "${{ steps.names.outputs.bundle_url }}"
+          --bundle-status "${{ steps.asset-state.outputs.bundle_status }}"
+          --manifest-status "${{ steps.asset-state.outputs.manifest_status }}"
+          --reused "${{ steps.existing-asg.outputs.exists }}"
+          --repository "${{ github.repository }}"
+          --run-id "${{ github.run_id }}"
+          --run-attempt "${{ github.run_attempt }}"
+          --output coordinated-ota-work/ota-result.json
+
+      - name: Stage ASG release assets
+        run: |
+          cp coordinated-ota-work/asg.apk "coordinated-ota-work/release-assets/${{ steps.names.outputs.apk_asset }}"
+          cp coordinated-ota-work/asg-provenance.json "coordinated-ota-work/release-assets/${{ steps.names.outputs.provenance_asset }}"
+
+      - name: Publish or reconcile immutable GitHub release assets
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$OTA_RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$OTA_RELEASE_TAG" --title "Mentra Coordinated OTA Artifacts" --prerelease \
+              --notes "Immutable ASG binaries and OTA manifests selected by coordinated Mentra release sets."
+          fi
+          release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${OTA_RELEASE_TAG}" --jq .id)
+          assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" | jq 'add')
+          for file in coordinated-ota-work/release-assets/*; do
+            name=$(basename "$file")
+            asset_id=$(jq -r --arg name "$name" '.[] | select(.name == $name) | .id' <<< "$assets")
+            if [[ -n "$asset_id" ]]; then
+              gh api -H "Accept: application/octet-stream" "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > coordinated-ota-work/existing-asset
+              if ! cmp -s "$file" coordinated-ota-work/existing-asset; then
+                echo "Refusing to overwrite immutable OTA asset $name with different bytes." >&2
+                exit 1
+              fi
+              echo "Reused immutable release asset $name"
+            else
+              gh release upload "$OTA_RELEASE_TAG" "$file"
+            fi
+          done
+
+      - name: Verify published OTA manifest
+        if: inputs.dry_run != true
+        run: >-
+          node .github/scripts/verify-public-release-asset.mjs
+          --file "coordinated-ota-work/release-assets/${{ steps.names.outputs.manifest_asset }}"
+          --url "${{ steps.names.outputs.manifest_url }}"
+
+      - name: Record workflow outputs
+        id: result
+        run: |
+          sha256=$(jq -er .manifest.sha256 coordinated-ota-work/ota-result.json)
+          echo "manifest_sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload coordinated OTA result
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.names.outputs.result_artifact }}
+          path: |
+            coordinated-ota-work/ota-result.json
+            coordinated-ota-work/asg-build-identity.json
+            coordinated-ota-work/asg-provenance.json
+            coordinated-ota-work/release-assets/${{ steps.names.outputs.selection_asset }}
+            coordinated-ota-work/release-assets/${{ steps.names.outputs.manifest_asset }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Summarize selected OTA set
+        run: |
+          {
+            echo "## Coordinated OTA release"
+            echo ""
+            echo "- Release set: \`${{ steps.names.outputs.release_set_id }}\`"
+            echo "- ASG fingerprint: \`${{ steps.asg-identity.outputs.fingerprint }}\`"
+            echo "- ASG version: \`${{ steps.asg-identity.outputs.version_name }}\`"
+            echo "- ASG reused: \`${{ steps.existing-asg.outputs.exists }}\`"
+            echo "- OTA manifest: ${{ steps.names.outputs.manifest_url }}"
+            echo "- Manifest SHA-256: \`${{ steps.result.outputs.manifest_sha256 }}\`"
+            echo "- Dry run: \`${{ inputs.dry_run }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What this changes

This layer turns the OTA side of a coordinated Mentra release into an immutable, verifiable publication step.

The central behavior is ASG reuse by effective build inputs. The workflow fingerprints the committed ASG source tree, StreamPackLite gitlink, build contract, and OTA build workflow. Firmware promotion data is deliberately excluded from that fingerprint, so an unchanged ASG APK is reused when only MTK or BES targets change. A changed ASG input produces a new version code, version name, content-addressed APK name, and provenance record.

For each release set, the workflow:

- validates the immutable release plan against the exact checkout and promoted firmware manifest
- selects an existing byte-identical ASG artifact when its full input fingerprint already exists
- otherwise builds the signed production ASG APK once, with one clean-cache retry
- verifies the APK signing certificate and embedded version metadata before use
- generates an immutable OTA manifest pinning the exact ASG URL, SHA-256, and byte count
- verifies that MTK and BES entries exactly match the release plan
- builds a deterministic portable OTA bundle containing all selected firmware
- publishes release-set-specific manifest and ASG-selection records without mutable overwrites
- emits a machine-readable result record for final coordinated release assembly

## Why

The coordinated release must not rebuild ASG simply because Engine, Bluetooth SDK, or MentraOS changed. It also must not silently overwrite a shared URL with different bytes. This gives ASG its own reproducible identity while allowing all three public products in a release set to pin the same exact OTA manifest.

The global publication lock serializes dev and staging reconciliation against the shared GitHub release. Existing assets are downloaded and byte-compared; a same-name/different-content collision fails rather than being replaced.

## Identity and provenance

The committed tree currently resolves to an ASG identity shaped like:

- version code: epoch-compatible monotonic Android code derived from the latest effective ASG input commit
- version name: `asg.<versionCode>.<fingerprint-prefix>`
- APK asset: `mentra-live-asg-<versionCode>-<fingerprint-prefix>.apk`
- provenance asset: the matching JSON name

Provenance records include the complete input identity, exact APK hash and size, public signing-certificate fingerprint, origin release set, source commit, and immutable download URL. Per-release selection records stay byte-stable across retries and therefore do not encode whether the ASG happened to be reused in a particular workflow attempt.

## Failure behavior

The workflow fails on:

- release-plan/source or promoted-firmware drift
- partial or duplicate reusable ASG assets
- an unexpected APK signing certificate
- embedded ASG version mismatch
- APK/provenance byte mismatch
- ASG, MTK, or BES manifest drift
- an attempted immutable asset overwrite
- a published manifest whose downloaded bytes do not converge to the expected SHA-256

## Validation

- `actionlint .github/workflows/reusable-coordinated-ota.yml`
- 16 focused Node tests across release-family, ASG identity, provenance, immutable selection, and OTA result validation
- Prettier check on all files in this layer
- `git diff --check`
- generated an ASG identity directly from the committed Git tree: 867 effective inputs, with deterministic version and artifact names

This is stack PR 12 and depends on #3764.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches production ASG signing, OTA manifest pinning, and immutable GitHub release publication with `contents: write`; mistakes could ship wrong firmware/APK pairings or block releases.
> 
> **Overview**
> Adds a **reusable coordinated OTA workflow** and Node helpers that turn each release set into immutable, verifiable GitHub release artifacts under `mentra-coordinated-ota`.
> 
> **ASG identity and reuse:** `compute-asg-build-identity.mjs` fingerprints committed ASG sources (excluding `ota_manifests/`) plus the build contract; `allocate-asg-version.mjs` assigns monotonic Android version codes above the legacy namespace, reuses an existing APK+provenance pair for the same fingerprint, and flags partial uploads for cleanup. Unchanged ASG inputs can skip rebuild when only MTK/BES promotion changes.
> 
> **Publication pipeline:** The workflow validates the release plan against checkout and `firmware_live.json`, builds or downloads the production-signed ASG APK, checks cert and embedded version metadata, writes provenance/selection records via `coordinated-ota-records.mjs`, generates the OTA manifest and deterministic bundle, and uploads assets only when names are new—**refusing byte mismatches** on same-name assets. A global concurrency group serializes publication; `verify-public-release-asset.mjs` polls until the public manifest URL matches local bytes. Dry-run skips GitHub uploads but still builds and verifies.
> 
> **Outputs:** Machine-readable `ota-result.json` and workflow outputs (`manifest_url`, `manifest_sha256`, `asg_fingerprint`) for downstream coordinated release assembly. Unit tests cover allocation, identity, record validation, and public asset convergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3d225a40a2a67b3b1c018adc2210fda80fec5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->