### PR TITLE
ci(release): coordinate native bluetooth sdk publication

### DIFF
--- a/.github/scripts/coordinated-sdk-native-records.mjs
+++ b/.github/scripts/coordinated-sdk-native-records.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/
+const STATUSES = new Set(["built", "published", "reused"])
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"))
+}
+
+function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex")
+}
+
+function requireHttps(value, label) {
+  const url = new URL(value)
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new Error(`${label} must be credential-free HTTPS without a fragment`)
+  }
+  return url.toString()
+}
+
+function validatePlan(plan) {
+  const sdk = plan.members?.["@mentra/bluetooth-sdk"]
+  if (
+    plan.releaseSetId !== `mentra-${plan.releaseIdentity}` ||
+    sdk?.version !== plan.releaseIdentity ||
+    !sdk?.publishTargets?.includes("maven-central") ||
+    !sdk?.publishTargets?.includes("swift-package-manager")
+  ) {
+    throw new Error("Release plan does not contain a coordinated Bluetooth SDK release")
+  }
+  return plan
+}
+
+function artifact({coordinate, file, url, provenanceUrl, status}) {
+  if (!STATUSES.has(status)) throw new Error(`Unsupported publication status ${JSON.stringify(status)}`)
+  if (!coordinate) throw new Error("Artifact coordinate is required")
+  return {
+    status,
+    coordinate,
+    url: requireHttps(url, `${coordinate} URL`),
+    sha256: sha256File(file),
+    size: statSync(file).size,
+    provenanceUrl: requireHttps(provenanceUrl, `${coordinate} provenance URL`),
+  }
+}
+
+export function createMavenRecord({plan, sdkAar, sdkUrl, lc3Aar, lc3Url, provenanceUrl, status}) {
+  validatePlan(plan)
+  const version = plan.releaseIdentity
+  const sdk = artifact({
+    coordinate: `com.mentraglass:bluetooth-sdk:${version}`,
+    file: sdkAar,
+    url: sdkUrl,
+    provenanceUrl,
+    status,
+  })
+  const lc3 = artifact({
+    coordinate: `com.mentraglass:lc3Lib:${version}`,
+    file: lc3Aar,
+    url: lc3Url,
+    provenanceUrl,
+    status,
+  })
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    publications: {"@mentra/bluetooth-sdk": {"maven-central": sdk}},
+    artifacts: [lc3],
+  }
+}
+
+export function verifySwiftPackage({plan, packageRoot, otaManifestUrl, otaManifestSha256}) {
+  validatePlan(plan)
+  if (!SHA256_PATTERN.test(otaManifestSha256)) throw new Error("Invalid OTA manifest SHA-256")
+  const generated = readFileSync(path.join(packageRoot, "ios/Source/GeneratedReleaseMetadata.swift"), "utf8")
+  const defaults = readFileSync(path.join(packageRoot, "ios/Source/BluetoothSdkDefaults.swift"), "utf8")
+  const readme = readFileSync(path.join(packageRoot, "README.md"), "utf8")
+  for (const value of [plan.familyBaseVersion, plan.releaseIdentity, plan.releaseSetId, plan.sourceCommit]) {
+    if (!generated.includes(JSON.stringify(value))) throw new Error(`Swift release metadata is missing ${value}`)
+  }
+  if (!generated.includes(JSON.stringify(otaManifestUrl)) || !generated.includes(JSON.stringify(otaManifestSha256))) {
+    throw new Error("Swift release metadata does not contain the selected OTA pin")
+  }
+  if (!defaults.includes(`swiftPackageSdkVersion = ${JSON.stringify(plan.releaseIdentity)}`)) {
+    throw new Error("Swift package SDK version does not match the release identity")
+  }
+  if (!readme.includes(`from: ${JSON.stringify(plan.releaseIdentity)}`)) {
+    throw new Error("Swift package README does not reference the release identity")
+  }
+  for (const contents of [generated, defaults, readme]) {
+    if (contents.includes("__MENTRA_BLUETOOTH_SDK_VERSION__")) {
+      throw new Error("Swift package contains an unresolved SDK version placeholder")
+    }
+  }
+}
+
+export function createSwiftPmRecord({plan, archive, archiveUrl, tagUrl, mirrorCommit, provenanceUrl, status}) {
+  validatePlan(plan)
+  if (!COMMIT_PATTERN.test(mirrorCommit)) throw new Error("SwiftPM mirror commit must be a full Git SHA")
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    mirrorCommit,
+    publications: {
+      "@mentra/bluetooth-sdk": {
+        "swift-package-manager": {
+          ...artifact({
+            coordinate: `Mentra-Community/mentra-bluetooth-sdk-ios@${plan.releaseIdentity}`,
+            file: archive,
+            url: archiveUrl,
+            provenanceUrl,
+            status,
+          }),
+          sourceTagUrl: requireHttps(tagUrl, "SwiftPM source tag URL"),
+        },
+      },
+    },
+    artifacts: [],
+  }
+}
+
+export function mergeNativeRecords({plan, maven, swiftpm}) {
+  validatePlan(plan)
+  for (const [name, record] of Object.entries({maven, swiftpm})) {
+    if (record.releaseSetId !== plan.releaseSetId) throw new Error(`${name} record belongs to another release set`)
+  }
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    mirrorCommit: swiftpm.mirrorCommit,
+    publications: {
+      "@mentra/bluetooth-sdk": {
+        ...maven.publications["@mentra/bluetooth-sdk"],
+        ...swiftpm.publications["@mentra/bluetooth-sdk"],
+      },
+    },
+    artifacts: [...(maven.artifacts || []), ...(swiftpm.artifacts || [])],
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const command = process.argv[2]
+  const args = parseArgs(process.argv.slice(3))
+  const plan = validatePlan(readJson(path.resolve(args.plan)))
+  let record
+  if (command === "verify-swiftpm") {
+    verifySwiftPackage({
+      plan,
+      packageRoot: path.resolve(args["package-root"]),
+      otaManifestUrl: args["ota-manifest-url"],
+      otaManifestSha256: args["ota-manifest-sha256"],
+    })
+    return
+  }
+  if (command === "create-maven") {
+    record = createMavenRecord({
+      plan,
+      sdkAar: path.resolve(args["sdk-aar"]),
+      sdkUrl: args["sdk-url"],
+      lc3Aar: path.resolve(args["lc3-aar"]),
+      lc3Url: args["lc3-url"],
+      provenanceUrl: args["provenance-url"],
+      status: args.status,
+    })
+  } else if (command === "create-swiftpm") {
+    record = createSwiftPmRecord({
+      plan,
+      archive: path.resolve(args.archive),
+      archiveUrl: args["archive-url"],
+      tagUrl: args["tag-url"],
+      mirrorCommit: args["mirror-commit"],
+      provenanceUrl: args["provenance-url"],
+      status: args.status,
+    })
+  } else if (command === "merge") {
+    record = mergeNativeRecords({plan, maven: readJson(args.maven), swiftpm: readJson(args.swiftpm)})
+  } else {
+    throw new Error(`Unknown command ${JSON.stringify(command)}`)
+  }
+  writeFileSync(args.output, serializeReleaseRecord(record))
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/coordinated-sdk-native-records.test.mjs
+++ b/.github/scripts/coordinated-sdk-native-records.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict"
+import {mkdirSync, mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {
+  createMavenRecord,
+  createSwiftPmRecord,
+  mergeNativeRecords,
+  verifySwiftPackage,
+} from "./coordinated-sdk-native-records.mjs"
+
+const plan = {
+  familyBaseVersion: "3.1.0",
+  releaseIdentity: "3.1.0-beta.57",
+  releaseSetId: "mentra-3.1.0-beta.57",
+  sourceCommit: "a".repeat(40),
+  members: {
+    "@mentra/bluetooth-sdk": {
+      version: "3.1.0-beta.57",
+      publishTargets: ["npm", "maven-central", "swift-package-manager"],
+    },
+  },
+}
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "sdk-native-records-"))
+  const sdkAar = path.join(root, "sdk.aar")
+  const lc3Aar = path.join(root, "lc3.aar")
+  const archive = path.join(root, "swift.tar")
+  writeFileSync(sdkAar, "sdk")
+  writeFileSync(lc3Aar, "lc3")
+  writeFileSync(archive, "swift")
+  return {root, sdkAar, lc3Aar, archive}
+}
+
+test("records exact Maven and SwiftPM artifacts and merges them", () => {
+  const files = fixture()
+  const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
+  const maven = createMavenRecord({
+    plan,
+    sdkAar: files.sdkAar,
+    sdkUrl: "https://repo.maven.apache.org/maven2/com/mentraglass/bluetooth-sdk/3.1.0-beta.57/sdk.aar",
+    lc3Aar: files.lc3Aar,
+    lc3Url: "https://repo.maven.apache.org/maven2/com/mentraglass/lc3Lib/3.1.0-beta.57/lc3.aar",
+    provenanceUrl,
+    status: "published",
+  })
+  const swiftpm = createSwiftPmRecord({
+    plan,
+    archive: files.archive,
+    archiveUrl:
+      "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57/mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar",
+    tagUrl: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/3.1.0-beta.57",
+    mirrorCommit: "b".repeat(40),
+    provenanceUrl,
+    status: "reused",
+  })
+  const merged = mergeNativeRecords({plan, maven, swiftpm})
+
+  assert.equal(merged.publications["@mentra/bluetooth-sdk"]["maven-central"].status, "published")
+  assert.equal(merged.publications["@mentra/bluetooth-sdk"]["swift-package-manager"].status, "reused")
+  assert.equal(
+    merged.publications["@mentra/bluetooth-sdk"]["swift-package-manager"].url,
+    "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57/mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar",
+  )
+  assert.equal(
+    merged.publications["@mentra/bluetooth-sdk"]["swift-package-manager"].sourceTagUrl,
+    "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/3.1.0-beta.57",
+  )
+  assert.equal(merged.mirrorCommit, "b".repeat(40))
+  assert.equal(merged.artifacts[0].coordinate, "com.mentraglass:lc3Lib:3.1.0-beta.57")
+})
+
+test("verifies the exported Swift package version and OTA pin", () => {
+  const {root} = fixture()
+  const source = path.join(root, "ios/Source")
+  mkdirSync(source, {recursive: true})
+  const otaUrl = "https://example.com/ota.json"
+  const otaSha = "c".repeat(64)
+  writeFileSync(
+    path.join(source, "GeneratedReleaseMetadata.swift"),
+    [plan.familyBaseVersion, plan.releaseIdentity, plan.releaseSetId, plan.sourceCommit, otaUrl, otaSha]
+      .map((value) => `static let value = ${JSON.stringify(value)}`)
+      .join("\n"),
+  )
+  writeFileSync(
+    path.join(source, "BluetoothSdkDefaults.swift"),
+    `private static let swiftPackageSdkVersion = ${JSON.stringify(plan.releaseIdentity)}\n`,
+  )
+  writeFileSync(path.join(root, "README.md"), `.package(from: ${JSON.stringify(plan.releaseIdentity)})\n`)
+
+  verifySwiftPackage({plan, packageRoot: root, otaManifestUrl: otaUrl, otaManifestSha256: otaSha})
+})
+
+test("rejects a Swift package with a mismatched release pin", () => {
+  const {root} = fixture()
+  const source = path.join(root, "ios/Source")
+  mkdirSync(source, {recursive: true})
+  writeFileSync(path.join(source, "GeneratedReleaseMetadata.swift"), "wrong")
+  writeFileSync(path.join(source, "BluetoothSdkDefaults.swift"), "wrong")
+  writeFileSync(path.join(root, "README.md"), "wrong")
+
+  assert.throws(
+    () =>
+      verifySwiftPackage({
+        plan,
+        packageRoot: root,
+        otaManifestUrl: "https://example.com/ota.json",
+        otaManifestSha256: "c".repeat(64),
+      }),
+    /missing|does not/,
+  )
+})

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -77,6 +77,7 @@ test("creates a deterministic release plan with exact dependency versions", () =
   assert.equal(plan.artifactNames.otaManifest, "mentra-live-ota-3.1.0-beta.57.json")
   assert.equal(plan.artifactNames.asgSelection, "mentra-live-asg-selection-3.1.0-beta.57.json")
   assert.equal(plan.artifactNames.androidStoreApp, "mentraos-3.1.0-beta.57-android.aab")
+  assert.equal(plan.artifactNames.iosSdkArchive, "mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar")
   assert.equal(plan.otaInputs.firmwareManifest, "firmware_live.json")
 })
 

--- a/.github/scripts/sonatype-central-deployment.mjs
+++ b/.github/scripts/sonatype-central-deployment.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+const BASE_URL = "https://central.sonatype.com"
+const WAITING_STATES = new Set(["PENDING", "VALIDATING", "PUBLISHING"])
+const RESUMABLE_STATES = new Set([...WAITING_STATES, "VALIDATED", "PUBLISHED"])
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function responseJson(response, label) {
+  const body = await response.text()
+  if (!response.ok) throw new Error(`${label} failed with HTTP ${response.status}: ${body}`)
+  try {
+    return JSON.parse(body)
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${error.message}`)
+  }
+}
+
+function requireDeploymentRecord(record) {
+  if (
+    record?.schemaVersion !== 1 ||
+    !UUID_PATTERN.test(record.deploymentId) ||
+    !record.deploymentName ||
+    !/^[0-9a-f]{64}$/.test(record.bundleSha256) ||
+    !Array.isArray(record.expectedPurls) ||
+    record.expectedPurls.length === 0
+  ) {
+    throw new Error("Invalid persisted Sonatype deployment record")
+  }
+  return record
+}
+
+function assertExpectedPurls(actual, expected, label) {
+  const actualSet = new Set(actual)
+  const missing = expected.filter((purl) => !actualSet.has(purl))
+  if (missing.length > 0) throw new Error(`${label} is missing expected components: ${missing.join(", ")}`)
+}
+
+export async function uploadManagedDeployment({bundle, token, deploymentName, expectedPurls, fetchImpl = fetch}) {
+  if (!bundle || !token || !deploymentName || expectedPurls.length === 0) {
+    throw new Error("Bundle, token, deployment name, and expected PURLs are required")
+  }
+  const bytes = readFileSync(bundle)
+  const url = new URL("/api/v1/publisher/upload", BASE_URL)
+  url.searchParams.set("name", deploymentName)
+  url.searchParams.set("publishingType", "USER_MANAGED")
+  const form = new FormData()
+  form.append("bundle", new Blob([bytes], {type: "application/octet-stream"}), path.basename(bundle))
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {Authorization: `Bearer ${token}`},
+    body: form,
+  })
+  const deploymentId = (await response.text()).trim()
+  if (!response.ok) {
+    throw new Error(`Sonatype deployment upload failed with HTTP ${response.status}: ${deploymentId}`)
+  }
+  if (!UUID_PATTERN.test(deploymentId)) throw new Error(`Sonatype returned an invalid deployment ID: ${deploymentId}`)
+  return {
+    schemaVersion: 1,
+    deploymentId,
+    deploymentName,
+    bundleSha256: createHash("sha256").update(bytes).digest("hex"),
+    expectedPurls,
+  }
+}
+
+async function deploymentStatus({fetchImpl, headers, deploymentId}) {
+  const url = new URL("/api/v1/publisher/status", BASE_URL)
+  url.searchParams.set("id", deploymentId)
+  const response = await fetchImpl(url, {method: "POST", headers})
+  return responseJson(response, "Sonatype deployment status")
+}
+
+async function requestPublication({fetchImpl, headers, deploymentId}) {
+  const url = new URL(`/api/v1/publisher/deployment/${deploymentId}`, BASE_URL)
+  const response = await fetchImpl(url, {method: "POST", headers})
+  const body = await response.text()
+  if (!response.ok) throw new Error(`Sonatype publication request failed with HTTP ${response.status}: ${body}`)
+}
+
+function requireMatchingStatus(record, status) {
+  if (status.deploymentId && status.deploymentId !== record.deploymentId) {
+    throw new Error("Sonatype status belongs to another deployment")
+  }
+  if (status.deploymentName && status.deploymentName !== record.deploymentName) {
+    throw new Error("Sonatype deployment name differs from the persisted release record")
+  }
+  return status
+}
+
+export async function inspectDeployment({record, token, fetchImpl = fetch}) {
+  requireDeploymentRecord(record)
+  if (!token) throw new Error("Sonatype token is required")
+  const status = requireMatchingStatus(
+    record,
+    await deploymentStatus({
+      fetchImpl,
+      headers: {Authorization: `Bearer ${token}`},
+      deploymentId: record.deploymentId,
+    }),
+  )
+  const purls = status.purls || []
+
+  if (status.deploymentState === "FAILED") {
+    return {...record, disposition: "replace", deploymentState: status.deploymentState, errors: status.errors || []}
+  }
+  if (!RESUMABLE_STATES.has(status.deploymentState)) {
+    throw new Error(
+      `Sonatype deployment ${record.deploymentName} has unknown state ${JSON.stringify(status.deploymentState)}`,
+    )
+  }
+  if (status.deploymentState === "PUBLISHED") {
+    assertExpectedPurls(purls, record.expectedPurls, `Published Sonatype deployment ${record.deploymentName}`)
+  }
+  return {...record, disposition: "resume", deploymentState: status.deploymentState, purls}
+}
+
+export async function publishDeployment({
+  record,
+  token,
+  fetchImpl = fetch,
+  sleepImpl = sleep,
+  statusAttempts = 360,
+  pollIntervalMs = 10_000,
+}) {
+  requireDeploymentRecord(record)
+  if (!token) throw new Error("Sonatype token is required")
+  const headers = {Authorization: `Bearer ${token}`}
+  let publicationRequested = false
+
+  for (let attempt = 1; attempt <= statusAttempts; attempt += 1) {
+    const status = requireMatchingStatus(
+      record,
+      await deploymentStatus({fetchImpl, headers, deploymentId: record.deploymentId}),
+    )
+    const purls = status.purls || []
+    if (status.deploymentState === "FAILED") {
+      throw new Error(`Sonatype deployment ${record.deploymentName} failed: ${JSON.stringify(status.errors || [])}`)
+    }
+    if (status.deploymentState === "PUBLISHED") {
+      assertExpectedPurls(purls, record.expectedPurls, `Published Sonatype deployment ${record.deploymentName}`)
+      return {...record, deploymentState: status.deploymentState, purls}
+    }
+    if (status.deploymentState === "VALIDATED") {
+      if (!publicationRequested) {
+        await requestPublication({fetchImpl, headers, deploymentId: record.deploymentId})
+        publicationRequested = true
+      }
+    } else if (!WAITING_STATES.has(status.deploymentState)) {
+      throw new Error(
+        `Sonatype deployment ${record.deploymentName} has unknown state ${JSON.stringify(status.deploymentState)}`,
+      )
+    }
+    if (attempt < statusAttempts) await sleepImpl(pollIntervalMs)
+  }
+  throw new Error(`Sonatype deployment ${record.deploymentName} did not publish after ${statusAttempts} status checks`)
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+async function main() {
+  const command = process.argv[2]
+  const args = parseArgs(process.argv.slice(3))
+  let result
+  if (command === "upload") {
+    result = await uploadManagedDeployment({
+      bundle: path.resolve(args.bundle),
+      token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
+      deploymentName: args.name,
+      expectedPurls: args["expected-purls"].split(","),
+    })
+  } else if (command === "inspect") {
+    result = await inspectDeployment({
+      record: JSON.parse(readFileSync(path.resolve(args.record), "utf8")),
+      token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
+    })
+  } else if (command === "publish") {
+    result = await publishDeployment({
+      record: JSON.parse(readFileSync(path.resolve(args.record), "utf8")),
+      token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
+    })
+  } else {
+    throw new Error(`Unknown command ${JSON.stringify(command)}`)
+  }
+  writeFileSync(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/.github/scripts/sonatype-central-deployment.test.mjs
+++ b/.github/scripts/sonatype-central-deployment.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict"
+import {mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {inspectDeployment, publishDeployment, uploadManagedDeployment} from "./sonatype-central-deployment.mjs"
+
+const deploymentId = "28570f16-da32-4c14-bd2e-c1acc0782365"
+const deploymentName = "mentra-3.1.0-beta.57-android-sdk"
+const expectedPurls = [
+  "pkg:maven/com.mentraglass/bluetooth-sdk@3.1.0-beta.57",
+  "pkg:maven/com.mentraglass/lc3Lib@3.1.0-beta.57",
+]
+
+function bundle() {
+  const file = path.join(mkdtempSync(path.join(tmpdir(), "central-bundle-")), "bundle.zip")
+  writeFileSync(file, "bundle")
+  return file
+}
+
+function record() {
+  return {
+    schemaVersion: 1,
+    deploymentId,
+    deploymentName,
+    bundleSha256: "a".repeat(64),
+    expectedPurls,
+  }
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {status})
+}
+
+test("uploads a user-managed deployment and returns a durable recovery record", async () => {
+  let request
+  const result = await uploadManagedDeployment({
+    bundle: bundle(),
+    token: "token",
+    deploymentName,
+    expectedPurls,
+    fetchImpl: async (url, options) => {
+      request = {url: String(url), options}
+      return new Response(deploymentId, {status: 201})
+    },
+  })
+
+  assert.match(request.url, /publishingType=USER_MANAGED/)
+  assert.match(request.url, /name=mentra-3.1.0-beta.57-android-sdk/)
+  assert.equal(request.options.method, "POST")
+  assert.equal(result.deploymentId, deploymentId)
+  assert.equal(result.bundleSha256.length, 64)
+  assert.deepEqual(result.expectedPurls, expectedPurls)
+})
+
+test("publishes a persisted deployment only after validation", async () => {
+  const states = ["PENDING", "VALIDATED", "VALIDATED", "PUBLISHING", "PUBLISHED"]
+  let publicationRequests = 0
+  const result = await publishDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async (url) => {
+      if (String(url).includes(`/deployment/${deploymentId}`)) {
+        publicationRequests += 1
+        return new Response(null, {status: 204})
+      }
+      const deploymentState = states.shift()
+      return jsonResponse({
+        deploymentId,
+        deploymentName,
+        deploymentState,
+        purls: deploymentState === "PUBLISHED" ? expectedPurls : [],
+      })
+    },
+    sleepImpl: async () => {},
+  })
+
+  assert.equal(publicationRequests, 1)
+  assert.equal(result.deploymentState, "PUBLISHED")
+})
+
+test("resumes a publishing deployment without sending another publication request", async () => {
+  const states = ["PUBLISHING", "PUBLISHED"]
+  let publicationRequests = 0
+  await publishDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async (url) => {
+      if (String(url).includes(`/deployment/${deploymentId}`)) publicationRequests += 1
+      const deploymentState = states.shift()
+      return jsonResponse({deploymentId, deploymentName, deploymentState, purls: expectedPurls})
+    },
+    sleepImpl: async () => {},
+  })
+  assert.equal(publicationRequests, 0)
+})
+
+test("replaces a persisted deployment only after Sonatype reports it failed", async () => {
+  const failed = await inspectDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async () =>
+      jsonResponse({deploymentId, deploymentName, deploymentState: "FAILED", errors: ["invalid signature"]}),
+  })
+  assert.equal(failed.disposition, "replace")
+  assert.deepEqual(failed.errors, ["invalid signature"])
+
+  const publishing = await inspectDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async () => jsonResponse({deploymentId, deploymentName, deploymentState: "PUBLISHING"}),
+  })
+  assert.equal(publishing.disposition, "resume")
+})
+
+test("rejects a published deployment with the wrong Maven coordinates", async () => {
+  await assert.rejects(
+    publishDeployment({
+      record: record(),
+      token: "token",
+      fetchImpl: async () =>
+        jsonResponse({deploymentId, deploymentName, deploymentState: "PUBLISHED", purls: [expectedPurls[0]]}),
+      sleepImpl: async () => {},
+    }),
+    /missing expected components/,
+  )
+})

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -1,0 +1,614 @@
+name: Reusable Coordinated Bluetooth SDK Native Release
+
+on:
+  workflow_call:
+    inputs:
+      source_commit:
+        required: true
+        type: string
+      release_plan_artifact:
+        required: true
+        type: string
+      ota_manifest_url:
+        required: true
+        type: string
+      ota_manifest_sha256:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      MAVEN_CENTRAL_TOKEN_BASE64:
+        required: false
+      MAVEN_SIGNING_KEY:
+        required: false
+      MAVEN_SIGNING_PASSWORD:
+        required: false
+      MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN:
+        required: false
+    outputs:
+      result_artifact:
+        value: ${{ jobs.result.outputs.result_artifact }}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: coordinated-sdk-native-publication
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare exact coordinated GitHub release
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - name: Create or verify the release container
+        id: release
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          identity=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "$SOURCE_COMMIT" ]]
+          tag="mentra-v$identity"
+          releases=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq 'add')
+          matches=$(jq --arg tag "$tag" '[.[] | select(.tag_name == $tag)]' <<< "$releases")
+          count=$(jq 'length' <<< "$matches")
+          if [[ "$count" -gt 1 ]]; then
+            echo "GitHub contains multiple releases for $tag." >&2
+            exit 1
+          fi
+          if [[ "$count" == 0 ]]; then
+            payload=$(jq -n \
+              --arg tag "$tag" \
+              --arg source "$SOURCE_COMMIT" \
+              --arg name "Mentra $identity" \
+              --arg body "Coordinated release $identity. Publication is incomplete until the release manifest is attached." \
+              '{tag_name: $tag, target_commitish: $source, name: $name, body: $body, draft: true, prerelease: true}')
+            release=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input - <<< "$payload")
+          else
+            release=$(jq '.[0]' <<< "$matches")
+          fi
+          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
+            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
+          else
+            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
+          fi
+          {
+            echo "release_id=$(jq -er .id <<< "$release")"
+            echo "release_tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+
+  maven:
+    name: Publish and verify Maven Central SDK
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - name: Resolve exact Maven coordinates
+        id: release
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          version=$(jq -er '.releaseIdentity' release-intent/release-plan.json)
+          source=$(jq -er '.sourceCommit' release-intent/release-plan.json)
+          [[ "$source" == "$SOURCE_COMMIT" ]]
+          base="https://repo.maven.apache.org/maven2/com/mentraglass"
+          {
+            echo "version=$version"
+            echo "deployment_name=mentra-$version-android-sdk"
+            echo "deployment_asset=mentra-$version-sonatype-deployment.json"
+            echo "sdk_purl=pkg:maven/com.mentraglass/bluetooth-sdk@$version"
+            echo "lc3_purl=pkg:maven/com.mentraglass/lc3Lib@$version"
+            echo "sdk_url=$base/bluetooth-sdk/$version/bluetooth-sdk-$version.aar"
+            echo "sdk_pom_url=$base/bluetooth-sdk/$version/bluetooth-sdk-$version.pom"
+            echo "lc3_url=$base/lc3Lib/$version/lc3Lib-$version.aar"
+            echo "lc3_pom_url=$base/lc3Lib/$version/lc3Lib-$version.pom"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - uses: android-actions/setup-android@v3
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Install exact mobile dependencies
+        working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Stage the coordinated family version and OTA pin
+        run: |
+          node .github/scripts/stage-release-family.mjs --plan release-intent/release-plan.json
+          node mobile/modules/bluetooth-sdk/scripts/write-release-metadata.mjs \
+            --family-base-version "$(jq -er .familyBaseVersion release-intent/release-plan.json)" \
+            --release-identity "${{ steps.release.outputs.version }}" \
+            --release-set-id "$(jq -er .releaseSetId release-intent/release-plan.json)" \
+            --source-commit "${{ inputs.source_commit }}" \
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}" \
+            --ota-manifest-sha256 "${{ inputs.ota_manifest_sha256 }}"
+
+      - name: Prepare generated Android project
+        working-directory: mobile
+        run: |
+          cp .env.example .env
+          bun expo prebuild --platform android
+
+      - name: Inspect public Maven state
+        id: existing
+        env:
+          LC3_POM_URL: ${{ steps.release.outputs.lc3_pom_url }}
+          SDK_POM_URL: ${{ steps.release.outputs.sdk_pom_url }}
+        run: |
+          set -euo pipefail
+          status() {
+            curl --silent --show-error --head --location --output /dev/null --write-out '%{http_code}' "$1" || true
+          }
+          sdk_status=$(status "$SDK_POM_URL")
+          lc3_status=$(status "$LC3_POM_URL")
+          if [[ "$sdk_status" == "200" && "$lc3_status" == "200" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$sdk_status" == "404" && "$lc3_status" == "404" ]]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$sdk_status" == "200" || "$lc3_status" == "200" ]]; then
+            echo "Maven Central contains only part of the coordinated Android SDK release." >&2
+            exit 1
+          else
+            echo "Unexpected Maven Central status (SDK $sdk_status, LC3 $lc3_status); refusing to guess registry state." >&2
+            exit 1
+          fi
+
+      - name: Build both Maven artifacts locally
+        working-directory: mobile/android
+        env:
+          MENTRA_MAVEN_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          ./gradlew \
+            :lc3Lib:publishToMavenLocal \
+            :mentra-bluetooth-sdk:publishToMavenLocal \
+            -PmentraPublicSdk=true \
+            --no-daemon \
+            --stacktrace
+
+      - name: Locate and verify locally built AARs
+        id: local
+        env:
+          OTA_MANIFEST_SHA256: ${{ inputs.ota_manifest_sha256 }}
+          OTA_MANIFEST_URL: ${{ inputs.ota_manifest_url }}
+          RELEASE_IDENTITY: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          sdk="$HOME/.m2/repository/com/mentraglass/bluetooth-sdk/$RELEASE_IDENTITY/bluetooth-sdk-$RELEASE_IDENTITY.aar"
+          lc3="$HOME/.m2/repository/com/mentraglass/lc3Lib/$RELEASE_IDENTITY/lc3Lib-$RELEASE_IDENTITY.aar"
+          test -f "$sdk"
+          test -f "$lc3"
+          unzip -p "$sdk" classes.jar > /tmp/mentra-sdk-classes.jar
+          javap -classpath /tmp/mentra-sdk-classes.jar -p -constants com.mentra.bluetoothsdk.GeneratedReleaseMetadata > /tmp/mentra-sdk-metadata.txt
+          javap -classpath /tmp/mentra-sdk-classes.jar -p -constants com.mentra.bluetoothsdk.BuildConfig >> /tmp/mentra-sdk-metadata.txt
+          grep -F "$RELEASE_IDENTITY" /tmp/mentra-sdk-metadata.txt
+          grep -F "$OTA_MANIFEST_URL" /tmp/mentra-sdk-metadata.txt
+          grep -F "$OTA_MANIFEST_SHA256" /tmp/mentra-sdk-metadata.txt
+          {
+            echo "sdk=$sdk"
+            echo "lc3=$lc3"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Require Maven Central credentials
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true'
+        env:
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+        run: |
+          set -euo pipefail
+          test -n "$MAVEN_CENTRAL_TOKEN_BASE64"
+
+      - name: Recover persisted Sonatype deployment
+        id: deployment
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+          RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
+          ASSET_NAME: ${{ steps.release.outputs.deployment_asset }}
+        run: |
+          set -euo pipefail
+          mkdir -p native-result/maven
+          assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?per_page=100" | jq 'add')
+          matches=$(jq --arg name "$ASSET_NAME" '[.[] | select(.name == $name)]' <<< "$assets")
+          count=$(jq 'length' <<< "$matches")
+          if [[ "$count" -gt 1 ]]; then
+            echo "Release contains duplicate Sonatype deployment records." >&2
+            exit 1
+          fi
+          if [[ "$count" == 1 ]]; then
+            asset_id=$(jq -er '.[0].id' <<< "$matches")
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > native-result/maven/sonatype-deployment.json
+            [[ "$(jq -er .deploymentName native-result/maven/sonatype-deployment.json)" == "${{ steps.release.outputs.deployment_name }}" ]]
+            jq -e \
+              --arg sdk "${{ steps.release.outputs.sdk_purl }}" \
+              --arg lc3 "${{ steps.release.outputs.lc3_purl }}" \
+              '.expectedPurls | sort == ([$sdk, $lc3] | sort)' \
+              native-result/maven/sonatype-deployment.json >/dev/null
+            node .github/scripts/sonatype-central-deployment.mjs inspect \
+              --record native-result/maven/sonatype-deployment.json \
+              --output native-result/maven/sonatype-inspection.json
+            if [[ "$(jq -er .disposition native-result/maven/sonatype-inspection.json)" == "replace" ]]; then
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id"
+              rm native-result/maven/sonatype-deployment.json
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Require Maven signing credentials for a new deployment
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true' && steps.deployment.outputs.exists != 'true'
+        env:
+          SIGNING_KEY: ${{ secrets.MAVEN_SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$SIGNING_KEY"
+          test -n "$SIGNING_PASSWORD"
+
+      - name: Build signed Maven Central bundle
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true' && steps.deployment.outputs.exists != 'true'
+        working-directory: mobile/android
+        env:
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+          MENTRA_MAVEN_STAGING_REPOSITORY_URL: file://${{ runner.temp }}/mentra-central-bundle
+          MENTRA_MAVEN_VERSION: ${{ steps.release.outputs.version }}
+          SIGNING_KEY: ${{ secrets.MAVEN_SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/mentra-central-bundle"
+          ./gradlew \
+            :lc3Lib:publishReleasePublicationToSonatypeCentralRepository \
+            :mentra-bluetooth-sdk:publishReleasePublicationToSonatypeCentralRepository \
+            -PmentraPublicSdk=true \
+            --no-daemon \
+            --stacktrace
+          find "$RUNNER_TEMP/mentra-central-bundle/com" -name 'maven-metadata.xml*' -delete
+          mkdir -p "$GITHUB_WORKSPACE/native-result/maven"
+          (
+            cd "$RUNNER_TEMP/mentra-central-bundle"
+            zip -q -r "$GITHUB_WORKSPACE/native-result/maven/central-bundle.zip" com
+          )
+
+      - name: Upload and persist a user-managed Sonatype deployment
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true' && steps.deployment.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+          RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
+          ASSET_NAME: ${{ steps.release.outputs.deployment_asset }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/sonatype-central-deployment.mjs upload \
+            --bundle native-result/maven/central-bundle.zip \
+            --name "${{ steps.release.outputs.deployment_name }}" \
+            --expected-purls "${{ steps.release.outputs.sdk_purl }},${{ steps.release.outputs.lc3_purl }}" \
+            --output native-result/maven/sonatype-deployment.json
+          encoded_name=$(jq -rn --arg value "$ASSET_NAME" '$value | @uri')
+          gh api \
+            --method POST \
+            -H "Content-Type: application/octet-stream" \
+            --input native-result/maven/sonatype-deployment.json \
+            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?name=$encoded_name" >/dev/null
+
+      - name: Publish or resume the persisted Sonatype deployment
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true'
+        env:
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+        run: |
+          node .github/scripts/sonatype-central-deployment.mjs publish \
+            --record native-result/maven/sonatype-deployment.json \
+            --output native-result/maven/sonatype-result.json
+
+      - name: Wait for and download public Maven artifacts
+        id: public
+        if: inputs.dry_run != true
+        env:
+          LC3_URL: ${{ steps.release.outputs.lc3_url }}
+          SDK_URL: ${{ steps.release.outputs.sdk_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p native-result/maven
+          for attempt in {1..180}; do
+            if curl --fail --silent --show-error --location "$SDK_URL" -o native-result/maven/bluetooth-sdk.aar \
+              && curl --fail --silent --show-error --location "$LC3_URL" -o native-result/maven/lc3Lib.aar; then
+              exit 0
+            fi
+            echo "Waiting for Maven Central propagation (attempt $attempt/180)"
+            sleep 10
+          done
+          echo "Maven Central did not expose the complete coordinated SDK within 30 minutes." >&2
+          exit 1
+
+      - name: Verify public Maven SDK metadata
+        if: inputs.dry_run != true
+        env:
+          OTA_MANIFEST_SHA256: ${{ inputs.ota_manifest_sha256 }}
+          OTA_MANIFEST_URL: ${{ inputs.ota_manifest_url }}
+          RELEASE_IDENTITY: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          unzip -p native-result/maven/bluetooth-sdk.aar classes.jar > /tmp/mentra-public-sdk-classes.jar
+          javap -classpath /tmp/mentra-public-sdk-classes.jar -p -constants com.mentra.bluetoothsdk.GeneratedReleaseMetadata > /tmp/mentra-public-sdk-metadata.txt
+          javap -classpath /tmp/mentra-public-sdk-classes.jar -p -constants com.mentra.bluetoothsdk.BuildConfig >> /tmp/mentra-public-sdk-metadata.txt
+          grep -F "$RELEASE_IDENTITY" /tmp/mentra-public-sdk-metadata.txt
+          grep -F "$OTA_MANIFEST_URL" /tmp/mentra-public-sdk-metadata.txt
+          grep -F "$OTA_MANIFEST_SHA256" /tmp/mentra-public-sdk-metadata.txt
+
+      - name: Stage dry-run Maven artifacts
+        if: inputs.dry_run == true
+        run: |
+          mkdir -p native-result/maven
+          cp "${{ steps.local.outputs.sdk }}" native-result/maven/bluetooth-sdk.aar
+          cp "${{ steps.local.outputs.lc3 }}" native-result/maven/lc3Lib.aar
+
+      - name: Write Maven publication record
+        env:
+          STATUS: ${{ inputs.dry_run && 'built' || ((steps.existing.outputs.exists == 'true' || steps.deployment.outputs.exists == 'true') && 'reused' || 'published') }}
+        run: >-
+          node .github/scripts/coordinated-sdk-native-records.mjs create-maven
+          --plan release-intent/release-plan.json
+          --sdk-aar native-result/maven/bluetooth-sdk.aar
+          --sdk-url "${{ steps.release.outputs.sdk_url }}"
+          --lc3-aar native-result/maven/lc3Lib.aar
+          --lc3-url "${{ steps.release.outputs.lc3_url }}"
+          --provenance-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --status "$STATUS"
+          --output native-result/maven-publication.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-sdk-maven-${{ github.run_id }}
+          path: native-result
+          if-no-files-found: error
+          retention-days: 90
+
+  swiftpm:
+    name: Publish and verify SwiftPM SDK
+    needs: prepare
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          path: MentraOS
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: MentraOS/release-intent
+
+      - name: Require SwiftPM mirror credential
+        if: inputs.dry_run != true
+        env:
+          PUSH_TOKEN: ${{ secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+        run: test -n "$PUSH_TOKEN"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: Mentra-Community/mentra-bluetooth-sdk-ios
+          path: mentra-bluetooth-sdk-ios
+          token: ${{ secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN || github.token }}
+          fetch-depth: 0
+
+      - name: Resolve SwiftPM release
+        id: release
+        working-directory: MentraOS
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          version=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          archive_name=$(jq -er .artifactNames.iosSdkArchive release-intent/release-plan.json)
+          [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "$SOURCE_COMMIT" ]]
+          {
+            echo "version=$version"
+            echo "archive_name=$archive_name"
+            echo "release_tag=mentra-v$version"
+            echo "archive_url=https://github.com/${{ github.repository }}/releases/download/mentra-v$version/$archive_name"
+            echo "tag_url=https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check public SwiftPM tag
+        id: existing
+        working-directory: mentra-bluetooth-sdk-ios
+        run: |
+          set -euo pipefail
+          git fetch --tags origin
+          if git rev-parse -q --verify "refs/tags/${{ steps.release.outputs.version }}^{commit}" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            git checkout --detach "refs/tags/${{ steps.release.outputs.version }}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stage coordinated Swift package source
+        if: steps.existing.outputs.exists != 'true'
+        working-directory: MentraOS
+        run: |
+          npm --prefix mobile/modules/bluetooth-sdk pkg set version="${{ steps.release.outputs.version }}"
+          node mobile/modules/bluetooth-sdk/scripts/write-release-metadata.mjs \
+            --family-base-version "$(jq -er .familyBaseVersion release-intent/release-plan.json)" \
+            --release-identity "${{ steps.release.outputs.version }}" \
+            --release-set-id "$(jq -er .releaseSetId release-intent/release-plan.json)" \
+            --source-commit "${{ inputs.source_commit }}" \
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}" \
+            --ota-manifest-sha256 "${{ inputs.ota_manifest_sha256 }}"
+          scripts/export-bluetooth-sdk-ios-spm.sh \
+            --target "$GITHUB_WORKSPACE/mentra-bluetooth-sdk-ios" \
+            --verify
+
+      - name: Commit exact SwiftPM export locally
+        if: steps.existing.outputs.exists != 'true'
+        working-directory: mentra-bluetooth-sdk-ios
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Package.swift README.md LICENSE ios .gitignore
+          if ! git diff --cached --quiet; then
+            git commit -m "Release MentraBluetoothSDK ${{ steps.release.outputs.version }}" \
+              -m "Exported from MentraOS ${{ inputs.source_commit }}."
+          fi
+
+      - name: Verify selected SwiftPM package and archive
+        id: selected
+        working-directory: mentra-bluetooth-sdk-ios
+        run: |
+          set -euo pipefail
+          mirror_sha=$(git rev-parse HEAD)
+          node "$GITHUB_WORKSPACE/MentraOS/.github/scripts/coordinated-sdk-native-records.mjs" verify-swiftpm \
+            --plan "$GITHUB_WORKSPACE/MentraOS/release-intent/release-plan.json" \
+            --package-root "$GITHUB_WORKSPACE/mentra-bluetooth-sdk-ios" \
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}" \
+            --ota-manifest-sha256 "${{ inputs.ota_manifest_sha256 }}"
+          mkdir -p "$GITHUB_WORKSPACE/native-result/swiftpm"
+          git archive --format=tar "$mirror_sha" > "$GITHUB_WORKSPACE/native-result/swiftpm/${{ steps.release.outputs.archive_name }}"
+          echo "mirror_sha=$mirror_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Publish verified SwiftPM commit and tag
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true'
+        working-directory: mentra-bluetooth-sdk-ios
+        run: |
+          set -euo pipefail
+          mirror_sha="${{ steps.selected.outputs.mirror_sha }}"
+          git push origin "${mirror_sha}:refs/heads/main"
+          git tag "${{ steps.release.outputs.version }}" "$mirror_sha"
+          git push origin "refs/tags/${{ steps.release.outputs.version }}"
+
+      - name: Publish exact SwiftPM archive as immutable release asset
+        if: inputs.dry_run != true
+        working-directory: MentraOS
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHIVE: ${{ github.workspace }}/native-result/swiftpm/${{ steps.release.outputs.archive_name }}
+          ARCHIVE_NAME: ${{ steps.release.outputs.archive_name }}
+          RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?per_page=100" | jq 'add')
+          matches=$(jq --arg name "$ARCHIVE_NAME" '[.[] | select(.name == $name)]' <<< "$assets")
+          count=$(jq 'length' <<< "$matches")
+          if [[ "$count" -gt 1 ]]; then
+            echo "Release contains duplicate SwiftPM archives." >&2
+            exit 1
+          elif [[ "$count" == 1 ]]; then
+            asset_id=$(jq -er '.[0].id' <<< "$matches")
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > "$RUNNER_TEMP/existing-swiftpm.tar"
+            cmp "$ARCHIVE" "$RUNNER_TEMP/existing-swiftpm.tar"
+          else
+            encoded_name=$(jq -rn --arg value "$ARCHIVE_NAME" '$value | @uri')
+            gh api \
+              --method POST \
+              -H "Content-Type: application/octet-stream" \
+              --input "$ARCHIVE" \
+              "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?name=$encoded_name" >/dev/null
+          fi
+
+      - name: Write SwiftPM publication record
+        working-directory: MentraOS
+        env:
+          STATUS: ${{ inputs.dry_run && 'built' || (steps.existing.outputs.exists == 'true' && 'reused' || 'published') }}
+        run: >-
+          node .github/scripts/coordinated-sdk-native-records.mjs create-swiftpm
+          --plan release-intent/release-plan.json
+          --archive "$GITHUB_WORKSPACE/native-result/swiftpm/${{ steps.release.outputs.archive_name }}"
+          --archive-url "${{ steps.release.outputs.archive_url }}"
+          --tag-url "${{ steps.release.outputs.tag_url }}"
+          --mirror-commit "${{ steps.selected.outputs.mirror_sha }}"
+          --provenance-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --status "$STATUS"
+          --output "$GITHUB_WORKSPACE/native-result/swiftpm-publication.json"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-sdk-swiftpm-${{ github.run_id }}
+          path: native-result
+          if-no-files-found: error
+          retention-days: 90
+
+  result:
+    name: Assemble native SDK result
+    needs: [maven, swiftpm]
+    runs-on: ubuntu-latest
+    outputs:
+      result_artifact: ${{ steps.name.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coordinated-sdk-maven-${{ github.run_id }}
+          path: result/maven
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coordinated-sdk-swiftpm-${{ github.run_id }}
+          path: result/swiftpm
+
+      - name: Merge exact native publication records
+        run: >-
+          node .github/scripts/coordinated-sdk-native-records.mjs merge
+          --plan release-intent/release-plan.json
+          --maven result/maven/maven-publication.json
+          --swiftpm result/swiftpm/swiftpm-publication.json
+          --output result/sdk-native-publications.json
+
+      - name: Name final result
+        id: name
+        run: echo "value=coordinated-sdk-native-$(jq -er .releaseSetId release-intent/release-plan.json)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.name.outputs.value }}
+          path: result
+          if-no-files-found: error
+          retention-days: 90

--- a/mobile/modules/bluetooth-sdk/android/build.gradle
+++ b/mobile/modules/bluetooth-sdk/android/build.gradle
@@ -379,10 +379,13 @@ afterEvaluate {
     repositories {
       maven {
         name = 'sonatypeCentral'
-        url = uri('https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/')
-        credentials {
-          username = centralUsername()
-          password = centralPassword()
+        def repositoryUrl = System.getenv('MENTRA_MAVEN_STAGING_REPOSITORY_URL') ?: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+        url = uri(repositoryUrl)
+        if (repositoryUrl.startsWith('http')) {
+          credentials {
+            username = centralUsername()
+            password = centralPassword()
+          }
         }
       }
     }

--- a/mobile/modules/bluetooth-sdk/android/lc3Lib/build.gradle
+++ b/mobile/modules/bluetooth-sdk/android/lc3Lib/build.gradle
@@ -181,10 +181,13 @@ afterEvaluate {
         repositories {
             maven {
                 name = 'sonatypeCentral'
-                url = uri('https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/')
-                credentials {
-                    username = centralUsername()
-                    password = centralPassword()
+                def repositoryUrl = System.getenv('MENTRA_MAVEN_STAGING_REPOSITORY_URL') ?: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+                url = uri(repositoryUrl)
+                if (repositoryUrl.startsWith('http')) {
+                    credentials {
+                        username = centralUsername()
+                        password = centralPassword()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What this changes

This layer moves the Bluetooth SDK's native Android and iOS distributions under the immutable coordinated release plan.

It adds one reusable workflow that consumes the exact source commit, release-plan artifact, and OTA manifest URL/hash selected by the coordinator. Maven Central and SwiftPM no longer derive an independent SDK version or OTA target.

## Maven Central

The Android job:

- stages the shared release identity into the isolated checkout after the frozen install
- generates Kotlin release metadata with the exact coordinated OTA pin
- builds both `com.mentraglass:bluetooth-sdk` and its required `com.mentraglass:lc3Lib` companion
- uses exact 200/404 checks and fails closed on network ambiguity or a partial existing release
- inspects compiled constants in the local SDK AAR for the release identity, OTA URL, and OTA SHA-256
- publishes both signed artifacts together with automatic Central publication
- waits until both coordinates are publicly downloadable
- repeats the compiled-metadata inspection against the public AAR
- emits hashes, sizes, coordinates, URLs, and provenance for both artifacts

An already-public pair is reused only after rebuilding the source and verifying the public SDK's embedded metadata. A single existing coordinate is treated as corruption, not as a skippable state.

## SwiftPM

The iOS job:

- stamps the exact shared version and release metadata into an isolated source checkout
- exports the public SwiftPM package with the repository's existing exporter
- runs `swift package describe` and a generic iOS Xcode build
- verifies the exported version, README constraint, source commit, release-set identity, and exact OTA URL/hash
- publishes one mirror commit and tags that exact commit with the coordinated release identity
- reconciles an existing public tag by checking out and verifying its contents
- records a deterministic Git archive hash plus the full mirror commit SHA

The public tag is the SwiftPM release. The workflow does not move or overwrite an existing tag.

## Coordination and retries

Native SDK publication has a global non-cancelling lock because Maven coordinates and Swift tags are shared immutable namespaces. Dev and beta packages are made publicly readable so downstream Engine publication can resolve the exact same-version SDK dependency before the release is finalized.

The final job merges Maven and SwiftPM evidence into one machine-readable native SDK result artifact for the release manifest.

## Validation

- `actionlint .github/workflows/reusable-coordinated-sdk-native.yml`
- 19 combined release tests, including native record merge and Swift package pin validation
- isolated real SwiftPM export and generic iOS Xcode build from the committed tree
- exported package release-metadata and placeholder verification
- Prettier and `git diff --check`

This stack layer depends on #3765.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Automates immutable Maven Central and external iOS mirror pushes with signing secrets and fail-closed registry checks; mistakes or partial publishes affect public SDK consumers and OTA pins embedded in artifacts.
> 
> **Overview**
> Adds a **reusable GitHub Actions workflow** that publishes `@mentra/bluetooth-sdk` to **Maven Central** and **SwiftPM** from the coordinated release plan (source commit, plan artifact, OTA URL/SHA), instead of independent native versioning.
> 
> **Maven:** Stages release metadata, builds `bluetooth-sdk` and `lc3Lib`, fails on partial Central state, publishes via **user-managed Sonatype** deployments with **recoverable** deployment records on the draft GitHub release, polls until both coordinates are public, and verifies embedded OTA pins in local and public AARs. **Gradle** can stage to a local `file://` repo via `MENTRA_MAVEN_STAGING_REPOSITORY_URL` for CI bundling.
> 
> **SwiftPM:** Exports to `mentra-bluetooth-sdk-ios`, verifies version/README/metadata/OTA pins, tags the mirror repo when needed, uploads a deterministic archive to the coordinated release, and records mirror commit + URLs.
> 
> New **Node helpers** create/merge canonical native publication records (`built` / `published` / `reused`) and drive Sonatype upload/inspect/publish; tests cover records, Swift pin checks, and deployment state machine. Release plan tests now expect **`iosSdkArchive`** naming. A global workflow **concurrency** lock serializes native publication; a final job merges Maven and Swift evidence into **`sdk-native-publications.json`** for downstream manifest assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3766a572c5f6a57161836f1fb3d56038187d781b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->