### PR TITLE
ci(release): coordinate MentraOS mobile distribution

### DIFF
--- a/.github/scripts/coordinated-mobile-records.mjs
+++ b/.github/scripts/coordinated-mobile-records.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+const STATUSES = new Set(["built", "published", "reused"])
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"))
+}
+
+function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex")
+}
+
+function requireHttps(value, label) {
+  const url = new URL(value)
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new Error(`${label} must be credential-free HTTPS without a fragment`)
+  }
+  return url.toString()
+}
+
+function validatePlan(plan) {
+  const app = plan.members?.mentraos
+  if (plan.releaseSetId !== `mentra-${plan.releaseIdentity}` || app?.version !== plan.releaseIdentity) {
+    throw new Error("Release plan does not contain the coordinated MentraOS product")
+  }
+  if (!Number.isSafeInteger(plan.native?.buildNumber) || plan.native.marketingVersion !== plan.familyBaseVersion) {
+    throw new Error("Release plan has invalid native version metadata")
+  }
+}
+
+function publication({status, coordinate, url, provenanceUrl, file}) {
+  if (!STATUSES.has(status)) throw new Error(`Unsupported mobile publication status ${JSON.stringify(status)}`)
+  return {
+    status,
+    coordinate,
+    url: requireHttps(url, `${coordinate} URL`),
+    provenanceUrl: requireHttps(provenanceUrl, `${coordinate} provenance URL`),
+    sha256: sha256File(file),
+    size: statSync(file).size,
+  }
+}
+
+export function createAndroidRecord({plan, apk, apkUrl, aab, aabUrl, playTrack, storeStatus, provenanceUrl}) {
+  validatePlan(plan)
+  if (!playTrack) throw new Error("Google Play track is required")
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    publications: {
+      mentraos: {
+        "google-play": publication({
+          status: storeStatus,
+          coordinate: `com.mentra.mentra:${plan.native.buildNumber}:${playTrack}`,
+          url: "https://play.google.com/console/",
+          provenanceUrl,
+          file: aab,
+        }),
+      },
+    },
+    artifacts: [
+      publication({
+        status: storeStatus,
+        coordinate: plan.artifactNames.androidApp,
+        url: apkUrl,
+        provenanceUrl,
+        file: apk,
+      }),
+      publication({
+        status: storeStatus,
+        coordinate: plan.artifactNames.androidStoreApp,
+        url: aabUrl,
+        provenanceUrl,
+        file: aab,
+      }),
+    ],
+  }
+}
+
+export function createIosRecord({plan, ipa, ipaUrl, testflightGroup, storeStatus, provenanceUrl}) {
+  validatePlan(plan)
+  if (!testflightGroup) throw new Error("TestFlight group is required")
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    publications: {
+      mentraos: {
+        "app-store-connect": publication({
+          status: storeStatus,
+          coordinate: `com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:${testflightGroup}`,
+          url: "https://appstoreconnect.apple.com/apps",
+          provenanceUrl,
+          file: ipa,
+        }),
+      },
+    },
+    artifacts: [
+      publication({
+        status: storeStatus,
+        coordinate: plan.artifactNames.iosApp,
+        url: ipaUrl,
+        provenanceUrl,
+        file: ipa,
+      }),
+    ],
+  }
+}
+
+export function mergeMobileRecords({plan, android, ios}) {
+  validatePlan(plan)
+  for (const [platform, record] of Object.entries({android, ios})) {
+    if (record.releaseSetId !== plan.releaseSetId) throw new Error(`${platform} result belongs to another release set`)
+  }
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    publications: {
+      mentraos: {...android.publications.mentraos, ...ios.publications.mentraos},
+    },
+    artifacts: [...android.artifacts, ...ios.artifacts],
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const command = process.argv[2]
+  const args = parseArgs(process.argv.slice(3))
+  const plan = readJson(path.resolve(args.plan))
+  let record
+  if (command === "create-android") {
+    record = createAndroidRecord({
+      plan,
+      apk: path.resolve(args.apk),
+      apkUrl: args["apk-url"],
+      aab: path.resolve(args.aab),
+      aabUrl: args["aab-url"],
+      playTrack: args["play-track"],
+      storeStatus: args.status,
+      provenanceUrl: args["provenance-url"],
+    })
+  } else if (command === "create-ios") {
+    record = createIosRecord({
+      plan,
+      ipa: path.resolve(args.ipa),
+      ipaUrl: args["ipa-url"],
+      testflightGroup: args["testflight-group"],
+      storeStatus: args.status,
+      provenanceUrl: args["provenance-url"],
+    })
+  } else if (command === "merge") {
+    record = mergeMobileRecords({plan, android: readJson(args.android), ios: readJson(args.ios)})
+  } else {
+    throw new Error(`Unknown command ${JSON.stringify(command)}`)
+  }
+  writeFileSync(args.output, serializeReleaseRecord(record))
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/coordinated-mobile-records.test.mjs
+++ b/.github/scripts/coordinated-mobile-records.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import {mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {createAndroidRecord, createIosRecord, mergeMobileRecords} from "./coordinated-mobile-records.mjs"
+
+const plan = {
+  familyBaseVersion: "3.1.0",
+  releaseIdentity: "3.1.0-beta.57",
+  releaseSetId: "mentra-3.1.0-beta.57",
+  native: {marketingVersion: "3.1.0", buildNumber: 310000057},
+  members: {mentraos: {version: "3.1.0-beta.57"}},
+  artifactNames: {
+    androidApp: "mentraos-3.1.0-beta.57-android.apk",
+    androidStoreApp: "mentraos-3.1.0-beta.57-android.aab",
+    iosApp: "mentraos-3.1.0-beta.57-ios.ipa",
+  },
+}
+
+test("records and merges exact mobile store and downloadable artifacts", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "coordinated-mobile-records-"))
+  const apk = path.join(root, "app.apk")
+  const aab = path.join(root, "app.aab")
+  const ipa = path.join(root, "app.ipa")
+  writeFileSync(apk, "apk")
+  writeFileSync(aab, "aab")
+  writeFileSync(ipa, "ipa")
+  const base = "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57"
+  const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
+  const android = createAndroidRecord({
+    plan,
+    apk,
+    apkUrl: `${base}/${plan.artifactNames.androidApp}`,
+    aab,
+    aabUrl: `${base}/${plan.artifactNames.androidStoreApp}`,
+    playTrack: "beta",
+    storeStatus: "published",
+    provenanceUrl,
+  })
+  const ios = createIosRecord({
+    plan,
+    ipa,
+    ipaUrl: `${base}/${plan.artifactNames.iosApp}`,
+    testflightGroup: "Beta",
+    storeStatus: "reused",
+    provenanceUrl,
+  })
+  const merged = mergeMobileRecords({plan, android, ios})
+
+  assert.equal(merged.publications.mentraos["google-play"].coordinate, "com.mentra.mentra:310000057:beta")
+  assert.equal(merged.publications.mentraos["app-store-connect"].status, "reused")
+  assert.equal(merged.artifacts.length, 3)
+})

--- a/.github/scripts/prepare-mobile-release-env.mjs
+++ b/.github/scripts/prepare-mobile-release-env.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+const CLOUDS = {
+  dev: {
+    core: "https://core.dev.us-west-2.mentraglass.com",
+    runtime: "https://runtime.dev.us-west-2.mentraglass.com",
+  },
+  staging: {
+    core: "https://core.staging.us-west-2.mentraglass.com",
+    runtime: "https://runtime.staging.us-west-2.mentraglass.com",
+  },
+  prod: {
+    core: "https://core.us-west-2.mentraglass.com",
+    runtime: "https://runtime.us-west-2.mentraglass.com",
+  },
+}
+
+function requireHttps(value, label) {
+  const url = new URL(value)
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new Error(`${label} must be credential-free HTTPS without a fragment`)
+  }
+  return url.toString()
+}
+
+function parseEnv(contents) {
+  const values = new Map()
+  for (const line of contents.split(/\r?\n/)) {
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line)
+    if (match) values.set(match[1], match[2])
+  }
+  return values
+}
+
+export function prepareMobileReleaseEnvironment({plan, template, cloudEnvironment, otaManifestUrl, publicValues}) {
+  if (plan.releaseSetId !== `mentra-${plan.releaseIdentity}` || plan.products?.mentraos !== plan.releaseIdentity) {
+    throw new Error("Release plan does not contain the coordinated MentraOS product")
+  }
+  if (!Number.isSafeInteger(plan.native?.buildNumber) || plan.native.buildNumber < 1) {
+    throw new Error("Release plan has no valid native build number")
+  }
+  if (plan.native.marketingVersion !== plan.familyBaseVersion) {
+    throw new Error("Native marketing version must equal the family base")
+  }
+  const cloud = CLOUDS[cloudEnvironment]
+  if (!cloud) throw new Error(`Unsupported mobile cloud environment ${JSON.stringify(cloudEnvironment)}`)
+  const values = parseEnv(template)
+  const updates = {
+    EXPO_PUBLIC_ASG_OTA_VERSION_URL: requireHttps(otaManifestUrl, "OTA manifest URL"),
+    EXPO_PUBLIC_BUILD_ENV: cloudEnvironment,
+    EXPO_PUBLIC_CLOUD_CORE_URL: cloud.core,
+    EXPO_PUBLIC_CLOUD_RUNTIME_URL: cloud.runtime,
+    EXPO_PUBLIC_MENTRAOS_VERSION: plan.releaseIdentity,
+    MENTRAOS_NATIVE_MARKETING_VERSION: plan.native.marketingVersion,
+    MENTRAOS_PINNED_BUILD_NUMBER: String(plan.native.buildNumber),
+    ...publicValues,
+  }
+  for (const [key, value] of Object.entries(updates)) {
+    if (typeof value !== "string" || value.trim() === "") throw new Error(`${key} must be a non-empty string`)
+    if (/\r|\n/.test(value)) throw new Error(`${key} must be a single-line value`)
+    values.set(key, value)
+  }
+  return `${[...values].map(([key, value]) => `${key}=${value}`).join("\n")}\n`
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const envFile = path.resolve(args["env-file"])
+  const rendered = prepareMobileReleaseEnvironment({
+    plan: JSON.parse(readFileSync(path.resolve(args.plan), "utf8")),
+    template: readFileSync(envFile, "utf8"),
+    cloudEnvironment: args["cloud-environment"],
+    otaManifestUrl: args["ota-manifest-url"],
+    publicValues: {
+      EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN: args["mapbox-public-token"],
+      EXPO_PUBLIC_SENTRY_DSN: args["sentry-dsn"],
+    },
+  })
+  writeFileSync(envFile, rendered)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/prepare-mobile-release-env.test.mjs
+++ b/.github/scripts/prepare-mobile-release-env.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {prepareMobileReleaseEnvironment} from "./prepare-mobile-release-env.mjs"
+
+const plan = {
+  familyBaseVersion: "3.1.0",
+  releaseIdentity: "3.1.0-beta.57",
+  releaseSetId: "mentra-3.1.0-beta.57",
+  products: {mentraos: "3.1.0-beta.57"},
+  native: {marketingVersion: "3.1.0", buildNumber: 310000057},
+}
+
+test("separates the observable release identity from native store version fields", () => {
+  const output = prepareMobileReleaseEnvironment({
+    plan,
+    template: "EXPO_PUBLIC_MENTRAOS_VERSION=old\nEXPO_PUBLIC_CLOUD_CORE_URL=old\n",
+    cloudEnvironment: "prod",
+    otaManifestUrl: "https://example.com/ota.json",
+    publicValues: {
+      EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN: "pk.example",
+      EXPO_PUBLIC_SENTRY_DSN: "https://public@example.ingest.sentry.io/1",
+    },
+  })
+
+  assert.match(output, /^EXPO_PUBLIC_MENTRAOS_VERSION=3\.1\.0-beta\.57$/m)
+  assert.match(output, /^MENTRAOS_NATIVE_MARKETING_VERSION=3\.1\.0$/m)
+  assert.match(output, /^MENTRAOS_PINNED_BUILD_NUMBER=310000057$/m)
+  assert.match(output, /^EXPO_PUBLIC_CLOUD_CORE_URL=https:\/\/core\.us-west-2\.mentraglass\.com$/m)
+})
+
+test("rejects unknown clouds and invalid OTA URLs", () => {
+  const input = {
+    plan,
+    template: "",
+    cloudEnvironment: "prod",
+    otaManifestUrl: "http://example.com/ota.json",
+    publicValues: {EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN: "pk.example", EXPO_PUBLIC_SENTRY_DSN: "https://example.com/1"},
+  }
+  assert.throws(() => prepareMobileReleaseEnvironment(input), /must be credential-free HTTPS/)
+  assert.throws(
+    () => prepareMobileReleaseEnvironment({...input, otaManifestUrl: "https://example.com", cloudEnvironment: "qa"}),
+    /Unsupported/,
+  )
+})

--- a/.github/scripts/publish-immutable-release-asset.mjs
+++ b/.github/scripts/publish-immutable-release-asset.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import {execFileSync} from "node:child_process"
+import {readFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function gh(args, options = {}) {
+  return execFileSync("gh", args, {stdio: ["ignore", "pipe", "inherit"], ...options})
+}
+
+export function matchingAsset(assets, name) {
+  const matches = assets.filter((asset) => asset.name === name)
+  if (matches.length > 1) throw new Error(`Release contains duplicate asset ${name}`)
+  return matches[0] || null
+}
+
+export function releaseAssetUploadUrl(repository, releaseId, name) {
+  return `https://uploads.github.com/repos/${repository}/releases/${releaseId}/assets?name=${encodeURIComponent(name)}`
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const file = path.resolve(args.file)
+  const name = args.name
+  const releaseId = args["release-id"]
+  const repository = args.repository
+  if (!file || !name || !releaseId || !repository) {
+    throw new Error("--file, --name, --release-id, and --repository are required")
+  }
+  if (path.basename(file) !== name) throw new Error("Immutable asset name must equal the source file basename")
+  const pages = JSON.parse(
+    gh(["api", "--paginate", "--slurp", `repos/${repository}/releases/${releaseId}/assets?per_page=100`], {
+      encoding: "utf8",
+    }),
+  )
+  const assets = pages.flat()
+  const existing = matchingAsset(assets, name)
+  if (!existing) {
+    gh(
+      [
+        "api",
+        "--method",
+        "POST",
+        "-H",
+        "Content-Type: application/octet-stream",
+        "--input",
+        file,
+        releaseAssetUploadUrl(repository, releaseId, name),
+      ],
+      {stdio: "inherit"},
+    )
+    console.log(`Published immutable release asset ${name}`)
+  } else {
+    const downloaded = gh(
+      ["api", "-H", "Accept: application/octet-stream", `repos/${repository}/releases/assets/${existing.id}`],
+      {encoding: null, maxBuffer: 1024 * 1024 * 1024},
+    )
+    if (!readFileSync(file).equals(downloaded)) {
+      throw new Error(`Refusing to overwrite immutable release asset ${name} with different bytes`)
+    }
+    console.log(`Verified existing immutable release asset ${name}`)
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/publish-immutable-release-asset.test.mjs
+++ b/.github/scripts/publish-immutable-release-asset.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {matchingAsset, releaseAssetUploadUrl} from "./publish-immutable-release-asset.mjs"
+
+test("selects one immutable release asset and rejects duplicates", () => {
+  assert.equal(matchingAsset([{name: "one"}, {name: "two"}], "two").name, "two")
+  assert.equal(matchingAsset([{name: "one"}], "missing"), null)
+  assert.throws(() => matchingAsset([{name: "one"}, {name: "one"}], "one"), /duplicate/)
+})
+
+test("targets GitHub's release upload host without enterprise API routing", () => {
+  assert.equal(
+    releaseAssetUploadUrl("Mentra-Community/MentraOS", "123", "Mentra 3.1.0 #1.apk"),
+    "https://uploads.github.com/repos/Mentra-Community/MentraOS/releases/123/assets?name=Mentra%203.1.0%20%231.apk",
+  )
+})

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -1,0 +1,736 @@
+name: Reusable Coordinated MentraOS Mobile Release
+
+on:
+  workflow_call:
+    inputs:
+      source_commit:
+        required: true
+        type: string
+      release_plan_artifact:
+        required: true
+        type: string
+      ota_manifest_url:
+        required: true
+        type: string
+      ota_manifest_sha256:
+        required: true
+        type: string
+      cloud_environment:
+        required: true
+        type: string
+      play_track:
+        required: true
+        type: string
+      testflight_group:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      UPLOAD_KEYSTORE_B64:
+        required: false
+      MENTRAOS_UPLOAD_STORE_PASSWORD:
+        required: false
+      MENTRAOS_UPLOAD_KEY_PASSWORD:
+        required: false
+      MENTRAOS_UPLOAD_KEY_ALIAS:
+        required: false
+      GOOGLE_PLAY_KEY_JSON:
+        required: false
+      ASC_API_KEY_P8_B64:
+        required: false
+      ASC_API_KEY_ID:
+        required: false
+      ASC_API_ISSUER_ID:
+        required: false
+      MATCH_PASSWORD:
+        required: false
+      MATCH_GIT_BASIC_AUTHORIZATION:
+        required: false
+      MAPBOX_PUBLIC_TOKEN:
+        required: false
+      MAPBOX_DOWNLOADS_TOKEN:
+        required: false
+      DOPPLER_TOKEN:
+        required: false
+      SENTRY_AUTH_TOKEN:
+        required: false
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID:
+        required: false
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY:
+        required: false
+    outputs:
+      result_artifact:
+        value: ${{ jobs.result.outputs.result_artifact }}
+      release_tag:
+        value: ${{ jobs.prepare.outputs.release_tag }}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: coordinated-mobile-publication
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare immutable mobile release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      release_identity: ${{ steps.release.outputs.release_identity }}
+      release_set_id: ${{ steps.release.outputs.release_set_id }}
+      marketing_version: ${{ steps.release.outputs.marketing_version }}
+      build_number: ${{ steps.release.outputs.build_number }}
+      apk_name: ${{ steps.release.outputs.apk_name }}
+      aab_name: ${{ steps.release.outputs.aab_name }}
+      ipa_name: ${{ steps.release.outputs.ipa_name }}
+      asset_base_url: ${{ steps.release.outputs.asset_base_url }}
+      release_id: ${{ steps.container.outputs.release_id }}
+      android_assets_exist: ${{ steps.container.outputs.android_assets_exist }}
+      apk_asset_id: ${{ steps.container.outputs.apk_asset_id }}
+      aab_asset_id: ${{ steps.container.outputs.aab_asset_id }}
+      ios_asset_exists: ${{ steps.container.outputs.ios_asset_exists }}
+      ipa_asset_id: ${{ steps.container.outputs.ipa_asset_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - name: Validate plan and resolve stable names
+        id: release
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          source=$(jq -er .sourceCommit release-intent/release-plan.json)
+          [[ "$source" == "$SOURCE_COMMIT" ]]
+          identity=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          release_set_id=$(jq -er .releaseSetId release-intent/release-plan.json)
+          tag="mentra-v${identity}"
+          {
+            echo "release_tag=$tag"
+            echo "release_identity=$identity"
+            echo "release_set_id=$release_set_id"
+            echo "marketing_version=$(jq -er .native.marketingVersion release-intent/release-plan.json)"
+            echo "build_number=$(jq -er .native.buildNumber release-intent/release-plan.json)"
+            echo "apk_name=$(jq -er .artifactNames.androidApp release-intent/release-plan.json)"
+            echo "aab_name=$(jq -er .artifactNames.androidStoreApp release-intent/release-plan.json)"
+            echo "ipa_name=$(jq -er .artifactNames.iosApp release-intent/release-plan.json)"
+            echo "asset_base_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify the selected OTA manifest is live and exact
+        if: inputs.dry_run != true
+        env:
+          EXPECTED_SHA256: ${{ inputs.ota_manifest_sha256 }}
+          MANIFEST_URL: ${{ inputs.ota_manifest_url }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location "$MANIFEST_URL" -o /tmp/coordinated-mobile-ota.json
+          actual=$(sha256sum /tmp/coordinated-mobile-ota.json | awk '{print $1}')
+          [[ "$actual" == "$EXPECTED_SHA256" ]]
+          .github/scripts/validate-asg-ota-manifest.sh /tmp/coordinated-mobile-ota.json --check-apk
+
+      - name: Create, verify, and inspect the release container
+        id: container
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release.outputs.release_tag }}"
+          releases=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq 'add')
+          matches=$(jq --arg tag "$tag" '[.[] | select(.tag_name == $tag)]' <<< "$releases")
+          count=$(jq 'length' <<< "$matches")
+          if [[ "$count" -gt 1 ]]; then
+            echo "GitHub contains multiple releases for $tag." >&2
+            exit 1
+          elif [[ "$count" == 0 ]]; then
+            payload=$(jq -n \
+              --arg tag "$tag" \
+              --arg source "$SOURCE_COMMIT" \
+              --arg name "Mentra ${{ steps.release.outputs.release_identity }}" \
+              --arg body "Coordinated release set ${{ steps.release.outputs.release_set_id }}. This draft is published only after every required target is verified." \
+              '{tag_name: $tag, target_commitish: $source, name: $name, body: $body, draft: true, prerelease: true}')
+            release=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input - <<< "$payload")
+          else
+            release=$(jq '.[0]' <<< "$matches")
+          fi
+          [[ "$(jq -r .name <<< "$release")" == "Mentra ${{ steps.release.outputs.release_identity }}" ]]
+          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
+            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
+          else
+            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
+          fi
+
+          release_id=$(jq -er .id <<< "$release")
+          assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$release_id/assets?per_page=100" | jq 'add')
+          asset_id() {
+            local name="$1"
+            local matches
+            matches=$(jq --arg name "$name" '[.[] | select(.name == $name)]' <<< "$assets")
+            [[ "$(jq 'length' <<< "$matches")" -le 1 ]] || {
+              echo "Release contains duplicate asset $name." >&2
+              exit 1
+            }
+            jq -r '.[0].id // empty' <<< "$matches"
+          }
+          apk_id=$(asset_id "${{ steps.release.outputs.apk_name }}")
+          aab_id=$(asset_id "${{ steps.release.outputs.aab_name }}")
+          ipa_id=$(asset_id "${{ steps.release.outputs.ipa_name }}")
+          android_assets_exist=false
+          if [[ -n "$apk_id" && -n "$aab_id" ]]; then
+            android_assets_exist=true
+          elif [[ -n "$apk_id" || -n "$aab_id" ]]; then
+            echo "Removing an interrupted Android asset pair before rebuilding it."
+            [[ -z "$apk_id" ]] || gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/$apk_id"
+            [[ -z "$aab_id" ]] || gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/$aab_id"
+            apk_id=""
+            aab_id=""
+          fi
+          {
+            echo "release_id=$release_id"
+            echo "android_assets_exist=$android_assets_exist"
+            echo "apk_asset_id=$apk_id"
+            echo "aab_asset_id=$aab_id"
+            echo "ios_asset_exists=$([[ -n "$ipa_id" ]] && echo true || echo false)"
+            echo "ipa_asset_id=$ipa_id"
+          } >> "$GITHUB_OUTPUT"
+
+  android:
+    name: Build and distribute coordinated Android app
+    needs: prepare
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 60
+    env:
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
+      ORG_GRADLE_PROJECT_reactNativeArchitectures: armeabi-v7a,arm64-v8a,x86,x86_64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install Android build tools used for artifact verification
+        run: sdkmanager "build-tools;36.0.0"
+
+      - uses: oven-sh/setup-bun@v2
+        if: inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true'
+        with:
+          bun-version: 1.4.0
+
+      - name: Install exact workspace dependencies
+        if: inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true'
+        working-directory: mobile
+        run: bun install --frozen-lockfile
+
+      - name: Generate exact mobile environment and package metadata
+        if: inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$DOPPLER_TOKEN"
+          test -n "$MAPBOX_PUBLIC_TOKEN"
+          response=$(curl --fail --silent --show-error --retry 3 -u "$DOPPLER_TOKEN:" \
+            "https://api.doppler.com/v3/configs/config/secret?name=EXPO_PUBLIC_SENTRY_DSN")
+          sentry_dsn=$(jq -er '.value.computed // .computed' <<< "$response")
+          echo "::add-mask::$sentry_dsn"
+          cp mobile/.env.example mobile/.env
+          node .github/scripts/prepare-mobile-release-env.mjs \
+            --plan release-intent/release-plan.json \
+            --env-file mobile/.env \
+            --cloud-environment "${{ inputs.cloud_environment }}" \
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}" \
+            --mapbox-public-token "$MAPBOX_PUBLIC_TOKEN" \
+            --sentry-dsn "$sentry_dsn"
+          node .github/scripts/stage-release-family.mjs --plan release-intent/release-plan.json
+          metadata=(
+            --family-base-version "${{ needs.prepare.outputs.marketing_version }}"
+            --release-identity "${{ needs.prepare.outputs.release_identity }}"
+            --release-set-id "${{ needs.prepare.outputs.release_set_id }}"
+            --source-commit "${{ inputs.source_commit }}"
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}"
+            --ota-manifest-sha256 "${{ inputs.ota_manifest_sha256 }}"
+          )
+          node mobile/modules/bluetooth-sdk/scripts/write-release-metadata.mjs "${metadata[@]}"
+          node mobile/modules/engine/scripts/write-release-metadata.mjs "${metadata[@]}"
+          grep -E '^(EXPO_PUBLIC_|MENTRAOS_NATIVE_MARKETING_VERSION|MENTRAOS_PINNED_BUILD_NUMBER)=' mobile/.env >> "$GITHUB_ENV"
+          echo "MENTRA_COORDINATED_RELEASE_CHANNEL=${{ inputs.play_track }}" >> "$GITHUB_ENV"
+
+      - name: Inject Android signing and Play credentials
+        uses: ./.github/actions/inject-signing
+        with:
+          mobile: ${{ inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true' }}
+          play: "true"
+          upload-keystore-b64: ${{ secrets.UPLOAD_KEYSTORE_B64 }}
+          upload-store-password: ${{ secrets.MENTRAOS_UPLOAD_STORE_PASSWORD }}
+          upload-key-password: ${{ secrets.MENTRAOS_UPLOAD_KEY_PASSWORD }}
+          upload-key-alias: ${{ secrets.MENTRAOS_UPLOAD_KEY_ALIAS }}
+          google-play-key-json: ${{ secrets.GOOGLE_PLAY_KEY_JSON }}
+
+      - name: Build signed coordinated APK and AAB
+        if: inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true'
+        working-directory: mobile
+        env:
+          MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
+          MENTRA_COORDINATED_OUTPUT_DIR: ${{ github.workspace }}/mobile-release/android
+          MENTRA_COORDINATED_RELEASE_IDENTITY: ${{ needs.prepare.outputs.release_identity }}
+          RNMAPBOX_MAPS_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
+          SENTRY_ALLOW_FAILURE: "false"
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: bun run release:android
+
+      - name: Download the existing immutable Android pair
+        if: inputs.dry_run != true && needs.prepare.outputs.android_assets_exist == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p mobile-release/android
+          gh api -H "Accept: application/octet-stream" \
+            "repos/${GITHUB_REPOSITORY}/releases/assets/${{ needs.prepare.outputs.apk_asset_id }}" \
+            > "mobile-release/android/${{ needs.prepare.outputs.apk_name }}"
+          gh api -H "Accept: application/octet-stream" \
+            "repos/${GITHUB_REPOSITORY}/releases/assets/${{ needs.prepare.outputs.aab_asset_id }}" \
+            > "mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
+
+      - name: Verify Android native version and production signature
+        env:
+          EXPECTED_BUILD: ${{ needs.prepare.outputs.build_number }}
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.marketing_version }}
+        run: |
+          set -euo pipefail
+          apk="mobile-release/android/${{ needs.prepare.outputs.apk_name }}"
+          apksigner=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -perm -111 | sort | tail -1)
+          aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm -111 | sort | tail -1)
+          "$apksigner" verify --print-certs "$apk" > /tmp/mentra-mobile-certs.txt
+          if grep -qi "CN=Android Debug" /tmp/mentra-mobile-certs.txt; then
+            echo "Android release artifact is debug-signed." >&2
+            exit 1
+          fi
+          "$aapt" dump badging "$apk" > /tmp/mentra-mobile-badging.txt
+          IFS= read -r badging < /tmp/mentra-mobile-badging.txt
+          [[ "$badging" == *"versionCode='$EXPECTED_BUILD'"* ]]
+          [[ "$badging" == *"versionName='$EXPECTED_VERSION'"* ]]
+
+      - name: Publish immutable Android release assets
+        if: inputs.dry_run != true && needs.prepare.outputs.android_assets_exist != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --release-id "${{ needs.prepare.outputs.release_id }}" \
+            --repository "${{ github.repository }}" \
+            --file "mobile-release/android/${{ needs.prepare.outputs.apk_name }}" \
+            --name "${{ needs.prepare.outputs.apk_name }}"
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --release-id "${{ needs.prepare.outputs.release_id }}" \
+            --repository "${{ github.repository }}" \
+            --file "mobile-release/android/${{ needs.prepare.outputs.aab_name }}" \
+            --name "${{ needs.prepare.outputs.aab_name }}"
+
+      - name: Prepare Google Play upload tooling
+        if: inputs.dry_run != true
+        run: |
+          set -euo pipefail
+          mkdir -p mobile-play/fastlane
+          cp mobile/ci/fastlane-android/Fastfile mobile-play/fastlane/Fastfile
+          cp mobile/ci/fastlane-android/Appfile mobile-play/fastlane/Appfile
+          cp mobile/ci/fastlane-android/Gemfile mobile-play/Gemfile
+
+      - name: Install Google Play upload tooling
+        if: inputs.dry_run != true
+        working-directory: mobile-play
+        run: bundle install
+
+      - name: Check selected Google Play track
+        id: play
+        if: inputs.dry_run != true
+        working-directory: mobile-play
+        env:
+          GOOGLE_PLAY_TRACK: ${{ inputs.play_track }}
+          GOOGLE_PLAY_VERSION_CODES_OUTPUT: ${{ runner.temp }}/mentra-play-version-codes.json
+        run: |
+          set -euo pipefail
+          bundle exec fastlane track_version_codes
+          if jq -e --argjson expected "${{ needs.prepare.outputs.build_number }}" 'map(tonumber) | index($expected) != null' "$GOOGLE_PLAY_VERSION_CODES_OUTPUT" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload exact AAB to Google Play
+        if: inputs.dry_run != true && steps.play.outputs.exists != 'true'
+        working-directory: mobile-play
+        env:
+          GOOGLE_PLAY_AAB: ${{ github.workspace }}/mobile-release/android/${{ needs.prepare.outputs.aab_name }}
+          GOOGLE_PLAY_TRACK: ${{ inputs.play_track }}
+        run: bundle exec fastlane google_play
+
+      - name: Write Android release result
+        env:
+          STATUS: ${{ inputs.dry_run && 'built' || (steps.play.outputs.exists == 'true' && 'reused' || 'published') }}
+        run: >-
+          node .github/scripts/coordinated-mobile-records.mjs create-android
+          --plan release-intent/release-plan.json
+          --apk "mobile-release/android/${{ needs.prepare.outputs.apk_name }}"
+          --apk-url "${{ needs.prepare.outputs.asset_base_url }}/${{ needs.prepare.outputs.apk_name }}"
+          --aab "mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
+          --aab-url "${{ needs.prepare.outputs.asset_base_url }}/${{ needs.prepare.outputs.aab_name }}"
+          --play-track "${{ inputs.play_track }}"
+          --status "$STATUS"
+          --provenance-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --output mobile-release/android-publication.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-mobile-android-${{ github.run_id }}
+          path: mobile-release
+          if-no-files-found: error
+          retention-days: 90
+
+  ios:
+    name: Build and distribute coordinated iOS app
+    needs: prepare
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 90
+    concurrency:
+      group: mentra-ios-signing-runner
+      cancel-in-progress: false
+    env:
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - name: Add runner-managed tools to PATH
+        run: |
+          {
+            echo "$HOME/.rbenv/shims"
+            echo "$HOME/.rbenv/bin"
+            echo "$HOME/.bun/bin"
+          } >> "$GITHUB_PATH"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: oven-sh/setup-bun@v2
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        with:
+          bun-version: 1.4.0
+
+      - name: Install exact workspace dependencies
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        working-directory: mobile
+        run: bun install --frozen-lockfile
+
+      - name: Generate exact mobile environment and package metadata
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$DOPPLER_TOKEN"
+          test -n "$MAPBOX_PUBLIC_TOKEN"
+          response=$(curl --fail --silent --show-error --retry 3 -u "$DOPPLER_TOKEN:" \
+            "https://api.doppler.com/v3/configs/config/secret?name=EXPO_PUBLIC_SENTRY_DSN")
+          sentry_dsn=$(jq -er '.value.computed // .computed' <<< "$response")
+          echo "::add-mask::$sentry_dsn"
+          cp mobile/.env.example mobile/.env
+          node .github/scripts/prepare-mobile-release-env.mjs \
+            --plan release-intent/release-plan.json \
+            --env-file mobile/.env \
+            --cloud-environment "${{ inputs.cloud_environment }}" \
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}" \
+            --mapbox-public-token "$MAPBOX_PUBLIC_TOKEN" \
+            --sentry-dsn "$sentry_dsn"
+          node .github/scripts/stage-release-family.mjs --plan release-intent/release-plan.json
+          metadata=(
+            --family-base-version "${{ needs.prepare.outputs.marketing_version }}"
+            --release-identity "${{ needs.prepare.outputs.release_identity }}"
+            --release-set-id "${{ needs.prepare.outputs.release_set_id }}"
+            --source-commit "${{ inputs.source_commit }}"
+            --ota-manifest-url "${{ inputs.ota_manifest_url }}"
+            --ota-manifest-sha256 "${{ inputs.ota_manifest_sha256 }}"
+          )
+          node mobile/modules/bluetooth-sdk/scripts/write-release-metadata.mjs "${metadata[@]}"
+          node mobile/modules/engine/scripts/write-release-metadata.mjs "${metadata[@]}"
+          grep -E '^(EXPO_PUBLIC_|MENTRAOS_NATIVE_MARKETING_VERSION|MENTRAOS_PINNED_BUILD_NUMBER)=' mobile/.env >> "$GITHUB_ENV"
+          echo "MENTRA_COORDINATED_RELEASE_CHANNEL=${{ inputs.testflight_group }}" >> "$GITHUB_ENV"
+
+      - name: Configure Mapbox SwiftPM credentials
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        env:
+          MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$MAPBOX_DOWNLOADS_TOKEN"
+          if [[ -f "$HOME/.netrc" ]]; then sed -i '' '/machine api.mapbox.com/,+2d' "$HOME/.netrc" || true; fi
+          printf 'machine api.mapbox.com\n  login mapbox\n  password %s\n' "$MAPBOX_DOWNLOADS_TOKEN" >> "$HOME/.netrc"
+          chmod 600 "$HOME/.netrc"
+          echo "MENTRA_CONFIGURED_MAPBOX_NETRC=true" >> "$GITHUB_ENV"
+
+      - name: Install iOS signing assets
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        working-directory: mobile
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          RAW_MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+          previous_keychains="${RUNNER_TEMP}/mentra-previous-keychains-${GITHUB_RUN_ID}.txt"
+          previous_default="${RUNNER_TEMP}/mentra-previous-default-keychain-${GITHUB_RUN_ID}.txt"
+          security list-keychains -d user \
+            | sed -E 's/^[[:space:]]*"(.*)"[[:space:]]*$/\1/' \
+            > "$previous_keychains"
+          security default-keychain -d user \
+            | sed -E 's/^[[:space:]]*"(.*)"[[:space:]]*$/\1/' \
+            > "$previous_default"
+          echo "MENTRA_PREVIOUS_KEYCHAINS=$previous_keychains" >> "$GITHUB_ENV"
+          echo "MENTRA_PREVIOUS_DEFAULT_KEYCHAIN=$previous_default" >> "$GITHUB_ENV"
+          MATCH_GIT_BASIC_AUTHORIZATION="$(printf '%s' "$RAW_MATCH_GIT_BASIC_AUTHORIZATION" | tr -d '\r\n')"
+          export MATCH_GIT_BASIC_AUTHORIZATION
+          bundle install
+          keychain="mentra-coordinated-${GITHUB_RUN_ID}.keychain-db"
+          password="$(openssl rand -hex 32)"
+          security delete-keychain "$keychain" 2>/dev/null || true
+          security create-keychain -p "$password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$password" "$keychain"
+          for wwdr in G2 G4 G5 G6; do
+            certificate="${RUNNER_TEMP}/AppleWWDRCA${wwdr}.cer"
+            if curl --fail --silent --show-error --location "https://www.apple.com/certificateauthority/AppleWWDRCA${wwdr}.cer" -o "$certificate"; then
+              security import "$certificate" -k "$keychain" -T /usr/bin/codesign 2>&1 | grep -v "already exists" || true
+            fi
+          done
+          keychains=("$keychain")
+          while IFS= read -r existing; do
+            existing="${existing#*\"}"
+            existing="${existing%\"*}"
+            [[ -n "$existing" && "$existing" != "$keychain" ]] && keychains+=("$existing")
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "${keychains[@]}"
+          security default-keychain -s "$keychain"
+          bundle exec fastlane match appstore --readonly --keychain_name "$keychain" --keychain_password "$password"
+          echo "MENTRA_CI_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          echo "MENTRA_CI_KEYCHAIN_PASSWORD=$password" >> "$GITHUB_ENV"
+
+      - name: Inject App Store Connect API credential
+        uses: ./.github/actions/inject-signing
+        with:
+          ios: "true"
+          asc-api-key-p8-b64: ${{ secrets.ASC_API_KEY_P8_B64 }}
+          asc-api-key-id: ${{ secrets.ASC_API_KEY_ID }}
+          asc-api-issuer-id: ${{ secrets.ASC_API_ISSUER_ID }}
+
+      - name: Build signed coordinated IPA
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        working-directory: mobile
+        env:
+          MENTRA_COORDINATED_OUTPUT_DIR: ${{ github.workspace }}/mobile-release/ios
+          MENTRA_COORDINATED_RELEASE_IDENTITY: ${{ needs.prepare.outputs.release_identity }}
+          SENTRY_ALLOW_FAILURE: "false"
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+          security unlock-keychain -p "$MENTRA_CI_KEYCHAIN_PASSWORD" "$MENTRA_CI_KEYCHAIN"
+          security set-keychain-settings "$MENTRA_CI_KEYCHAIN"
+          bun run release:ios
+
+      - name: Download the existing immutable iOS app
+        if: inputs.dry_run != true && needs.prepare.outputs.ios_asset_exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p mobile-release/ios
+          gh api -H "Accept: application/octet-stream" \
+            "repos/${GITHUB_REPOSITORY}/releases/assets/${{ needs.prepare.outputs.ipa_asset_id }}" \
+            > "mobile-release/ios/${{ needs.prepare.outputs.ipa_name }}"
+
+      - name: Verify iOS native version and build number
+        env:
+          EXPECTED_BUILD: ${{ needs.prepare.outputs.build_number }}
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.marketing_version }}
+        run: |
+          set -euo pipefail
+          ipa="mobile-release/ios/${{ needs.prepare.outputs.ipa_name }}"
+          unzip -p "$ipa" 'Payload/*.app/Info.plist' > /tmp/mentra-mobile-info.plist
+          [[ "$(plutil -extract CFBundleShortVersionString raw /tmp/mentra-mobile-info.plist)" == "$EXPECTED_VERSION" ]]
+          [[ "$(plutil -extract CFBundleVersion raw /tmp/mentra-mobile-info.plist)" == "$EXPECTED_BUILD" ]]
+
+      - name: Publish immutable iOS release asset
+        if: inputs.dry_run != true && needs.prepare.outputs.ios_asset_exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node .github/scripts/publish-immutable-release-asset.mjs
+          --release-id "${{ needs.prepare.outputs.release_id }}"
+          --repository "${{ github.repository }}"
+          --file "mobile-release/ios/${{ needs.prepare.outputs.ipa_name }}"
+          --name "${{ needs.prepare.outputs.ipa_name }}"
+
+      - name: Resolve App Store Connect credential path
+        if: inputs.dry_run != true
+        id: asc
+        run: |
+          set -euo pipefail
+          config="$MENTRA_ASC_CONFIG_PATH"
+          key_path=$(sed -n 's/^ASC_API_KEY_PATH=//p' "$config")
+          test -f "$key_path"
+          echo "key_path=$key_path" >> "$GITHUB_OUTPUT"
+
+      - name: Check exact App Store Connect build number
+        if: inputs.dry_run != true
+        id: app-store
+        run: >-
+          node mobile/scripts/app-store-connect-build.mjs lookup
+          --issuer-id "${{ secrets.ASC_API_ISSUER_ID }}"
+          --key-id "${{ secrets.ASC_API_KEY_ID }}"
+          --key-path "${{ steps.asc.outputs.key_path }}"
+          --bundle-id com.mentra.mentra
+          --build-number "${{ needs.prepare.outputs.build_number }}"
+
+      - name: Upload exact IPA to App Store Connect
+        if: inputs.dry_run != true && steps.app-store.outputs.exists != 'true'
+        env:
+          API_PRIVATE_KEYS_DIR: ${{ runner.temp }}/mentra-creds
+        run: >-
+          xcrun altool --upload-app
+          -f "mobile-release/ios/${{ needs.prepare.outputs.ipa_name }}"
+          -t ios
+          --apiKey "${{ secrets.ASC_API_KEY_ID }}"
+          --apiIssuer "${{ secrets.ASC_API_ISSUER_ID }}"
+
+      - name: Wait for processing and assign the channel TestFlight group
+        if: inputs.dry_run != true
+        run: >-
+          node mobile/scripts/app-store-connect-build.mjs assign
+          --issuer-id "${{ secrets.ASC_API_ISSUER_ID }}"
+          --key-id "${{ secrets.ASC_API_KEY_ID }}"
+          --key-path "${{ steps.asc.outputs.key_path }}"
+          --bundle-id com.mentra.mentra
+          --build-number "${{ needs.prepare.outputs.build_number }}"
+          --group-name "${{ inputs.testflight_group }}"
+
+      - name: Write iOS release result
+        env:
+          STATUS: ${{ inputs.dry_run && 'built' || (steps.app-store.outputs.exists == 'true' && 'reused' || 'published') }}
+        run: >-
+          node .github/scripts/coordinated-mobile-records.mjs create-ios
+          --plan release-intent/release-plan.json
+          --ipa "mobile-release/ios/${{ needs.prepare.outputs.ipa_name }}"
+          --ipa-url "${{ needs.prepare.outputs.asset_base_url }}/${{ needs.prepare.outputs.ipa_name }}"
+          --testflight-group "${{ inputs.testflight_group }}"
+          --status "$STATUS"
+          --provenance-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --output mobile-release/ios-publication.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-mobile-ios-${{ github.run_id }}
+          path: mobile-release
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Clean persistent-runner credentials
+        if: always()
+        run: |
+          if [[ -n "${MENTRA_CI_KEYCHAIN:-}" ]]; then
+            security delete-keychain "$MENTRA_CI_KEYCHAIN" 2>/dev/null || true
+          fi
+          if [[ -f "${MENTRA_PREVIOUS_KEYCHAINS:-}" ]]; then
+            previous_keychains=()
+            while IFS= read -r keychain; do
+              [[ -n "$keychain" ]] && previous_keychains+=("$keychain")
+            done < "$MENTRA_PREVIOUS_KEYCHAINS"
+            if (( ${#previous_keychains[@]} > 0 )); then
+              security list-keychains -d user -s "${previous_keychains[@]}" || true
+            fi
+          fi
+          if [[ -f "${MENTRA_PREVIOUS_DEFAULT_KEYCHAIN:-}" ]]; then
+            previous_default=$(head -1 "$MENTRA_PREVIOUS_DEFAULT_KEYCHAIN")
+            [[ -n "$previous_default" ]] && security default-keychain -d user -s "$previous_default" || true
+          fi
+          if [[ "${MENTRA_CONFIGURED_MAPBOX_NETRC:-}" == "true" && -f "$HOME/.netrc" ]]; then
+            sed -i '' '/machine api.mapbox.com/,+2d' "$HOME/.netrc" || true
+          fi
+
+  result:
+    name: Assemble coordinated mobile result
+    needs: [prepare, android, ios]
+    runs-on: ubuntu-latest
+    outputs:
+      result_artifact: ${{ steps.name.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coordinated-mobile-android-${{ github.run_id }}
+          path: result/android
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coordinated-mobile-ios-${{ github.run_id }}
+          path: result/ios
+
+      - name: Merge mobile publication records
+        run: >-
+          node .github/scripts/coordinated-mobile-records.mjs merge
+          --plan release-intent/release-plan.json
+          --android result/android/android-publication.json
+          --ios result/ios/ios-publication.json
+          --output result/mobile-publications.json
+
+      - name: Name final result
+        id: name
+        run: echo "value=coordinated-mobile-$(jq -er .releaseSetId release-intent/release-plan.json)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.name.outputs.value }}
+          path: result
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -411,6 +411,9 @@ jobs:
   build-mobile-ios:
     name: Build Mobile App (iOS)
     runs-on: [self-hosted, macOS, ARM64]
+    concurrency:
+      group: mentra-ios-signing-runner
+      cancel-in-progress: false
     env:
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -91,7 +91,10 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
     ...config,
     name: appName,
     slug: "Mentra",
-    version: process.env.EXPO_PUBLIC_MENTRAOS_VERSION || "2.9.1",
+    // Coordinated prereleases expose their full identity (for example,
+    // 3.1.0-beta.57) to shipped JavaScript while stores retain the plain
+    // marketing version so the exact tested binary can be promoted.
+    version: process.env.MENTRAOS_NATIVE_MARKETING_VERSION || process.env.EXPO_PUBLIC_MENTRAOS_VERSION || "2.9.1",
     scheme: "com.mentra",
     orientation: "portrait",
     userInterfaceStyle: "automatic",

--- a/mobile/ci/fastlane-android/Fastfile
+++ b/mobile/ci/fastlane-android/Fastfile
@@ -1,11 +1,20 @@
+require "json"
+
 default_platform(:android)
 
 platform :android do
-  desc "Upload AAB to Google Play internal track"
+  desc "Read version codes from the selected Google Play track"
+  lane :track_version_codes do
+    output = ENV.fetch("GOOGLE_PLAY_VERSION_CODES_OUTPUT")
+    codes = google_play_track_version_codes(track: ENV.fetch("GOOGLE_PLAY_TRACK", "internal"))
+    File.write(output, JSON.generate(codes))
+  end
+
+  desc "Upload AAB to the selected Google Play track"
   lane :google_play do
     upload_to_play_store(
-      track: "internal",
-      aab: "app/build/outputs/bundle/release/app-release.aab",
+      track: ENV.fetch("GOOGLE_PLAY_TRACK", "internal"),
+      aab: ENV.fetch("GOOGLE_PLAY_AAB", "app/build/outputs/bundle/release/app-release.aab"),
       skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_images: true,

--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import {readFileSync} from "node:fs"
+import {createPrivateKey, sign} from "node:crypto"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+const API_ROOT = "https://api.appstoreconnect.apple.com"
+
+function base64url(value) {
+  return Buffer.from(value).toString("base64url")
+}
+
+export function createAppStoreConnectToken({issuerId, keyId, privateKey, now = Date.now()}) {
+  const issuedAt = Math.floor(now / 1000)
+  const header = base64url(JSON.stringify({alg: "ES256", kid: keyId, typ: "JWT"}))
+  const payload = base64url(
+    JSON.stringify({iss: issuerId, iat: issuedAt, exp: issuedAt + 19 * 60, aud: "appstoreconnect-v1"}),
+  )
+  const input = `${header}.${payload}`
+  const signature = sign("sha256", Buffer.from(input), {
+    key: createPrivateKey(privateKey),
+    dsaEncoding: "ieee-p1363",
+  }).toString("base64url")
+  return `${input}.${signature}`
+}
+
+export function createAppStoreConnectClient({issuerId, keyId, privateKey, fetchImpl = fetch}) {
+  async function request(resource, options = {}) {
+    const response = await fetchImpl(new URL(resource, API_ROOT), {
+      ...options,
+      headers: {
+        "Authorization": `Bearer ${createAppStoreConnectToken({issuerId, keyId, privateKey})}`,
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    })
+    const body = await response.text()
+    if (!response.ok)
+      throw new Error(
+        `App Store Connect ${options.method || "GET"} ${resource} failed with HTTP ${response.status}: ${body}`,
+      )
+    return body ? JSON.parse(body) : null
+  }
+  return {request}
+}
+
+function query(pathname, parameters) {
+  const url = new URL(pathname, API_ROOT)
+  for (const [key, value] of Object.entries(parameters)) url.searchParams.set(key, value)
+  return `${url.pathname}${url.search}`
+}
+
+function exactlyOne(response, label) {
+  if (!Array.isArray(response?.data) || response.data.length !== 1) {
+    throw new Error(`Expected exactly one ${label}, found ${response?.data?.length ?? 0}`)
+  }
+  return response.data[0]
+}
+
+export async function collectPaginatedData(client, resource) {
+  const data = []
+  const visited = new Set()
+  let next = resource
+  while (next) {
+    if (visited.has(next)) throw new Error(`App Store Connect pagination loop at ${next}`)
+    visited.add(next)
+    const response = await client.request(next)
+    if (!Array.isArray(response?.data)) throw new Error(`App Store Connect page ${next} has no data array`)
+    data.push(...response.data)
+    next = response.links?.next || null
+  }
+  return data
+}
+
+export async function findApp(client, bundleId) {
+  return exactlyOne(
+    await client.request(query("/v1/apps", {"filter[bundleId]": bundleId, "limit": "2"})),
+    `app ${bundleId}`,
+  )
+}
+
+export async function findBuild(client, {appId, buildNumber}) {
+  const response = await client.request(
+    query("/v1/builds", {"filter[app]": appId, "filter[version]": String(buildNumber), "limit": "2"}),
+  )
+  if (!Array.isArray(response?.data) || response.data.length === 0) return null
+  return exactlyOne(response, `build ${buildNumber}`)
+}
+
+export async function findProcessedBuild(client, {appId, buildNumber}) {
+  const build = await findBuild(client, {appId, buildNumber})
+  if (!build) return null
+  const state = build.attributes?.processingState
+  if (state === "FAILED" || state === "INVALID") throw new Error(`App Store Connect build ${buildNumber} is ${state}`)
+  return state === "VALID" ? build : null
+}
+
+export async function waitForProcessedBuild(client, {appId, buildNumber, attempts = 120, delay = 10_000}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const build = await findProcessedBuild(client, {appId, buildNumber})
+    if (build) return build
+    if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, delay))
+  }
+  throw new Error(`App Store Connect build ${buildNumber} did not finish processing`)
+}
+
+export async function assignBuildToGroup(client, {appId, buildId, groupName}) {
+  const group = exactlyOne(
+    await client.request(query("/v1/betaGroups", {"filter[app]": appId, "filter[name]": groupName, "limit": "2"})),
+    `TestFlight group ${groupName}`,
+  )
+  const relationship = `/v1/betaGroups/${group.id}/relationships/builds`
+  const existing = await collectPaginatedData(client, query(relationship, {limit: "200"}))
+  if (existing.some((build) => build.id === buildId)) return {group, reused: true}
+  await client.request(relationship, {
+    method: "POST",
+    body: JSON.stringify({data: [{type: "builds", id: buildId}]}),
+  })
+  const confirmed = await collectPaginatedData(client, query(relationship, {limit: "200"}))
+  if (!confirmed.some((build) => build.id === buildId)) {
+    throw new Error(`App Store Connect did not retain build ${buildId} in TestFlight group ${groupName}`)
+  }
+  return {group, reused: false}
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+async function main() {
+  const command = process.argv[2]
+  const args = parseArgs(process.argv.slice(3))
+  const client = createAppStoreConnectClient({
+    issuerId: args["issuer-id"],
+    keyId: args["key-id"],
+    privateKey: readFileSync(path.resolve(args["key-path"]), "utf8"),
+  })
+  const app = await findApp(client, args["bundle-id"])
+  if (command === "lookup") {
+    const build = await findBuild(client, {appId: app.id, buildNumber: args["build-number"]})
+    if (process.env.GITHUB_OUTPUT) {
+      const {appendFileSync} = await import("node:fs")
+      appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `exists=${Boolean(build)}\nprocessed=${build?.attributes?.processingState === "VALID"}\nbuild_id=${build?.id || ""}\n`,
+      )
+    }
+    console.log(build ? `Found App Store Connect build ${args["build-number"]}` : "Build is absent")
+    return
+  }
+  if (command === "assign") {
+    const build = await waitForProcessedBuild(client, {appId: app.id, buildNumber: args["build-number"]})
+    const result = await assignBuildToGroup(client, {appId: app.id, buildId: build.id, groupName: args["group-name"]})
+    console.log(
+      `${result.reused ? "Verified" : "Added"} build ${args["build-number"]} in TestFlight group ${result.group.attributes?.name || args["group-name"]}`,
+    )
+    return
+  }
+  throw new Error(`Unknown command ${JSON.stringify(command)}`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main()

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  assignBuildToGroup,
+  collectPaginatedData,
+  findProcessedBuild,
+  waitForProcessedBuild,
+} from "./app-store-connect-build.mjs"
+
+function client(responses) {
+  const calls = []
+  return {
+    calls,
+    async request(resource, options = {}) {
+      calls.push({resource, options})
+      const next = responses.shift()
+      if (next instanceof Error) throw next
+      return next
+    },
+  }
+}
+
+test("waits for an uploaded build to finish processing", async () => {
+  const api = client([
+    {data: []},
+    {data: [{id: "build-1", attributes: {processingState: "PROCESSING"}}]},
+    {data: [{id: "build-1", attributes: {processingState: "VALID"}}]},
+  ])
+  const build = await waitForProcessedBuild(api, {appId: "app-1", buildNumber: 310000057, attempts: 3, delay: 0})
+  assert.equal(build.id, "build-1")
+  assert.match(api.calls[0].resource, /filter%5Bversion%5D=310000057/)
+})
+
+test("fails when App Store Connect marks a build invalid", async () => {
+  const api = client([{data: [{id: "build-1", attributes: {processingState: "FAILED"}}]}])
+  await assert.rejects(() => findProcessedBuild(api, {appId: "app-1", buildNumber: 12}), /is FAILED/)
+})
+
+test("idempotently adds a build to exactly one TestFlight group", async () => {
+  const api = client([
+    {data: [{id: "group-1", attributes: {name: "Beta"}}]},
+    {data: []},
+    null,
+    {data: [{type: "builds", id: "build-1"}]},
+  ])
+  const result = await assignBuildToGroup(api, {appId: "app-1", buildId: "build-1", groupName: "Beta"})
+  assert.equal(result.reused, false)
+  assert.equal(api.calls[2].options.method, "POST")
+  assert.deepEqual(JSON.parse(api.calls[2].options.body), {data: [{type: "builds", id: "build-1"}]})
+})
+
+test("does not post when the group already contains the build", async () => {
+  const api = client([{data: [{id: "group-1", attributes: {name: "Dev"}}]}, {data: [{type: "builds", id: "build-1"}]}])
+  const result = await assignBuildToGroup(api, {appId: "app-1", buildId: "build-1", groupName: "Dev"})
+  assert.equal(result.reused, true)
+  assert.equal(api.calls.length, 2)
+})
+
+test("follows every TestFlight relationship page before posting", async () => {
+  const api = client([
+    {data: [], links: {next: "/v1/betaGroups/group-1/relationships/builds?cursor=next"}},
+    {data: [{type: "builds", id: "build-1"}], links: {next: null}},
+  ])
+  const data = await collectPaginatedData(api, "/v1/betaGroups/group-1/relationships/builds?limit=200")
+  assert.deepEqual(data, [{type: "builds", id: "build-1"}])
+  assert.equal(api.calls.length, 2)
+})

--- a/mobile/scripts/release-android.mjs
+++ b/mobile/scripts/release-android.mjs
@@ -115,6 +115,37 @@ console.log('APK built successfully');
 validateReleaseArchive(apkPath, 'Android');
 console.log('Verified Android release JS bundle configuration');
 
+// Coordinated release CI owns immutable artifact naming and distribution. Keep
+// the established build/sign/validation path, but return both store and
+// sideload artifacts before the legacy mutable GitHub release logic runs.
+const coordinatedOutputDir = process.env.MENTRA_COORDINATED_OUTPUT_DIR;
+if (coordinatedOutputDir) {
+  const releaseIdentity = process.env.MENTRA_COORDINATED_RELEASE_IDENTITY;
+  if (!releaseIdentity) {
+    throw new Error('MENTRA_COORDINATED_RELEASE_IDENTITY is required with MENTRA_COORDINATED_OUTPUT_DIR');
+  }
+  console.log('\n━━━ Coordinated release: building AAB ━━━');
+  await withRetry(
+    'gradlew bundleRelease',
+    () => {
+      const p = $({ cwd: 'android' })`./gradlew bundleRelease`;
+      p.stdout.pipe(process.stdout);
+      p.stderr.pipe(process.stderr);
+      return p;
+    },
+    { shouldRetry: isSentryTransientError }
+  );
+  const coordinatedAabPath = path.resolve('android/app/build/outputs/bundle/release/app-release.aab');
+  if (!existsSync(coordinatedAabPath)) throw new Error(`AAB not found at ${coordinatedAabPath}`);
+  await mkdir(coordinatedOutputDir, { recursive: true });
+  const coordinatedApk = path.resolve(coordinatedOutputDir, `mentraos-${releaseIdentity}-android.apk`);
+  const coordinatedAab = path.resolve(coordinatedOutputDir, `mentraos-${releaseIdentity}-android.aab`);
+  await cp(apkPath, coordinatedApk);
+  await cp(coordinatedAabPath, coordinatedAab);
+  console.log(`Coordinated Android artifacts: ${coordinatedApk}, ${coordinatedAab}`);
+  process.exit(0);
+}
+
 // ── Step 6: Determine beta number & rename APK ───────────────────────────────
 
 console.log('\n━━━ Step 6: Determining beta number ━━━');

--- a/mobile/scripts/release-bundle-config.mjs
+++ b/mobile/scripts/release-bundle-config.mjs
@@ -34,6 +34,9 @@ function xcodeEnvironmentEntries(env, nodeBinary) {
     .map(([key, value]) => [key, String(value)])
     .sort(([left], [right]) => left.localeCompare(right))
 
+  if (env.MENTRAOS_NATIVE_MARKETING_VERSION) {
+    entries.push(["MENTRAOS_NATIVE_MARKETING_VERSION", String(env.MENTRAOS_NATIVE_MARKETING_VERSION)])
+  }
   if (env.MENTRAOS_PINNED_BUILD_NUMBER) {
     entries.push(["MENTRAOS_PINNED_BUILD_NUMBER", String(env.MENTRAOS_PINNED_BUILD_NUMBER)])
   }

--- a/mobile/scripts/release-bundle-config.test.mjs
+++ b/mobile/scripts/release-bundle-config.test.mjs
@@ -9,6 +9,7 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
     {
       EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/it's-pinned.json",
       EXPO_PUBLIC_EMPTY: "",
+      MENTRAOS_NATIVE_MARKETING_VERSION: "3.1.0",
       MENTRAOS_PINNED_BUILD_NUMBER: "123",
       NODE_ENV: "production",
       PRIVATE_SECRET: "do-not-export",
@@ -18,6 +19,7 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
 
   assert.deepEqual(lines, [
     `export EXPO_PUBLIC_ASG_OTA_VERSION_URL='https://example.test/it'"'"'s-pinned.json'`,
+    "export MENTRAOS_NATIVE_MARKETING_VERSION='3.1.0'",
     "export MENTRAOS_PINNED_BUILD_NUMBER='123'",
     "export NODE_ENV='production'",
     "export NODE_BINARY='/opt/node with spaces/bin/node'",
@@ -38,6 +40,7 @@ test("xcodeBuildSettings exposes the same public values to every build phase", (
     {
       EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/pin.json?channel=staging build",
       EXPO_PUBLIC_EMPTY: "",
+      MENTRAOS_NATIVE_MARKETING_VERSION: "3.1.0",
       MENTRAOS_PINNED_BUILD_NUMBER: 123,
       NODE_ENV: "production",
       PRIVATE_SECRET: "do-not-export",
@@ -47,6 +50,7 @@ test("xcodeBuildSettings exposes the same public values to every build phase", (
 
   assert.deepEqual(settings, [
     "EXPO_PUBLIC_ASG_OTA_VERSION_URL=https://example.test/pin.json?channel=staging build",
+    "MENTRAOS_NATIVE_MARKETING_VERSION=3.1.0",
     "MENTRAOS_PINNED_BUILD_NUMBER=123",
     "NODE_ENV=production",
     "NODE_BINARY=/opt/node with spaces/bin/node",

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -8,6 +8,7 @@ import {
   xcodeBuildSettings,
 } from './release-bundle-config.mjs';
 import { getBuildNumber } from './build-number.mjs';
+import { cp, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -268,6 +269,22 @@ console.log('IPA exported:', ipaPath);
 // build environment into Metro. Refuse to publish that binary anywhere.
 validateReleaseArchive(ipaPath, 'iOS');
 console.log('Verified iOS release JS bundle configuration');
+
+// Coordinated release CI distributes the exact validated IPA and owns its
+// immutable name. Exit before the legacy best-effort TestFlight upload and
+// mutable `_Beta_N` GitHub release path.
+const coordinatedOutputDir = process.env.MENTRA_COORDINATED_OUTPUT_DIR;
+if (coordinatedOutputDir) {
+  const releaseIdentity = process.env.MENTRA_COORDINATED_RELEASE_IDENTITY;
+  if (!releaseIdentity) {
+    throw new Error('MENTRA_COORDINATED_RELEASE_IDENTITY is required with MENTRA_COORDINATED_OUTPUT_DIR');
+  }
+  await mkdir(coordinatedOutputDir, { recursive: true });
+  const coordinatedIpa = path.resolve(coordinatedOutputDir, `mentraos-${releaseIdentity}-ios.ipa`);
+  await cp(ipaPath, coordinatedIpa);
+  console.log(`Coordinated iOS artifact: ${coordinatedIpa}`);
+  process.exit(0);
+}
 
 // ── Step 6: Upload to App Store Connect (TestFlight) ──────────────────────────
 

--- a/mobile/scripts/set-build-env.mjs
+++ b/mobile/scripts/set-build-env.mjs
@@ -54,7 +54,8 @@ export async function setBuildEnv() {
   await clearAutolinkingCache()
 
   const gitCommit = (await $`git rev-parse --short HEAD`).stdout.trim()
-  const gitBranch = (await $`git rev-parse --abbrev-ref HEAD`).stdout.trim()
+  const gitBranch =
+    process.env.MENTRA_COORDINATED_RELEASE_CHANNEL || (await $`git rev-parse --abbrev-ref HEAD`).stdout.trim()
   const gitUsername = (await $`git config user.name`).stdout.trim().replace(/ /g, "_")  // format: 2025-11-18_12-00
   const buildTime = new Date()
     .toLocaleString("en-US", {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces production store uploads, signing/keychain handling, and immutable release publishing; misconfiguration or idempotency bugs could block releases or ship wrong versions.
> 
> **Overview**
> Adds a **reusable coordinated mobile release pipeline** that takes a release plan, pins OTA/cloud/version metadata, builds signed Android (APK+AAB) and iOS (IPA) in parallel, and publishes to **immutable GitHub release assets** plus **Google Play** (configurable track) and **App Store Connect / TestFlight** (with idempotent reuse when the build already exists).
> 
> Supporting Node scripts generate the release `.env` (full **release identity** in JS vs **native marketing version** + pinned build for stores), upload or byte-verify immutable GH assets, and emit merged **publication records** (hashes, coordinates, `built`/`published`/`reused`). Mobile release scripts gain a **`MENTRA_COORDINATED_OUTPUT_DIR` early-exit** path that skips legacy `_Beta_N` GitHub/TestFlight flows; **Fastlane** accepts track and AAB path via env; a new **App Store Connect** helper handles build lookup, processing wait, and TestFlight group assignment.
> 
> **Staging iOS** jobs now share a **`mentra-ios-signing-runner` concurrency** group with the coordinated workflow to avoid signing races on self-hosted Macs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc76724a82b1637d973af25db23d17ce0650dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->