### PR TITLE
ci(release): orchestrate coordinated prereleases

### DIFF
--- a/.github/scripts/assemble-coordinated-release-results.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"))
+}
+
+function provenanceUrl(ota) {
+  return `https://github.com/${ota.workflow.repository}/actions/runs/${ota.workflow.runId}`
+}
+
+function mergePublicationRecords(plan, records) {
+  const publications = {}
+  const artifacts = []
+  for (const record of records) {
+    if (record.releaseSetId !== plan.releaseSetId) throw new Error("Publication record belongs to another release set")
+    for (const [member, targets] of Object.entries(record.publications || {})) {
+      publications[member] ||= {}
+      for (const [target, publication] of Object.entries(targets)) {
+        const existing = publications[member][target]
+        if (existing && JSON.stringify(existing) !== JSON.stringify(publication)) {
+          throw new Error(`Conflicting publication records for ${member}:${target}`)
+        }
+        publications[member][target] = publication
+      }
+    }
+    artifacts.push(...(record.artifacts || []))
+  }
+  return {publications, artifacts}
+}
+
+function requirePublicationCoverage(plan, publications) {
+  for (const [member, definition] of Object.entries(plan.members)) {
+    for (const target of definition.publishTargets) {
+      if (!publications[member]?.[target]) throw new Error(`Missing publication result for ${member}:${target}`)
+    }
+  }
+}
+
+function verifyAsgSelection(plan, ota, selectionFile) {
+  if (
+    ota.releaseIdentity !== plan.releaseIdentity ||
+    ota.sourceCommit !== plan.sourceCommit ||
+    ota.selection?.asset !== plan.artifactNames.asgSelection
+  ) {
+    throw new Error("OTA result does not match the release plan")
+  }
+  const bytes = readFileSync(selectionFile)
+  const sha256 = createHash("sha256").update(bytes).digest("hex")
+  if (sha256 !== ota.selection.sha256 || statSync(selectionFile).size !== ota.selection.size) {
+    throw new Error("ASG selection file differs from the OTA result")
+  }
+  const selection = JSON.parse(bytes)
+  if (
+    selection.releaseSetId !== plan.releaseSetId ||
+    selection.releaseIdentity !== plan.releaseIdentity ||
+    selection.sourceCommit !== plan.sourceCommit ||
+    selection.fingerprint !== ota.asg.fingerprint ||
+    selection.versionCode !== ota.asg.versionCode ||
+    selection.versionName !== ota.asg.versionName ||
+    selection.apk?.asset !== ota.asg.artifact.asset ||
+    selection.apk?.sha256 !== ota.asg.artifact.sha256
+  ) {
+    throw new Error("ASG selection does not describe the OTA result")
+  }
+  return {sha256, size: bytes.length}
+}
+
+export function assembleCoordinatedReleaseResults({
+  plan,
+  ota,
+  npmRecords,
+  native,
+  mobile,
+  asgSelectionFile,
+  enginePackage,
+  releaseAssetBaseUrl,
+}) {
+  if (plan.releaseSetId !== `mentra-${plan.releaseIdentity}` || ota.releaseSetId !== plan.releaseSetId) {
+    throw new Error("Release plan and OTA result do not identify the same release set")
+  }
+  const merged = mergePublicationRecords(plan, [...npmRecords, native, mobile])
+  requirePublicationCoverage(plan, merged.publications)
+  const selection = verifyAsgSelection(plan, ota, asgSelectionFile)
+  const otaProvenanceUrl = provenanceUrl(ota)
+  const artifacts = [
+    ...merged.artifacts,
+    {
+      status: ota.bundle.status,
+      coordinate: ota.bundle.asset,
+      url: ota.bundle.url,
+      sha256: ota.bundle.sha256,
+      size: ota.bundle.size,
+      provenanceUrl: otaProvenanceUrl,
+    },
+    {
+      status: ota.asg.reused ? "reused" : ota.manifest.status,
+      coordinate: ota.asg.artifact.asset,
+      url: ota.asg.artifact.url,
+      sha256: ota.asg.artifact.sha256,
+      size: ota.asg.artifact.size,
+      signingCertificateSha256: ota.asg.artifact.signingCertificateSha256,
+      provenanceUrl: otaProvenanceUrl,
+    },
+    {
+      status: ota.selection.status,
+      coordinate: ota.selection.asset,
+      url: ota.selection.url,
+      sha256: selection.sha256,
+      size: selection.size,
+      provenanceUrl: otaProvenanceUrl,
+    },
+  ]
+
+  if (enginePackage) {
+    const enginePublication = merged.publications["@mentra/engine"]?.npm
+    if (!enginePublication) throw new Error("Engine package artifact has no matching npm publication")
+    const bytes = readFileSync(enginePackage)
+    const sha256 = createHash("sha256").update(bytes).digest("hex")
+    if (sha256 !== enginePublication.sha256) throw new Error("Engine release asset differs from the npm package")
+    artifacts.push({
+      status: enginePublication.status,
+      coordinate: plan.artifactNames.enginePackage,
+      url: `${releaseAssetBaseUrl}/${plan.artifactNames.enginePackage}`,
+      sha256,
+      size: statSync(enginePackage).size,
+      provenanceUrl: enginePublication.provenanceUrl,
+    })
+  }
+
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    publications: merged.publications,
+    otaManifest: {
+      status: ota.manifest.status,
+      coordinate: ota.manifest.asset,
+      url: ota.manifest.url,
+      sha256: ota.manifest.sha256,
+      size: ota.manifest.size,
+      provenanceUrl: otaProvenanceUrl,
+    },
+    artifacts,
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const result = assembleCoordinatedReleaseResults({
+    plan: readJson(path.resolve(args.plan)),
+    ota: readJson(path.resolve(args.ota)),
+    npmRecords: [args["npm-foundation"], args["npm-sdk"], args["npm-miniapp"], args["npm-engine"]].map((file) =>
+      readJson(path.resolve(file)),
+    ),
+    native: readJson(path.resolve(args.native)),
+    mobile: readJson(path.resolve(args.mobile)),
+    asgSelectionFile: path.resolve(args["asg-selection"]),
+    enginePackage: args["engine-package"] ? path.resolve(args["engine-package"]) : undefined,
+    releaseAssetBaseUrl: args["release-asset-base-url"],
+  })
+  writeFileSync(args.output, serializeReleaseRecord(result))
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/assemble-coordinated-release-results.test.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.test.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict"
+import {createHash} from "node:crypto"
+import {mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+import {fileURLToPath} from "node:url"
+
+import {assembleCoordinatedReleaseResults} from "./assemble-coordinated-release-results.mjs"
+import {createReleasePlan, finalizeReleaseManifest, loadReleaseFamily} from "./release-family.mjs"
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const plan = createReleasePlan({
+  family: loadReleaseFamily({rootDir}),
+  channel: "beta",
+  sequence: 57,
+  sourceCommit: "a".repeat(40),
+  nativeBuildNumber: 310000057,
+})
+const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
+
+function publication(coordinate, sha256 = "b".repeat(64)) {
+  return {
+    status: "published",
+    coordinate,
+    url: `https://example.com/${encodeURIComponent(coordinate)}`,
+    sha256,
+    provenanceUrl,
+  }
+}
+
+function npmRecord(names) {
+  return {
+    releaseSetId: plan.releaseSetId,
+    publications: Object.fromEntries(
+      names.map((name) => [name, {npm: publication(`${name}@${plan.releaseIdentity}`)}]),
+    ),
+  }
+}
+
+test("assembles every product target and finalizes one complete release manifest", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "coordinated-results-"))
+  const enginePackage = path.join(directory, plan.artifactNames.enginePackage)
+  const asgSelectionFile = path.join(directory, plan.artifactNames.asgSelection)
+  writeFileSync(enginePackage, "engine package")
+  const asgSelection = {
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    sourceCommit: plan.sourceCommit,
+    fingerprint: "f".repeat(64),
+    versionCode: 100057,
+    versionName: "asg.100057.ffffffffffff",
+    apk: {asset: "mentra-live-asg.apk", sha256: "e".repeat(64)},
+  }
+  writeFileSync(asgSelectionFile, JSON.stringify(asgSelection))
+  const selectionSha = createHash("sha256").update(JSON.stringify(asgSelection)).digest("hex")
+  const engineSha = createHash("sha256").update("engine package").digest("hex")
+  const npmRecords = [
+    npmRecord(["@mentra/jspolyfill", "@mentra/cloud-protocol", "@mentra/crust", "@mentra/cloud-client"]),
+    npmRecord(["@mentra/bluetooth-sdk"]),
+    npmRecord(["@mentra/miniapp"]),
+    {
+      releaseSetId: plan.releaseSetId,
+      publications: {"@mentra/engine": {npm: publication(`@mentra/engine@${plan.releaseIdentity}`, engineSha)}},
+    },
+  ]
+  const native = {
+    releaseSetId: plan.releaseSetId,
+    publications: {
+      "@mentra/bluetooth-sdk": {
+        "maven-central": publication(`com.mentraglass:bluetooth-sdk:${plan.releaseIdentity}`),
+        "swift-package-manager": publication(`Mentra-Community/mentra-bluetooth-sdk-ios@${plan.releaseIdentity}`),
+      },
+    },
+    artifacts: [publication(`com.mentraglass:lc3Lib:${plan.releaseIdentity}`)],
+  }
+  const mobile = {
+    releaseSetId: plan.releaseSetId,
+    publications: {
+      mentraos: {
+        "google-play": publication(`com.mentra.mentra:${plan.native.buildNumber}:beta`),
+        "app-store-connect": publication(
+          `com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:Beta`,
+        ),
+      },
+    },
+    artifacts: [
+      publication(plan.artifactNames.androidApp),
+      publication(plan.artifactNames.androidStoreApp),
+      publication(plan.artifactNames.iosApp),
+    ],
+  }
+  const ota = {
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    sourceCommit: plan.sourceCommit,
+    selection: {
+      status: "published",
+      asset: plan.artifactNames.asgSelection,
+      url: "https://example.com/asg-selection.json",
+      sha256: selectionSha,
+      size: Buffer.byteLength(JSON.stringify(asgSelection)),
+    },
+    manifest: {
+      status: "published",
+      asset: plan.artifactNames.otaManifest,
+      url: "https://example.com/ota.json",
+      sha256: "c".repeat(64),
+      size: 100,
+    },
+    bundle: {
+      status: "published",
+      asset: "mentra-live-ota-bundle.zip",
+      url: "https://example.com/ota.zip",
+      sha256: "d".repeat(64),
+      size: 200,
+    },
+    asg: {
+      fingerprint: asgSelection.fingerprint,
+      versionCode: asgSelection.versionCode,
+      versionName: asgSelection.versionName,
+      reused: false,
+      artifact: {
+        asset: "mentra-live-asg.apk",
+        url: "https://example.com/asg.apk",
+        sha256: "e".repeat(64),
+        size: 300,
+        signingCertificateSha256: "f".repeat(64),
+      },
+    },
+    workflow: {repository: "Mentra-Community/MentraOS", runId: "123"},
+  }
+
+  const results = assembleCoordinatedReleaseResults({
+    plan,
+    ota,
+    npmRecords,
+    native,
+    mobile,
+    asgSelectionFile,
+    enginePackage,
+    releaseAssetBaseUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v${plan.releaseIdentity}`,
+  })
+  const manifest = finalizeReleaseManifest({plan, results, completedAt: "2026-08-25T02:00:00.000Z"})
+
+  assert.equal(Object.keys(manifest.publications).length, 8)
+  assert.equal(manifest.publications["@mentra/bluetooth-sdk"]["maven-central"].status, "published")
+  assert.equal(manifest.publications.mentraos["app-store-connect"].status, "published")
+  assert.ok(manifest.artifacts.some((artifact) => artifact.coordinate === plan.artifactNames.asgSelection))
+  assert.equal(manifest.artifacts.at(-1).coordinate, plan.artifactNames.enginePackage)
+
+  writeFileSync(asgSelectionFile, `${JSON.stringify(asgSelection)}\n`)
+  assert.throws(
+    () =>
+      assembleCoordinatedReleaseResults({
+        plan,
+        ota,
+        npmRecords,
+        native,
+        mobile,
+        asgSelectionFile,
+        enginePackage,
+        releaseAssetBaseUrl: "https://example.com/release",
+      }),
+    /selection file differs/,
+  )
+})

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -1,0 +1,416 @@
+name: Coordinated Mentra Release
+
+on:
+  push:
+    branches: [dev, staging]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build and verify the selected branch without publishing
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+
+concurrency:
+  group: coordinated-mentra-release-publication
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Allocate immutable release identity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      source_commit: ${{ steps.release.outputs.source_commit }}
+      release_identity: ${{ steps.release.outputs.release_identity }}
+      release_set_id: ${{ steps.release.outputs.release_set_id }}
+      plan_artifact: ${{ steps.release.outputs.plan_artifact }}
+      npm_foundation_artifact: ${{ steps.release.outputs.npm_foundation_artifact }}
+      npm_sdk_artifact: ${{ steps.release.outputs.npm_sdk_artifact }}
+      npm_miniapp_artifact: ${{ steps.release.outputs.npm_miniapp_artifact }}
+      npm_engine_artifact: ${{ steps.release.outputs.npm_engine_artifact }}
+      cloud_environment: ${{ steps.release.outputs.cloud_environment }}
+      play_track: ${{ steps.release.outputs.play_track }}
+      testflight_group: ${{ steps.release.outputs.testflight_group }}
+      dry_run: ${{ steps.release.outputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Resolve branch release channel
+        id: channel
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$BRANCH" in
+            dev)
+              echo "cloud_environment=dev" >> "$GITHUB_OUTPUT"
+              echo "play_track=internal" >> "$GITHUB_OUTPUT"
+              echo "testflight_group=Dev" >> "$GITHUB_OUTPUT"
+              ;;
+            staging)
+              echo "cloud_environment=staging" >> "$GITHUB_OUTPUT"
+              echo "play_track=beta" >> "$GITHUB_OUTPUT"
+              echo "testflight_group=Beta" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Coordinated prereleases only run from dev or staging, not $BRANCH." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Collect promoted firmware inputs
+        run: node .github/scripts/collect-ota-release-inputs.mjs
+
+      - name: Create deterministic release plan
+        run: |
+          set -euo pipefail
+          node .github/scripts/create-release-plan.mjs \
+            --branch "${{ github.ref_name }}" \
+            --sequence "${{ github.run_number }}" \
+            --source-commit "${{ github.sha }}" \
+            --native-build-number "$((310000000 + ${{ github.run_number }}))" \
+            --ota-inputs ota-release-inputs.json \
+            --require-version-mirrors true \
+            --output release-plan.json
+          cp release-plan.json release-plan.first.json
+          node .github/scripts/create-release-plan.mjs \
+            --branch "${{ github.ref_name }}" \
+            --sequence "${{ github.run_number }}" \
+            --source-commit "${{ github.sha }}" \
+            --native-build-number "$((310000000 + ${{ github.run_number }}))" \
+            --ota-inputs ota-release-inputs.json \
+            --require-version-mirrors true \
+            --output release-plan.json
+          cmp release-plan.first.json release-plan.json
+
+      - name: Export immutable release coordinates
+        id: release
+        env:
+          CLOUD_ENVIRONMENT: ${{ steps.channel.outputs.cloud_environment }}
+          PLAY_TRACK: ${{ steps.channel.outputs.play_track }}
+          TESTFLIGHT_GROUP: ${{ steps.channel.outputs.testflight_group }}
+        run: |
+          set -euo pipefail
+          identity=$(jq -er .releaseIdentity release-plan.json)
+          release_set_id=$(jq -er .releaseSetId release-plan.json)
+          dry_run=false
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.dry_run }}" == "true" ]]; then
+            dry_run=true
+          fi
+          {
+            echo "source_commit=${{ github.sha }}"
+            echo "release_identity=$identity"
+            echo "release_set_id=$release_set_id"
+            echo "plan_artifact=coordinated-release-plan-$release_set_id"
+            echo "npm_foundation_artifact=coordinated-npm-foundation-$release_set_id"
+            echo "npm_sdk_artifact=coordinated-npm-sdk-$release_set_id"
+            echo "npm_miniapp_artifact=coordinated-npm-miniapp-$release_set_id"
+            echo "npm_engine_artifact=coordinated-npm-engine-$release_set_id"
+            echo "cloud_environment=$CLOUD_ENVIRONMENT"
+            echo "play_track=$PLAY_TRACK"
+            echo "testflight_group=$TESTFLIGHT_GROUP"
+            echo "dry_run=$dry_run"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.release.outputs.plan_artifact }}
+          path: |
+            release-plan.json
+            ota-release-inputs.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize release intent
+        run: |
+          {
+            echo "## Coordinated release intent"
+            echo ""
+            echo "- Release: \`${{ steps.release.outputs.release_identity }}\`"
+            echo "- Source: \`${{ github.sha }}\`"
+            echo "- Mobile cloud: \`${{ steps.release.outputs.cloud_environment }}\`"
+            echo "- Google Play: \`${{ steps.release.outputs.play_track }}\`"
+            echo "- TestFlight: \`${{ steps.release.outputs.testflight_group }}\`"
+            echo "- Dry run: \`${{ steps.release.outputs.dry_run }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  ota:
+    name: Publish immutable Mentra Live OTA set
+    needs: plan
+    uses: ./.github/workflows/reusable-coordinated-ota.yml
+    with:
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  npm-foundation:
+    name: Publish leaf npm dependency closure
+    needs: [plan, ota]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/jspolyfill,@mentra/cloud-protocol,@mentra/crust,@mentra/cloud-client"
+      result_artifact: ${{ needs.plan.outputs.npm_foundation_artifact }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  npm-sdk:
+    name: Publish Bluetooth SDK npm package
+    needs: [plan, ota, npm-foundation]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/bluetooth-sdk"
+      result_artifact: ${{ needs.plan.outputs.npm_sdk_artifact }}
+      ota_manifest_url: ${{ needs.ota.outputs.manifest_url }}
+      ota_manifest_sha256: ${{ needs.ota.outputs.manifest_sha256 }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  sdk-native:
+    name: Publish Bluetooth SDK native packages
+    needs: [plan, ota, npm-foundation]
+    uses: ./.github/workflows/reusable-coordinated-sdk-native.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      ota_manifest_url: ${{ needs.ota.outputs.manifest_url }}
+      ota_manifest_sha256: ${{ needs.ota.outputs.manifest_sha256 }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  npm-miniapp:
+    name: Publish remaining Engine npm dependency
+    needs: [plan, ota, npm-sdk, sdk-native]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/miniapp"
+      result_artifact: ${{ needs.plan.outputs.npm_miniapp_artifact }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  npm-engine:
+    name: Publish Mentra Engine with exact SDK closure
+    needs: [plan, ota, npm-sdk, sdk-native, npm-miniapp]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/engine"
+      result_artifact: ${{ needs.plan.outputs.npm_engine_artifact }}
+      ota_manifest_url: ${{ needs.ota.outputs.manifest_url }}
+      ota_manifest_sha256: ${{ needs.ota.outputs.manifest_sha256 }}
+      sdk_package_artifact: ${{ needs.plan.outputs.npm_sdk_artifact }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  mobile:
+    name: Build and distribute MentraOS mobile apps
+    needs: [plan, ota, npm-engine]
+    uses: ./.github/workflows/reusable-coordinated-mobile.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      ota_manifest_url: ${{ needs.ota.outputs.manifest_url }}
+      ota_manifest_sha256: ${{ needs.ota.outputs.manifest_sha256 }}
+      cloud_environment: ${{ needs.plan.outputs.cloud_environment }}
+      play_track: ${{ needs.plan.outputs.play_track }}
+      testflight_group: ${{ needs.plan.outputs.testflight_group }}
+      dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
+    secrets: inherit
+
+  finalize:
+    name: Finalize immutable release bill of materials
+    needs: [plan, ota, npm-foundation, npm-sdk, sdk-native, npm-miniapp, npm-engine, mobile]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.source_commit }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.plan_artifact }}
+          path: release-input/plan
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.ota.outputs.result_artifact }}
+          path: release-input/ota
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_foundation_artifact }}
+          path: release-input/npm-foundation
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_sdk_artifact }}
+          path: release-input/npm-sdk
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_miniapp_artifact }}
+          path: release-input/npm-miniapp
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_engine_artifact }}
+          path: release-input/npm-engine
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.sdk-native.outputs.result_artifact }}
+          path: release-input/sdk-native
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.mobile.outputs.result_artifact }}
+          path: release-input/mobile
+
+      - name: Assemble complete publication evidence
+        id: results
+        run: |
+          set -euo pipefail
+          mkdir -p finalized-release
+          plan=release-input/plan/release-plan.json
+          identity=$(jq -er .releaseIdentity "$plan")
+          tag="mentra-v$identity"
+          asg_selection="release-input/ota/$(jq -er .artifactNames.asgSelection "$plan")"
+          test -f "$asg_selection"
+          engine_package=$(find release-input/npm-engine -type f -name 'mentra-engine-*.tgz' -print -quit)
+          test -n "$engine_package"
+          node .github/scripts/assemble-coordinated-release-results.mjs \
+            --plan "$plan" \
+            --ota release-input/ota/ota-result.json \
+            --npm-foundation release-input/npm-foundation/npm-publications.json \
+            --npm-sdk release-input/npm-sdk/npm-publications.json \
+            --npm-miniapp release-input/npm-miniapp/npm-publications.json \
+            --npm-engine release-input/npm-engine/npm-publications.json \
+            --native release-input/sdk-native/sdk-native-publications.json \
+            --mobile release-input/mobile/mobile-publications.json \
+            --asg-selection "$asg_selection" \
+            --engine-package "$engine_package" \
+            --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag" \
+            --output finalized-release/publication-results.json
+          cp "$plan" "finalized-release/$(jq -er .artifactNames.releasePlan "$plan")"
+          cp "$engine_package" "finalized-release/$(jq -er .artifactNames.enginePackage "$plan")"
+          {
+            echo "tag=$tag"
+            echo "identity=$identity"
+            echo "plan_name=$(jq -er .artifactNames.releasePlan "$plan")"
+            echo "manifest_name=$(jq -er .artifactNames.releaseManifest "$plan")"
+            echo "engine_name=$(jq -er .artifactNames.enginePackage "$plan")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve and verify the exact release container
+        id: release-container
+        if: needs.plan.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ needs.plan.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.results.outputs.tag }}"
+          releases=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq 'add')
+          matches=$(jq --arg tag "$tag" '[.[] | select(.tag_name == $tag)]' <<< "$releases")
+          [[ "$(jq 'length' <<< "$matches")" == 1 ]]
+          release=$(jq '.[0]' <<< "$matches")
+          [[ "$(jq -r .name <<< "$release")" == "Mentra ${{ steps.results.outputs.identity }}" ]]
+          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
+            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
+          else
+            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
+          fi
+          echo "release_id=$(jq -er .id <<< "$release")" >> "$GITHUB_OUTPUT"
+
+      - name: Finalize release manifest
+        if: needs.plan.outputs.dry_run != 'true'
+        run: >-
+          node .github/scripts/finalize-release-manifest.mjs
+          --plan release-input/plan/release-plan.json
+          --results finalized-release/publication-results.json
+          --completed-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+          --output "finalized-release/${{ steps.results.outputs.manifest_name }}"
+
+      - name: Publish immutable plan, package, and manifest assets
+        if: needs.plan.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for name in \
+            "${{ steps.results.outputs.plan_name }}" \
+            "${{ steps.results.outputs.engine_name }}" \
+            "${{ steps.results.outputs.manifest_name }}"; do
+            node .github/scripts/publish-immutable-release-asset.mjs \
+              --file "finalized-release/$name" \
+              --name "$name" \
+              --release-id "${{ steps.release-container.outputs.release_id }}" \
+              --repository "${{ github.repository }}"
+          done
+
+      - name: Publish completed release set
+        if: needs.plan.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.results.outputs.tag }}"
+          payload=$(jq -n \
+            --arg name "Mentra ${{ steps.results.outputs.identity }}" \
+            --arg body "Coordinated Mentra release ${{ steps.results.outputs.identity }} from ${{ needs.plan.outputs.source_commit }}. Every required target is recorded in ${{ steps.results.outputs.manifest_name }}." \
+            '{draft: false, prerelease: true, name: $name, body: $body}')
+          gh api --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/releases/${{ steps.release-container.outputs.release_id }}" \
+            --input - <<< "$payload" \
+            --jq '.draft == false and .prerelease == true' | grep -qx true
+          git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+          [[ "$(git rev-parse "$tag^{commit}")" == "${{ needs.plan.outputs.source_commit }}" ]]
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/${{ steps.results.outputs.manifest_name }}"
+          node .github/scripts/verify-public-release-asset.mjs \
+            --file "finalized-release/${{ steps.results.outputs.manifest_name }}" \
+            --url "$url"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-release-result-${{ needs.plan.outputs.release_set_id }}
+          path: finalized-release
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize completed release
+        run: |
+          {
+            echo "## Coordinated release result"
+            echo ""
+            echo "- Release: \`${{ steps.results.outputs.identity }}\`"
+            echo "- Source: \`${{ needs.plan.outputs.source_commit }}\`"
+            echo "- OTA manifest: ${{ needs.ota.outputs.manifest_url }}"
+            echo "- Dry run: \`${{ needs.plan.outputs.dry_run }}\`"
+            if [[ "${{ needs.plan.outputs.dry_run }}" != "true" ]]; then
+              echo "- GitHub release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ steps.results.outputs.tag }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-coordinated-npm.yml
+++ b/.github/workflows/reusable-coordinated-npm.yml
@@ -29,6 +29,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      NPM_TOKEN:
+        required: false
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces automated multi-target prerelease publication (npm, OTA, mobile stores, GitHub releases); misconfiguration or verification gaps could ship inconsistent or wrong release artifacts.
> 
> **Overview**
> Adds a **Coordinated Mentra Release** GitHub Actions workflow that runs on `dev`/`staging` pushes (and manual dispatch with optional **dry run**), wiring the existing reusable OTA, npm, native SDK, and mobile jobs into one ordered pipeline with shared release-plan artifacts.
> 
> The new **finalize** job downloads all publication records, runs **`assemble-coordinated-release-results.mjs`** to merge npm/native/mobile/OTA evidence (with coverage checks, conflicting-publication detection, and ASG selection SHA/content verification), then—when not a dry run—finalizes the release manifest, uploads immutable plan/engine/manifest assets to the matching GitHub prerelease, and publishes the release after verifying the tag and public manifest URL.
> 
> Also declares an optional **`NPM_TOKEN`** secret on **`reusable-coordinated-npm.yml`** for callable workflows, plus unit tests for the assembler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a460af7a0f883b4fc9652d8ae1e11193cb0751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->