### PR TITLE
ci(release): promote completed beta sets to production

### DIFF
--- a/.github/scripts/assemble-production-release-results.mjs
+++ b/.github/scripts/assemble-production-release-results.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+function mergeRecords(plan, records) {
+  const publications = {}
+  const artifacts = []
+  for (const record of records) {
+    if (record.releaseSetId !== plan.releaseSetId) throw new Error("Production record belongs to another release set")
+    for (const [member, targets] of Object.entries(record.publications || {})) {
+      publications[member] ||= {}
+      for (const [target, publication] of Object.entries(targets)) {
+        if (publications[member][target]) throw new Error(`Duplicate production publication ${member}:${target}`)
+        publications[member][target] = publication
+      }
+    }
+    artifacts.push(...(record.artifacts || []))
+  }
+  for (const [member, definition] of Object.entries(plan.members)) {
+    for (const target of definition.publishTargets) {
+      if (!publications[member]?.[target]) throw new Error(`Missing production publication ${member}:${target}`)
+    }
+  }
+  return {publications, artifacts}
+}
+
+export function assembleProductionReleaseResults({plan, npmRecords, native, promotion, enginePackage, assetBaseUrl}) {
+  if (
+    plan.channel !== "production" ||
+    promotion.promotion?.selectedBetaReleaseSetId !== plan.promotion?.selectedBetaReleaseSetId
+  ) {
+    throw new Error("Production plan and promotion record do not select the same beta")
+  }
+  const merged = mergeRecords(plan, [...npmRecords, native, promotion])
+  const enginePublication = merged.publications["@mentra/engine"]?.npm
+  const bytes = readFileSync(enginePackage)
+  const sha256 = createHash("sha256").update(bytes).digest("hex")
+  if (sha256 !== enginePublication?.sha256) throw new Error("Stable Engine release asset differs from npm publication")
+  merged.artifacts.push({
+    status: enginePublication.status,
+    coordinate: plan.artifactNames.enginePackage,
+    url: `${assetBaseUrl}/${plan.artifactNames.enginePackage}`,
+    sha256,
+    size: statSync(enginePackage).size,
+    provenanceUrl: enginePublication.provenanceUrl,
+  })
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    promotion: promotion.promotion,
+    publications: merged.publications,
+    otaManifest: promotion.otaManifest,
+    artifacts: merged.artifacts,
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(path.resolve(file), "utf8"))
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const result = assembleProductionReleaseResults({
+    plan: readJson(args.plan),
+    npmRecords: [args["npm-foundation"], args["npm-sdk"], args["npm-miniapp"], args["npm-engine"]].map(readJson),
+    native: readJson(args.native),
+    promotion: readJson(args.promotion),
+    enginePackage: path.resolve(args["engine-package"]),
+    assetBaseUrl: args["asset-base-url"],
+  })
+  writeFileSync(path.resolve(args.output), serializeReleaseRecord(result))
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/assemble-production-release-results.test.mjs
+++ b/.github/scripts/assemble-production-release-results.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict"
+import {createHash} from "node:crypto"
+import {mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+import {fileURLToPath} from "node:url"
+
+import {assembleProductionReleaseResults} from "./assemble-production-release-results.mjs"
+import {createReleasePlan, finalizeReleaseManifest, loadReleaseFamily} from "./release-family.mjs"
+
+const plan = createReleasePlan({
+  family: loadReleaseFamily({rootDir: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")}),
+  channel: "production",
+  sourceCommit: "a".repeat(40),
+  nativeBuildNumber: 310000057,
+})
+plan.promotion = {
+  selectedBetaReleaseSetId: "mentra-3.1.0-beta.57",
+  selectedBetaIdentity: "3.1.0-beta.57",
+  selectedBetaManifest: {url: "https://example.com/beta.json", sha256: "b".repeat(64)},
+}
+const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/456"
+
+function publication(coordinate, sha256 = "c".repeat(64)) {
+  return {
+    status: "published",
+    coordinate,
+    url: `https://example.com/${encodeURIComponent(coordinate)}`,
+    sha256,
+    provenanceUrl,
+  }
+}
+
+function npmRecord(names) {
+  return {
+    releaseSetId: plan.releaseSetId,
+    publications: Object.fromEntries(
+      names.map((name) => [name, {npm: publication(`${name}@${plan.releaseIdentity}`)}]),
+    ),
+  }
+}
+
+test("assembles stable packages with exact promoted beta mobile and OTA bytes", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "production-results-"))
+  const enginePackage = path.join(directory, plan.artifactNames.enginePackage)
+  writeFileSync(enginePackage, "stable engine package")
+  const engineSha = createHash("sha256").update("stable engine package").digest("hex")
+  const npmRecords = [
+    npmRecord(["@mentra/jspolyfill", "@mentra/cloud-protocol", "@mentra/crust", "@mentra/cloud-client"]),
+    npmRecord(["@mentra/bluetooth-sdk"]),
+    npmRecord(["@mentra/miniapp"]),
+    {
+      releaseSetId: plan.releaseSetId,
+      publications: {"@mentra/engine": {npm: publication(`@mentra/engine@${plan.releaseIdentity}`, engineSha)}},
+    },
+  ]
+  const native = {
+    releaseSetId: plan.releaseSetId,
+    publications: {
+      "@mentra/bluetooth-sdk": {
+        "maven-central": publication(`com.mentraglass:bluetooth-sdk:${plan.releaseIdentity}`),
+        "swift-package-manager": publication(`Mentra-Community/mentra-bluetooth-sdk-ios@${plan.releaseIdentity}`),
+      },
+    },
+  }
+  const promotion = {
+    releaseSetId: plan.releaseSetId,
+    promotion: plan.promotion,
+    publications: {
+      mentraos: {
+        "google-play": {
+          ...publication(`com.mentra.mentra:${plan.native.buildNumber}:production`),
+          status: "promoted",
+        },
+        "app-store-connect": {
+          ...publication(`com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:App Store`),
+          status: "promoted",
+        },
+      },
+    },
+    otaManifest: {...publication("mentra-live-ota-3.1.0-beta.57.json"), status: "promoted"},
+    artifacts: [
+      {...publication("mentraos-3.1.0-beta.57-android.apk"), status: "promoted"},
+      {...publication("mentraos-3.1.0-beta.57-android.aab"), status: "promoted"},
+      {...publication("mentraos-3.1.0-beta.57-ios.ipa"), status: "promoted"},
+      {...publication("mentra-live-asg-selection-3.1.0-beta.57.json"), status: "promoted"},
+      {...publication("mentra-live-ota-bundle-3.1.0-beta.57.zip"), status: "promoted"},
+      {...publication("mentra-live-asg-100057.apk"), status: "promoted"},
+    ],
+  }
+  const results = assembleProductionReleaseResults({
+    plan,
+    npmRecords,
+    native,
+    promotion,
+    enginePackage,
+    assetBaseUrl: "https://example.com/stable",
+  })
+  const manifest = finalizeReleaseManifest({plan, results, completedAt: "2026-08-25T03:00:00.000Z"})
+  assert.equal(manifest.releaseIdentity, "3.1.0")
+  assert.equal(manifest.promotion.selectedBetaIdentity, "3.1.0-beta.57")
+  assert.equal(manifest.publications.mentraos["google-play"].status, "promoted")
+  assert.equal(manifest.otaManifest.coordinate, "mentra-live-ota-3.1.0-beta.57.json")
+
+  results.otaManifest.status = "published"
+  assert.throws(
+    () => finalizeReleaseManifest({plan, results, completedAt: "2026-08-25T03:00:00.000Z"}),
+    /must be promoted from the selected beta/,
+  )
+})

--- a/.github/scripts/create-production-promotion-records.mjs
+++ b/.github/scripts/create-production-promotion-records.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex")
+}
+
+function verifySelectedFile(file, selected, label) {
+  const sha256 = sha256File(file)
+  if (sha256 !== selected.sha256) throw new Error(`${label} differs from the selected beta artifact`)
+  if (selected.size !== undefined && statSync(file).size !== selected.size) {
+    throw new Error(`${label} size differs from the selected beta artifact`)
+  }
+  return selected
+}
+
+export function createProductionPromotionRecords({plan, selection, apk, aab, ipa, provenanceUrl}) {
+  if (plan.channel !== "production" || plan.releaseIdentity !== plan.familyBaseVersion) {
+    throw new Error("A stable production release plan is required")
+  }
+  if (
+    selection.releaseSetId !== plan.releaseSetId ||
+    selection.sourceCommit !== plan.sourceCommit ||
+    selection.native.buildNumber !== plan.native.buildNumber
+  ) {
+    throw new Error("Promotion selection does not match the stable release plan")
+  }
+  const androidApk = verifySelectedFile(apk, selection.mobileArtifacts.androidApk, "Android APK")
+  const androidAab = verifySelectedFile(aab, selection.mobileArtifacts.androidAab, "Android AAB")
+  const iosIpa = verifySelectedFile(ipa, selection.mobileArtifacts.iosIpa, "iOS IPA")
+  const promoted = (record) => ({...record, status: "promoted", provenanceUrl})
+
+  return {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    promotion: {
+      selectedBetaReleaseSetId: selection.selectedBetaReleaseSetId,
+      selectedBetaIdentity: selection.selectedBetaIdentity,
+      selectedBetaManifest: selection.betaManifest,
+    },
+    publications: {
+      mentraos: {
+        "google-play": {
+          status: "promoted",
+          coordinate: `com.mentra.mentra:${plan.native.buildNumber}:production`,
+          url: "https://play.google.com/console/",
+          sha256: androidAab.sha256,
+          provenanceUrl,
+        },
+        "app-store-connect": {
+          status: "promoted",
+          coordinate: `com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:App Store`,
+          url: "https://appstoreconnect.apple.com/apps",
+          sha256: iosIpa.sha256,
+          provenanceUrl,
+        },
+      },
+    },
+    otaManifest: promoted(selection.otaManifest),
+    artifacts: [promoted(androidApk), promoted(androidAab), promoted(iosIpa), ...selection.otaArtifacts.map(promoted)],
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const result = createProductionPromotionRecords({
+    plan: JSON.parse(readFileSync(path.resolve(args.plan), "utf8")),
+    selection: JSON.parse(readFileSync(path.resolve(args.selection), "utf8")),
+    apk: path.resolve(args.apk),
+    aab: path.resolve(args.aab),
+    ipa: path.resolve(args.ipa),
+    provenanceUrl: args["provenance-url"],
+  })
+  writeFileSync(path.resolve(args.output), serializeReleaseRecord(result))
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/create-production-promotion-records.test.mjs
+++ b/.github/scripts/create-production-promotion-records.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import {createHash} from "node:crypto"
+import {mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {createProductionPromotionRecords} from "./create-production-promotion-records.mjs"
+
+const root = mkdtempSync(path.join(tmpdir(), "production-promotion-"))
+const files = Object.fromEntries(
+  ["apk", "aab", "ipa"].map((name) => {
+    const file = path.join(root, name)
+    writeFileSync(file, `${name} bytes`)
+    return [name, file]
+  }),
+)
+
+function selected(file, coordinate) {
+  const bytes = Buffer.from(`${path.basename(file)} bytes`)
+  return {
+    status: "published",
+    coordinate,
+    url: `https://example.com/${coordinate}`,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    size: bytes.length,
+    provenanceUrl: "https://example.com/beta-run",
+  }
+}
+
+const plan = {
+  releaseSetId: "mentra-3.1.0",
+  releaseIdentity: "3.1.0",
+  familyBaseVersion: "3.1.0",
+  channel: "production",
+  sourceCommit: "a".repeat(40),
+  native: {marketingVersion: "3.1.0", buildNumber: 310000057},
+}
+const selection = {
+  releaseSetId: plan.releaseSetId,
+  selectedBetaReleaseSetId: "mentra-3.1.0-beta.57",
+  selectedBetaIdentity: "3.1.0-beta.57",
+  sourceCommit: plan.sourceCommit,
+  native: plan.native,
+  betaManifest: {url: "https://example.com/beta.json", sha256: "b".repeat(64)},
+  otaManifest: selected(files.apk, "ota.json"),
+  otaArtifacts: [selected(files.apk, "ota.zip"), selected(files.apk, "asg.apk")],
+  mobileArtifacts: {
+    androidApk: selected(files.apk, "app.apk"),
+    androidAab: selected(files.aab, "app.aab"),
+    iosIpa: selected(files.ipa, "app.ipa"),
+  },
+}
+
+test("records exact beta mobile and OTA bytes as production promotions", () => {
+  const result = createProductionPromotionRecords({
+    plan,
+    selection,
+    apk: files.apk,
+    aab: files.aab,
+    ipa: files.ipa,
+    provenanceUrl: "https://example.com/promotion-run",
+  })
+  assert.equal(result.publications.mentraos["google-play"].status, "promoted")
+  assert.equal(result.publications.mentraos["app-store-connect"].sha256, selection.mobileArtifacts.iosIpa.sha256)
+  assert.equal(result.otaManifest.url, selection.otaManifest.url)
+  assert.equal(result.artifacts.length, 5)
+})
+
+test("rejects substituted mobile bytes", () => {
+  writeFileSync(files.apk, "substituted")
+  assert.throws(
+    () =>
+      createProductionPromotionRecords({
+        plan,
+        selection,
+        apk: files.apk,
+        aab: files.aab,
+        ipa: files.ipa,
+        provenanceUrl: "https://example.com/promotion-run",
+      }),
+    /differs from the selected beta artifact/,
+  )
+  writeFileSync(files.apk, "apk bytes")
+})

--- a/.github/scripts/prepare-production-release.mjs
+++ b/.github/scripts/prepare-production-release.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {createReleasePlan, loadReleaseFamily, releaseRecordSha256, serializeReleaseRecord} from "./release-family.mjs"
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"))
+}
+
+function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex")
+}
+
+function exactArtifact(manifest, coordinate) {
+  const matches = (manifest.artifacts || []).filter((artifact) => artifact.coordinate === coordinate)
+  if (matches.length !== 1) throw new Error(`Expected one beta artifact ${coordinate}, found ${matches.length}`)
+  return matches[0]
+}
+
+export function prepareProductionRelease({family, betaPlan, betaManifest, betaManifestSha256, repository}) {
+  if (betaPlan.channel !== "beta" || !/^\d+\.\d+\.\d+-beta\.\d+$/.test(betaPlan.releaseIdentity)) {
+    throw new Error("Production can only select a completed beta release plan")
+  }
+  if (
+    betaManifest.channel !== "beta" ||
+    betaManifest.releaseSetId !== betaPlan.releaseSetId ||
+    betaManifest.releaseIdentity !== betaPlan.releaseIdentity ||
+    betaManifest.sourceCommit !== betaPlan.sourceCommit
+  ) {
+    throw new Error("Beta release manifest does not match its plan")
+  }
+  if (betaManifest.releasePlanSha256 !== releaseRecordSha256(betaPlan)) {
+    throw new Error("Beta release plan digest does not match the completed manifest")
+  }
+  if (betaPlan.familyBaseVersion !== family.familyBaseVersion) {
+    throw new Error("Selected beta belongs to a different family base")
+  }
+  if (!SHA256_PATTERN.test(betaManifestSha256)) throw new Error("Invalid beta manifest SHA-256")
+  if (!Number.isSafeInteger(betaPlan.native?.buildNumber) || betaPlan.native.buildNumber < 1) {
+    throw new Error("Selected beta has no valid native build number")
+  }
+
+  const betaTag = `mentra-v${betaPlan.releaseIdentity}`
+  const betaAssetBaseUrl = `https://github.com/${repository}/releases/download/${betaTag}`
+  const betaManifestUrl = `${betaAssetBaseUrl}/${betaPlan.artifactNames.releaseManifest}`
+  const productionPlan = createReleasePlan({
+    family,
+    channel: "production",
+    sourceCommit: betaPlan.sourceCommit,
+    nativeBuildNumber: betaPlan.native.buildNumber,
+    otaInputs: betaPlan.otaInputs,
+  })
+  productionPlan.promotion = {
+    selectedBetaReleaseSetId: betaPlan.releaseSetId,
+    selectedBetaIdentity: betaPlan.releaseIdentity,
+    selectedBetaManifest: {
+      url: betaManifestUrl,
+      sha256: betaManifestSha256,
+    },
+  }
+
+  const mobileArtifacts = {
+    androidApk: exactArtifact(betaManifest, betaPlan.artifactNames.androidApp),
+    androidAab: exactArtifact(betaManifest, betaPlan.artifactNames.androidStoreApp),
+    iosIpa: exactArtifact(betaManifest, betaPlan.artifactNames.iosApp),
+  }
+  const otaArtifacts = (betaManifest.artifacts || []).filter(
+    (artifact) => artifact.provenanceUrl === betaManifest.otaManifest.provenanceUrl,
+  )
+  if (otaArtifacts.length < 2) throw new Error("Completed beta manifest is missing its OTA bundle or ASG artifact")
+
+  return {
+    productionPlan,
+    selection: {
+      schemaVersion: 1,
+      releaseSetId: productionPlan.releaseSetId,
+      selectedBetaReleaseSetId: betaPlan.releaseSetId,
+      selectedBetaIdentity: betaPlan.releaseIdentity,
+      sourceCommit: betaPlan.sourceCommit,
+      native: betaPlan.native,
+      betaManifest: productionPlan.promotion.selectedBetaManifest,
+      otaManifest: betaManifest.otaManifest,
+      otaArtifacts,
+      mobileArtifacts,
+    },
+  }
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const betaPlanPath = path.resolve(args["beta-plan"])
+  const betaManifestPath = path.resolve(args["beta-manifest"])
+  const result = prepareProductionRelease({
+    family: loadReleaseFamily({rootDir: path.resolve(args.root || process.cwd()), requireVersionMirrors: true}),
+    betaPlan: readJson(betaPlanPath),
+    betaManifest: readJson(betaManifestPath),
+    betaManifestSha256: sha256File(betaManifestPath),
+    repository: args.repository,
+  })
+  writeFileSync(path.resolve(args["plan-output"]), serializeReleaseRecord(result.productionPlan))
+  writeFileSync(path.resolve(args["selection-output"]), serializeReleaseRecord(result.selection))
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/prepare-production-release.test.mjs
+++ b/.github/scripts/prepare-production-release.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {releaseRecordSha256} from "./release-family.mjs"
+import {prepareProductionRelease} from "./prepare-production-release.mjs"
+
+const family = {
+  familyBaseVersion: "3.1.0",
+  products: ["mentraos"],
+  publicationOrder: ["mentraos"],
+  members: [
+    {
+      name: "mentraos",
+      manifest: "mobile/package.json",
+      kind: "product",
+      publishTargets: ["app-store-connect", "google-play"],
+      dependencies: [],
+    },
+  ],
+}
+
+const betaPlan = {
+  schemaVersion: 1,
+  releaseSetId: "mentra-3.1.0-beta.57",
+  familyBaseVersion: "3.1.0",
+  releaseIdentity: "3.1.0-beta.57",
+  channel: "beta",
+  sequence: 57,
+  sourceCommit: "a".repeat(40),
+  native: {marketingVersion: "3.1.0", buildNumber: 310000057},
+  products: {mentraos: "3.1.0-beta.57"},
+  members: {
+    mentraos: {
+      version: "3.1.0-beta.57",
+      kind: "product",
+      manifest: "mobile/package.json",
+      publishTargets: ["app-store-connect", "google-play"],
+      dependencies: {},
+    },
+  },
+  publicationOrder: ["mentraos"],
+  artifactNames: {
+    releaseManifest: "mentra-release-3.1.0-beta.57.json",
+    androidApp: "mentraos-3.1.0-beta.57-android.apk",
+    androidStoreApp: "mentraos-3.1.0-beta.57-android.aab",
+    iosApp: "mentraos-3.1.0-beta.57-ios.ipa",
+  },
+  otaInputs: {firmwareManifest: {sha256: "b".repeat(64)}},
+}
+
+function artifact(coordinate, provenanceUrl = "https://github.com/example/actions/runs/mobile") {
+  return {
+    status: "published",
+    coordinate,
+    url: `https://example.com/${coordinate}`,
+    sha256: "c".repeat(64),
+    provenanceUrl,
+  }
+}
+
+function manifest() {
+  return {
+    releaseSetId: betaPlan.releaseSetId,
+    releaseIdentity: betaPlan.releaseIdentity,
+    channel: "beta",
+    sourceCommit: betaPlan.sourceCommit,
+    releasePlanSha256: releaseRecordSha256(betaPlan),
+    otaManifest: artifact("mentra-live-ota-3.1.0-beta.57.json", "https://github.com/example/actions/runs/ota"),
+    artifacts: [
+      artifact(betaPlan.artifactNames.androidApp),
+      artifact(betaPlan.artifactNames.androidStoreApp),
+      artifact(betaPlan.artifactNames.iosApp),
+      artifact("mentra-live-ota-bundle-3.1.0-beta.57.zip", "https://github.com/example/actions/runs/ota"),
+      artifact("mentra-live-asg-100057.apk", "https://github.com/example/actions/runs/ota"),
+    ],
+  }
+}
+
+test("derives a stable plan while preserving the selected beta bytes and native build", () => {
+  const result = prepareProductionRelease({
+    family,
+    betaPlan,
+    betaManifest: manifest(),
+    betaManifestSha256: "d".repeat(64),
+    repository: "Mentra-Community/MentraOS",
+  })
+  assert.equal(result.productionPlan.releaseIdentity, "3.1.0")
+  assert.equal(result.productionPlan.sourceCommit, betaPlan.sourceCommit)
+  assert.equal(result.productionPlan.native.buildNumber, betaPlan.native.buildNumber)
+  assert.equal(result.selection.mobileArtifacts.androidAab.coordinate, betaPlan.artifactNames.androidStoreApp)
+  assert.equal(result.selection.otaManifest.sha256, "c".repeat(64))
+  assert.equal(result.selection.otaArtifacts.length, 2)
+})
+
+test("rejects a beta manifest whose plan digest does not match", () => {
+  const invalid = manifest()
+  invalid.releasePlanSha256 = "0".repeat(64)
+  assert.throws(
+    () =>
+      prepareProductionRelease({
+        family,
+        betaPlan,
+        betaManifest: invalid,
+        betaManifestSha256: "d".repeat(64),
+        repository: "Mentra-Community/MentraOS",
+      }),
+    /plan digest/,
+  )
+})

--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -14,6 +14,14 @@ export function npmReleaseTag(channel) {
   throw new Error(`Unsupported npm release channel ${JSON.stringify(channel)}`)
 }
 
+export function resolveNpmReleaseTag(channel, override) {
+  if (!override) return npmReleaseTag(channel)
+  if (!/^[a-z][a-z0-9._-]*$/.test(override) || /^v?\d+\.\d+\.\d+/.test(override)) {
+    throw new Error(`Invalid npm dist-tag override ${JSON.stringify(override)}`)
+  }
+  return override
+}
+
 export function sha512Integrity(bytes) {
   return `sha512-${createHash("sha512").update(bytes).digest("base64")}`
 }
@@ -257,13 +265,14 @@ export function publishReleaseNpm({
   otaManifestUrl,
   otaManifestSha256,
   sdkTarball,
+  npmTagOverride,
 }) {
   requirePlanSourceCommit(rootDir, plan.sourceCommit)
   const family = loadReleaseFamily({rootDir})
   if (plan.familyBaseVersion !== family.familyBaseVersion)
     throw new Error("Release plan does not match source family base")
   const orderedNames = npmMembersInOrder(family, memberNames)
-  const tag = npmReleaseTag(plan.channel)
+  const tag = resolveNpmReleaseTag(plan.channel, npmTagOverride)
   const publications = {}
   let selectedSdkTarball = sdkTarball
   mkdirSync(outputDir, {recursive: true})
@@ -379,6 +388,7 @@ function main() {
     otaManifestUrl: args["ota-manifest-url"],
     otaManifestSha256: args["ota-manifest-sha256"],
     sdkTarball: args["sdk-tarball"],
+    npmTagOverride: args["npm-tag"],
   })
 }
 

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -12,6 +12,7 @@ import {
   releaseMetadataArgs,
   requireNpmProvenanceSource,
   requirePlanSourceCommit,
+  resolveNpmReleaseTag,
   sha512Integrity,
 } from "./publish-release-npm.mjs"
 
@@ -22,6 +23,8 @@ test("maps coordinated channels to npm tags", () => {
   assert.equal(npmReleaseTag("beta"), "beta")
   assert.throws(() => npmReleaseTag("production"), /explicit candidate dist-tag/)
   assert.throws(() => npmReleaseTag("nightly"), /Unsupported/)
+  assert.equal(resolveNpmReleaseTag("production", "candidate-3-1-0"), "candidate-3-1-0")
+  assert.throws(() => resolveNpmReleaseTag("production", "3.1.0"), /Invalid npm dist-tag/)
 })
 
 test("selects npm packages in dependency order", () => {

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -380,6 +380,24 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
     if (!artifactCoordinates.has(coordinate)) throw new Error(`Missing required artifact ${coordinate}`)
   }
 
+  let promotion
+  if (plan.channel === "production") {
+    promotion = results.promotion
+    if (
+      !promotion ||
+      promotion.selectedBetaReleaseSetId !== plan.promotion?.selectedBetaReleaseSetId ||
+      promotion.selectedBetaIdentity !== plan.promotion?.selectedBetaIdentity ||
+      promotion.selectedBetaManifest?.url !== plan.promotion?.selectedBetaManifest?.url ||
+      promotion.selectedBetaManifest?.sha256 !== plan.promotion?.selectedBetaManifest?.sha256
+    ) {
+      throw new Error("Production release is missing its exact selected beta provenance")
+    }
+    requirePublicHttpsUrl(promotion.selectedBetaManifest.url, "promotion.selectedBetaManifest.url")
+    if (!SHA256_PATTERN.test(promotion.selectedBetaManifest.sha256)) {
+      throw new Error("promotion.selectedBetaManifest.sha256 must be a lowercase SHA-256 digest")
+    }
+  }
+
   return {
     schemaVersion: 1,
     releaseSetId: plan.releaseSetId,
@@ -393,5 +411,6 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
     publications,
     otaManifest,
     artifacts,
+    ...(promotion ? {promotion} : {}),
   }
 }

--- a/.github/scripts/verify-release-artifacts.mjs
+++ b/.github/scripts/verify-release-artifacts.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {readFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {requirePublicHttpsUrl} from "./release-family.mjs"
+
+function uniqueDownloadableRecords(manifest) {
+  const records = [manifest.otaManifest, ...(manifest.artifacts || [])]
+  for (const [member, targets] of Object.entries(manifest.publications || {})) {
+    if (member === "mentraos") continue
+    records.push(...Object.values(targets))
+  }
+  const byUrl = new Map()
+  for (const record of records) {
+    if (!record?.url || !record?.sha256) throw new Error("Release manifest contains an incomplete artifact record")
+    const existing = byUrl.get(record.url)
+    if (existing && existing.sha256 !== record.sha256) throw new Error(`Conflicting hashes recorded for ${record.url}`)
+    byUrl.set(record.url, record)
+  }
+  return [...byUrl.values()]
+}
+
+export async function verifyReleaseArtifacts(manifest, fetchImpl = fetch) {
+  const verified = []
+  for (const record of uniqueDownloadableRecords(manifest)) {
+    const url = requirePublicHttpsUrl(record.url, `Artifact ${record.coordinate} URL`)
+    const response = await fetchImpl(url)
+    if (!response.ok) throw new Error(`Artifact ${record.coordinate} returned HTTP ${response.status}`)
+    const bytes = Buffer.from(await response.arrayBuffer())
+    const sha256 = createHash("sha256").update(bytes).digest("hex")
+    if (sha256 !== record.sha256) throw new Error(`Artifact ${record.coordinate} no longer matches its release hash`)
+    verified.push({coordinate: record.coordinate, url: record.url, sha256, size: bytes.length})
+  }
+  return verified
+}
+
+async function main() {
+  const index = process.argv.indexOf("--manifest")
+  if (index < 0 || !process.argv[index + 1]) throw new Error("Missing --manifest")
+  const manifest = JSON.parse(readFileSync(path.resolve(process.argv[index + 1]), "utf8"))
+  const verified = await verifyReleaseArtifacts(manifest)
+  console.log(`Verified ${verified.length} immutable release artifacts`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main()

--- a/.github/scripts/verify-release-artifacts.test.mjs
+++ b/.github/scripts/verify-release-artifacts.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import {createHash} from "node:crypto"
+import test from "node:test"
+
+import {verifyReleaseArtifacts} from "./verify-release-artifacts.mjs"
+
+const bytes = Buffer.from("immutable artifact")
+const sha256 = createHash("sha256").update(bytes).digest("hex")
+
+test("verifies every downloadable package and artifact while excluding store console links", async () => {
+  const requested = []
+  const manifest = {
+    otaManifest: {coordinate: "ota", url: "https://example.com/ota", sha256},
+    artifacts: [{coordinate: "apk", url: "https://example.com/apk", sha256}],
+    publications: {
+      "@mentra/engine": {npm: {coordinate: "engine", url: "https://example.com/engine", sha256}},
+      "mentraos": {"google-play": {coordinate: "play", url: "https://play.google.com/console/", sha256}},
+    },
+  }
+  const result = await verifyReleaseArtifacts(manifest, async (url) => {
+    requested.push(url.toString())
+    return new Response(bytes)
+  })
+  assert.equal(result.length, 3)
+  assert.equal(requested.includes("https://play.google.com/console/"), false)
+})
+
+test("rejects bytes that no longer match the completed manifest", async () => {
+  await assert.rejects(
+    () =>
+      verifyReleaseArtifacts(
+        {otaManifest: {coordinate: "ota", url: "https://example.com/ota", sha256: "0".repeat(64)}},
+        async () => new Response(bytes),
+      ),
+    /no longer matches/,
+  )
+})
+
+test("rejects credentialed release artifact URLs before fetching", async () => {
+  await assert.rejects(
+    () =>
+      verifyReleaseArtifacts(
+        {otaManifest: {coordinate: "ota", url: "https://token@example.com/ota", sha256}},
+        async () => {
+          throw new Error("must not fetch")
+        },
+      ),
+    /credential-free HTTPS/,
+  )
+})

--- a/.github/workflows/coordinated-production-promotion.yml
+++ b/.github/workflows/coordinated-production-promotion.yml
@@ -1,0 +1,394 @@
+name: Coordinated Mentra Production Promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      beta_identity:
+        description: Completed beta identity to promote, for example 3.1.0-beta.57
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+
+concurrency:
+  group: coordinated-mentra-production-promotion
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    name: Approve selected production candidate
+    runs-on: ubuntu-latest
+    environment:
+      name: coordinated-production-release
+    steps:
+      - run: echo "Approved production promotion of ${{ inputs.beta_identity }}"
+
+  plan:
+    name: Verify beta and derive stable release intent
+    needs: approve
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      source_commit: ${{ steps.release.outputs.source_commit }}
+      release_identity: ${{ steps.release.outputs.release_identity }}
+      release_set_id: ${{ steps.release.outputs.release_set_id }}
+      plan_artifact: ${{ steps.release.outputs.plan_artifact }}
+      ota_manifest_url: ${{ steps.release.outputs.ota_manifest_url }}
+      ota_manifest_sha256: ${{ steps.release.outputs.ota_manifest_sha256 }}
+      npm_foundation_artifact: ${{ steps.release.outputs.npm_foundation_artifact }}
+      npm_sdk_artifact: ${{ steps.release.outputs.npm_sdk_artifact }}
+      npm_miniapp_artifact: ${{ steps.release.outputs.npm_miniapp_artifact }}
+      npm_engine_artifact: ${{ steps.release.outputs.npm_engine_artifact }}
+      npm_candidate_tag: ${{ steps.release.outputs.npm_candidate_tag }}
+      release_id: ${{ steps.release-container.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Download the selected completed beta plan and manifest
+        env:
+          BETA_IDENTITY: ${{ inputs.beta_identity }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$BETA_IDENTITY" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*$ ]]
+          tag="mentra-v$BETA_IDENTITY"
+          state=$(gh release view "$tag" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv')
+          [[ "$state" == $'false\ttrue' ]]
+          mkdir -p selected-beta
+          gh release download "$tag" \
+            --pattern "mentra-release-plan-$BETA_IDENTITY.json" \
+            --pattern "mentra-release-$BETA_IDENTITY.json" \
+            --dir selected-beta
+          mv "selected-beta/mentra-release-plan-$BETA_IDENTITY.json" selected-beta/release-plan.json
+          mv "selected-beta/mentra-release-$BETA_IDENTITY.json" selected-beta/release-manifest.json
+
+      - name: Verify every immutable beta package, OTA, and downloadable artifact
+        run: node .github/scripts/verify-release-artifacts.mjs --manifest selected-beta/release-manifest.json
+
+      - name: Require the selected beta source in main
+        run: |
+          set -euo pipefail
+          source_commit=$(jq -er .sourceCommit selected-beta/release-plan.json)
+          git fetch origin main
+          git cat-file -e "$source_commit^{commit}"
+          git merge-base --is-ancestor "$source_commit" origin/main
+
+      - name: Derive deterministic stable plan from selected beta
+        run: |
+          set -euo pipefail
+          mkdir -p production-intent
+          node .github/scripts/prepare-production-release.mjs \
+            --beta-plan selected-beta/release-plan.json \
+            --beta-manifest selected-beta/release-manifest.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --plan-output production-intent/release-plan.json \
+            --selection-output production-intent/production-selection.json
+          cp selected-beta/release-plan.json production-intent/selected-beta-plan.json
+          cp selected-beta/release-manifest.json production-intent/selected-beta-manifest.json
+
+      - name: Export stable release coordinates
+        id: release
+        run: |
+          set -euo pipefail
+          identity=$(jq -er .releaseIdentity production-intent/release-plan.json)
+          release_set_id=$(jq -er .releaseSetId production-intent/release-plan.json)
+          source_commit=$(jq -er .sourceCommit production-intent/release-plan.json)
+          ota_url=$(jq -er .otaManifest.url production-intent/production-selection.json)
+          ota_sha=$(jq -er .otaManifest.sha256 production-intent/production-selection.json)
+          candidate_tag="candidate-${identity//./-}"
+          {
+            echo "source_commit=$source_commit"
+            echo "release_identity=$identity"
+            echo "release_set_id=$release_set_id"
+            echo "plan_artifact=coordinated-production-plan-$release_set_id"
+            echo "ota_manifest_url=$ota_url"
+            echo "ota_manifest_sha256=$ota_sha"
+            echo "npm_foundation_artifact=coordinated-npm-foundation-$release_set_id"
+            echo "npm_sdk_artifact=coordinated-npm-sdk-$release_set_id"
+            echo "npm_miniapp_artifact=coordinated-npm-miniapp-$release_set_id"
+            echo "npm_engine_artifact=coordinated-npm-engine-$release_set_id"
+            echo "npm_candidate_tag=$candidate_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Allocate or verify the exact stable release container
+        id: release-container
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          identity=$(jq -er .releaseIdentity production-intent/release-plan.json)
+          source_commit=$(jq -er .sourceCommit production-intent/release-plan.json)
+          tag="mentra-v$identity"
+          name="Mentra $identity"
+          releases=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq 'add')
+          matches=$(jq --arg tag "$tag" '[.[] | select(.tag_name == $tag)]' <<< "$releases")
+          count=$(jq 'length' <<< "$matches")
+          [[ "$count" -le 1 ]]
+          if [[ "$count" == 0 ]]; then
+            payload=$(jq -n \
+              --arg tag "$tag" \
+              --arg target "$source_commit" \
+              --arg name "$name" \
+              '{tag_name: $tag, target_commitish: $target, name: $name, body: "Coordinated Mentra production promotion in progress.", draft: true, prerelease: false}')
+            release=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input - <<< "$payload")
+          else
+            release=$(jq '.[0]' <<< "$matches")
+          fi
+          [[ "$(jq -r .name <<< "$release")" == "$name" ]]
+          [[ "$(jq -r .prerelease <<< "$release")" == "false" ]]
+          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
+            [[ "$(jq -r .target_commitish <<< "$release")" == "$source_commit" ]]
+          else
+            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+            [[ "$(git rev-parse "$tag^{commit}")" == "$source_commit" ]]
+          fi
+          echo "release_id=$(jq -er .id <<< "$release")" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.release.outputs.plan_artifact }}
+          path: production-intent
+          if-no-files-found: error
+          retention-days: 90
+
+  npm-foundation:
+    name: Publish stable leaf npm dependency closure
+    needs: plan
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/jspolyfill,@mentra/cloud-protocol,@mentra/crust,@mentra/cloud-client"
+      result_artifact: ${{ needs.plan.outputs.npm_foundation_artifact }}
+      npm_tag: ${{ needs.plan.outputs.npm_candidate_tag }}
+    secrets: inherit
+
+  npm-sdk:
+    name: Publish stable Bluetooth SDK npm package
+    needs: [plan, npm-foundation]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/bluetooth-sdk"
+      result_artifact: ${{ needs.plan.outputs.npm_sdk_artifact }}
+      ota_manifest_url: ${{ needs.plan.outputs.ota_manifest_url }}
+      ota_manifest_sha256: ${{ needs.plan.outputs.ota_manifest_sha256 }}
+      npm_tag: ${{ needs.plan.outputs.npm_candidate_tag }}
+    secrets: inherit
+
+  sdk-native:
+    name: Publish stable Bluetooth SDK native packages
+    needs: [plan, npm-foundation]
+    uses: ./.github/workflows/reusable-coordinated-sdk-native.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      ota_manifest_url: ${{ needs.plan.outputs.ota_manifest_url }}
+      ota_manifest_sha256: ${{ needs.plan.outputs.ota_manifest_sha256 }}
+    secrets: inherit
+
+  npm-miniapp:
+    name: Publish stable remaining Engine dependency
+    needs: [plan, npm-sdk, sdk-native]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/miniapp"
+      result_artifact: ${{ needs.plan.outputs.npm_miniapp_artifact }}
+      npm_tag: ${{ needs.plan.outputs.npm_candidate_tag }}
+    secrets: inherit
+
+  npm-engine:
+    name: Publish stable Engine with exact SDK closure
+    needs: [plan, npm-sdk, sdk-native, npm-miniapp]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.plan.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+      members: "@mentra/engine"
+      result_artifact: ${{ needs.plan.outputs.npm_engine_artifact }}
+      ota_manifest_url: ${{ needs.plan.outputs.ota_manifest_url }}
+      ota_manifest_sha256: ${{ needs.plan.outputs.ota_manifest_sha256 }}
+      sdk_package_artifact: ${{ needs.plan.outputs.npm_sdk_artifact }}
+      npm_tag: ${{ needs.plan.outputs.npm_candidate_tag }}
+    secrets: inherit
+
+  mobile:
+    name: Promote exact beta mobile builds
+    needs: [plan, npm-engine, sdk-native]
+    uses: ./.github/workflows/reusable-coordinated-mobile-promotion.yml
+    with:
+      release_plan_artifact: ${{ needs.plan.outputs.plan_artifact }}
+    secrets: inherit
+
+  finalize:
+    name: Finalize stable release and public package pointers
+    needs: [plan, npm-foundation, npm-sdk, sdk-native, npm-miniapp, npm-engine, mobile]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Finalization consumes verified records and does not rebuild the selected
+      # beta source. Keep the current promotion tooling available for old betas.
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.plan_artifact }}
+          path: release-input/plan
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_foundation_artifact }}
+          path: release-input/npm-foundation
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_sdk_artifact }}
+          path: release-input/npm-sdk
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_miniapp_artifact }}
+          path: release-input/npm-miniapp
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.npm_engine_artifact }}
+          path: release-input/npm-engine
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.sdk-native.outputs.result_artifact }}
+          path: release-input/sdk-native
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.mobile.outputs.result_artifact }}
+          path: release-input/promotion
+
+      - name: Assemble stable publication evidence
+        id: release
+        run: |
+          set -euo pipefail
+          mkdir -p finalized-release
+          plan=release-input/plan/release-plan.json
+          identity=$(jq -er .releaseIdentity "$plan")
+          tag="mentra-v$identity"
+          engine_package=$(find release-input/npm-engine -type f -name 'mentra-engine-*.tgz' -print -quit)
+          test -n "$engine_package"
+          node .github/scripts/assemble-production-release-results.mjs \
+            --plan "$plan" \
+            --npm-foundation release-input/npm-foundation/npm-publications.json \
+            --npm-sdk release-input/npm-sdk/npm-publications.json \
+            --npm-miniapp release-input/npm-miniapp/npm-publications.json \
+            --npm-engine release-input/npm-engine/npm-publications.json \
+            --native release-input/sdk-native/sdk-native-publications.json \
+            --promotion release-input/promotion/production-promotion-records.json \
+            --engine-package "$engine_package" \
+            --asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag" \
+            --output finalized-release/publication-results.json
+          cp "$plan" "finalized-release/$(jq -er .artifactNames.releasePlan "$plan")"
+          cp "$engine_package" "finalized-release/$(jq -er .artifactNames.enginePackage "$plan")"
+          node .github/scripts/finalize-release-manifest.mjs \
+            --plan "$plan" \
+            --results finalized-release/publication-results.json \
+            --completed-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+            --output "finalized-release/$(jq -er .artifactNames.releaseManifest "$plan")"
+          {
+            echo "tag=$tag"
+            echo "identity=$identity"
+            echo "plan_name=$(jq -er .artifactNames.releasePlan "$plan")"
+            echo "engine_name=$(jq -er .artifactNames.enginePackage "$plan")"
+            echo "manifest_name=$(jq -er .artifactNames.releaseManifest "$plan")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify the allocated stable release container
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ needs.plan.outputs.source_commit }}
+          RELEASE_ID: ${{ needs.plan.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release.outputs.tag }}"
+          release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID")
+          [[ "$(jq -r .tag_name <<< "$release")" == "$tag" ]]
+          [[ "$(jq -r .name <<< "$release")" == "Mentra ${{ steps.release.outputs.identity }}" ]]
+          [[ "$(jq -r .prerelease <<< "$release")" == "false" ]]
+          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
+            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
+          else
+            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
+          fi
+
+      - name: Publish immutable stable release records
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for name in \
+            "${{ steps.release.outputs.plan_name }}" \
+            "${{ steps.release.outputs.engine_name }}" \
+            "${{ steps.release.outputs.manifest_name }}"; do
+            node .github/scripts/publish-immutable-release-asset.mjs \
+              --file "finalized-release/$name" \
+              --name "$name" \
+              --release-id "${{ needs.plan.outputs.release_id }}" \
+              --repository "${{ github.repository }}"
+          done
+
+      - name: Move the complete stable npm family to latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          identity="${{ steps.release.outputs.identity }}"
+          jq -r '.members | to_entries[] | select(.value.publishTargets | index("npm")) | .key' release-input/plan/release-plan.json \
+            | while IFS= read -r member; do
+                npm dist-tag add "$member@$identity" latest
+                [[ "$(npm view "$member" dist-tags.latest --json | jq -r .)" == "$identity" ]]
+              done
+
+      - name: Publish stable GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release.outputs.tag }}"
+          payload=$(jq -n \
+            --arg name "Mentra ${{ steps.release.outputs.identity }}" \
+            --arg body "Stable coordinated Mentra release promoted from ${{ inputs.beta_identity }}. Mobile and OTA bytes are the exact completed beta artifacts; stable packages were reproduced from the same source and OTA pin." \
+            '{draft: false, prerelease: false, make_latest: "true", name: $name, body: $body}')
+          gh api --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/releases/${{ needs.plan.outputs.release_id }}" \
+            --input - <<< "$payload" \
+            --jq '.draft == false and .prerelease == false' | grep -qx true
+          git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+          [[ "$(git rev-parse "$tag^{commit}")" == "${{ needs.plan.outputs.source_commit }}" ]]
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/${{ steps.release.outputs.manifest_name }}"
+          node .github/scripts/verify-public-release-asset.mjs \
+            --file "finalized-release/${{ steps.release.outputs.manifest_name }}" \
+            --url "$url"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-production-result-${{ needs.plan.outputs.release_set_id }}
+          path: finalized-release
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/reusable-coordinated-mobile-promotion.yml
+++ b/.github/workflows/reusable-coordinated-mobile-promotion.yml
@@ -1,0 +1,168 @@
+name: Reusable Coordinated Mobile Promotion
+
+on:
+  workflow_call:
+    inputs:
+      release_plan_artifact:
+        required: true
+        type: string
+    secrets:
+      GOOGLE_PLAY_KEY_JSON:
+        required: true
+      ASC_API_KEY_P8_B64:
+        required: true
+      ASC_API_KEY_ID:
+        required: true
+      ASC_API_ISSUER_ID:
+        required: true
+    outputs:
+      result_artifact:
+        value: ${{ jobs.promote.outputs.result_artifact }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coordinated-production-mobile-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote exact beta mobile binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      result_artifact: ${{ steps.result.outputs.name }}
+    steps:
+      # This job promotes already-built beta binaries; it does not rebuild from
+      # source. Use the current promotion tooling while the plan job separately
+      # verifies the selected beta source commit and artifact hashes.
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.release_plan_artifact }}
+          path: release-intent
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install pinned store promotion tooling
+        working-directory: mobile
+        run: bundle install
+
+      - name: Inject Google Play and App Store Connect credentials
+        uses: ./.github/actions/inject-signing
+        with:
+          play: "true"
+          ios: "true"
+          google-play-key-json: ${{ secrets.GOOGLE_PLAY_KEY_JSON }}
+          asc-api-key-p8-b64: ${{ secrets.ASC_API_KEY_P8_B64 }}
+          asc-api-key-id: ${{ secrets.ASC_API_KEY_ID }}
+          asc-api-issuer-id: ${{ secrets.ASC_API_ISSUER_ID }}
+
+      - name: Download and verify exact beta mobile artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p promotion-input/mobile
+          selection=release-intent/production-selection.json
+          download() {
+            local key="$1" output="$2"
+            local url expected actual
+            url=$(jq -er ".mobileArtifacts.${key}.url" "$selection")
+            expected=$(jq -er ".mobileArtifacts.${key}.sha256" "$selection")
+            curl --fail --silent --show-error --location --retry 3 "$url" -o "$output"
+            actual=$(sha256sum "$output" | awk '{print $1}')
+            [[ "$actual" == "$expected" ]]
+          }
+          download androidApk promotion-input/mobile/app.apk
+          download androidAab promotion-input/mobile/app.aab
+          download iosIpa promotion-input/mobile/app.ipa
+
+      - name: Promote the exact Android version code to production
+        working-directory: mobile
+        env:
+          GOOGLE_PLAY_PROMOTION_OUTPUT: ${{ runner.temp }}/google-play-promotion.json
+          GOOGLE_PLAY_SOURCE_TRACK: beta
+          GOOGLE_PLAY_TARGET_TRACK: production
+        run: |
+          set -euo pipefail
+          export GOOGLE_PLAY_VERSION_CODE
+          GOOGLE_PLAY_VERSION_CODE=$(jq -er .native.buildNumber ../release-intent/release-plan.json)
+          rm -rf fastlane
+          mkdir fastlane
+          cp ci/fastlane-android/Fastfile ci/fastlane-android/Appfile fastlane/
+          bundle exec fastlane promote_google_play
+
+      - name: Resolve App Store Connect credential path
+        id: asc
+        run: |
+          set -euo pipefail
+          key_path=$(sed -n 's/^ASC_API_KEY_PATH=//p' "$MENTRA_ASC_CONFIG_PATH")
+          test -f "$key_path"
+          echo "key_path=$key_path" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether the exact iOS build is already in production review
+        id: app-store
+        run: >-
+          node mobile/scripts/app-store-connect-build.mjs production-status
+          --issuer-id "${{ secrets.ASC_API_ISSUER_ID }}"
+          --key-id "${{ secrets.ASC_API_KEY_ID }}"
+          --key-path "${{ steps.asc.outputs.key_path }}"
+          --bundle-id com.mentra.mentra
+          --app-version "$(jq -er .native.marketingVersion release-intent/release-plan.json)"
+          --build-number "$(jq -er .native.buildNumber release-intent/release-plan.json)"
+
+      - name: Submit the exact existing iOS build to App Review
+        if: steps.app-store.outputs.promoted != 'true'
+        working-directory: mobile
+        env:
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_KEY_PATH: ${{ steps.asc.outputs.key_path }}
+        run: |
+          set -euo pipefail
+          export MENTRA_MARKETING_VERSION MENTRA_BUILD_NUMBER
+          MENTRA_MARKETING_VERSION=$(jq -er .native.marketingVersion ../release-intent/release-plan.json)
+          MENTRA_BUILD_NUMBER=$(jq -er .native.buildNumber ../release-intent/release-plan.json)
+          rm -rf fastlane
+          mkdir fastlane
+          cp ci/fastlane-ios-production/Fastfile fastlane/Fastfile
+          bundle exec fastlane promote_app_store
+
+      - name: Verify iOS entered the production review flow
+        run: >-
+          node mobile/scripts/app-store-connect-build.mjs wait-production
+          --issuer-id "${{ secrets.ASC_API_ISSUER_ID }}"
+          --key-id "${{ secrets.ASC_API_KEY_ID }}"
+          --key-path "${{ steps.asc.outputs.key_path }}"
+          --bundle-id com.mentra.mentra
+          --app-version "$(jq -er .native.marketingVersion release-intent/release-plan.json)"
+          --build-number "$(jq -er .native.buildNumber release-intent/release-plan.json)"
+
+      - name: Record exact promoted mobile and OTA artifacts
+        run: >-
+          node .github/scripts/create-production-promotion-records.mjs
+          --plan release-intent/release-plan.json
+          --selection release-intent/production-selection.json
+          --apk promotion-input/mobile/app.apk
+          --aab promotion-input/mobile/app.aab
+          --ipa promotion-input/mobile/app.ipa
+          --provenance-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --output production-promotion-records.json
+
+      - name: Name promotion result artifact
+        id: result
+        run: echo "name=coordinated-production-promotion-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.result.outputs.name }}
+          path: production-promotion-records.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/reusable-coordinated-npm.yml
+++ b/.github/workflows/reusable-coordinated-npm.yml
@@ -25,6 +25,10 @@ on:
       sdk_package_artifact:
         required: false
         type: string
+      npm_tag:
+        description: Optional temporary dist-tag used to defer a coordinated stable latest pointer.
+        required: false
+        type: string
       dry_run:
         required: false
         default: false
@@ -42,10 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout exact release source
+      - name: Checkout current release tooling
+        uses: actions/checkout@v4
+
+      - name: Checkout exact package source
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_commit }}
+          path: release-source
 
       - name: Download immutable release plan
         uses: actions/download-artifact@v4
@@ -72,14 +80,18 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install exact root workspace dependencies
+        working-directory: release-source
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Install exact mobile workspace dependencies
-        working-directory: mobile
+        working-directory: release-source/mobile
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Stage coordinated package identities
-        run: node .github/scripts/stage-release-family.mjs --plan release-intent/release-plan.json
+        run: >-
+          node .github/scripts/stage-release-family.mjs
+          --root release-source
+          --plan release-intent/release-plan.json
 
       - name: Test npm release tooling
         run: node --test .github/scripts/publish-release-npm.test.mjs
@@ -87,6 +99,7 @@ jobs:
       - name: Build, pack, reconcile, and publish in dependency order
         run: |
           args=(
+            --root release-source
             --plan release-intent/release-plan.json
             --members "$RELEASE_MEMBERS"
             --output-dir release-output
@@ -103,6 +116,9 @@ jobs:
             fi
             args+=(--sdk-tarball "${sdk_tarballs[0]}")
           fi
+          if [[ -n "$NPM_TAG" ]]; then
+            args+=(--npm-tag "$NPM_TAG")
+          fi
           node .github/scripts/publish-release-npm.mjs "${args[@]}"
         env:
           DRY_RUN: ${{ inputs.dry_run }}
@@ -111,6 +127,7 @@ jobs:
           OTA_MANIFEST_URL: ${{ inputs.ota_manifest_url }}
           RELEASE_MEMBERS: ${{ inputs.members }}
           SDK_PACKAGE_ARTIFACT: ${{ inputs.sdk_package_artifact }}
+          NPM_TAG: ${{ inputs.npm_tag }}
 
       - name: Upload exact npm artifacts and publication records
         uses: actions/upload-artifact@v4

--- a/mobile/ci/fastlane-android/Fastfile
+++ b/mobile/ci/fastlane-android/Fastfile
@@ -21,4 +21,35 @@ platform :android do
       skip_upload_screenshots: true,
     )
   end
+
+  desc "Promote one exact existing version code between Google Play tracks"
+  lane :promote_google_play do
+    source = ENV.fetch("GOOGLE_PLAY_SOURCE_TRACK")
+    target = ENV.fetch("GOOGLE_PLAY_TARGET_TRACK", "production")
+    version_code = Integer(ENV.fetch("GOOGLE_PLAY_VERSION_CODE"))
+    output = ENV.fetch("GOOGLE_PLAY_PROMOTION_OUTPUT")
+
+    source_codes = google_play_track_version_codes(track: source).map(&:to_i)
+    UI.user_error!("Version code #{version_code} is absent from Google Play #{source}") unless source_codes.include?(version_code)
+    target_codes = google_play_track_version_codes(track: target).map(&:to_i)
+    reused = target_codes.include?(version_code)
+    unless reused
+      upload_to_play_store(
+        track: source,
+        track_promote_to: target,
+        version_code: version_code,
+        track_promote_release_status: "completed",
+        skip_upload_apk: true,
+        skip_upload_aab: true,
+        skip_upload_metadata: true,
+        skip_upload_changelogs: true,
+        skip_upload_images: true,
+        skip_upload_screenshots: true,
+      )
+    end
+
+    confirmed = google_play_track_version_codes(track: target).map(&:to_i)
+    UI.user_error!("Google Play did not retain version code #{version_code} on #{target}") unless confirmed.include?(version_code)
+    File.write(output, JSON.generate({ versionCode: version_code, source: source, target: target, reused: reused }))
+  end
 end

--- a/mobile/ci/fastlane-ios-production/Fastfile
+++ b/mobile/ci/fastlane-ios-production/Fastfile
@@ -1,0 +1,27 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Submit one exact existing TestFlight build to App Review"
+  lane :promote_app_store do
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_API_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_API_ISSUER_ID"),
+      key_filepath: ENV.fetch("ASC_API_KEY_PATH"),
+      duration: 1200,
+    )
+
+    deliver(
+      api_key: api_key,
+      app_identifier: "com.mentra.mentra",
+      app_version: ENV.fetch("MENTRA_MARKETING_VERSION"),
+      build_number: ENV.fetch("MENTRA_BUILD_NUMBER"),
+      submit_for_review: true,
+      automatic_release: true,
+      force: true,
+      skip_binary_upload: true,
+      skip_metadata: true,
+      skip_screenshots: true,
+      run_precheck_before_submit: false,
+    )
+  end
+end

--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -123,6 +123,58 @@ export async function assignBuildToGroup(client, {appId, buildId, groupName}) {
   return {group, reused: false}
 }
 
+export async function findAppStoreVersion(client, {appId, versionString}) {
+  const response = await client.request(
+    query("/v1/appStoreVersions", {
+      "filter[app]": appId,
+      "filter[platform]": "IOS",
+      "filter[versionString]": versionString,
+      "limit": "2",
+    }),
+  )
+  if (!Array.isArray(response?.data) || response.data.length === 0) return null
+  return exactlyOne(response, `iOS App Store version ${versionString}`)
+}
+
+const SUBMITTED_APP_STORE_STATES = new Set([
+  "WAITING_FOR_REVIEW",
+  "IN_REVIEW",
+  "PENDING_DEVELOPER_RELEASE",
+  "PROCESSING_FOR_APP_STORE",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "PENDING_APPLE_RELEASE",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+])
+
+export async function productionSubmissionStatus(client, {appId, versionString, buildId}) {
+  const version = await findAppStoreVersion(client, {appId, versionString})
+  if (!version) return {version: null, state: "ABSENT", attachedBuildId: null, promoted: false}
+  const relationship = await client.request(`/v1/appStoreVersions/${version.id}/relationships/build`)
+  const attachedBuildId = relationship?.data?.id || null
+  if (attachedBuildId && attachedBuildId !== buildId) {
+    throw new Error(`App Store version ${versionString} is attached to unexpected build ${attachedBuildId}`)
+  }
+  const state = version.attributes?.appStoreState || version.attributes?.appVersionState
+  if (!state) throw new Error(`App Store version ${versionString} has no state`)
+  if (SUBMITTED_APP_STORE_STATES.has(state) && attachedBuildId !== buildId) {
+    throw new Error(`Submitted App Store version ${versionString} is not attached to build ${buildId}`)
+  }
+  return {version, state, attachedBuildId, promoted: SUBMITTED_APP_STORE_STATES.has(state)}
+}
+
+export async function waitForProductionSubmission(
+  client,
+  {appId, versionString, buildId, attempts = 30, delay = 10_000},
+) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const status = await productionSubmissionStatus(client, {appId, versionString, buildId})
+    if (status.promoted) return status
+    if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, delay))
+  }
+  throw new Error(`App Store version ${versionString} did not enter the review or release flow`)
+}
+
 function parseArgs(args) {
   const values = {}
   for (let index = 0; index < args.length; index += 2) {
@@ -161,6 +213,23 @@ async function main() {
     console.log(
       `${result.reused ? "Verified" : "Added"} build ${args["build-number"]} in TestFlight group ${result.group.attributes?.name || args["group-name"]}`,
     )
+    return
+  }
+  if (command === "production-status" || command === "wait-production") {
+    const build = await waitForProcessedBuild(client, {appId: app.id, buildNumber: args["build-number"]})
+    const options = {appId: app.id, versionString: args["app-version"], buildId: build.id}
+    const status =
+      command === "wait-production"
+        ? await waitForProductionSubmission(client, options)
+        : await productionSubmissionStatus(client, options)
+    if (process.env.GITHUB_OUTPUT) {
+      const {appendFileSync} = await import("node:fs")
+      appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `promoted=${status.promoted}\nstate=${status.state}\nversion_id=${status.version?.id || ""}\nbuild_id=${build.id}\n`,
+      )
+    }
+    console.log(`App Store version ${args["app-version"]} is ${status.state} with build ${args["build-number"]}`)
     return
   }
   throw new Error(`Unknown command ${JSON.stringify(command)}`)

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -5,6 +5,8 @@ import {
   assignBuildToGroup,
   collectPaginatedData,
   findProcessedBuild,
+  productionSubmissionStatus,
+  waitForProductionSubmission,
   waitForProcessedBuild,
 } from "./app-store-connect-build.mjs"
 
@@ -65,4 +67,49 @@ test("follows every TestFlight relationship page before posting", async () => {
   const data = await collectPaginatedData(api, "/v1/betaGroups/group-1/relationships/builds?limit=200")
   assert.deepEqual(data, [{type: "builds", id: "build-1"}])
   assert.equal(api.calls.length, 2)
+})
+
+test("recognizes the exact build after App Store submission", async () => {
+  const api = client([
+    {data: [{id: "version-1", attributes: {appStoreState: "WAITING_FOR_REVIEW"}}]},
+    {data: {type: "builds", id: "build-1"}},
+  ])
+  const status = await productionSubmissionStatus(api, {
+    appId: "app-1",
+    versionString: "3.1.0",
+    buildId: "build-1",
+  })
+  assert.equal(status.promoted, true)
+  assert.equal(status.state, "WAITING_FOR_REVIEW")
+})
+
+test("recognizes a build that App Store Connect is processing for distribution", async () => {
+  const api = client([
+    {data: [{id: "version-1", attributes: {appStoreState: "PROCESSING_FOR_DISTRIBUTION"}}]},
+    {data: {type: "builds", id: "build-1"}},
+  ])
+  const status = await productionSubmissionStatus(api, {
+    appId: "app-1",
+    versionString: "3.1.0",
+    buildId: "build-1",
+  })
+  assert.equal(status.promoted, true)
+  assert.equal(status.state, "PROCESSING_FOR_DISTRIBUTION")
+})
+
+test("waits for the App Store version to leave preparation", async () => {
+  const api = client([
+    {data: [{id: "version-1", attributes: {appStoreState: "PREPARE_FOR_SUBMISSION"}}]},
+    {data: {type: "builds", id: "build-1"}},
+    {data: [{id: "version-1", attributes: {appStoreState: "IN_REVIEW"}}]},
+    {data: {type: "builds", id: "build-1"}},
+  ])
+  const status = await waitForProductionSubmission(api, {
+    appId: "app-1",
+    versionString: "3.1.0",
+    buildId: "build-1",
+    attempts: 2,
+    delay: 0,
+  })
+  assert.equal(status.state, "IN_REVIEW")
 })

--- a/notes/coordinated-release-system-proposal.md
+++ b/notes/coordinated-release-system-proposal.md
@@ -537,9 +537,11 @@ It then:
 
 Stable package metadata cannot literally reuse prerelease package bytes when
 the embedded package version must change. It must be reproduced from the same
-source and inputs, with only approved channel/version metadata differences, and
-the workflow must compare normalized contents. The ASG, MTK, BES, OTA manifest,
-IPA, and Android store artifact are not rebuilt.
+source commit and OTA pin. The existing package-specific release validators
+inspect the stable npm, Maven, and SwiftPM outputs for the exact stable version,
+dependency graph, source commit, and OTA metadata. A second generic archive
+normalization system is deliberately out of scope. The ASG, MTK, BES, OTA
+manifest, IPA, and Android store artifact are not rebuilt.
 
 ## Starter Kit and Documentation
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches production store promotion (Google Play/App Store), npm `latest` dist-tags, and immutable release manifests; mistakes could ship wrong binaries or prematurely point consumers at stable packages.
> 
> **Overview**
> Adds a **manual coordinated production promotion** path that takes a completed beta identity (e.g. `3.1.0-beta.57`), verifies the beta plan/manifest and downloadable artifact hashes, derives a stable production plan pinned to the same source commit and OTA bytes, then publishes stable npm/Maven/SwiftPM from that commit while **promoting the exact beta mobile and OTA artifacts** without rebuilding them.
> 
> New `.github/scripts` cover beta selection (`prepare-production-release`), hash-checked promotion records (`create-production-promotion-records`), merging publication evidence (`assemble-production-release-results`), and remote artifact verification (`verify-release-artifacts`). **`finalizeReleaseManifest`** now requires production releases to record **selected-beta provenance** and a **promoted** OTA manifest. Stable npm publishes use a temporary **`candidate-*` dist-tag** until finalize moves the family to **`latest`**.
> 
> **`reusable-coordinated-npm`** checks out current release tooling plus an isolated **`release-source`** at the plan commit. Mobile adds Google Play track promotion, App Store submission without re-upload, and ASC **`production-status` / `wait-production`** helpers. Release design notes clarify stable packages are validated via existing per-package checks rather than a generic archive normalizer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b7ccd996c67bc11425e71dde447b04fb70bc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->