### PR TITLE
Harden Mentra Live pairing handoff

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/audio/PairingCodePcmStitcher.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/audio/PairingCodePcmStitcher.java
@@ -24,7 +24,8 @@ public final class PairingCodePcmStitcher {
     private static final String TAG = "PairingCodePcmStitcher";
     static final int CROSSFADE_MS = 60;
     static final int SILENCE_THRESHOLD = 512;
-    private static final String CACHE_NAME = "pairing_code.wav";
+    private static final String CACHE_PREFIX = "pairing_code_";
+    private static final String CACHE_SUFFIX = ".wav";
 
     private PairingCodePcmStitcher() {}
 
@@ -38,15 +39,13 @@ public final class PairingCodePcmStitcher {
             wavs.add(readAssetBytes(context, asset));
         }
         byte[] stitched = stitchWavs(wavs);
-        File out = new File(context.getCacheDir(), CACHE_NAME);
+        File out = File.createTempFile(CACHE_PREFIX, CACHE_SUFFIX, context.getCacheDir());
         try (FileOutputStream fos = new FileOutputStream(out)) {
             fos.write(stitched);
         }
         Log.i(
                 TAG,
-                "stitched pairing code="
-                        + code
-                        + " clips="
+                "stitched pairing code clips="
                         + wavs.size()
                         + " bytes="
                         + stitched.length

--- a/asg_client/app/src/main/java/com/mentra/asg_client/audio/PairingCodeSpeaker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/audio/PairingCodeSpeaker.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.utils.WakeLockManager;
 import java.io.File;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Stitches a pairing code into one I2S WAV and plays it. Used by the MCU {@code hm_spkcode} path
@@ -14,6 +16,7 @@ public final class PairingCodeSpeaker {
 
     private static final String TAG = "PairingCodeSpeaker";
     private static final long WAKE_LOCK_MS = 8000L;
+    private static final Pattern PAIRING_CODE = Pattern.compile("[0-9A-F]{4}");
 
     private PairingCodeSpeaker() {}
 
@@ -22,9 +25,11 @@ public final class PairingCodeSpeaker {
             Log.w(TAG, "speak skipped: missing context, hardware, or code");
             return false;
         }
-        String normalized = code.trim();
-        if (normalized.isEmpty()) {
-            Log.w(TAG, "speak skipped: empty pairing code");
+        String normalized = code.trim().toUpperCase(Locale.US);
+        if (!PAIRING_CODE.matcher(normalized).matches()) {
+            Log.w(
+                    TAG,
+                    "speak skipped: pairing code must contain exactly four hexadecimal characters");
             return false;
         }
         if (!hardwareManager.supportsAudioPlayback()) {
@@ -38,15 +43,13 @@ public final class PairingCodeSpeaker {
             boolean played = hardwareManager.playAudioFile(wav);
             Log.i(
                     TAG,
-                    "pairing code playback code="
-                            + normalized
-                            + " file="
+                    "pairing code playback file="
                             + wav.getAbsolutePath()
                             + " playAudioFile="
                             + played);
             return played;
         } catch (Exception e) {
-            Log.e(TAG, "failed to speak pairing code " + normalized, e);
+            Log.e(TAG, "failed to speak pairing code", e);
             return false;
         }
     }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/audio/PairingCodeAssetIntegrityTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/audio/PairingCodeAssetIntegrityTest.java
@@ -24,7 +24,8 @@ public class PairingCodeAssetIntegrityTest {
         Application app = ApplicationProvider.getApplicationContext();
         File wav = PairingCodePcmStitcher.stitchCodeToCache(app, "A12B");
 
-        assertThat(wav.getName()).isEqualTo("pairing_code.wav");
+        assertThat(wav.getName()).startsWith("pairing_code_");
+        assertThat(wav.getName()).endsWith(".wav");
         assertThat(wav).exists();
 
         PairingCodePcmStitcher.PcmClip stitched =

--- a/asg_client/app/src/test/java/com/mentra/asg_client/audio/PairingCodeSpeakerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/audio/PairingCodeSpeakerTest.java
@@ -35,11 +35,13 @@ public class PairingCodeSpeakerTest {
         app = ApplicationProvider.getApplicationContext();
         hardware = mock(IHardwareManager.class);
         WakeLockManager.release(WakeOwner.PAIRING_CODE);
+        deletePairingCacheFiles();
     }
 
     @After
     public void tearDown() {
         WakeLockManager.release(WakeOwner.PAIRING_CODE);
+        deletePairingCacheFiles();
     }
 
     @Test
@@ -56,13 +58,22 @@ public class PairingCodeSpeakerTest {
     }
 
     @Test
+    public void speak_malformedCode_returnsFalse() {
+        assertThat(PairingCodeSpeaker.speak(app, hardware, "A-B")).isFalse();
+        assertThat(PairingCodeSpeaker.speak(app, hardware, "12345")).isFalse();
+        assertThat(PairingCodeSpeaker.speak(app, hardware, "12G4")).isFalse();
+        verify(hardware, never()).playAudioFile(any());
+    }
+
+    @Test
     public void speak_playbackUnsupported_skipsStitching() {
         when(hardware.supportsAudioPlayback()).thenReturn(false);
 
         assertThat(PairingCodeSpeaker.speak(app, hardware, "A12B")).isFalse();
         verify(hardware, never()).playAudioFile(any());
-        File cache = new File(app.getCacheDir(), "pairing_code.wav");
-        assertThat(cache).doesNotExist();
+        File[] cache =
+                app.getCacheDir().listFiles((dir, name) -> name.startsWith("pairing_code_"));
+        assertThat(cache).isEmpty();
     }
 
     @Test
@@ -88,7 +99,32 @@ public class PairingCodeSpeakerTest {
 
         ArgumentCaptor<File> file = ArgumentCaptor.forClass(File.class);
         verify(hardware).playAudioFile(file.capture());
-        assertThat(file.getValue().getName()).isEqualTo("pairing_code.wav");
+        assertThat(file.getValue().getName()).startsWith("pairing_code_");
+        assertThat(file.getValue().getName()).endsWith(".wav");
         assertThat(file.getValue()).exists();
+    }
+
+    @Test
+    public void speak_repeatedCode_usesDistinctFiles() {
+        when(hardware.supportsAudioPlayback()).thenReturn(true);
+        when(hardware.playAudioFile(any(File.class))).thenReturn(true);
+
+        assertThat(PairingCodeSpeaker.speak(app, hardware, "A12B")).isTrue();
+        assertThat(PairingCodeSpeaker.speak(app, hardware, "A12B")).isTrue();
+
+        ArgumentCaptor<File> files = ArgumentCaptor.forClass(File.class);
+        verify(hardware, org.mockito.Mockito.times(2)).playAudioFile(files.capture());
+        assertThat(files.getAllValues().get(0)).isNotEqualTo(files.getAllValues().get(1));
+    }
+
+    private void deletePairingCacheFiles() {
+        File[] files =
+                app.getCacheDir().listFiles((dir, name) -> name.startsWith("pairing_code_"));
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            file.delete();
+        }
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/PairingAudioEventSubscriberTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/PairingAudioEventSubscriberTest.java
@@ -59,6 +59,8 @@ public class PairingAudioEventSubscriberTest {
 
         ArgumentCaptor<File> file = ArgumentCaptor.forClass(File.class);
         verify(hardware).playAudioFile(file.capture());
-        assertThat(file.getValue().getName()).isEqualTo("pairing_code.wav");
+        assertThat(file.getValue().getName()).startsWith("pairing_code_");
+        assertThat(file.getValue().getName()).endsWith(".wav");
+        assertThat(file.getValue()).exists();
     }
 }

--- a/mobile/modules/bluetooth-sdk/Package.swift
+++ b/mobile/modules/bluetooth-sdk/Package.swift
@@ -44,6 +44,11 @@ let package = Package(
       cSettings: [
         .headerSearchPath(".")
       ]
+    ),
+    .testTarget(
+      name: "MentraBluetoothSDKTests",
+      dependencies: ["MentraBluetoothSDK"],
+      path: "ios/Tests"
     )
   ]
 )

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -148,21 +148,17 @@ public class Bridge private constructor() {
         @JvmStatic
         fun sendPairingInfo(
             hadPreviousBond: Boolean,
-            transferId: String? = null,
             pairingCode: String? = null,
             classicBondReady: Boolean = false,
             securePairingCapable: Boolean = true,
             protocolVersion: Int = 1,
-            binding: String? = null,
         ) {
             val data = HashMap<String, Any>()
             data["had_previous_bond"] = hadPreviousBond
-            if (transferId != null) data["transfer_id"] = transferId
             if (pairingCode != null) data["pairing_code"] = pairingCode
             data["classic_bond_ready"] = classicBondReady
             data["secure_pairing_capable"] = securePairingCapable
             data["protocol_version"] = protocolVersion
-            if (binding != null) data["binding"] = binding
             sendTypedMessage("pairing_info", data as Map<String, Any>)
         }
 
@@ -912,4 +908,3 @@ public class Bridge private constructor() {
         }
     }
 }
-

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1359,9 +1359,7 @@ class DeviceManager {
         if (pendingDeviceAddress.isNotEmpty()) {
             deviceAddress = pendingDeviceAddress
         }
-        pendingDeviceName = ""
-        pendingDeviceAddress = ""
-        pendingWearable = ""
+        clearPendingConnection()
 
         val readyKey = "${sgc?.type}:${deviceName}"
         val now = System.currentTimeMillis()
@@ -2137,7 +2135,7 @@ class DeviceManager {
             return
         }
 
-        disconnect()
+        disconnect(clearPendingIdentity = false)
         Thread.sleep(100)
         searching = true
         pendingDeviceName = name
@@ -2170,7 +2168,7 @@ class DeviceManager {
         handleDeviceReady()
     }
 
-    fun disconnect() {
+    fun disconnect(clearPendingIdentity: Boolean = true) {
         sgc?.clearDisplay()
         sgc?.disconnect()
         sgc = null // Clear the SGC reference after disconnect
@@ -2202,6 +2200,15 @@ class DeviceManager {
         DeviceStore.apply("glasses", "controllerConnected", false)
         controller?.disconnect()
         controller = null
+        if (clearPendingIdentity) {
+            clearPendingConnection()
+        }
+    }
+
+    private fun clearPendingConnection() {
+        pendingDeviceName = ""
+        pendingDeviceAddress = ""
+        pendingWearable = ""
     }
 
     fun disconnectController() {
@@ -2276,9 +2283,7 @@ class DeviceManager {
         defaultWearable = ""
         deviceName = ""
         deviceAddress = ""
-        pendingDeviceName = ""
-        pendingDeviceAddress = ""
-        pendingWearable = ""
+        clearPendingConnection()
         Bridge.saveSetting("default_wearable", "")
         Bridge.saveSetting("device_name", "")
         Bridge.saveSetting("device_address", "")

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3783,19 +3783,16 @@ class MentraLive : SGCManager() {
                 val body = HashMap<String, Any>()
                 body["window_ms"] = windowMs
                 body["reason"] = json.optString("reason", "user_gesture")
-                if (json.has("txn")) body["txn"] = json.optInt("txn")
                 Bridge.sendTypedMessage("entering_pairing_mode", body)
             }
             "pairing_info" ->
                     Bridge.sendPairingInfo(
                             json.optBoolean("had_previous_bond", false),
-                            jsonNullableString(json, "transfer_id"),
                             jsonNullableString(json, "pairing_code"),
                             json.optBoolean("classic_bond_ready", false),
                             // Legacy firmware that omits this field is not secure-capable.
                             json.optBoolean("secure_pairing_capable", false),
                             json.optInt("protocol_version", 1),
-                            jsonNullableString(json, "binding"),
                     )
             "imu_response",
             "imu_stream_response",

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -159,59 +159,25 @@ class MentraLive : SGCManager() {
                 10_000L // 10s before first scan after shutdown
 
         private const val MENTRA_MANUFACTURER_ID = 0xB822
-        private const val ADV_MANUF_PAIRING_FLAG_OFFSET = 5
-        private const val ADV_PAIRING_DISCOVERABLE: Byte = 0x01
-        private const val ADV_PAIRING_PROTOCOL_VERSION_MIN = 1
-        private const val ADV_PAIRING_PROTOCOL_VERSION_MAX = 15
 
         private fun manufacturerData(result: ScanResult): ByteArray? {
             return result.scanRecord?.getManufacturerSpecificData(MENTRA_MANUFACTURER_ID)
         }
 
-        /**
-         * OS-1615 ads append `flag | version | capability | code_lo | code_hi` after the
-         * connected byte. Field firmware uses the same 0xB822 company id but then writes the
-         * XOR'd Classic MAC at those offsets. Length alone is not a pairing flag: treating MAC
-         * bytes as version/capability hides every old unit as "secure, not in pairing mode".
-         */
-        private fun hasSecurePairingTrailer(manufData: ByteArray?): Boolean {
-            if (manufData == null) {
-                return false
-            }
-            val trailerBase = ADV_MANUF_PAIRING_FLAG_OFFSET + 1
-            if (manufData.size < trailerBase + 4) {
-                return false
-            }
-            val version = manufData[trailerBase].toInt() and 0xFF
-            val capability = manufData[trailerBase + 1].toInt() and 0xFF
-            return version in ADV_PAIRING_PROTOCOL_VERSION_MIN..ADV_PAIRING_PROTOCOL_VERSION_MAX &&
-                    (capability and 0x01) != 0
-        }
-
         private fun isPairingDiscoverable(result: ScanResult): Boolean {
-            val manufData = manufacturerData(result) ?: return false
-            if (!hasSecurePairingTrailer(manufData)) {
-                return false
-            }
-            return manufData[ADV_MANUF_PAIRING_FLAG_OFFSET] == ADV_PAIRING_DISCOVERABLE
+            return MentraLivePairingAdvertisementParser.parse(manufacturerData(result))?.pairingMode ==
+                    true
         }
 
         private fun advertisesPairingFlag(result: ScanResult): Boolean {
-            return hasSecurePairingTrailer(manufacturerData(result))
+            return MentraLivePairingAdvertisementParser.parse(manufacturerData(result)) != null
         }
 
-        /** Trailer immediately after pairing flag: version | capability | code_lo | code_hi */
         private fun parseSecurePairingTrailer(result: ScanResult): Triple<Boolean, String?, Boolean> {
-            val manufData = manufacturerData(result) ?: return Triple(false, null, false)
-            if (!hasSecurePairingTrailer(manufData)) {
-                return Triple(false, null, false)
-            }
-            val pairingMode = manufData[ADV_MANUF_PAIRING_FLAG_OFFSET] == ADV_PAIRING_DISCOVERABLE
-            val trailerBase = ADV_MANUF_PAIRING_FLAG_OFFSET + 1
-            val codeLo = manufData[trailerBase + 2].toInt() and 0xFF
-            val codeHi = manufData[trailerBase + 3].toInt() and 0xFF
-            val code = String.format("%02X%02X", codeHi, codeLo)
-            return Triple(pairingMode, code, true)
+            val advertisement =
+                    MentraLivePairingAdvertisementParser.parse(manufacturerData(result))
+                            ?: return Triple(false, null, false)
+            return Triple(advertisement.pairingMode, advertisement.pairingCode, true)
         }
 
         fun isMentraLiveBluetoothName(name: String?): Boolean {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisement.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisement.kt
@@ -1,0 +1,54 @@
+package com.mentra.bluetoothsdk.sgcs
+
+internal data class MentraLivePairingAdvertisement(
+    val pairingMode: Boolean,
+    val pairingCode: String,
+)
+
+internal object MentraLivePairingAdvertisementParser {
+    private const val PAIRING_FLAG_OFFSET = 5
+    private const val PAIRING_DISCOVERABLE: Byte = 0x01
+    private const val PROTOCOL_VERSION_OFFSET = PAIRING_FLAG_OFFSET + 1
+    private const val CAPABILITY_OFFSET = PROTOCOL_VERSION_OFFSET + 1
+    private const val CODE_LOW_OFFSET = CAPABILITY_OFFSET + 1
+    private const val CODE_HIGH_OFFSET = CODE_LOW_OFFSET + 1
+    private const val MAGIC_FIRST_OFFSET = CODE_HIGH_OFFSET + 1
+    private const val MAGIC_SECOND_OFFSET = MAGIC_FIRST_OFFSET + 1
+    private const val PROTOCOL_VERSION_MIN = 2
+    private const val PROTOCOL_VERSION_MAX = 15
+    private const val SECURE_PAIRING_CAPABILITY = 0x01
+    private const val MAGIC_FIRST = 0x4D // M
+    private const val MAGIC_SECOND = 0x50 // P
+
+    /**
+     * Parses company-id-stripped 0xB822 manufacturer data.
+     *
+     * Legacy firmware stores an XOR'd Classic MAC where the original pairing implementation
+     * expected version and capability bytes. Requiring the `MP` marker makes the formats
+     * unambiguous instead of probabilistically classifying MAC bytes as a secure trailer.
+     */
+    fun parse(manufacturerData: ByteArray?): MentraLivePairingAdvertisement? {
+        if (manufacturerData == null || manufacturerData.size <= MAGIC_SECOND_OFFSET) {
+            return null
+        }
+
+        val version = manufacturerData[PROTOCOL_VERSION_OFFSET].toInt() and 0xFF
+        val capability = manufacturerData[CAPABILITY_OFFSET].toInt() and 0xFF
+        val magicFirst = manufacturerData[MAGIC_FIRST_OFFSET].toInt() and 0xFF
+        val magicSecond = manufacturerData[MAGIC_SECOND_OFFSET].toInt() and 0xFF
+        if (version !in PROTOCOL_VERSION_MIN..PROTOCOL_VERSION_MAX ||
+            (capability and SECURE_PAIRING_CAPABILITY) == 0 ||
+            magicFirst != MAGIC_FIRST ||
+            magicSecond != MAGIC_SECOND
+        ) {
+            return null
+        }
+
+        val codeLow = manufacturerData[CODE_LOW_OFFSET].toInt() and 0xFF
+        val codeHigh = manufacturerData[CODE_HIGH_OFFSET].toInt() and 0xFF
+        return MentraLivePairingAdvertisement(
+            pairingMode = manufacturerData[PAIRING_FLAG_OFFSET] == PAIRING_DISCOVERABLE,
+            pairingCode = String.format("%02X%02X", codeHigh, codeLow),
+        )
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisementParserTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisementParserTest.kt
@@ -1,0 +1,75 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MentraLivePairingAdvertisementParserTest {
+    @Test
+    fun parsesMarkedSecurePairingAdvertisement() {
+        val result = MentraLivePairingAdvertisementParser.parse(securePayload(pairingFlag = 1))
+
+        assertEquals("1234", result?.pairingCode)
+        assertTrue(result?.pairingMode == true)
+    }
+
+    @Test
+    fun parsesMarkedOwnedAdvertisement() {
+        val result = MentraLivePairingAdvertisementParser.parse(securePayload(pairingFlag = 0))
+
+        assertEquals("1234", result?.pairingCode)
+        assertFalse(result?.pairingMode == true)
+    }
+
+    @Test
+    fun rejectsLegacyPayloadThatMatchesOldVersionCapabilityHeuristic() {
+        val legacyPayload = ByteArray(27)
+        legacyPayload[5] = 0
+        legacyPayload[6] = 1
+        legacyPayload[7] = 1
+        legacyPayload[8] = 0x34
+        legacyPayload[9] = 0x12
+
+        assertNull(MentraLivePairingAdvertisementParser.parse(legacyPayload))
+    }
+
+    @Test
+    fun rejectsUnmarkedFirstGenerationSecureTrailer() {
+        val unmarkedPayload = securePayload(pairingFlag = 1)
+        unmarkedPayload[10] = 0x11
+        unmarkedPayload[11] = 0x22
+
+        assertNull(MentraLivePairingAdvertisementParser.parse(unmarkedPayload))
+    }
+
+    @Test
+    fun rejectsEveryLegacyVersionAndCapabilityCombination() {
+        for (version in 0..255) {
+            for (capability in 0..255) {
+                val legacyPayload = ByteArray(27)
+                legacyPayload[5] = 1
+                legacyPayload[6] = version.toByte()
+                legacyPayload[7] = capability.toByte()
+                legacyPayload[10] = 0x4D
+                // Offset 11 is padding in the legacy format, so it cannot contain the second
+                // non-zero marker byte.
+                legacyPayload[11] = 0
+                assertNull(MentraLivePairingAdvertisementParser.parse(legacyPayload))
+            }
+        }
+    }
+
+    private fun securePayload(pairingFlag: Int): ByteArray {
+        return ByteArray(27).also {
+            it[5] = pairingFlag.toByte()
+            it[6] = 2
+            it[7] = 1
+            it[8] = 0x34
+            it[9] = 0x12
+            it[10] = 0x4D
+            it[11] = 0x50
+        }
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -100,12 +100,10 @@ class Bridge {
 
     static func sendPairingInfo(
         hadPreviousBond: Bool,
-        transferId: String? = nil,
         pairingCode: String? = nil,
         classicBondReady: Bool = false,
         securePairingCapable: Bool = true,
-        protocolVersion: Int = 1,
-        binding: String? = nil
+        protocolVersion: Int = 1
     ) {
         var body: [String: Any] = [
             "had_previous_bond": hadPreviousBond,
@@ -113,9 +111,7 @@ class Bridge {
             "secure_pairing_capable": securePairingCapable,
             "protocol_version": protocolVersion,
         ]
-        if let transferId { body["transfer_id"] = transferId }
         if let pairingCode { body["pairing_code"] = pairingCode }
-        if let binding { body["binding"] = binding }
         Bridge.sendTypedMessage("pairing_info", body: body)
     }
 
@@ -659,7 +655,6 @@ class Bridge {
         return payload
     }
 }
-
 
 
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1012,9 +1012,7 @@ struct ViewState {
         if !pendingDeviceAddress.isEmpty {
             deviceAddress = pendingDeviceAddress
         }
-        pendingDeviceName = ""
-        pendingDeviceAddress = ""
-        pendingWearable = ""
+        clearPendingConnection()
         defaultWearable = sgc.type
         searching = false
 
@@ -1792,7 +1790,7 @@ struct ViewState {
         }
 
         Task {
-            disconnect()
+            disconnect(clearPendingConnection: false)
             try? await Task.sleep(nanoseconds: 100 * 1_000_000) // 100ms
             self.searching = true
             self.pendingDeviceName = name
@@ -1826,7 +1824,7 @@ struct ViewState {
         handleDeviceReady()
     }
 
-    func disconnect() {
+    func disconnect(clearPendingConnection: Bool = true) {
         sgc?.clearDisplay() // clear the screen
         sgc?.disconnect()
         sgc = nil // Clear the SGC reference after disconnect
@@ -1855,6 +1853,15 @@ struct ViewState {
         DeviceStore.shared.apply("glasses", "controllerConnected", false)
         controller?.disconnect()
         controller = nil // Clear the controller reference after disconnect
+        if clearPendingConnection {
+            self.clearPendingConnection()
+        }
+    }
+
+    private func clearPendingConnection() {
+        pendingDeviceName = ""
+        pendingDeviceAddress = ""
+        pendingWearable = ""
     }
 
     func disconnectController() {
@@ -1874,9 +1881,7 @@ struct ViewState {
         defaultWearable = ""
         deviceName = ""
         deviceAddress = ""
-        pendingDeviceName = ""
-        pendingDeviceAddress = ""
-        pendingWearable = ""
+        clearPendingConnection()
         Bridge.saveSetting("default_wearable", "")
         Bridge.saveSetting("device_name", "")
         Bridge.saveSetting("device_address", "")

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -942,10 +942,30 @@ extension MentraLive: CBCentralManagerDelegate {
     nonisolated func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            let matchesActiveAttempt = self.connectingPeripheral === peripheral
+            guard MentraLiveConnectionAttemptPolicy.shouldAcceptDidConnect(
+                pairingYieldActive: self.pairingYieldActive,
+                matchesActiveAttempt: matchesActiveAttempt
+            ) else {
+                Bridge.log(
+                    "LIVE: Rejecting stale connection callback during pairing yield or after attempt replacement: \(peripheral.identifier)"
+                )
+                self.stopConnectionTimeout()
+                if self.connectingPeripheral === peripheral {
+                    self.connectingPeripheral = nil
+                }
+                if self.connectedPeripheral === peripheral {
+                    self.connectedPeripheral = nil
+                }
+                self.isConnecting = false
+                self.centralManager?.cancelPeripheralConnection(peripheral)
+                return
+            }
             Bridge.log("Connected to GATT server, discovering services...")
 
             self.stopConnectionTimeout()
             self.isConnecting = false
+            self.connectingPeripheral = nil
             self.connectedPeripheral = peripheral
 
             // Save device name and address for future reconnection
@@ -1345,56 +1365,17 @@ class MentraLive: NSObject, SGCManager {
     private let BLOCK_AUDIO_DUPLEX = false
     private static let voiceActivityDetectionSwitchType = 8
     private static let loudnessGateSwitchType = 10
-    private let mentraManufacturerId: UInt16 = 0xB822
-    // Payload-relative offset of the pairing flag, matching Android's index into the
-    // company-id-stripped manufacturer data from getManufacturerSpecificData().
-    private let advManufPairingFlagOffset = 5
-    // CoreBluetooth returns manufacturer data with the 2-byte company id prefix still attached,
-    // whereas Android strips it. Skip the prefix so both platforms read the same payload byte.
-    private let advManufCompanyIdLength = 2
-    private let advPairingDiscoverable: UInt8 = 0x01
-
-    // CoreBluetooth returns manufacturer data prefixed with the 2-byte company id
-    // (little-endian) and does NOT filter by company id itself (unlike Android's
-    // getManufacturerSpecificData(companyId)), so every reader of this data must
-    // verify the company id before trusting any flag/trailer byte.
-    private func mentraManufacturerData(_ advertisementData: [String: Any]) -> Data? {
-        guard let manufData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
-              manufData.count >= advManufCompanyIdLength
-        else {
-            return nil
-        }
-        let companyId = UInt16(manufData[0]) | (UInt16(manufData[1]) << 8)
-        guard companyId == mentraManufacturerId else {
-            return nil
-        }
-        return manufData
-    }
-
-    /// OS-1615 ads append `flag | version | capability | code_lo | code_hi` after the
-    /// connected byte. Field firmware uses the same 0xB822 company id but then writes
-    /// the XOR'd Classic MAC at those offsets. Length alone is not a pairing flag.
-    private func hasSecurePairingTrailer(_ advertisementData: [String: Any]) -> Bool {
-        let flagIndex = advManufCompanyIdLength + advManufPairingFlagOffset
-        let trailerBase = flagIndex + 1
-        guard let manufData = mentraManufacturerData(advertisementData),
-              manufData.count >= trailerBase + 4
-        else {
-            return false
-        }
-        let version = Int(manufData[trailerBase])
-        let capability = Int(manufData[trailerBase + 1])
-        return (1...15).contains(version) && (capability & 0x01) != 0
+    private func pairingAdvertisement(
+        _ advertisementData: [String: Any]
+    ) -> MentraLivePairingAdvertisement? {
+        MentraLivePairingAdvertisement.parse(
+            coreBluetoothManufacturerData:
+            advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
+        )
     }
 
     private func isPairingDiscoverable(_ advertisementData: [String: Any]) -> Bool {
-        guard hasSecurePairingTrailer(advertisementData),
-              let manufData = mentraManufacturerData(advertisementData)
-        else {
-            return false
-        }
-        let flagIndex = advManufCompanyIdLength + advManufPairingFlagOffset
-        return manufData[flagIndex] == advPairingDiscoverable
+        pairingAdvertisement(advertisementData)?.pairingMode == true
     }
 
     private struct SecurePairingTrailer {
@@ -1403,24 +1384,19 @@ class MentraLive: NSObject, SGCManager {
         let secureCapable: Bool
     }
 
-    /// Trailer immediately after pairing flag: version | capability | code_lo | code_hi
     private func parseSecurePairingTrailer(_ advertisementData: [String: Any]) -> SecurePairingTrailer {
-        guard hasSecurePairingTrailer(advertisementData),
-              let manufData = mentraManufacturerData(advertisementData)
-        else {
+        guard let advertisement = pairingAdvertisement(advertisementData) else {
             return SecurePairingTrailer(pairingMode: false, pairingCode: nil, secureCapable: false)
         }
-        let flagIndex = advManufCompanyIdLength + advManufPairingFlagOffset
-        let trailerBase = flagIndex + 1
-        let pairingMode = manufData[flagIndex] == advPairingDiscoverable
-        let codeLo = Int(manufData[trailerBase + 2])
-        let codeHi = Int(manufData[trailerBase + 3])
-        let code = String(format: "%02X%02X", codeHi, codeLo)
-        return SecurePairingTrailer(pairingMode: pairingMode, pairingCode: code, secureCapable: true)
+        return SecurePairingTrailer(
+            pairingMode: advertisement.pairingMode,
+            pairingCode: advertisement.pairingCode,
+            secureCapable: true
+        )
     }
 
     private func advertisesPairingFlag(_ advertisementData: [String: Any]) -> Bool {
-        hasSecurePairingTrailer(advertisementData)
+        pairingAdvertisement(advertisementData) != nil
     }
 
     var connectionState: String = ConnTypes.DISCONNECTED

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2890,25 +2890,20 @@ class MentraLive: NSObject, SGCManager {
             let windowMs = max(5_000, min(180_000, json["window_ms"] as? Int ?? 120_000))
             Bridge.log("LIVE: Glasses entering pairing mode — yield \(windowMs)ms (no forget)")
             enterPairingYield(windowMs: windowMs)
-            var body: [String: Any] = [
+            let body: [String: Any] = [
                 "window_ms": windowMs,
                 "reason": json["reason"] as? String ?? "user_gesture",
             ]
-            if let txn = json["txn"] {
-                body["txn"] = txn
-            }
             Bridge.sendTypedMessage("entering_pairing_mode", body: body)
 
         case "pairing_info":
             Bridge.sendPairingInfo(
                 hadPreviousBond: json["had_previous_bond"] as? Bool ?? false,
-                transferId: json["transfer_id"] as? String,
                 pairingCode: json["pairing_code"] as? String,
                 classicBondReady: json["classic_bond_ready"] as? Bool ?? false,
                 // Legacy firmware that omits this field is not secure-capable.
                 securePairingCapable: json["secure_pairing_capable"] as? Bool ?? false,
-                protocolVersion: json["protocol_version"] as? Int ?? 1,
-                binding: json["binding"] as? String
+                protocolVersion: json["protocol_version"] as? Int ?? 1
             )
 
         case "imu_response", "imu_stream_response", "imu_gesture_response",

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLivePairingAdvertisement.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLivePairingAdvertisement.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct MentraLivePairingAdvertisement: Equatable {
+    let pairingMode: Bool
+    let pairingCode: String
+
+    private static let manufacturerId: UInt16 = 0xB822
+    private static let companyIdLength = 2
+    private static let pairingFlagOffset = 5
+    private static let pairingDiscoverable: UInt8 = 0x01
+    private static let protocolVersionOffset = pairingFlagOffset + 1
+    private static let capabilityOffset = protocolVersionOffset + 1
+    private static let codeLowOffset = capabilityOffset + 1
+    private static let codeHighOffset = codeLowOffset + 1
+    private static let magicFirstOffset = codeHighOffset + 1
+    private static let magicSecondOffset = magicFirstOffset + 1
+    private static let protocolVersionRange = 2 ... 15
+    private static let securePairingCapability = 0x01
+    private static let magicFirst: UInt8 = 0x4D // M
+    private static let magicSecond: UInt8 = 0x50 // P
+
+    /// Parses CoreBluetooth manufacturer data, including its two-byte company-id prefix.
+    ///
+    /// Legacy firmware stores an XOR'd Classic MAC where the original pairing implementation
+    /// expected version and capability bytes. Requiring the `MP` marker makes the formats
+    /// unambiguous instead of probabilistically classifying MAC bytes as a secure trailer.
+    static func parse(coreBluetoothManufacturerData data: Data?) -> MentraLivePairingAdvertisement? {
+        guard let data, data.count > companyIdLength + magicSecondOffset else {
+            return nil
+        }
+
+        let companyId = UInt16(data[0]) | (UInt16(data[1]) << 8)
+        guard companyId == manufacturerId else {
+            return nil
+        }
+
+        let payloadBase = companyIdLength
+        let version = Int(data[payloadBase + protocolVersionOffset])
+        let capability = Int(data[payloadBase + capabilityOffset])
+        guard protocolVersionRange.contains(version),
+              capability & securePairingCapability != 0,
+              data[payloadBase + magicFirstOffset] == magicFirst,
+              data[payloadBase + magicSecondOffset] == magicSecond
+        else {
+            return nil
+        }
+
+        let codeLow = Int(data[payloadBase + codeLowOffset])
+        let codeHigh = Int(data[payloadBase + codeHighOffset])
+        return MentraLivePairingAdvertisement(
+            pairingMode: data[payloadBase + pairingFlagOffset] == pairingDiscoverable,
+            pairingCode: String(format: "%02X%02X", codeHigh, codeLow)
+        )
+    }
+}
+
+enum MentraLiveConnectionAttemptPolicy {
+    static func shouldAcceptDidConnect(
+        pairingYieldActive: Bool,
+        matchesActiveAttempt: Bool
+    ) -> Bool {
+        !pairingYieldActive && matchesActiveAttempt
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Tests/MentraLivePairingAdvertisementTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/MentraLivePairingAdvertisementTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+@testable import MentraBluetoothSDK
+import XCTest
+
+final class MentraLivePairingAdvertisementTests: XCTestCase {
+    func testConnectionCallbackPolicyRejectsPairingYieldAndStaleAttempts() {
+        XCTAssertFalse(
+            MentraLiveConnectionAttemptPolicy.shouldAcceptDidConnect(
+                pairingYieldActive: true,
+                matchesActiveAttempt: true
+            )
+        )
+        XCTAssertFalse(
+            MentraLiveConnectionAttemptPolicy.shouldAcceptDidConnect(
+                pairingYieldActive: false,
+                matchesActiveAttempt: false
+            )
+        )
+        XCTAssertTrue(
+            MentraLiveConnectionAttemptPolicy.shouldAcceptDidConnect(
+                pairingYieldActive: false,
+                matchesActiveAttempt: true
+            )
+        )
+    }
+
+    func testParsesMarkedSecurePairingAdvertisement() {
+        let result = MentraLivePairingAdvertisement.parse(
+            coreBluetoothManufacturerData: securePayload(pairingFlag: 1)
+        )
+
+        XCTAssertEqual(result?.pairingCode, "1234")
+        XCTAssertEqual(result?.pairingMode, true)
+    }
+
+    func testParsesMarkedOwnedAdvertisement() {
+        let result = MentraLivePairingAdvertisement.parse(
+            coreBluetoothManufacturerData: securePayload(pairingFlag: 0)
+        )
+
+        XCTAssertEqual(result?.pairingCode, "1234")
+        XCTAssertEqual(result?.pairingMode, false)
+    }
+
+    func testRejectsLegacyPayloadThatMatchesOldVersionCapabilityHeuristic() {
+        var payload = legacyPayload()
+        payload[2 + 5] = 0
+        payload[2 + 6] = 1
+        payload[2 + 7] = 1
+        payload[2 + 8] = 0x34
+        payload[2 + 9] = 0x12
+
+        XCTAssertNil(
+            MentraLivePairingAdvertisement.parse(coreBluetoothManufacturerData: payload)
+        )
+    }
+
+    func testRejectsUnmarkedFirstGenerationSecureTrailer() {
+        var payload = securePayload(pairingFlag: 1)
+        payload[2 + 10] = 0x11
+        payload[2 + 11] = 0x22
+
+        XCTAssertNil(
+            MentraLivePairingAdvertisement.parse(coreBluetoothManufacturerData: payload)
+        )
+    }
+
+    func testRejectsEveryLegacyVersionAndCapabilityCombination() {
+        for version in UInt8.min ... UInt8.max {
+            for capability in UInt8.min ... UInt8.max {
+                var payload = legacyPayload()
+                payload[2 + 5] = 1
+                payload[2 + 6] = version
+                payload[2 + 7] = capability
+                payload[2 + 10] = 0x4D
+                // Offset 11 is padding in the legacy format, so it cannot contain the second
+                // non-zero marker byte.
+                payload[2 + 11] = 0
+                XCTAssertNil(
+                    MentraLivePairingAdvertisement.parse(coreBluetoothManufacturerData: payload)
+                )
+            }
+        }
+    }
+
+    private func legacyPayload() -> Data {
+        var data = Data(repeating: 0, count: 29)
+        data[0] = 0x22
+        data[1] = 0xB8
+        return data
+    }
+
+    private func securePayload(pairingFlag: UInt8) -> Data {
+        var data = legacyPayload()
+        data[2 + 5] = pairingFlag
+        data[2 + 6] = 2
+        data[2 + 7] = 1
+        data[2 + 8] = 0x34
+        data[2 + 9] = 0x12
+        data[2 + 10] = 0x4D
+        data[2 + 11] = 0x50
+        return data
+    }
+}

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -652,20 +652,15 @@ export type PairFailureEvent = {
 
 export type PairingInfoEvent = {
   had_previous_bond: boolean
-  /** 16-char uppercase hex transfer id when secure pairing is active. */
-  transfer_id?: string
   pairing_code?: string
   classic_bond_ready?: boolean
   secure_pairing_capable?: boolean
   protocol_version?: number
-  /** Credential binding mode negotiated for this transfer, when reported by the glasses. */
-  binding?: "ctkd" | "temporal" | "none" | string
 }
 
 export type EnteringPairingModeEvent = {
   window_ms: number
   reason?: string
-  txn?: number
 }
 
 export type OwnerReplacedEvent = {

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -245,7 +245,6 @@ describe("pairing loading screen", () => {
       emitBluetoothSdkEvent("pairing_info", {
         had_previous_bond: false,
         secure_pairing_capable: true,
-        transfer_id: "ABCDEF0123456789",
       })
     })
     act(() => {
@@ -298,7 +297,6 @@ describe("pairing loading screen", () => {
       emitBluetoothSdkEvent("pairing_info", {
         had_previous_bond: true,
         secure_pairing_capable: true,
-        transfer_id: "ABCDEF0123456789",
         classic_bond_ready: true,
       })
     })
@@ -322,7 +320,6 @@ describe("pairing loading screen", () => {
       emitBluetoothSdkEvent("pairing_info", {
         had_previous_bond: true,
         secure_pairing_capable: true,
-        transfer_id: "ABCDEF0123456789",
         classic_bond_ready: true,
       })
     })


### PR DESCRIPTION
## Summary

- require the protocol-v2 `MP` advertisement marker on Android and iOS, eliminating legacy-firmware false positives from XORd MAC bytes
- reject stale iOS `didConnect` callbacks after pairing yield or connection-attempt replacement
- clear pending device identity on internal disconnect paths while preserving the selected target during an intentional handoff
- validate four-character hexadecimal pairing codes and generate immutable per-playback WAV files
- remove the abandoned `txn`, `transfer_id`, and `binding` transport fields
- add exhaustive legacy-payload parser tests on Android and iOS

## Firmware dependency and rollout

Depends on Mentra-Community/mentra-live-bes#42. Deploy the version-2 firmware first. The currently shipped parser accepts version 2, while this change deliberately treats unmarked firmware as legacy so random MAC bytes can never hide a legacy unit.

## Automated validation

- [x] `MENTRA_ANDROID_CHECK_SKIP_PREBUILD=1 ./scripts/check-android-compile.sh bluetooth-sdk`
- [x] Android `MentraLivePairingAdvertisementParserTest`
- [x] iOS simulator `xcodebuild` package tests — 6 tests
- [x] Pairing loading Jest suite — 8 tests
- [x] TypeScript `tsc --noEmit`
- [x] Full ASG `:app:testDebugUnitTest` suite — 870 tests, 2 skipped
- [x] `git diff --check`

`spotlessCheck` cannot complete because the repository-wide task currently fails while parsing unchanged `MediaUploadQueueManager.java`; the touched ASG tests compile and pass.

## Required hardware validation before merge

- [ ] New app with legacy firmware across multiple legacy units/MAC payloads
- [ ] Old app with protocol-v2 firmware, followed by new app with protocol-v2 firmware
- [ ] Android two-phone ownership transfer, CTKD attach, owner reconnect, and stranger rejection
- [ ] iOS Classic-first two-phone ownership transfer and a queued-connect/yield race
- [ ] Permission revoke, Bluetooth off/on, cancel, failed selection, and default reconnect identity handling
- [ ] Repeated spoken-code playback confirms correct, non-glitched code

## Complexity decision

This PR removes heuristic parsing and obsolete ownership-transfer plumbing. It keeps the remaining platform-specific BLE/Classic sequencing explicit because Android and iOS genuinely pair in different orders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 50b1c6674899ffc98e30989b2cb38c0a9318b9d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->