### PR TITLE
fix(release): handle clean runners and publication propagation

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -73,3 +73,13 @@ test("mobile release selects an existing Doppler token for its backend", () => {
   assert.equal([...mobile.matchAll(/prod\) DOPPLER_TOKEN="\$DOPPLER_TOKEN_MOBILE_PRD"/g)].length, 2)
   assert.doesNotMatch(mobile, /DOPPLER_TOKEN_MOBILE_PRD \|\|/)
 })
+
+test("Maven generation builds the Crust config plugin before Expo prebuild", () => {
+  const sdkNative = jobBlock(workflow("reusable-coordinated-sdk-native.yml"), "maven")
+  const pluginBuild = sdkNative.indexOf("bun run build:plugin")
+  const prebuild = sdkNative.indexOf("bun expo prebuild --platform android")
+
+  assert.notEqual(pluginBuild, -1)
+  assert.notEqual(prebuild, -1)
+  assert.ok(pluginBuild < prebuild)
+})

--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -79,7 +79,7 @@ function npmView(spec, field) {
 }
 
 function parseViewValue(output) {
-  if (output === null) return null
+  if (output === null || output === "") return null
   try {
     return JSON.parse(output)
   } catch {
@@ -87,11 +87,18 @@ function parseViewValue(output) {
   }
 }
 
-function npmViewPublished(spec, field) {
-  for (let attempt = 1; attempt <= 12; attempt += 1) {
-    const value = parseViewValue(npmView(spec, field))
-    if (value !== null) return value
-    if (attempt < 12) execFileSync("sleep", ["5"])
+export function isHttpsRegistryUrl(value) {
+  return typeof value === "string" && value.startsWith("https://")
+}
+
+export function npmViewPublishedTarball(
+  spec,
+  {attempts = 36, view = npmView, sleep = () => execFileSync("sleep", ["5"])} = {},
+) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const value = parseViewValue(view(spec, "dist.tarball"))
+    if (isHttpsRegistryUrl(value)) return value
+    if (attempt < attempts) sleep()
   }
   return null
 }
@@ -354,8 +361,8 @@ export function publishReleaseNpm({
 
     let url = `https://registry.npmjs.org/${encodeURIComponent(name)}`
     if (!dryRun) {
-      const registryUrl = npmViewPublished(coordinate, "dist.tarball")
-      if (typeof registryUrl !== "string" || !registryUrl.startsWith("https://")) {
+      const registryUrl = npmViewPublishedTarball(coordinate)
+      if (!isHttpsRegistryUrl(registryUrl)) {
         throw new Error(`${coordinate} was published but has no HTTPS registry tarball URL`)
       }
       url = registryUrl

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -7,8 +7,10 @@ import {fileURLToPath} from "node:url"
 
 import {loadReleaseFamily} from "./release-family.mjs"
 import {
+  isHttpsRegistryUrl,
   npmMembersInOrder,
   npmReleaseTag,
+  npmViewPublishedTarball,
   releaseMetadataArgs,
   requireNpmProvenanceSource,
   requirePlanSourceCommit,
@@ -61,6 +63,29 @@ test("admits Engine only as the final selected npm package", () => {
 
 test("creates npm-compatible SHA-512 integrity values", () => {
   assert.match(sha512Integrity(Buffer.from("mentra")), /^sha512-[A-Za-z0-9+/]+=*$/)
+})
+
+test("accepts only propagated HTTPS npm tarball metadata", () => {
+  assert.equal(isHttpsRegistryUrl("https://registry.npmjs.org/@mentra/crust/-/crust-3.1.0.tgz"), true)
+  assert.equal(isHttpsRegistryUrl(""), false)
+  assert.equal(isHttpsRegistryUrl(null), false)
+  assert.equal(isHttpsRegistryUrl("http://registry.npmjs.org/package.tgz"), false)
+})
+
+test("waits through empty npm metadata until the registry exposes the tarball", () => {
+  const responses = ["", null, '"https://registry.npmjs.org/package/-/package-3.1.0.tgz"']
+  let sleeps = 0
+  assert.equal(
+    npmViewPublishedTarball("package@3.1.0", {
+      attempts: responses.length,
+      view: () => responses.shift(),
+      sleep: () => {
+        sleeps += 1
+      },
+    }),
+    "https://registry.npmjs.org/package/-/package-3.1.0.tgz",
+  )
+  assert.equal(sleeps, 2)
 })
 
 test("requires the package checkout to match the immutable release plan", () => {

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -138,6 +138,10 @@ jobs:
         working-directory: mobile
         run: bun install --frozen-lockfile --ignore-scripts
 
+      - name: Build Expo config plugin required by prebuild
+        working-directory: mobile/modules/crust
+        run: bun run build:plugin
+
       - name: Stage the coordinated family version and OTA pin
         run: |
           node .github/scripts/stage-release-family.mjs --plan release-intent/release-plan.json

--- a/mobile/scripts/set-build-env.mjs
+++ b/mobile/scripts/set-build-env.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env zx
 import {config} from "dotenv"
+import {execFileSync} from "child_process"
 import {writeFile, readFile, chmod} from "fs/promises"
 import {homedir} from "os"
 import {join} from "path"
@@ -40,6 +41,25 @@ async function syncMapboxNetrc() {
   console.log("  ~/.netrc updated with Mapbox SPM credentials (from environment)")
 }
 
+export function resolveBuildUser({
+  githubActor = process.env.GITHUB_ACTOR,
+  readGitUsername = () =>
+    execFileSync("git", ["config", "user.name"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }),
+} = {}) {
+  const actor = githubActor?.trim()
+  if (actor) return actor.replace(/\s+/g, "_")
+
+  try {
+    const username = readGitUsername().trim()
+    return username ? username.replace(/\s+/g, "_") : "unknown"
+  } catch {
+    return "unknown"
+  }
+}
+
 export async function setBuildEnv() {
   // Keep src/generated/bundledMiniapps.ts in sync with assets/miniapps/*.zip
   // before any prebuild/bundle so newly-dropped bundles get shipped.
@@ -56,7 +76,7 @@ export async function setBuildEnv() {
   const gitCommit = (await $`git rev-parse --short HEAD`).stdout.trim()
   const gitBranch =
     process.env.MENTRA_COORDINATED_RELEASE_CHANNEL || (await $`git rev-parse --abbrev-ref HEAD`).stdout.trim()
-  const gitUsername = (await $`git config user.name`).stdout.trim().replace(/ /g, "_")  // format: 2025-11-18_12-00
+  const gitUsername = resolveBuildUser()
   const buildTime = new Date()
     .toLocaleString("en-US", {
       timeZone: "America/Los_Angeles",

--- a/mobile/scripts/set-build-env.test.mjs
+++ b/mobile/scripts/set-build-env.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {resolveBuildUser} from "./set-build-env.mjs"
+
+test("uses the GitHub actor for CI build metadata", () => {
+  assert.equal(
+    resolveBuildUser({
+      githubActor: "mentra release bot",
+      readGitUsername: () => {
+        throw new Error("Git config should not be read")
+      },
+    }),
+    "mentra_release_bot",
+  )
+})
+
+test("falls back to the local Git username outside CI", () => {
+  assert.equal(resolveBuildUser({githubActor: "", readGitUsername: () => "Philippe Ferreira\n"}), "Philippe_Ferreira")
+})
+
+test("does not fail a build when Git user.name is unset", () => {
+  assert.equal(
+    resolveBuildUser({
+      githubActor: null,
+      readGitUsername: () => {
+        throw new Error("missing git user.name")
+      },
+    }),
+    "unknown",
+  )
+})


### PR DESCRIPTION
## Summary

Fixes the three clean-environment failures exposed by the first coordinated `dev` release after #3771 merged.

The failed `3.1.0-dev.1` run is https://github.com/Mentra-Community/MentraOS/actions/runs/32887544747. Its immutable OTA bundle and SwiftPM package were published successfully, but the release remains intentionally incomplete: it has no final release manifest.

## Failures observed

### Android mobile build

The Blacksmith runner had no global `git config user.name`. `mobile/scripts/set-build-env.mjs` treated that optional diagnostic value as mandatory, so `bun run release:android` exited before Gradle started.

This change uses `GITHUB_ACTOR` in GitHub Actions, falls back to the local Git username for developer builds, and finally uses `unknown`. Missing optional author metadata can no longer abort Android or iOS builds.

### npm family publication

npm accepted and published `@mentra/crust@3.1.0-dev.1`, but immediately afterward `npm view ... dist.tarball` returned an empty successful response while registry metadata propagated. The release script treated any non-null response, including an empty string, as terminal and failed after 55 seconds.

This change:

- treats empty `npm view` output as unavailable metadata;
- waits for an actual HTTPS tarball URL rather than any non-null value;
- allows up to three minutes for npm propagation;
- preserves exact-byte reconciliation for packages already visible in the registry.

The interrupted run published `@mentra/jspolyfill`, `@mentra/cloud-protocol`, and `@mentra/crust` at `3.1.0-dev.1`. The remaining npm family members were not published. A successful follow-up merge will allocate and publish the new immutable identity `3.1.0-dev.2`; it does not mutate or pretend to complete `dev.1`.

### Maven Central SDK build

The Maven job installs the mobile workspace with `--ignore-scripts`, then uses Expo prebuild to generate the Android project. On a clean runner, `@mentra/crust/app.plugin.js` could not load `./plugin/build` because the Crust config plugin had never been compiled.

This change explicitly builds only the Crust Expo config plugin before prebuild. It keeps the native SDK lane's intentionally narrow dependency setup and avoids running the full mobile postinstall pipeline.

## Release behavior preserved

- The coordinated release identity remains allocated once per branch head.
- Partial publications remain resumable and cannot produce a completed release manifest.
- The ASG/OTA selection and immutable artifacts are unchanged.
- No checked-in package version changes are required; CI will derive `3.1.0-dev.2` from the existing `3.1.0` family base.

## Verification

- `node --test .github/scripts/*.test.mjs mobile/scripts/*.test.mjs` (`99/99` passing)
- `bun run build:plugin` in `mobile/modules/crust`
- loaded `mobile/modules/crust/app.plugin.js` successfully after the targeted build
- `actionlint .github/workflows/reusable-coordinated-sdk-native.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated release CI and npm post-publish verification; incorrect behavior could block or mis-record family publications, but scope is limited to runner/propagation edge cases.
> 
> **Overview**
> Addresses three coordinated-release failures on clean CI runners after the first `dev` release.
> 
> **Mobile builds** no longer require global `git config user.name`. `resolveBuildUser()` sets `EXPO_PUBLIC_BUILD_USER` from `GITHUB_ACTOR` in Actions, then local Git `user.name`, then `unknown`, so optional metadata cannot abort Android/iOS release builds.
> 
> **npm family publication** waits for real registry metadata after publish: empty `npm view` output is ignored, polling targets an HTTPS `dist.tarball` via `npmViewPublishedTarball` (up to ~3 minutes), with tests for the new helpers.
> 
> **Maven / SDK native lane** runs `bun run build:plugin` in `mobile/modules/crust` before `expo prebuild`, so the Crust Expo config plugin exists when install uses `--ignore-scripts`. A workflow contract test enforces that ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0b075ff5ef70eeb310afdf72ded023368f7f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->