### PR TITLE
fix(release): unblock native package and Android builds

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -74,12 +74,28 @@ test("mobile release selects an existing Doppler token for its backend", () => {
   assert.doesNotMatch(mobile, /DOPPLER_TOKEN_MOBILE_PRD \|\|/)
 })
 
-test("Maven generation builds the Crust config plugin before Expo prebuild", () => {
+test("Maven generation builds every local config plugin before Expo prebuild", () => {
   const sdkNative = jobBlock(workflow("reusable-coordinated-sdk-native.yml"), "maven")
-  const pluginBuild = sdkNative.indexOf("bun run build:plugin")
+  const crustPluginBuild = sdkNative.search(
+    /working-directory: mobile\/modules\/crust\n\s+run: bun run build:plugin/,
+  )
+  const bluetoothPluginBuild = sdkNative.search(
+    /working-directory: mobile\/modules\/bluetooth-sdk\n\s+run: bun run build:plugin/,
+  )
   const prebuild = sdkNative.indexOf("bun expo prebuild --platform android")
 
-  assert.notEqual(pluginBuild, -1)
+  assert.notEqual(crustPluginBuild, -1)
+  assert.notEqual(bluetoothPluginBuild, -1)
   assert.notEqual(prebuild, -1)
-  assert.ok(pluginBuild < prebuild)
+  assert.ok(crustPluginBuild < prebuild)
+  assert.ok(bluetoothPluginBuild < prebuild)
+})
+
+test("Android release preserves the Expo-configured marketing version", () => {
+  const androidPlugin = readFileSync(new URL("../../mobile/plugins/android.ts", import.meta.url), "utf8")
+  const mobile = workflow("reusable-coordinated-mobile.yml")
+
+  assert.doesNotMatch(androidPlugin, /replace\([^\n]*versionName/)
+  assert.match(mobile, /version_name=\$\(sed -n "s\/\.\*versionName=/)
+  assert.match(mobile, /Android versionName \$\{version_name:-<missing>\} does not match \$EXPECTED_VERSION/)
 })

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -332,9 +332,17 @@ jobs:
             exit 1
           fi
           "$aapt" dump badging "$apk" > /tmp/mentra-mobile-badging.txt
-          IFS= read -r badging < /tmp/mentra-mobile-badging.txt
-          [[ "$badging" == *"versionCode='$EXPECTED_BUILD'"* ]]
-          [[ "$badging" == *"versionName='$EXPECTED_VERSION'"* ]]
+          badging=$(sed -n '1p' /tmp/mentra-mobile-badging.txt)
+          version_code=$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<< "$badging")
+          version_name=$(sed -n "s/.*versionName='\([^']*\)'.*/\1/p" <<< "$badging")
+          if [[ "$version_code" != "$EXPECTED_BUILD" ]]; then
+            echo "Android versionCode ${version_code:-<missing>} does not match $EXPECTED_BUILD." >&2
+            exit 1
+          fi
+          if [[ "$version_name" != "$EXPECTED_VERSION" ]]; then
+            echo "Android versionName ${version_name:-<missing>} does not match $EXPECTED_VERSION." >&2
+            exit 1
+          fi
 
       - name: Publish immutable Android release assets
         if: inputs.dry_run != true && needs.prepare.outputs.android_assets_exist != 'true'

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -138,8 +138,12 @@ jobs:
         working-directory: mobile
         run: bun install --frozen-lockfile --ignore-scripts
 
-      - name: Build Expo config plugin required by prebuild
+      - name: Build Crust Expo config plugin required by prebuild
         working-directory: mobile/modules/crust
+        run: bun run build:plugin
+
+      - name: Build Bluetooth SDK Expo config plugin required by prebuild
+        working-directory: mobile/modules/bluetooth-sdk
         run: bun run build:plugin
 
       - name: Stage the coordinated family version and OTA pin

--- a/mobile/plugins/android.ts
+++ b/mobile/plugins/android.ts
@@ -108,10 +108,7 @@ if (project.hasProperty("sentryUploadEnabled") && project.property("sentryUpload
       )
     }
 
-    // 2. Update versionName to 3.0.0
-    buildGradle = buildGradle.replace(/versionName\s+["'][^"']*["']/, 'versionName "3.0.0"')
-
-    // 3. Add externalNativeBuild configuration in defaultConfig
+    // 2. Add externalNativeBuild configuration in defaultConfig
     if (!buildGradle.includes("externalNativeBuild")) {
       buildGradle = buildGradle.replace(
         /(buildConfigField\s+"String",\s+"REACT_NATIVE_RELEASE_LEVEL"[^}]+)/,
@@ -127,7 +124,7 @@ if (project.hasProperty("sentryUploadEnabled") && project.property("sentryUpload
       )
     }
 
-    // 4. Add additional packagingOptions
+    // 3. Add additional packagingOptions
     if (!buildGradle.includes("pickFirst '**/libjsc.so'")) {
       buildGradle = buildGradle.replace(
         /(packagingOptions\s*{[^}]*jniLibs\s*{[^}]*})/,


### PR DESCRIPTION
## First-run failures addressed

Coordinated `dev` release [#32892429711](https://github.com/Mentra-Community/MentraOS/actions/runs/32892429711) exposed two independent clean-release failures after #3778:

### Maven prebuild could not load the Bluetooth SDK config plugin

The workflow installs mobile dependencies with `--ignore-scripts`, so package lifecycle hooks intentionally do not generate config-plugin outputs. It explicitly built Crust's plugin, but Expo prebuild then failed while importing `mobile/modules/bluetooth-sdk/app.plugin.js`:

```
Cannot find module './plugin/build'
```

This PR explicitly builds both local config plugins consumed by the app before Maven's Android prebuild:

- `mobile/modules/crust`
- `mobile/modules/bluetooth-sdk`

### Android's generated versionName was forced back to 3.0.0

The coordinated Android build itself succeeded and produced APK/AAB files with the planned `versionCode=310000002`. Post-build verification then failed because `mobile/plugins/android.ts` replaced Expo's generated `versionName` with a hardcoded `3.0.0`, overriding the coordinated native marketing version `3.1.0`.

This PR removes that legacy rewrite. `mobile/app.config.ts` and `MENTRAOS_NATIVE_MARKETING_VERSION` remain the single source of truth shared with iOS. Android artifact verification now extracts and reports actual `versionCode` and `versionName` values instead of exiting silently on a substring mismatch.

## Coverage and verification

- Workflow contract requires the Crust directory-command pair before Maven prebuild.
- Workflow contract requires the Bluetooth SDK directory-command pair before Maven prebuild.
- Workflow contract rejects any Android plugin rewrite of `versionName`.
- Workflow contract requires descriptive Android version-name verification.
- Clean mobile install with lifecycle scripts disabled: `bun install --frozen-lockfile --ignore-scripts`.
- Explicit config-plugin builds succeed for both modules.
- Clean Android Expo prebuild now generates:
  - `versionCode 310000002`
  - `versionName "3.1.0"`
- `node --test .github/scripts/*.test.mjs`: `81/81` passing.
- `actionlint` passes for both changed workflows (with the repository's existing custom Blacksmith runner label allowed).
- `git diff --check` passes.

## Separate npm prerequisite

The same release run published the first four npm members at `3.1.0-dev.2`, then npm rejected `@mentra/bluetooth-sdk` because that package disallows the existing automation token without a 2FA-capable trusted publisher. The workflow already has `id-token: write`, Node 24/npm 11, and exact MentraOS repository metadata. npm's package-side trusted-publisher configuration is being corrected before this PR is merged, avoiding another known partial release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinated release CI and Android versioning; wrong plugin order or version checks could block releases, but changes are narrowly scoped to known failure modes.
> 
> **Overview**
> Fixes coordinated **Maven** lane prebuild failures when `bun install --ignore-scripts` skips config-plugin builds: the workflow now runs `bun run build:plugin` for **Crust** and **Bluetooth SDK** before `expo prebuild`, and contract tests require both module paths—not a single generic plugin step.
> 
> **Android marketing version** is no longer forced to `3.0.0` in `mobile/plugins/android.ts`; release APK checks parse `versionCode` / `versionName` from `aapt` badging and fail with clear messages when they don’t match the release plan. A new contract test locks in that the plugin doesn’t rewrite `versionName` and that the mobile workflow validates it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c46fc0395d98395fcd886271137360e9ab79d8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->