### PR TITLE
fix(release): wait for Sonatype PURL propagation

### DIFF
--- a/.github/scripts/sonatype-central-deployment.mjs
+++ b/.github/scripts/sonatype-central-deployment.mjs
@@ -37,10 +37,9 @@ function requireDeploymentRecord(record) {
   return record
 }
 
-function assertExpectedPurls(actual, expected, label) {
+function missingExpectedPurls(actual, expected) {
   const actualSet = new Set(actual)
-  const missing = expected.filter((purl) => !actualSet.has(purl))
-  if (missing.length > 0) throw new Error(`${label} is missing expected components: ${missing.join(", ")}`)
+  return expected.filter((purl) => !actualSet.has(purl))
 }
 
 export async function uploadManagedDeployment({bundle, token, deploymentName, expectedPurls, fetchImpl = fetch}) {
@@ -117,9 +116,6 @@ export async function inspectDeployment({record, token, fetchImpl = fetch}) {
       `Sonatype deployment ${record.deploymentName} has unknown state ${JSON.stringify(status.deploymentState)}`,
     )
   }
-  if (status.deploymentState === "PUBLISHED") {
-    assertExpectedPurls(purls, record.expectedPurls, `Published Sonatype deployment ${record.deploymentName}`)
-  }
   return {...record, disposition: "resume", deploymentState: status.deploymentState, purls}
 }
 
@@ -135,6 +131,7 @@ export async function publishDeployment({
   if (!token) throw new Error("Sonatype token is required")
   const headers = {Authorization: `Bearer ${token}`}
   let publicationRequested = false
+  let missingPublishedPurls = []
 
   for (let attempt = 1; attempt <= statusAttempts; attempt += 1) {
     const status = requireMatchingStatus(
@@ -146,10 +143,11 @@ export async function publishDeployment({
       throw new Error(`Sonatype deployment ${record.deploymentName} failed: ${JSON.stringify(status.errors || [])}`)
     }
     if (status.deploymentState === "PUBLISHED") {
-      assertExpectedPurls(purls, record.expectedPurls, `Published Sonatype deployment ${record.deploymentName}`)
-      return {...record, deploymentState: status.deploymentState, purls}
-    }
-    if (status.deploymentState === "VALIDATED") {
+      missingPublishedPurls = missingExpectedPurls(purls, record.expectedPurls)
+      if (missingPublishedPurls.length === 0) {
+        return {...record, deploymentState: status.deploymentState, purls}
+      }
+    } else if (status.deploymentState === "VALIDATED") {
       if (!publicationRequested) {
         await requestPublication({fetchImpl, headers, deploymentId: record.deploymentId})
         publicationRequested = true
@@ -160,6 +158,12 @@ export async function publishDeployment({
       )
     }
     if (attempt < statusAttempts) await sleepImpl(pollIntervalMs)
+  }
+  if (missingPublishedPurls.length > 0) {
+    throw new Error(
+      `Published Sonatype deployment ${record.deploymentName} is still missing expected components after ` +
+        `${statusAttempts} status checks: ${missingPublishedPurls.join(", ")}`,
+    )
   }
   throw new Error(`Sonatype deployment ${record.deploymentName} did not publish after ${statusAttempts} status checks`)
 }

--- a/.github/scripts/sonatype-central-deployment.test.mjs
+++ b/.github/scripts/sonatype-central-deployment.test.mjs
@@ -96,6 +96,28 @@ test("resumes a publishing deployment without sending another publication reques
   assert.equal(publicationRequests, 0)
 })
 
+test("keeps polling while published deployment PURLs are still propagating", async () => {
+  const purlsByAttempt = [[], expectedPurls]
+  let publicationRequests = 0
+  const result = await publishDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async (url) => {
+      if (String(url).includes(`/deployment/${deploymentId}`)) publicationRequests += 1
+      return jsonResponse({
+        deploymentId,
+        deploymentName,
+        deploymentState: "PUBLISHED",
+        purls: purlsByAttempt.shift(),
+      })
+    },
+    sleepImpl: async () => {},
+  })
+
+  assert.equal(publicationRequests, 0)
+  assert.deepEqual(result.purls, expectedPurls)
+})
+
 test("replaces a persisted deployment only after Sonatype reports it failed", async () => {
   const failed = await inspectDeployment({
     record: record(),
@@ -114,6 +136,18 @@ test("replaces a persisted deployment only after Sonatype reports it failed", as
   assert.equal(publishing.disposition, "resume")
 })
 
+test("resumes a published deployment while its PURLs are still propagating", async () => {
+  const result = await inspectDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async () =>
+      jsonResponse({deploymentId, deploymentName, deploymentState: "PUBLISHED", purls: [expectedPurls[0]]}),
+  })
+
+  assert.equal(result.disposition, "resume")
+  assert.deepEqual(result.purls, [expectedPurls[0]])
+})
+
 test("rejects a published deployment with the wrong Maven coordinates", async () => {
   await assert.rejects(
     publishDeployment({
@@ -122,6 +156,7 @@ test("rejects a published deployment with the wrong Maven coordinates", async ()
       fetchImpl: async () =>
         jsonResponse({deploymentId, deploymentName, deploymentState: "PUBLISHED", purls: [expectedPurls[0]]}),
       sleepImpl: async () => {},
+      statusAttempts: 2,
     }),
     /missing expected components/,
   )


### PR DESCRIPTION
## Problem

The coordinated `3.1.0-dev.3` release reached Sonatype deployment state `PUBLISHED`, but the first published status response still returned no package PURLs. The release job treated that brief metadata propagation gap as a permanent coordinate mismatch and failed before the existing public-artifact verification could run.

Observed in [run 32897278520, Maven job](https://github.com/Mentra-Community/MentraOS/actions/runs/32897278520/job/97964485451):

- both `com.mentraglass:bluetooth-sdk:3.1.0-dev.3` and `com.mentraglass:lc3Lib:3.1.0-dev.3` built and signed successfully
- Sonatype accepted deployment `3064d5b3-b817-49ff-9c7a-1f46dc2b7753`
- the deployment advanced through validation and publication to `PUBLISHED`
- the first `PUBLISHED` response had not yet exposed either expected PURL, causing an immediate failure

## Change

Treat `PUBLISHED` with incomplete PURLs as a resumable propagation state. The publisher continues polling until the exact expected coordinate set appears, while preserving the existing bounded timeout and failure if the coordinates never become complete.

The persisted-deployment inspection path now also allows a rerun to resume a published deployment whose PURL metadata is still propagating. It does not upload or publish a replacement deployment.

## Safety

- `FAILED` deployments are still the only deployments eligible for replacement.
- Unknown Sonatype states still fail closed.
- A published deployment with permanently missing or wrong coordinates still fails after the bounded status attempts.
- Reruns reuse the persisted deployment ID and never send a second publication request for a `PUBLISHED` deployment.
- Public Maven AAR download and embedded release-metadata verification remain required after the PURL gate.

## Verification

- `node --test .github/scripts/*.test.mjs` (83/83)
- Prettier check for both changed files
- `git diff --check`
- Added regression coverage for PURL propagation after `PUBLISHED`, rerun inspection during that window, and bounded failure for a genuinely incomplete coordinate set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Maven Central publish/inspect behavior in CI; bounded timeouts and wrong-coordinate failures are preserved, but a bug could delay or incorrectly pass/fail releases.
> 
> **Overview**
> Fixes release failures when Sonatype reports **`PUBLISHED`** before expected Maven PURLs appear in status responses.
> 
> **`publishDeployment`** now treats incomplete PURLs on a published deployment as propagation in progress: it keeps polling until the full expected coordinate set is present, then succeeds. If PURLs never complete within the existing **`statusAttempts`** budget, it fails with an explicit “still missing expected components” error instead of failing on the first empty response.
> 
> **`inspectDeployment`** no longer rejects **`PUBLISHED`** deployments with partial PURLs, so workflow reruns can **resume** the same deployment instead of treating the gap as a hard coordinate mismatch.
> 
> PURL checking is refactored from **`assertExpectedPurls`** (throw immediately) to **`missingExpectedPurls`** (returns missing list). Tests cover propagation polling, resume during partial PURLs, and bounded failure for permanently incomplete coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9feca597bd7fae4ba4de954300cc0239374049d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->