### PR TITLE
fix(release): install pinned Android Play tooling

### DIFF
--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -228,6 +228,11 @@ jobs:
       - name: Install Android build tools used for artifact verification
         run: sdkmanager "build-tools;36.0.0"
 
+      - uses: ruby/setup-ruby@v1
+        if: inputs.dry_run != true
+        with:
+          ruby-version: "3.3"
+
       - uses: oven-sh/setup-bun@v2
         if: inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true'
         with:
@@ -367,7 +372,8 @@ jobs:
           mkdir -p mobile-play/fastlane
           cp mobile/ci/fastlane-android/Fastfile mobile-play/fastlane/Fastfile
           cp mobile/ci/fastlane-android/Appfile mobile-play/fastlane/Appfile
-          cp mobile/ci/fastlane-android/Gemfile mobile-play/Gemfile
+          cp mobile/Gemfile mobile-play/Gemfile
+          cp mobile/Gemfile.lock mobile-play/Gemfile.lock
 
       - name: Install Google Play upload tooling
         if: inputs.dry_run != true


### PR DESCRIPTION
## What failed

The first coordinated `3.1.0-dev.3` Android release successfully built and verified the signed APK/AAB and published both immutable GitHub release assets. It then failed before Google Play reconciliation because the Blacksmith Linux runner did not provide a `bundle` executable:

```
.../sh: line 1: bundle: command not found
```

## Fix

- Set up Ruby 3.3 in the Android distribution job before the Play-only steps.
- Reuse `mobile/Gemfile` and `mobile/Gemfile.lock` for the temporary `mobile-play` workspace instead of the separate unpinned Fastlane Gemfile.
- Keep Ruby setup disabled for dry runs, where no Google Play operation occurs.

This aligns the Android release path with the existing promotion workflow and gives both upload paths the repository-pinned Fastlane 2.235 dependency closure.

## Scope

This does not rebuild or alter Android application code, signing, immutable asset publication, track selection, or upload behavior. It only makes the already-defined Play reconciliation/upload steps runnable and reproducible on the Linux release runner.

## Verification

- `bunx prettier --check .github/workflows/reusable-coordinated-mobile.yml`
- `actionlint -ignore 'label ".*" is unknown' .github/workflows/reusable-coordinated-mobile.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes for Ruby/Fastlane setup; no changes to Android builds, signing, or Play upload logic.
> 
> **Overview**
> Fixes coordinated Android releases failing after GitHub asset publication when **`bundle`** was missing on the Blacksmith Linux runner.
> 
> The Android job now runs **`ruby/setup-ruby@v1`** (Ruby **3.3**) before Google Play steps, gated off for **`dry_run`**. The temporary **`mobile-play`** workspace copies **`mobile/Gemfile`** and **`mobile/Gemfile.lock`** instead of the unpinned Fastlane-only Gemfile, so **`bundle install`** matches the repo-pinned Fastlane closure used elsewhere (e.g. promotion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92d952c0a19ecf1c96972b24e93414cf4112983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->