### PR TITLE
fix(release): verify Maven from public artifacts

### DIFF
--- a/.github/scripts/sonatype-central-deployment.mjs
+++ b/.github/scripts/sonatype-central-deployment.mjs
@@ -37,11 +37,6 @@ function requireDeploymentRecord(record) {
   return record
 }
 
-function missingExpectedPurls(actual, expected) {
-  const actualSet = new Set(actual)
-  return expected.filter((purl) => !actualSet.has(purl))
-}
-
 export async function uploadManagedDeployment({bundle, token, deploymentName, expectedPurls, fetchImpl = fetch}) {
   if (!bundle || !token || !deploymentName || expectedPurls.length === 0) {
     throw new Error("Bundle, token, deployment name, and expected PURLs are required")
@@ -131,7 +126,6 @@ export async function publishDeployment({
   if (!token) throw new Error("Sonatype token is required")
   const headers = {Authorization: `Bearer ${token}`}
   let publicationRequested = false
-  let missingPublishedPurls = []
 
   for (let attempt = 1; attempt <= statusAttempts; attempt += 1) {
     const status = requireMatchingStatus(
@@ -143,10 +137,7 @@ export async function publishDeployment({
       throw new Error(`Sonatype deployment ${record.deploymentName} failed: ${JSON.stringify(status.errors || [])}`)
     }
     if (status.deploymentState === "PUBLISHED") {
-      missingPublishedPurls = missingExpectedPurls(purls, record.expectedPurls)
-      if (missingPublishedPurls.length === 0) {
-        return {...record, deploymentState: status.deploymentState, purls}
-      }
+      return {...record, deploymentState: status.deploymentState, purls}
     } else if (status.deploymentState === "VALIDATED") {
       if (!publicationRequested) {
         await requestPublication({fetchImpl, headers, deploymentId: record.deploymentId})
@@ -158,12 +149,6 @@ export async function publishDeployment({
       )
     }
     if (attempt < statusAttempts) await sleepImpl(pollIntervalMs)
-  }
-  if (missingPublishedPurls.length > 0) {
-    throw new Error(
-      `Published Sonatype deployment ${record.deploymentName} is still missing expected components after ` +
-        `${statusAttempts} status checks: ${missingPublishedPurls.join(", ")}`,
-    )
   }
   throw new Error(`Sonatype deployment ${record.deploymentName} did not publish after ${statusAttempts} status checks`)
 }

--- a/.github/scripts/sonatype-central-deployment.test.mjs
+++ b/.github/scripts/sonatype-central-deployment.test.mjs
@@ -96,8 +96,7 @@ test("resumes a publishing deployment without sending another publication reques
   assert.equal(publicationRequests, 0)
 })
 
-test("keeps polling while published deployment PURLs are still propagating", async () => {
-  const purlsByAttempt = [[], expectedPurls]
+test("accepts published deployment while optional PURLs are absent", async () => {
   let publicationRequests = 0
   const result = await publishDeployment({
     record: record(),
@@ -108,14 +107,14 @@ test("keeps polling while published deployment PURLs are still propagating", asy
         deploymentId,
         deploymentName,
         deploymentState: "PUBLISHED",
-        purls: purlsByAttempt.shift(),
+        purls: [],
       })
     },
     sleepImpl: async () => {},
   })
 
   assert.equal(publicationRequests, 0)
-  assert.deepEqual(result.purls, expectedPurls)
+  assert.deepEqual(result.purls, [])
 })
 
 test("replaces a persisted deployment only after Sonatype reports it failed", async () => {
@@ -136,7 +135,7 @@ test("replaces a persisted deployment only after Sonatype reports it failed", as
   assert.equal(publishing.disposition, "resume")
 })
 
-test("resumes a published deployment while its PURLs are still propagating", async () => {
+test("resumes a published deployment when status PURLs are incomplete", async () => {
   const result = await inspectDeployment({
     record: record(),
     token: "token",
@@ -148,16 +147,14 @@ test("resumes a published deployment while its PURLs are still propagating", asy
   assert.deepEqual(result.purls, [expectedPurls[0]])
 })
 
-test("rejects a published deployment with the wrong Maven coordinates", async () => {
-  await assert.rejects(
-    publishDeployment({
-      record: record(),
-      token: "token",
-      fetchImpl: async () =>
-        jsonResponse({deploymentId, deploymentName, deploymentState: "PUBLISHED", purls: [expectedPurls[0]]}),
-      sleepImpl: async () => {},
-      statusAttempts: 2,
-    }),
-    /missing expected components/,
-  )
+test("preserves partial published PURLs for observability", async () => {
+  const result = await publishDeployment({
+    record: record(),
+    token: "token",
+    fetchImpl: async () =>
+      jsonResponse({deploymentId, deploymentName, deploymentState: "PUBLISHED", purls: [expectedPurls[0]]}),
+    sleepImpl: async () => {},
+  })
+
+  assert.deepEqual(result.purls, [expectedPurls[0]])
 })


### PR DESCRIPTION
## What the live release showed

The `3.1.0-dev.4` Sonatype deployment reached `PUBLISHED`, and both coordinated AARs became publicly downloadable from Maven Central:

- `com.mentraglass:bluetooth-sdk:3.1.0-dev.4`
- `com.mentraglass:lc3Lib:3.1.0-dev.4`

However, the Publisher API continued returning an empty/incomplete optional `purls` array for more than twenty minutes. The release remained stuck in the status-polling step even though the exact public artifacts were already available.

## Fix

Treat Sonatype's documented `PUBLISHED` deployment state as the end of the deployment-state poll. Preserve any returned PURLs in the result for observability, but do not use that eventually populated metadata as a second publication gate.

The following existing workflow steps remain the authoritative component proof:

1. Poll both exact versioned Maven Central AAR URLs until both are public.
2. Download the public Bluetooth SDK AAR and inspect its compiled release metadata.
3. Require the coordinated release identity, immutable OTA manifest URL, and OTA manifest SHA from the release plan.

The persisted deployment record still binds the Sonatype deployment ID and name to the SHA-256 of the exact signed two-component upload bundle, so retry recovery remains deterministic.

## Why this is simpler and stronger

The release no longer waits on optional duplicate API metadata after publication. Success still requires the actual consumer-facing artifacts and their embedded metadata, which is the stronger end-state proof.

## Verification

- Full `.github/scripts/*.test.mjs` suite: 83/83 passing
- Prettier check on both changed files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release scripting only; artifact proof still happens in later Maven Central polling steps described in the PR.
> 
> **Overview**
> **Sonatype `publishDeployment` now completes as soon as the deployment reaches `PUBLISHED`**, instead of continuing to poll until the status API’s optional `purls` list matches `record.expectedPurls`.
> 
> The `missingExpectedPurls` helper and the timeout error for “missing expected components” are removed. Whatever `purls` Sonatype returns (including empty or partial) is still attached to the result for logging.
> 
> Tests are updated to expect success with empty or partial `purls` on publish, and to drop the case that rejected published deployments with wrong/incomplete coordinates via that gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a7ee014bf1e826df883601afb5db1c8ec86377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->