### PR TITLE
fix(release): allow npm registry propagation

### DIFF
--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -93,7 +93,7 @@ export function isHttpsRegistryUrl(value) {
 
 export function npmViewPublishedTarball(
   spec,
-  {attempts = 36, view = npmView, sleep = () => execFileSync("sleep", ["5"])} = {},
+  {attempts = 120, view = npmView, sleep = () => execFileSync("sleep", ["5"])} = {},
 ) {
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const value = parseViewValue(view(spec, "dist.tarball"))
@@ -157,9 +157,13 @@ function transitiveDependencies(family, memberName) {
 
 function prepareBluetoothSdkBuild({rootDir, plan, otaManifestUrl, otaManifestSha256}) {
   requireReleaseMetadata({otaManifestUrl, otaManifestSha256})
-  run("node", ["scripts/write-release-metadata.mjs", ...releaseMetadataArgs({plan, otaManifestUrl, otaManifestSha256})], {
-    cwd: path.join(rootDir, "mobile/modules/bluetooth-sdk"),
-  })
+  run(
+    "node",
+    ["scripts/write-release-metadata.mjs", ...releaseMetadataArgs({plan, otaManifestUrl, otaManifestSha256})],
+    {
+      cwd: path.join(rootDir, "mobile/modules/bluetooth-sdk"),
+    },
+  )
 }
 
 function prepareEngineBuild({rootDir, family, plan, otaManifestUrl, otaManifestSha256}) {

--- a/.github/workflows/reusable-coordinated-npm.yml
+++ b/.github/workflows/reusable-coordinated-npm.yml
@@ -41,7 +41,7 @@ jobs:
   publish:
     name: Publish exact npm family closure
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout exact package source
         uses: actions/checkout@v4


### PR DESCRIPTION
## What the live release showed

The coordinated `3.1.0-dev.6` npm lane successfully published `@mentra/crust` with npm provenance. npm itself reported that the package was being processed and could take a few minutes to become available.

The package did not expose `dist.tarball` within the release script's current three-minute window (36 attempts at five seconds), so the job failed. The exact HTTPS tarball metadata became publicly resolvable shortly afterward.

## Fix

- Increase per-package npm registry reconciliation from 3 minutes to 10 minutes.
- Increase the bounded npm job timeout from 30 minutes to 45 minutes so a legitimate delayed package can finish without consuming all job headroom.

Publication remains dependency ordered. Existing versions are still accepted only when their registry integrity equals the just-built tarball; new versions still require provenance publication and an HTTPS registry tarball URL.

## Scope

This does not change package contents, versions, tags, OIDC authentication, integrity checks, provenance, or retry reconciliation. It only gives npm's documented asynchronous package processing enough bounded time to expose the metadata the release already requires.

Prettier also normalized one pre-existing multiline call in the touched script.

## Verification

- Full `.github/scripts/*.test.mjs` suite: 83/83 passing
- Prettier check on changed files
- `actionlint .github/workflows/reusable-coordinated-npm.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI timing and retry defaults only; no changes to publish logic, auth, or package contents.
> 
> **Overview**
> Coordinated npm releases were failing when npm took longer than ~3 minutes after publish to expose `dist.tarball`, even though publication succeeded.
> 
> **`npmViewPublishedTarball`** now polls the registry for up to **10 minutes** (120 × 5s attempts, up from 36). The reusable coordinated npm workflow job **timeout** rises from **30 to 45 minutes** so multi-package runs can absorb that wait without hitting the job limit.
> 
> Integrity checks, provenance, dependency order, and reuse logic are unchanged; only bounded wait/timeout headroom increases. A Prettier-only reformat applies to one `run()` call in the release script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35dcb0ec9dcd7d4a75f56f27628b48ebae565c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->