### PR TITLE
Fix coordinated release finalizer OTA artifact path

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -29,6 +29,15 @@ test("coordinated OTA assets have bounded release ownership", () => {
   assert.doesNotMatch(ota, /OTA_RELEASE_TAG/)
 })
 
+test("release finalization reads the preserved OTA artifact layout", () => {
+  const finalize = jobBlock(workflow("coordinated-release.yml"), "finalize")
+
+  assert.match(
+    finalize,
+    /asg_selection="release-input\/ota\/release-assets\/\$\(jq -er \.artifactNames\.asgSelection "\$plan"\)"/,
+  )
+})
+
 test("production validates before approval and proves packages before mobile promotion", () => {
   const production = workflow("coordinated-production-promotion.yml")
 
@@ -76,9 +85,7 @@ test("mobile release selects an existing Doppler token for its backend", () => {
 
 test("Maven generation builds every local config plugin before Expo prebuild", () => {
   const sdkNative = jobBlock(workflow("reusable-coordinated-sdk-native.yml"), "maven")
-  const crustPluginBuild = sdkNative.search(
-    /working-directory: mobile\/modules\/crust\n\s+run: bun run build:plugin/,
-  )
+  const crustPluginBuild = sdkNative.search(/working-directory: mobile\/modules\/crust\n\s+run: bun run build:plugin/)
   const bluetoothPluginBuild = sdkNative.search(
     /working-directory: mobile\/modules\/bluetooth-sdk\n\s+run: bun run build:plugin/,
   )

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -291,7 +291,7 @@ jobs:
           plan=release-input/plan/release-plan.json
           identity=$(jq -er .releaseIdentity "$plan")
           tag="mentra-v$identity"
-          asg_selection="release-input/ota/$(jq -er .artifactNames.asgSelection "$plan")"
+          asg_selection="release-input/ota/release-assets/$(jq -er .artifactNames.asgSelection "$plan")"
           test -f "$asg_selection"
           engine_package=$(find release-input/npm -type f -name 'mentra-engine-*.tgz' -print -quit)
           test -n "$engine_package"


### PR DESCRIPTION
## Problem

The first otherwise-complete coordinated dev release, `3.1.0-dev.7`, passed npm, Maven Central, SwiftPM, OTA publication, Android/Google Play, iOS/TestFlight, and both clean external Engine consumer builds. Its final BOM job then failed before assembly.

The OTA result artifact preserves the producer directory layout. The ASG selection record is downloaded as:

```text
release-input/ota/release-assets/mentra-live-asg-selection-<version>.json
```

The finalizer incorrectly looked for that file directly under `release-input/ota/`, so its `test -f` guard exited immediately.

## Fix

- Read the ASG selection record from the preserved `release-assets/` directory.
- Add a workflow contract test tying the finalizer path to that artifact layout.

No package, SDK, OTA, or mobile artifact generation behavior changes.

## Verification

- `node --test .github/scripts/*.test.mjs` (84/84)
- `node --test .github/scripts/coordinated-workflow-contract.test.mjs` (7/7)
- `actionlint .github/workflows/coordinated-release.yml`
- `npx prettier@3.6.2 --check .github/workflows/coordinated-release.yml .github/scripts/coordinated-workflow-contract.test.mjs`
- `git diff --check`

Live failure evidence: https://github.com/Mentra-Community/MentraOS/actions/runs/32905974737/job/98001914827

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path fix in release finalization plus a contract test; no auth, data, or artifact generation logic changes.
> 
> **Overview**
> Fixes the **finalize** job in coordinated releases so it locates the ASG selection JSON where the OTA workflow artifact actually lands: under `release-input/ota/release-assets/`, not directly under `release-input/ota/`. That mismatch caused an otherwise successful release (e.g. `3.1.0-dev.7`) to fail on `test -f` during BOM assembly.
> 
> Adds a workflow contract test on the `finalize` job so the `asg_selection` path stays aligned with the preserved OTA artifact layout. No changes to package, SDK, OTA, or mobile publication behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632e04eb00ec4610952ced9e772ba0a5ef4374d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->