### PR TITLE
Fix Miniapp Developer visibility and OTA UI

### DIFF
--- a/mintlify-docs/app-devs/getting-started/quickstart.mdx
+++ b/mintlify-docs/app-devs/getting-started/quickstart.mdx
@@ -57,10 +57,7 @@ save and forwards the miniapp's console logs back to your terminal.
 ### Step 4: Load it on your phone
 
 In the Mentra App, go to **Settings → Miniapp Developer Settings → Scan Miniapp
-QR Code** and scan the QR from your terminal. If Miniapp Developer Settings is
-hidden, open **Settings → Debug Settings**, enable **Miniapp Developer
-Settings**, then return to Settings. If Debug Settings is hidden, tap the
-version number at the bottom of Settings ten times to reveal it.
+QR Code** and scan the QR from your terminal.
 
 <Info>
 Your phone and your laptop must be on the **same Wi-Fi network**. `bun dev`

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -3,7 +3,7 @@
   "theme": "aspen",
   "name": "MentraOS",
   "banner": {
-    "content": "**Beta.** The Mentra Miniapp SDK and these docs are subject to change. Enable it at **Settings → Debug Settings → Miniapp Developer Settings** in the Mentra App. Send feedback with an in-app bug report, on [Discord](https://discord.gg/5ukNvkEAqT), or by [email](mailto:help@mentra.glass).",
+    "content": "**Beta.** The Mentra Miniapp SDK and these docs are subject to change. Open **Settings → Miniapp Developer Settings** in the Mentra App to access the developer tools. Send feedback with an in-app bug report, on [Discord](https://discord.gg/5ukNvkEAqT), or by [email](mailto:help@mentra.glass).",
     "dismissible": false
   },
   "colors": {

--- a/mintlify-docs/snippets/beta-note.mdx
+++ b/mintlify-docs/snippets/beta-note.mdx
@@ -1,10 +1,7 @@
 <Warning>
   **The Mentra Miniapp SDK is in beta.** It has not been thoroughly tested yet,
-  so it ships behind a developer toggle in the Mentra App rather than on by
-  default. Open **Settings → Debug Settings**, enable **Miniapp Developer
-  Settings**, then return to Settings and open **Miniapp Developer Settings**.
-  If Debug Settings is hidden, tap the version number at the bottom of Settings
-  ten times to reveal it.
+  and the developer tools are available in the Mentra App under **Settings →
+  Miniapp Developer Settings**.
 
   These docs describe the SDK as it stands today. Both the SDK and the docs are
   subject to change, and some of it will change based on what beta testers run

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -797,13 +797,13 @@ function FlowButton({
       style={({pressed}) => [
         styles.button,
         {
-          backgroundColor: secondary ? colors.background : colors.primary,
-          borderColor: secondary ? colors.border : colors.primary,
+          backgroundColor: secondary ? colors.background : colors.foreground,
+          borderColor: secondary ? colors.border : colors.foreground,
           opacity: disabled ? 0.45 : pressed ? 0.75 : 1,
         },
       ]}
       testID={`button-${label}`}>
-      <Text style={[styles.buttonText, {color: secondary ? colors.foreground : colors.primaryText}]}>{label}</Text>
+      <Text style={[styles.buttonText, {color: secondary ? colors.foreground : colors.background}]}>{label}</Text>
     </Pressable>
   )
 }
@@ -846,11 +846,11 @@ const styles = StyleSheet.create({
   progressFill: {borderRadius: 4, height: 8},
   button: {
     alignItems: "center",
-    borderRadius: 10,
+    borderRadius: 50,
     borderWidth: 1,
     justifyContent: "center",
-    minHeight: 48,
+    minHeight: 44,
     paddingHorizontal: 20,
   },
-  buttonText: {fontSize: 15, fontWeight: "700"},
+  buttonText: {fontSize: 14, fontWeight: "500"},
 })

--- a/mobile/modules/engine/src/stores/__tests__/appVisibility.test.ts
+++ b/mobile/modules/engine/src/stores/__tests__/appVisibility.test.ts
@@ -1,0 +1,19 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, test} from "bun:test"
+
+import {resolveHiddenStatus} from "../appVisibility"
+
+describe("resolveHiddenStatus", () => {
+  test("keeps registry-hidden apps off the home screen", () => {
+    expect(resolveHiddenStatus(true, false)).toBe(true)
+  })
+
+  test("preserves a user's persisted hidden state", () => {
+    expect(resolveHiddenStatus(false, true)).toBe(true)
+  })
+
+  test("shows an app only when neither source hides it", () => {
+    expect(resolveHiddenStatus(false, false)).toBe(false)
+  })
+})

--- a/mobile/modules/engine/src/stores/appVisibility.ts
+++ b/mobile/modules/engine/src/stores/appVisibility.ts
@@ -1,0 +1,3 @@
+/** Combine registry-enforced visibility with the user's home-screen choice. */
+export const resolveHiddenStatus = (registryHidden: boolean, userHidden: boolean): boolean =>
+  registryHidden || userHidden

--- a/mobile/modules/engine/src/stores/apps.ts
+++ b/mobile/modules/engine/src/stores/apps.ts
@@ -25,6 +25,7 @@ import {islandNotifications} from "../services/NotificationsEmitter"
 import sttModelManager from "../services/STTModelManager"
 import {miniappLauncher} from "../services/MiniappLauncher"
 import {miniappRunningRegistry} from "../services/MiniappRunningRegistry"
+import {resolveHiddenStatus} from "./appVisibility"
 import {SETTINGS, useSettingsStore} from "./settings"
 import BluetoothSdk from "@mentra/bluetooth-sdk"
 
@@ -221,7 +222,12 @@ function projectApps(previousState: AppStatusState, localApps: ClientApp[]): Cli
       ...app,
       screenshot: previousByPackage.get(app.packageName)?.screenshot ?? app.screenshot,
       compatibility: HardwareCompatibility.checkCompatibility(app.hardwareRequirements, capabilities),
-      hidden: previousState.getHiddenStatus(app.packageName),
+      // A registry source can force an app off the primary home screen (for
+      // example, Miniapp Developer while its home-screen setting is disabled).
+      // Compose that gate with the user's persisted home-screen layout instead
+      // of replacing it, otherwise a default-false persisted value makes a
+      // source-hidden app visible again during projection.
+      hidden: resolveHiddenStatus(app.hidden, previousState.getHiddenStatus(app.packageName)),
       // Derive the foreground flag from the store's single source of truth
       // (`foregroundedPackage`), NOT from the previous snapshot. Carrying it over
       // per-app meant a refresh that momentarily omitted an app (e.g. the

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -166,7 +166,7 @@ const en = {
       "Press the power button 5 times quickly. The LED flashes and the glasses speak a 4-character code. Then select the glasses again.",
     tryAgain: "Try Again",
     pairingCodeLabel: "Code {{code}}",
-    legacyFirmwareLabel: "Legacy firmware",
+    legacyFirmwareLabel: "Legacy software",
     ar99Step1: "1. Confirm that the Bluetooth switch of the mobile phone is turned on.",
     ar99Step2: "2. Press and hold the power button for 3 to 5 seconds to turn on the glasses.",
   },

--- a/mobile/src/services/miniapps/BuiltInMiniappCatalog.test.ts
+++ b/mobile/src/services/miniapps/BuiltInMiniappCatalog.test.ts
@@ -46,6 +46,7 @@ describe("BuiltInMiniappCatalog", () => {
         hidden: true,
       }),
     )
+    expect(engine.miniapps.setHiddenStatus).toHaveBeenCalledWith(miniappDeveloperPackageName, true)
 
     const settingListener = (engine.settings.onChanged as jest.Mock).mock.calls.find(
       ([key]) => key === SETTINGS.miniapp_dev_mode.key,
@@ -54,7 +55,9 @@ describe("BuiltInMiniappCatalog", () => {
     expect(settingListener).toEqual(expect.any(Function))
     settingListener(true)
     expect(appRegistry.setOfflineAppHidden).toHaveBeenLastCalledWith(miniappDeveloperPackageName, false)
+    expect(engine.miniapps.setHiddenStatus).toHaveBeenLastCalledWith(miniappDeveloperPackageName, false)
     settingListener(false)
     expect(appRegistry.setOfflineAppHidden).toHaveBeenLastCalledWith(miniappDeveloperPackageName, true)
+    expect(engine.miniapps.setHiddenStatus).toHaveBeenLastCalledWith(miniappDeveloperPackageName, true)
   })
 })

--- a/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
+++ b/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
@@ -72,9 +72,12 @@ class BuiltInMiniappCatalog {
       void this.syncGlassesMenuApps()
     })
 
-    engine.settings.onChanged<boolean>(SETTINGS.miniapp_dev_mode.key, (showOnHomeScreen) => {
+    const syncMiniappDeveloperVisibility = (showOnHomeScreen: boolean) => {
       appRegistry.setOfflineAppHidden(miniappDeveloperPackageName, !showOnHomeScreen)
-    })
+      engine.miniapps.setHiddenStatus(miniappDeveloperPackageName, !showOnHomeScreen)
+    }
+    syncMiniappDeveloperVisibility(Boolean(engine.settings.get(SETTINGS.miniapp_dev_mode.key)))
+    engine.settings.onChanged<boolean>(SETTINGS.miniapp_dev_mode.key, syncMiniappDeveloperVisibility)
 
     void this.syncGlassesMenuApps()
   }


### PR DESCRIPTION
## Summary

- keep the Miniapp Developer launcher hidden when its Home Screen setting is disabled and synchronize the dedicated toggle with persisted app placement
- restyle Mentra Live OTA actions to use the standard pill treatment instead of the bespoke green button
- rename the older-device scan label from “Legacy firmware” to “Legacy software”
- update Miniapp SDK beta guidance to point directly to Settings → Miniapp Developer Settings and remove the obsolete ten-tap instructions

## Test evidence

- `bun test mobile/modules/engine/src/stores/__tests__/appVisibility.test.ts` (3 passing)
- `jq empty mintlify-docs/docs.json`
- `git diff --check`
- React Native Jest tests were not run because this workspace does not have Jest/React Native dependencies installed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted home-screen projection and catalog sync with unit tests; remaining changes are OTA styling and documentation strings.
> 
> **Overview**
> **Miniapp Developer** no longer leaks onto the home screen when “Show on Home Screen” is off. Home visibility now **combines** registry-enforced hiding with the user’s persisted layout via `resolveHiddenStatus`, and the catalog keeps **both** `setOfflineAppHidden` and `engine.miniapps.setHiddenStatus` in sync when `miniapp_dev_mode` changes (including on init).
> 
> **Mentra Live OTA** primary actions use the standard **pill** treatment (rounded buttons, foreground fill, lighter label weight) instead of the green primary style.
> 
> **Copy/docs:** pairing scan label **“Legacy firmware” → “Legacy software”**; Mintlify beta/quickstart/banner text now points straight to **Settings → Miniapp Developer Settings** and drops the Debug Settings / version-tap unlock steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be6b0701793d227a66a060ce03efc454a2d2e81d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->