### PR TITLE
Wait for BES UART before sending OTA install guard

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1284,8 +1284,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     }
 
     /**
-     * Queue the phone guard and BES authorization as one outbound FIFO action. The guard is a
-     * normal framed write; only its actual UART success permits the exclusive OTA lease and mh_ota.
+     * Queue the phone guard and BES authorization as one outbound FIFO action. The authorization
+     * lease first waits for a proven rendezvous link, then carries both normal-framed writes. Only
+     * the guard's actual UART success permits durable authorization reservation and mh_ota.
      */
     public boolean queueBesOtaAuthorization(
             byte[] installGuard, byte[] data, BesOtaAuthorizationCallback callback) {
@@ -1299,23 +1300,26 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         byte[] payload = Arrays.copyOf(data, data.length);
         return queueOutboundAction(
                 () -> {
-                    if (guard != null) {
-                        publishOutboundMessage(guard, true);
-                        boolean guardSent =
-                                transportCoordinator.runNormalWrite(
-                                        () -> sendMessageInternalLocked(guard));
-                        if (!guardSent) {
-                            callback.onInstallGuardWriteFailed();
-                            return;
-                        }
-                    }
-
                     BesUartTransportCoordinator.OperationLease lease =
                             transportCoordinator.beginOtaAuthorization();
                     if (lease == null) {
                         callback.onWriteComplete(false, false);
                         return;
                     }
+
+                    if (guard != null) {
+                        publishOutboundMessage(guard, true);
+                        boolean guardSent =
+                                transportCoordinator.runOtaAuthorizationWrite(
+                                        lease,
+                                        () -> sendMessageInternalLocked(guard));
+                        if (!guardSent) {
+                            transportCoordinator.endOta(lease);
+                            callback.onInstallGuardWriteFailed();
+                            return;
+                        }
+                    }
+
                     if (!callback.onLeaseAcquired(lease)) {
                         transportCoordinator.endOta(lease);
                         callback.onWriteComplete(false, false);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesUartTransportCoordinatorTest.java
@@ -388,6 +388,41 @@ public class BesUartTransportCoordinatorTest {
     }
 
     @Test
+    public void otaAuthorization_waitsForStartupDiscoveryBeforeLeasingAndWriting() throws Exception {
+        coordinator.onSerialReady(host.session);
+        assertThat(coordinator.getState())
+                .isEqualTo(BesUartTransportCoordinator.State.DISCOVERING);
+
+        ExecutorService caller = Executors.newSingleThreadExecutor();
+        Future<BesUartTransportCoordinator.OperationLease> leaseFuture =
+                caller.submit(coordinator::beginOtaAuthorization);
+        try {
+            Thread.sleep(50);
+            assertThat(leaseFuture.isDone()).isFalse();
+
+            assertThat(systemVersion("17.26.7.4"))
+                    .isEqualTo(BesUartTransportCoordinator.SystemVersionResult.READY);
+            BesUartTransportCoordinator.OperationLease lease = leaseFuture.get(1, TimeUnit.SECONDS);
+
+            assertThat(lease).isNotNull();
+            assertThat(coordinator.getOperation())
+                    .isEqualTo(BesUartTransportCoordinator.Operation.OTA_AUTHORIZATION);
+            assertThat(
+                            coordinator.runOtaAuthorizationWrite(
+                                    lease,
+                                    () -> {
+                                        host.controlCommands.add("install_guard");
+                                        return true;
+                                    }))
+                    .isTrue();
+            assertThat(host.controlCommands).contains("install_guard");
+            coordinator.endOta(lease);
+        } finally {
+            caller.shutdownNow();
+        }
+    }
+
+    @Test
     public void failedOtaEndsInRawFirstRecoveryInsteadOfPermanentQuarantine() throws Exception {
         coordinator.onSerialReady(host.session);
         assertThat(systemVersion("17.26.7.4"))


### PR DESCRIPTION
## Problem

A real OTA from MentraOS TestFlight `3.1.0-dev.9` failed after the ASG APK step completed and the glasses restarted into the newly installed ASG client.

The OTA session was:

- session: `4e0c26c6`
- steps: `apk`, `bes`
- installed ASG: `asg.100000009.90061aa12d5f`
- MTK: `MentraLive_20260709` (already current)
- BES before/after failure: `26.8.8.0`
- manifest BES target: `26.8.19.4`

After reconnect, `ota_query_status` returned the persisted terminal state:

```json
{"status":"failed","st":"bes","phase":"install","err":"install_failed"}
```

The ASG diagnostic projection retained the underlying reason:

```text
Failed to send BES install guard
```

No BES authorization exchange or firmware transfer began. The target firmware therefore never reached the chip.

FactoryTest was opened manually only after the OTA had already failed and is not part of the failure path.

## Root cause

`queueBesOtaAuthorization()` orders two normal-framed writes before BES raw OTA mode:

1. send the phone-visible BES install guard
2. send `mh_ota` authorization

Before this change, the guard was sent with `runNormalWrite()` **before** calling `beginOtaAuthorization()`.

That ordering creates a startup race after an APK replacement:

- the new ASG process starts;
- the UART coordinator is still `DISCOVERING` and has not yet received a valid `sr_syvr` proof;
- the resumed OTA reaches the BES install prelude;
- `runNormalWrite()` rejects immediately because the coordinator is not READY;
- the guard callback durably fails the top-level OTA session;
- moments later UART discovery succeeds, but the OTA is already terminal.

This bypassed the readiness behavior already implemented by `beginOtaAuthorization()`. That method waits, with the existing 10-second bound, until the link is proven and at the rendezvous baud required for BES OTA.

## Fix

Acquire the existing `OTA_AUTHORIZATION` lease before writing the install guard.

The transaction is now:

1. `beginOtaAuthorization()` waits for a proven rendezvous link and acquires exclusive ownership;
2. write the install guard under that lease, still through the normal framed parser;
3. only after confirmed guard write success, durably reserve authorization ownership;
4. write `mh_ota` under the same lease;
5. promote to raw OTA routing only after the BES authorization response.

This does not add retries, timers, queues, states, or another coordinator. It uses the existing bounded readiness/rendezvous mechanism and preserves the important invariant that the phone-visible guard must physically succeed before durable reservation and `mh_ota`.

If the guard write itself fails, the lease is explicitly released before the existing failure callback runs, so ordinary UART traffic is not left blocked.

## Regression coverage

Added a coordinator regression that starts authorization while the UART is `DISCOVERING`, proves that authorization remains pending, supplies the startup `sr_syvr` proof, then verifies that the authorization lease and guard write succeed in order.

Locally passed:

```text
BesUartTransportCoordinatorTest
OtaHelperBesGuardTest
BesOtaManagerArtifactLifetimeTest
BesOtaStateStoreTest
BesOtaAuthRoutingIntegrationTest
```

`git diff --check` also passes.

A full local `spotlessJavaCheck` is currently blocked by the pre-existing non-contiguous imports in `MediaUploadQueueManager.java`; this PR does not modify that file. The changed-file diff remains limited to the authorization ordering and its regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches BES OTA UART ordering on a critical firmware path; behavior is narrowed to use existing lease/readiness APIs with targeted regression coverage.
> 
> **Overview**
> Fixes a post-APK BES OTA failure where the phone-visible **install guard** was sent with `runNormalWrite()` while the UART coordinator was still **DISCOVERING**, so the write failed immediately and the session ended with “Failed to send BES install guard” before `mh_ota` could run.
> 
> **`queueBesOtaAuthorization`** now calls **`beginOtaAuthorization()` first**, so the outbound worker waits for a proven rendezvous link (existing bounded wait) and holds the **OTA_AUTHORIZATION** lease for the whole prelude. The optional guard is sent with **`runOtaAuthorizationWrite(lease, …)`** instead of a pre-lease normal write; on guard failure the lease is **`endOta`**’d before the existing install-guard callback. Authorization payload and durable reservation behavior are unchanged.
> 
> Adds **`otaAuthorization_waitsForStartupDiscoveryBeforeLeasingAndWriting`** in `BesUartTransportCoordinatorTest` to assert authorization stays pending until startup `sr_syvr`, then the guard write succeeds under the lease.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8692b8c8c330c0625727981836ea644d21c6a2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->