### PR TITLE
Show full Mentra Live pairing instructions

### DIFF
--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -249,6 +249,7 @@ export default function PairingPrepScreen() {
         title: translate("pairing:livePairingModeTitle"),
         subtitle: translate("pairing:livePairingModeSubtitle"),
         info: translate("pairing:livePairingModeInfo"),
+        compactHeader: true,
       },
     ]
 

--- a/mobile/src/components/onboarding/OnboardingGuide.tsx
+++ b/mobile/src/components/onboarding/OnboardingGuide.tsx
@@ -942,7 +942,6 @@ export function OnboardingGuide({
             <Text
               className="text-start text-sm font-medium text-muted-foreground mr-5"
               text={step.info}
-              numberOfLines={2}
               style={{lineHeight: 16}}
             />
           </View>


### PR DESCRIPTION
## Summary
- remove the shared two-line cap from onboarding info text
- let the Mentra Live pairing-mode header size to its full content
- show the complete power-button and spoken-code instructions before scanning

## Validation
- `bunx eslint src/app/pairing/prep.tsx src/components/onboarding/OnboardingGuide.tsx` (0 errors; pre-existing warnings only)
- `git diff --check`

## Notes
- `bun run compile` still reports an unrelated existing type error in `src/services/miniapps/BuiltInMiniappCatalog.ts:80`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding copy layout on pairing prep; no auth, data, or connection logic changes.
> 
> **Overview**
> Mentra Live pairing prep now shows **complete** power-on and pairing-mode guidance instead of truncating helper text or squeezing the header into a fixed height.
> 
> **OnboardingGuide** no longer caps step `info` copy at two lines (`numberOfLines={2}` removed), so longer instructions (including spoken-code / power-button details) can wrap in full. The pairing-mode tutorial step sets **`compactHeader: true`**, which drops the default fixed header height (`h-34`) so the title/subtitle/info block can grow and the hero image starts directly below the real content height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18356320d200ecde1b1aeaa29743bbc75d625bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->