### PR TITLE
Enable ASG downgrades to Mentra 3.0

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
@@ -45,7 +45,7 @@ public class RecoveryWorkerManager {
     // recovery_worker/app/build.gradle versionCode (the asset is built from that project in
     // CI): if this lags, a device already on the previous worker skips the redeploy and every
     // pinned downgrade is refused by the MIN_RECOVERY_VERSION_FOR_DOWNGRADE gate.
-    private static final int ASSETS_RECOVERY_VERSION = 9;
+    private static final int ASSETS_RECOVERY_VERSION = 10;
     private static final String PREFS = "RecoveryWorkerManagerPrefs";
     private static final String KEY_PURGED_LEGACY = "legacy_updater_purged";
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
@@ -124,9 +124,8 @@ public class OtaConstants {
      * downgrade-safe contract — most importantly the shared media root
      * ({@code MediaStorage.MEDIA_ROOT_PATH}): older builds capture into the app-owned
      * external-files tree, which the OEM uninstall deletes (hardware-verified 2026-07-21), and
-     * read media from the pre-relocation paths. Must be set to the versionCode of the first
-     * release shipping the media relocation before downgrades are enabled in production; 0 leaves
-     * the floor open for RFC/bench testing only.
+     * read media from the pre-relocation paths. Mentra 3.0 is the first release shipping the
+     * downgrade-safe contract, so production downgrades must never target an older build.
      */
-    public static final long DOWNGRADE_FLOOR_VERSION_CODE = 0L;
+    public static final long DOWNGRADE_FLOOR_VERSION_CODE = 51518114L;
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
@@ -108,17 +108,15 @@ public class OtaConstants {
      */
     public static final long DOWNGRADE_SUPERVISION_TIMEOUT_MS = 40 * 60 * 1000L;
     /**
-     * Oldest recovery worker versionCode that understands the downgrade handoff
+     * Oldest recovery worker versionCode eligible for a production downgrade handoff
      * ({@code ACTION_REQUEST_DOWNGRADE}). ASG deploys its bundled recovery worker asynchronously
-     * at startup, so a downgrade must not be staged until the installed recovery worker is at
-     * least this new — an older receiver would silently drop the handoff after ASG already
-     * reported the install as started.
+     * at startup, so a downgrade must not be staged until the installed recovery worker both
+     * supports the verdict protocol and enforces the production target floor.
      */
-    // v8 = first worker that answers every handoff with an accepted/refused verdict and claims
-    // the staged APK by rename. The verdict is load-bearing: the watchdog treats "no answer" as
-    // "no transaction exists", which is only true when the worker is verdict-capable — an older
-    // silent worker could accept without answering and the timeout would misreport refusal.
-    public static final long MIN_RECOVERY_VERSION_FOR_DOWNGRADE = 8L;
+    // v10 = first worker that enables the production downgrade floor. Requiring it here prevents
+    // a still-installed v8/v9 worker from accepting the handoff protocol but rejecting every
+    // production target while the bundled-worker upgrade is still landing asynchronously.
+    public static final long MIN_RECOVERY_VERSION_FOR_DOWNGRADE = 10L;
     /**
      * Oldest ASG versionCode a pinned downgrade may target. Builds below this floor predate the
      * downgrade-safe contract — most importantly the shared media root

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/DowngradeGateTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/DowngradeGateTest.java
@@ -1,17 +1,23 @@
 package com.mentra.asg_client.io.ota.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 public class DowngradeGateTest {
-    private static final long FLOOR = 49000000L;
+    private static final long FLOOR = OtaConstants.DOWNGRADE_FLOOR_VERSION_CODE;
+
+    @Test
+    public void productionFloorStartsAtMentraThree() {
+        assertEquals(51518114L, FLOOR);
+    }
 
     @Test
     public void lowerPinnedVersionDowngradesWhenAboveFloor() {
-        assertTrue(DowngradeGate.shouldDowngrade(49076573L, 49066528L, FLOOR));
-        assertTrue(DowngradeGate.shouldDowngrade(49076573L, 49000000L, FLOOR));
+        assertTrue(DowngradeGate.shouldDowngrade(51530000L, 51520000L, FLOOR));
+        assertTrue(DowngradeGate.shouldDowngrade(51530000L, FLOOR, FLOOR));
     }
 
     @Test
@@ -40,6 +46,6 @@ public class DowngradeGateTest {
     @Test
     public void targetsBelowTheFloorAreRefusedEvenWhenPinned() {
         // Below the floor: predates the downgrade-safe contract (e.g. media relocation build).
-        assertFalse(DowngradeGate.shouldDowngrade(49076573L, 48999999L, FLOOR));
+        assertFalse(DowngradeGate.shouldDowngrade(51530000L, FLOOR - 1L, FLOOR));
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/DowngradeGateTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/DowngradeGateTest.java
@@ -31,16 +31,16 @@ public class DowngradeGateTest {
     @Test
     public void exactOrNewerPinDoesNotDowngrade() {
         // Equal version: exact pin already satisfied, nothing to do.
-        assertFalse(DowngradeGate.shouldDowngrade(49000000L, 49000000L, FLOOR));
+        assertFalse(DowngradeGate.shouldDowngrade(FLOOR, FLOOR, FLOOR));
         // Higher version: that is the normal upgrade path, not a downgrade.
-        assertFalse(DowngradeGate.shouldDowngrade(49000000L, 49076573L, FLOOR));
+        assertFalse(DowngradeGate.shouldDowngrade(FLOOR, FLOOR + 1L, FLOOR));
     }
 
     @Test
     public void invalidManifestVersionNeverDowngrades() {
         // Zero/negative pins (e.g. the zeroed legacy rescue manifests) are never actionable.
-        assertFalse(DowngradeGate.shouldDowngrade(49076573L, 0L, FLOOR));
-        assertFalse(DowngradeGate.shouldDowngrade(49076573L, -1L, FLOOR));
+        assertFalse(DowngradeGate.shouldDowngrade(FLOOR + 1L, 0L, FLOOR));
+        assertFalse(DowngradeGate.shouldDowngrade(FLOOR + 1L, -1L, FLOOR));
     }
 
     @Test

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -148,6 +148,10 @@ Mentra Live has multiple update surfaces:
 - MTK/system firmware update flows.
 - BES MCU firmware OTA over UART.
 
+Phone-pinned `asg_client` APK downgrades are supported when the target version code is at least
+`51518114` (Mentra 3.0). Older targets predate the downgrade-safe media and recovery contract and
+must be refused.
+
 Update flows must preserve device recoverability, report progress where possible, and avoid interrupting active media operations without cleanup.
 
 The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. At startup, `asg_client` retries discovery at 460800 before making one bounded probe at 1152000, then returns to 460800 if neither rate answers. The alternate probe does not depend on app-local cached state, so an APK reinstall can recover a BES that survived at the negotiated rate. Once traffic confirms a negotiated 1152000 link, BES keeps that baud across UART driver restarts and Android sleep; ordinary phone heartbeats and expected MTK sleep silence must not return one endpoint to 460800. If an older BES nevertheless falls back or reboots while ASG remains alive, several small unframed reads or an idle-link health probe cause `asg_client` to verify 1152000, probe 460800, and renegotiate the fast link after finding BES at the rendezvous rate. If neither rate answers, ASG remains at 460800 and retries the two-rate scan with capped exponential backoff so a later BES boot cannot leave the endpoints split indefinitely. Each scan is bounded and recovery is suppressed during BES OTA, file transfer, and active baud transitions. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.

--- a/asg_client/recovery_worker/app/build.gradle
+++ b/asg_client/recovery_worker/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.mentra.recovery"
         minSdk 29
         targetSdk 35
-        versionCode 9
-        versionName "1.1.1"
+        versionCode 10
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/asg_client/recovery_worker/app/src/main/java/com/mentra/recovery/downgrade/DowngradeController.java
+++ b/asg_client/recovery_worker/app/src/main/java/com/mentra/recovery/downgrade/DowngradeController.java
@@ -23,8 +23,8 @@ public final class DowngradeController {
       Context context, long targetVersion, String apkPath, String apkSha256) {
     // Fail closed, mirroring ASG's DowngradeGate: a non-positive floor means downgrades are not
     // enabled for this release channel, so reject regardless of target.
-    if (RecoveryConstants.DOWNGRADE_FLOOR_VERSION_CODE <= 0
-        || targetVersion < RecoveryConstants.DOWNGRADE_FLOOR_VERSION_CODE) {
+    if (!DowngradeTargetPolicy.isAllowed(
+        targetVersion, RecoveryConstants.DOWNGRADE_FLOOR_VERSION_CODE)) {
       Log.e(
           RecoveryConstants.TAG,
           "Rejected downgrade handoff (floor="

--- a/asg_client/recovery_worker/app/src/main/java/com/mentra/recovery/downgrade/DowngradeTargetPolicy.java
+++ b/asg_client/recovery_worker/app/src/main/java/com/mentra/recovery/downgrade/DowngradeTargetPolicy.java
@@ -1,0 +1,10 @@
+package com.mentra.recovery.downgrade;
+
+/** Applies the recovery worker's independent downgrade target floor. */
+final class DowngradeTargetPolicy {
+  private DowngradeTargetPolicy() {}
+
+  static boolean isAllowed(long targetVersion, long floorVersion) {
+    return floorVersion > 0 && targetVersion >= floorVersion;
+  }
+}

--- a/asg_client/recovery_worker/app/src/main/java/com/mentra/recovery/util/RecoveryConstants.java
+++ b/asg_client/recovery_worker/app/src/main/java/com/mentra/recovery/util/RecoveryConstants.java
@@ -104,10 +104,10 @@ public final class RecoveryConstants {
    * Oldest ASG versionCode a downgrade transaction may target. Mirrors ASG's
    * {@code OtaConstants.DOWNGRADE_FLOOR_VERSION_CODE} as defense in depth (this package updates
    * independently of ASG): builds below the floor predate the downgrade-safe contract (media
-   * storage layout, post-uninstall behavior). 0 leaves the floor open for RFC/bench testing only;
-   * raise both constants together before enabling downgrades in production.
+   * storage layout, post-uninstall behavior). Mentra 3.0 is the first release shipping that
+   * contract. A non-positive floor disables recovery-side downgrades entirely.
    */
-  public static final long DOWNGRADE_FLOOR_VERSION_CODE = 0L;
+  public static final long DOWNGRADE_FLOOR_VERSION_CODE = 51518114L;
 
   /** Uninstall broadcast dispatch until the factory /system revert is observed. */
   public static final long DOWNGRADE_REVERT_TIMEOUT_MS = 90_000L;

--- a/asg_client/recovery_worker/app/src/test/java/com/mentra/recovery/downgrade/DowngradeTargetPolicyTest.java
+++ b/asg_client/recovery_worker/app/src/test/java/com/mentra/recovery/downgrade/DowngradeTargetPolicyTest.java
@@ -1,0 +1,34 @@
+package com.mentra.recovery.downgrade;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.mentra.recovery.util.RecoveryConstants;
+
+import org.junit.Test;
+
+public class DowngradeTargetPolicyTest {
+  private static final long FLOOR = RecoveryConstants.DOWNGRADE_FLOOR_VERSION_CODE;
+
+  @Test
+  public void productionFloorStartsAtMentraThree() {
+    assertEquals(51518114L, FLOOR);
+  }
+
+  @Test
+  public void exactFloorIsAllowed() {
+    assertTrue(DowngradeTargetPolicy.isAllowed(FLOOR, FLOOR));
+  }
+
+  @Test
+  public void targetBelowFloorIsRefused() {
+    assertFalse(DowngradeTargetPolicy.isAllowed(FLOOR - 1L, FLOOR));
+  }
+
+  @Test
+  public void nonPositiveFloorDisablesDowngrades() {
+    assertFalse(DowngradeTargetPolicy.isAllowed(FLOOR, 0L));
+    assertFalse(DowngradeTargetPolicy.isAllowed(FLOOR, -1L));
+  }
+}


### PR DESCRIPTION
## Summary

- enable phone-pinned ASG APK downgrades down to version code `51518114` (Mentra 3.0)
- enable the matching recovery-worker floor and add recovery-side boundary coverage
- release recovery worker v10 and require v10 before ASG stages a downgrade, preventing the previous v8/v9 worker from rejecting the handoff while the bundled upgrade is still landing
- keep the bundled-worker version fallback synchronized at v10
- document the supported floor in the Mentra Live spec

## Testing

- `cd asg_client/recovery_worker && ./gradlew :app:testDebugUnitTest`
- `cd asg_client && ./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.ota.utils.DowngradeGateTest`
- `./scripts/check-android-compile.sh asg`
- `cd asg_client/recovery_worker && ./build_and_deploy.sh`
- verified bundled release APK package `com.mentra.recovery`, version code `10`, version name `1.1.2`, v2 signature, and signing certificate
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches release publishing, OTA/ASG artifact identity, npm provenance, and the single required `ci-gate-dev` check—mistakes can block merges or ship inconsistent artifacts.
> 
> **Overview**
> Introduces a **coordinated release family** for MentraOS (`release-family.json` plus Node scripts) that plans beta/production releases, stamps versions, publishes npm packages in dependency order, builds ASG/OTA/mobile artifacts with immutable provenance, and assembles finalized release manifests. Production promotion reuses exact beta bytes (mobile, OTA, ASG) with hash verification rather than rebuilding.
> 
> **CI and publishing model shifts:** `ci-gate-dev` documentation and allowlist now include `Coordinated Release Family Checks` instead of treating legacy staging-only mobile/ASG publisher checks as PR blockers; the full `Coordinated Mentra Release` publisher stays off the dev PR gate. Product-family packages (`@mentra/engine`, miniapp stack, etc.) leave `npm-channel.mjs` / per-package `*-release-info.mjs` scripts in favor of coordinated `publish-release-npm.mjs` and related record assemblers; **developer tools** keep channel-based publishing via new `developer-tools-release-info.mjs`.
> 
> Also adds **agent skills** (`ci-triage`, `sync-miniapp`), ASG version allocation above a legacy baseline, portable Bluetooth SDK OTA bundle tooling, and workflow contract tests that lock coordinated job ordering and secrets usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e6c81fa353edca40dec8db2394b00b7fbd285a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->