### PR TITLE
Stop auto-selecting connected Mentra Live glasses

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -1265,11 +1265,9 @@ class MentraLive : SGCManager() {
             val generation = ++scanGeneration
             isScanning = true
             bluetoothScanner!!.startScan(filters, settings, scanCallback)
-            // Connected glasses stop advertising (BLE_CONNECTION_MAX=1). Pairing scan
-            // would otherwise return empty even though GATT is already up.
-            if (!isReconnecting) {
-                handler.post { emitConnectedDeviceForPairingScan() }
-            }
+            // Pairing discovery must stay advertisement-driven. An already-connected
+            // device has no current pairing-mode advertisement, so surfacing it here
+            // would make RN treat the owner's glasses as pairable and auto-select them.
 
             // Set a timeout to stop scanning
             handler.postDelayed(
@@ -1349,33 +1347,6 @@ class MentraLive : SGCManager() {
         val body = HashMap<String, Any>()
         body["deviceModel"] = DeviceTypes.LIVE
         Bridge.sendTypedMessage("compatible_glasses_search_stop", body)
-    }
-
-    /**
-     * Pairing scan listens for advertisements. A unit that is already GATT-connected
-     * (typical after a CTKD retry / back-out on field firmware) has stopped ADV, so
-     * emit it as pairable or the scan list stays empty.
-     */
-    private fun emitConnectedDeviceForPairingScan() {
-        if (!isConnected || isReconnecting || pairingYieldActive) {
-            return
-        }
-        val device = connectedDevice ?: bluetoothGatt?.device ?: return
-        val name = safeBondedDeviceName(device)
-        if (!isMentraLiveBluetoothName(name)) {
-            return
-        }
-        Bridge.log(
-                "LIVE: Pairing scan: already GATT-connected to $name — emitting as pairable (ADV off while connected)"
-        )
-        Bridge.sendDiscoveredDevice(
-                DeviceTypes.LIVE,
-                name,
-                device.address ?: "",
-                pairingMode = true,
-                pairingCode = null,
-                securePairingCapable = false,
-        )
     }
 
     var seenDevices: MutableSet<String> = HashSet()

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2364,9 +2364,9 @@ class MentraLive: NSObject, SGCManager {
 
         centralManager?.scanForPeripherals(withServices: nil, options: scanOptions)
 
-        // Fresh advertisements refill pairing metadata. Re-emitting the last scan's
-        // cache would keep a unit pairable after it left pairing mode.
-        emitConnectedDeviceForPairingScan()
+        // Pairing discovery must stay advertisement-driven. An already-connected
+        // peripheral has no current pairing-mode advertisement, so surfacing it here
+        // would make RN treat the owner's glasses as pairable and auto-select them.
 
         // var dName = DeviceManager.shared.deviceName
         // if dName.isEmpty {
@@ -5501,25 +5501,6 @@ class MentraLive: NSObject, SGCManager {
     }
 
     // MARK: - Event Emission
-
-    /// Pairing scan listens for advertisements. A unit that is already GATT-connected
-    /// has stopped ADV, so emit it as pairable or the scan list stays empty.
-    private func emitConnectedDeviceForPairingScan() {
-        guard connected, let peripheral = connectedPeripheral, let name = peripheral.name,
-              name == "Xy_A" || name.hasPrefix("XyBLE_") || name.hasPrefix("MENTRA_LIVE_BLE")
-              || name.hasPrefix("MENTRA_LIVE_BT") || name.lowercased().hasPrefix("mentra_live")
-        else {
-            return
-        }
-        Bridge.log("LIVE: Pairing scan: already GATT-connected to \(name) — emitting as pairable (ADV off while connected)")
-        emitDiscoveredDevice(
-            name,
-            identifier: peripheral.identifier.uuidString,
-            pairingMode: true,
-            pairingCode: nil,
-            securePairingCapable: discoveredAdvPairing[name]?.securePairingCapable ?? false
-        )
-    }
 
     private func cacheAdvPairing(
         _ name: String,


### PR DESCRIPTION
## Summary
- stop iOS and Android manual pairing scans from synthesizing the already-connected Mentra Live as pairable
- keep pairing discovery driven by real advertisements so the current owner's glasses are not auto-selected
- preserve automatic pairing for unconnected legacy firmware and genuine pairing-mode advertisements

## Report
- https://mentra-labs.slack.com/archives/C0A8015JBPT/p1787712233692259
- `rep_01M0XZ7PBDEMJHSYS03BTP0K9B`

## Validation
- `npm test -- --runInBand src/__tests__/app/pairing/scan.test.tsx` (18 tests passed)
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `xcodebuild -workspace ios/Mentra.xcworkspace -scheme MentraBluetoothSDK -configuration Debug -sdk iphonesimulator -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- `swiftformat --lint --linerange 2360,2375 mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BLE pairing scan behavior on both platforms; wrong regression could leave some edge cases with empty scan lists, but the change narrows behavior rather than expanding it.
> 
> **Overview**
> **Stops manual pairing scans from injecting the already GATT-connected Mentra Live into the discoverable list** on both Android and iOS.
> 
> The native SDK previously called `emitConnectedDeviceForPairingScan()` when a pairing scan started, because connected units stop BLE advertisements and would otherwise never appear. That synthetic `pairingMode: true` event made React Native treat the owner’s in-use glasses as pairable and auto-select them.
> 
> This change **removes that helper and its call sites** so pairing discovery stays **advertisement-only**. Comments now document the tradeoff: connected devices without a current pairing-mode ADV must not be surfaced as pairable.
> 
> Unconnected legacy firmware and real pairing-mode advertisements are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d870404c67e0e926cad051b1b7d1c268ab576c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->