### PR TITLE
Make Mentra Live pairing scan adaptive

### DIFF
--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -145,6 +145,8 @@ import {useNavigationStore} from "@/stores/navigation"
 import {requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import SelectGlassesBluetoothScreen from "@/app/pairing/scan"
 import {useCoreStore} from "@mentra/engine-host-internal"
+// The glasses store is private to the local engine workspace and has no public test export.
+// eslint-disable-next-line no-restricted-imports
 import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
 import {SETTINGS} from "@mentra/engine"
 import {useSettingsStore} from "@mentra/engine-host-internal"
@@ -170,9 +172,7 @@ describe("pairing scan screen", () => {
     useSettingsStore.getState().resetAllSettingsLocally()
     // The screen reads scan results through the pairing facade now; delegate the
     // mocked facade to the real core store this test seeds via setState().
-    ;(engine.pairing.searchResults as jest.Mock).mockImplementation(() => [
-      ...useCoreStore.getState().searchResults,
-    ])
+    ;(engine.pairing.searchResults as jest.Mock).mockImplementation(() => [...useCoreStore.getState().searchResults])
     ;(engine.pairing.onFound as jest.Mock).mockImplementation((cb: (results: unknown) => void) =>
       useCoreStore.subscribe((s) => s.searchResults, cb),
     )
@@ -228,11 +228,13 @@ describe("pairing scan screen", () => {
   })
 
   it("marks the chosen model pending on entry", async () => {
-    render(<SelectGlassesBluetoothScreen />)
+    const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
       expect(useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key)).toBe("Mentra Live")
     })
+    expect(getByText("pairing:liveScanTitle")).toBeTruthy()
+    expect(getByText("pairing:liveScanSubtitle")).toBeTruthy()
   })
 
   it("back-out delegates cleanup to the live abandonAttempt and keeps the pending marker", async () => {
@@ -355,8 +357,8 @@ describe("pairing scan screen", () => {
       const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
       await waitFor(() => {
-        expect(getByText("pairing:noGlassesFound")).toBeTruthy()
-        expect(getByText("pairing:tryAgain")).toBeTruthy()
+        expect(getByText("pairing:liveScanHelpTitle")).toBeTruthy()
+        expect(getByText("pairing:scanAgain")).toBeTruthy()
       })
       const {bluetoothSdkMock} = require("@/test-utils/mockBluetoothSdk")
       expect(bluetoothSdkMock.stopScan).toHaveBeenCalled()
@@ -377,13 +379,16 @@ describe("pairing scan screen", () => {
         jest.advanceTimersByTime(15_000)
       })
 
-      expect(getByText("pairing:noGlassesFound")).toBeTruthy()
+      expect(getByText("pairing:liveScanHelpTitle")).toBeTruthy()
+      expect(getByText("pairing:liveScanHelpInfo")).toBeTruthy()
+      expect(getByText("pairing:liveUpdatedGlassesHint")).toBeTruthy()
+      expect(getByText("pairing:livePairingModeInfo")).toBeTruthy()
     } finally {
       jest.useRealTimers()
     }
   })
 
-  it("Try Again restarts scan in place without navigating back", async () => {
+  it("Scan Again restarts scan in place without navigating back", async () => {
     jest.useFakeTimers()
     try {
       setPlatformOS("android")
@@ -393,10 +398,10 @@ describe("pairing scan screen", () => {
       act(() => {
         jest.advanceTimersByTime(15_000)
       })
-      expect(getByText("pairing:noGlassesFound")).toBeTruthy()
+      expect(getByText("pairing:liveScanHelpTitle")).toBeTruthy()
       ;(engine.pairing.scan as jest.Mock).mockClear()
 
-      fireEvent.press(getByText("pairing:tryAgain"))
+      fireEvent.press(getByText("pairing:scanAgain"))
 
       await waitFor(() => {
         expect(engine.pairing.scan).toHaveBeenCalledWith("Mentra Live")
@@ -434,6 +439,7 @@ describe("pairing scan screen", () => {
     const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
+      expect(getByText("pairing:liveChooseGlassesTitle")).toBeTruthy()
       expect(getByText(/pairing:pairingCodeLabel:A1B2/)).toBeTruthy()
       expect(getByText(/pairing:pairingCodeLabel:C3D4/)).toBeTruthy()
     })
@@ -587,38 +593,33 @@ describe("pairing scan screen", () => {
     expect(push).toHaveBeenCalledTimes(1)
   })
 
-  it("keeps scanning without a list when only non-pairing Mentra Live units are nearby", async () => {
-    jest.useFakeTimers()
-    try {
-      setPlatformOS("android")
-      useCoreStore.setState({
-        searchResults: [
-          {
-            id: "idle",
-            model: "Mentra Live",
-            name: "MENTRA_LIVE_BLE_IDLE",
-            address: "idle",
-            pairingMode: false,
-            securePairingCapable: true,
-          },
-        ],
-      })
+  it("shows pairing-mode instructions immediately when a newer idle Mentra Live is nearby", async () => {
+    setPlatformOS("android")
+    useCoreStore.setState({
+      searchResults: [
+        {
+          id: "idle",
+          model: "Mentra Live",
+          name: "MENTRA_LIVE_BLE_IDLE",
+          address: "idle",
+          pairingMode: false,
+          securePairingCapable: true,
+        },
+      ],
+    })
 
-      const {getByText, queryByText} = render(<SelectGlassesBluetoothScreen />)
+    const {getByText, queryByText} = render(<SelectGlassesBluetoothScreen />)
 
-      expect(queryByText(/IDLE/)).toBeNull()
-      expect(push).not.toHaveBeenCalled()
-
-      act(() => {
-        jest.advanceTimersByTime(15_000)
-      })
-
-      expect(getByText("pairing:noGlassesFound")).toBeTruthy()
-      expect(getByText("pairing:nearbyNotInPairingModeHint")).toBeTruthy()
-      expect(queryByText(/IDLE/)).toBeNull()
-    } finally {
-      jest.useRealTimers()
-    }
+    await waitFor(() => {
+      expect(getByText("pairing:livePairingFoundTitle")).toBeTruthy()
+      expect(getByText("pairing:livePairingFoundSubtitle")).toBeTruthy()
+      expect(getByText("pairing:livePairingModeInfo")).toBeTruthy()
+      expect(getByText("pairing:scanAgain")).toBeTruthy()
+    })
+    const {bluetoothSdkMock} = require("@/test-utils/mockBluetoothSdk")
+    expect(bluetoothSdkMock.stopScan).toHaveBeenCalled()
+    expect(queryByText(/IDLE/)).toBeNull()
+    expect(push).not.toHaveBeenCalled()
   })
 
   it("filters AR99 scan results to the selected AR99 project", async () => {

--- a/mobile/src/__tests__/app/pairing/select-glasses-model.test.tsx
+++ b/mobile/src/__tests__/app/pairing/select-glasses-model.test.tsx
@@ -1,0 +1,118 @@
+import {act, fireEvent, render} from "@testing-library/react-native"
+import type {ReactNode} from "react"
+
+import SelectGlassesModelScreen from "@/app/pairing/select-glasses-model"
+import {useNavigationStore} from "@/stores/navigation"
+import {preparePairingScan} from "@/utils/pairing/preparePairingScan"
+
+jest.mock("@/../../cloud/packages/types/src", () => ({
+  DeviceTypes: {
+    LIVE: "Mentra Live",
+    G1: "Even Realities G1",
+    G2: "Even Realities G2",
+    AR99: "AR99",
+    MACH1: "Mentra Mach1",
+    Z100: "Vuzix Z100",
+    NEX: "Mentra Nex",
+    NIMO: "Nimo",
+  },
+}))
+
+jest.mock("@mentra/engine", () => ({
+  SETTINGS: {super_mode: {key: "super_mode"}},
+  useSetting: () => [false],
+}))
+
+jest.mock("@/stores/navigation", () => ({
+  useNavigationStore: {getState: jest.fn()},
+}))
+
+jest.mock("@/utils/pairing/preparePairingScan", () => ({
+  preparePairingScan: jest.fn(),
+}))
+
+jest.mock("@/contexts/ThemeContext", () => ({
+  useAppTheme: () => ({theme: {colors: {text: "#000"}, spacing: {s4: 16}}}),
+}))
+
+jest.mock("@/utils/getGlassesImage", () => ({
+  AR99_MODEL_OPTIONS: [],
+  getGlassesImage: jest.fn(() => 1),
+}))
+
+jest.mock("@/components/ignite", () => {
+  const {Text: RNText, View} = require("react-native")
+  return {
+    Header: () => <View />,
+    Text: ({text}: {text?: string}) => <RNText>{text}</RNText>,
+  }
+})
+
+jest.mock("@/components/ignite/Screen", () => {
+  const {View} = require("react-native")
+  return {Screen: ({children}: {children: ReactNode}) => <View>{children}</View>}
+})
+
+jest.mock("@/components/ui/GlassView", () => {
+  const {View} = require("react-native")
+  function MockGlassView({children}: {children: ReactNode}) {
+    return <View>{children}</View>
+  }
+  return MockGlassView
+})
+
+jest.mock("@/components/ui/Spacer", () => ({
+  Spacer: () => null,
+}))
+
+jest.mock("@/components/brands/EvenRealitiesLogo", () => ({EvenRealitiesLogo: () => null}))
+jest.mock("@/components/brands/MentraLogo", () => ({MentraLogo: () => null}))
+jest.mock("@/components/brands/MentraLogoStandalone", () => ({MentraLogoStandalone: () => null}))
+jest.mock("@/components/brands/NimoLogo", () => ({NimoLogo: () => null}))
+jest.mock("@/components/brands/VuzixLogo", () => ({VuzixLogo: () => null}))
+jest.mock("@/components/brands/XingyiLogo", () => ({XingyiLogo: () => null}))
+
+describe("glasses model selection", () => {
+  const push = jest.fn()
+  const goBack = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useNavigationStore.getState as jest.Mock).mockReturnValue({push, goBack})
+    ;(preparePairingScan as jest.Mock).mockResolvedValue(true)
+  })
+
+  it("prepares permissions and opens the scan directly for Mentra Live", async () => {
+    const {getByTestId} = render(<SelectGlassesModelScreen />)
+
+    await act(async () => {
+      fireEvent.press(getByTestId("pairing-model-mentra_live"))
+    })
+
+    expect(preparePairingScan).toHaveBeenCalledWith("Mentra Live")
+    expect(push).toHaveBeenCalledWith("/pairing/scan", {deviceModel: "Mentra Live"})
+  })
+
+  it("keeps the existing prep flow for other glasses", () => {
+    const {getByTestId} = render(<SelectGlassesModelScreen />)
+
+    fireEvent.press(getByTestId("pairing-model-evenrealities_g1"))
+
+    expect(preparePairingScan).not.toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith("/pairing/prep", {
+      deviceModel: "Even Realities G1",
+      ar99ProjectName: undefined,
+    })
+  })
+
+  it("stays on model selection when pairing prerequisites are denied", async () => {
+    ;(preparePairingScan as jest.Mock).mockResolvedValue(false)
+    const {getByTestId} = render(<SelectGlassesModelScreen />)
+
+    await act(async () => {
+      fireEvent.press(getByTestId("pairing-model-mentra_live"))
+    })
+
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -1,15 +1,13 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
 import {useRoute} from "@react-navigation/native"
-import {Linking, PermissionsAndroid, Image, Platform, ScrollView, View} from "react-native"
-import type {ImageStyle, Permission, ViewStyle} from "react-native"
+import {Image, Platform, ScrollView, View} from "react-native"
+import type {ImageStyle, ViewStyle} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
 import {Button, Header, Icon, Screen, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import {showAlert} from "@/utils/AlertUtils"
-import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import GlassesDisplayMirror from "@/components/mirror/GlassesDisplayMirror"
 import {useState} from "react"
 import GlassesTroubleshootingModal from "@/components/glasses/GlassesTroubleshootingModal"
@@ -18,8 +16,7 @@ import {CDN_BASE_URL} from "@/constants/appConfig"
 import {engine} from "@mentra/engine"
 import {getAr99DisplayName, getAr99ImageSource} from "@/utils/getGlassesImage"
 import {ThemedStyle} from "@/theme"
-
-type BluetoothPermission = Permission | "android.permission.BLUETOOTH" | "android.permission.BLUETOOTH_ADMIN"
+import {preparePairingScan} from "@/utils/pairing/preparePairingScan"
 
 export default function PairingPrepScreen() {
   const route = useRoute()
@@ -29,179 +26,8 @@ export default function PairingPrepScreen() {
   const {themed} = useAppTheme()
 
   const advanceToPairing = async () => {
-    if (deviceModel == null || deviceModel == "") {
-      console.log("SOME WEIRD ERROR HERE")
-      return
-    }
-
-    // Always request Bluetooth permissions - required for Android 14+ foreground service
-    let needsBluetoothPermissions = true
-    // we don't need bluetooth permissions for simulated glasses
-    if (deviceModel.startsWith(DeviceTypes.SIMULATED) && Platform.OS === "ios") {
-      needsBluetoothPermissions = false
-    }
-
-    try {
-      // Check for Android-specific permissions
-      if (Platform.OS === "android") {
-        // Android-specific Phone State permission - request for ALL glasses including simulated
-        console.log("Requesting PHONE_STATE permission...")
-        const phoneStateGranted = await requestFeaturePermissions(PermissionFeatures.PHONE_STATE)
-        console.log("PHONE_STATE permission result:", phoneStateGranted)
-
-        if (!phoneStateGranted) {
-          // The specific alert for previously denied permission is already handled in requestFeaturePermissions
-          // We just need to stop the flow here
-          return
-        }
-
-        // Bluetooth permissions only for physical glasses
-        if (needsBluetoothPermissions) {
-          const bluetoothPermissions: BluetoothPermission[] = []
-
-          // Bluetooth permissions based on Android version
-          if (typeof Platform.Version === "number" && Platform.Version < 31) {
-            // For Android 9, 10, and 11 (API 28-30), use legacy Bluetooth permissions
-            bluetoothPermissions.push("android.permission.BLUETOOTH")
-            bluetoothPermissions.push("android.permission.BLUETOOTH_ADMIN")
-          }
-          if (typeof Platform.Version === "number" && Platform.Version >= 31) {
-            bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN)
-            bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT)
-            bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE)
-          }
-
-          // Request Bluetooth permissions directly
-          if (bluetoothPermissions.length > 0) {
-            console.log("RIGHT BEFORE ASKING FOR PERMS")
-            console.log("Bluetooth permissions array:", bluetoothPermissions)
-            console.log(
-              "Bluetooth permission values:",
-              bluetoothPermissions.map((p) => `${p} (${typeof p})`),
-            )
-
-            const results = await PermissionsAndroid.requestMultiple(bluetoothPermissions as Permission[])
-            const allGranted = Object.values(results).every((value) => value === PermissionsAndroid.RESULTS.GRANTED)
-
-            // Since we now handle NEVER_ASK_AGAIN in requestFeaturePermissions,
-            // we just need to check if all are granted
-            if (!allGranted) {
-              // Check if any are NEVER_ASK_AGAIN to show proper dialog
-              const anyNeverAskAgain = Object.values(results).some(
-                (value) => value === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN,
-              )
-
-              if (anyNeverAskAgain) {
-                // Show "previously denied" dialog for Bluetooth
-                showAlert(
-                  translate("pairing:permissionRequired"),
-                  translate("pairing:bluetoothPermissionPreviouslyDenied"),
-                  [
-                    {
-                      text: translate("pairing:openSettings"),
-                      onPress: () => Linking.openSettings(),
-                    },
-                    {
-                      text: translate("common:cancel"),
-                      style: "cancel",
-                    },
-                  ],
-                )
-              } else {
-                // Show standard permission required dialog
-                showAlert(
-                  translate("pairing:bluetoothPermissionRequiredTitle"),
-                  translate("pairing:bluetoothPermissionRequiredMessage"),
-                  [{text: translate("common:ok")}],
-                )
-              }
-              return
-            }
-          }
-
-          // Phone state permission already requested above for all Android devices
-        } // End of Bluetooth permissions block
-      } // End of Android-specific permissions block
-
-      // Check connectivity early for iOS (permissions work differently)
-      console.log("DEBUG: needsBluetoothPermissions:", needsBluetoothPermissions, "Platform.OS:", Platform.OS)
-      if (needsBluetoothPermissions && Platform.OS === "ios") {
-        console.log("DEBUG: Running iOS connectivity check early")
-        const requirementsCheck = await checkConnectivityRequirementsUI()
-        if (!requirementsCheck) {
-          return
-        }
-      }
-
-      // Cross-platform permissions needed for both iOS and Android (only if connectivity check passed)
-      if (needsBluetoothPermissions) {
-        const hasBluetoothPermission = await requestFeaturePermissions(PermissionFeatures.BLUETOOTH)
-        if (!hasBluetoothPermission) {
-          showAlert(
-            translate("pairing:bluetoothPermissionRequiredTitle"),
-            translate("pairing:bluetoothPermissionRequiredMessageAlt"),
-            [{text: translate("common:ok")}],
-          )
-          return // Stop the connection process
-        }
-      }
-
-      // Request microphone permission (needed for both platforms)
-      console.log("Requesting microphone permission...")
-
-      // This now handles showing alerts for previously denied permissions internally
-      const micGranted = await requestFeaturePermissions(PermissionFeatures.MICROPHONE)
-
-      console.log("Microphone permission result:", micGranted)
-
-      if (!micGranted) {
-        // The specific alert for previously denied permission is already handled in requestFeaturePermissions
-        // We just need to stop the flow here
-        return
-      }
-
-      // Request location permission (needed for Android BLE scanning)
-      if (Platform.OS === "android") {
-        console.log("Requesting location permission for Android BLE scanning...")
-
-        // This now handles showing alerts for previously denied permissions internally
-        const locGranted = await requestFeaturePermissions(PermissionFeatures.LOCATION)
-
-        console.log("Location permission result:", locGranted)
-
-        if (!locGranted) {
-          // The specific alert for previously denied permission is already handled in requestFeaturePermissions
-          // We just need to stop the flow here
-          return
-        }
-
-        // Check connectivity for Android AFTER all permissions are granted
-        // This must be done after location permission is granted to avoid premature "Connection issue" popup
-        if (needsBluetoothPermissions) {
-          const requirementsCheck = await checkConnectivityRequirementsUI()
-          if (!requirementsCheck) {
-            return
-          }
-        }
-      } else {
-        console.log("Skipping location permission on iOS - not needed after BLE fix")
-      }
-    } catch (error) {
-      console.error("Error requesting permissions:", error)
-      showAlert(translate("pairing:errorTitle"), translate("pairing:permissionsError"), [
-        {text: translate("common:ok")},
-      ])
-      return
-    }
-
-    console.log("needsBluetoothPermissions", needsBluetoothPermissions)
-
-    // Stop any running apps from previous sessions to prevent mic race conditions.
-    // This is symmetric with the logic in DeviceSettings that stops apps when unpairing.
-    // Fire-and-forget: stopAll() awaits a per-app backend stop call that can take many
-    // seconds (or hang with no internet / NO_ACTIVE_SESSION). We don't need it to finish
-    // before navigating to the scan screen, so don't block pairing on it.
-    void engine.miniapps.stopAll()
+    const readyToScan = await preparePairingScan(deviceModel)
+    if (!readyToScan) return
 
     // skip pairing for simulated glasses:
     if (deviceModel.startsWith(DeviceTypes.SIMULATED)) {

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -35,9 +35,7 @@ export default function SelectGlassesBluetoothScreen() {
   const bluetoothClassicConnected = useEngineSnapshot(engine.pairing.readiness, (onChange) =>
     engine.pairing.onReadiness(onChange),
   ).bluetoothClassicConnected
-  const searchResults = useEngineSnapshot(engine.pairing.searchResults, (onChange) =>
-    engine.pairing.onFound(onChange),
-  )
+  const searchResults = useEngineSnapshot(engine.pairing.searchResults, (onChange) => engine.pairing.onFound(onChange))
   const [rememberedSearchResults, setRememberedSearchResults] = useState<Device[]>(searchResults)
   const [scanTimedOut, setScanTimedOut] = useState(false)
   const connectingRef = useRef(false)
@@ -131,9 +129,7 @@ export default function SelectGlassesBluetoothScreen() {
   // Secure Mentra Live ads with pairingMode=false are nearby but not pairable yet.
   // Legacy firmware (no secure flag) stays pairable even when pairingMode is unset/false.
   const isLivePairable = (device: Device) =>
-    !isMentraLivePairingScan ||
-    device.pairingMode !== false ||
-    device.securePairingCapable === false
+    !isMentraLivePairingScan || device.pairingMode !== false || device.securePairingCapable === false
 
   useEffect(() => {
     void startScanAttempt()
@@ -153,10 +149,7 @@ export default function SelectGlassesBluetoothScreen() {
   const pairableResults = useMemo(
     () =>
       visibleResults.filter(
-        (device) =>
-          !isMentraLivePairingScan ||
-          device.pairingMode !== false ||
-          device.securePairingCapable === false,
+        (device) => !isMentraLivePairingScan || device.pairingMode !== false || device.securePairingCapable === false,
       ),
     [visibleResults, isMentraLivePairingScan],
   )
@@ -167,9 +160,19 @@ export default function SelectGlassesBluetoothScreen() {
     [isMentraLivePairingScan, visibleResults],
   )
   const listResults = isMentraLivePairingScan ? pairableResults : visibleResults
-  const shouldShowDeviceList = isMentraLivePairingScan
-    ? listResults.length >= 2
-    : listResults.length > 0
+  const shouldShowDeviceList = isMentraLivePairingScan ? listResults.length >= 2 : listResults.length > 0
+
+  useEffect(() => {
+    // A secure Mentra Live advertisement tells us the glasses are nearby but idle.
+    // Pause immediately so the required five-press action is visible and the next
+    // scan gets a fresh advertisement carrying the pairing-mode flag and code.
+    if (!hasNearbyNotInPairingMode || pairableResults.length > 0 || scanTimedOut) {
+      return
+    }
+
+    setScanTimedOut(true)
+    void BluetoothSdk.stopScan()
+  }, [hasNearbyNotInPairingMode, pairableResults.length, scanTimedOut])
 
   useEffect(() => {
     // Timeout only when no pairable Mentra Live appeared; non-pairing nearby units still count
@@ -194,11 +197,9 @@ export default function SelectGlassesBluetoothScreen() {
 
   const triggerGlassesPairingGuide = async (device: Device) => {
     if (isMentraLivePairingScan && !isLivePairable(device)) {
-      showAlert(
-        translate("pairing:notInPairingModeAlertTitle"),
-        translate("pairing:notInPairingModeAlertMessage"),
-        [{text: "OK"}],
-      )
+      showAlert(translate("pairing:notInPairingModeAlertTitle"), translate("pairing:notInPairingModeAlertMessage"), [
+        {text: "OK"},
+      ])
       return
     }
 
@@ -236,8 +237,12 @@ export default function SelectGlassesBluetoothScreen() {
 
   const startPairing = async (device: Device) => {
     const deviceTypesWithBtClassic = [DeviceTypes.LIVE]
-    const resolvedProjectName = deviceModel === DeviceTypes.AR99 ? device.projectName ?? ar99ProjectName : undefined
-    if (Platform.OS === "android" || bluetoothClassicConnected || !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)) {
+    const resolvedProjectName = deviceModel === DeviceTypes.AR99 ? (device.projectName ?? ar99ProjectName) : undefined
+    if (
+      Platform.OS === "android" ||
+      bluetoothClassicConnected ||
+      !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)
+    ) {
       setTimeout(() => {
         engine.pairing.pair(device).catch((error) => {
           console.error("Failed to connect to glasses:", error)
@@ -330,22 +335,53 @@ export default function SelectGlassesBluetoothScreen() {
     void startScanAttempt()
   }
 
+  const scanTitle = (() => {
+    if (!isMentraLivePairingScan) {
+      return scanTimedOut
+        ? translate("pairing:noGlassesFound")
+        : translate("pairing:scanningForGlassesModel", {model: selectedDisplayName})
+    }
+    if (scanTimedOut) {
+      return hasNearbyNotInPairingMode
+        ? translate("pairing:livePairingFoundTitle")
+        : translate("pairing:liveScanHelpTitle")
+    }
+    return shouldShowDeviceList ? translate("pairing:liveChooseGlassesTitle") : translate("pairing:liveScanTitle")
+  })()
+
+  const showLivePairingHelp = isMentraLivePairingScan && scanTimedOut
+
   return (
     <Screen preset="fixed" safeAreaEdges={["bottom"]} extraAndroidInsets>
       <Header leftIcon="chevron-left" onLeftPress={handleBackOut} RightActionComponent={<MentraLogoStandalone />} />
       <View className="flex-1 justify-center">
         <GlassView className="gap-6 rounded-3xl p-6 bg-primary-foreground" transparent={false}>
           <Image source={selectedImage} className="h-[90px] w-[156px] mx-auto" resizeMode="contain" />
-          <Text
-            className="text-center text-xl font-semibold text-text-dim"
-            text={
-              scanTimedOut
-                ? translate("pairing:noGlassesFound")
-                : translate("pairing:scanningForGlassesModel", {model: selectedDisplayName})
-            }
-          />
+          <Text className="text-center text-xl font-semibold text-text-dim" text={scanTitle} />
 
-          {scanTimedOut ? (
+          {showLivePairingHelp ? (
+            <View className="gap-3 py-2">
+              <Text
+                className="text-center text-base font-medium text-foreground"
+                text={
+                  hasNearbyNotInPairingMode
+                    ? translate("pairing:livePairingFoundSubtitle")
+                    : translate("pairing:liveScanHelpInfo")
+                }
+              />
+              {!hasNearbyNotInPairingMode ? (
+                <Text
+                  className="text-center text-base font-semibold text-foreground"
+                  text={translate("pairing:liveUpdatedGlassesHint")}
+                />
+              ) : null}
+              <Text
+                className="text-center text-sm leading-5 text-muted-foreground"
+                text={translate("pairing:livePairingModeInfo")}
+              />
+              <Button preset="primary" tx="pairing:scanAgain" onPress={handleTryAgain} className="w-full mt-2" />
+            </View>
+          ) : scanTimedOut ? (
             <View className="gap-4 py-4">
               <Text
                 className="text-center text-sm text-muted-foreground"
@@ -391,14 +427,21 @@ export default function SelectGlassesBluetoothScreen() {
               <ActivityIndicator size="large" color={theme.colors.foreground} />
             </View>
           ) : !shouldShowDeviceList ? (
-            <View className="justify-center min-h-20 py-4">
+            <View className="justify-center items-center gap-3 min-h-20 py-4">
+              {isMentraLivePairingScan ? (
+                <Text
+                  className="text-center text-sm text-muted-foreground"
+                  text={translate("pairing:liveScanSubtitle")}
+                />
+              ) : null}
               <ActivityIndicator size="large" color={theme.colors.foreground} />
             </View>
           ) : (
             <ScrollView className="max-h-[300px] -mr-4 pr-4" contentContainerClassName="my-4">
               <Group>
                 {listResults.map((res: Device) => {
-                  const deviceTitle = deviceModel === DeviceTypes.AR99 ? getAr99ResultDisplayName(res) : selectedDisplayName
+                  const deviceTitle =
+                    deviceModel === DeviceTypes.AR99 ? getAr99ResultDisplayName(res) : selectedDisplayName
                   const deviceSubtitle =
                     deviceModel === DeviceTypes.AR99
                       ? formatAr99Subtitle(res)
@@ -406,7 +449,9 @@ export default function SelectGlassesBluetoothScreen() {
                         ? formatLiveSubtitle(res)
                         : filterDeviceName(res.name)
                   return (
-                    <View key={res.id} className="flex-row items-center justify-between px-4 py-3 bg-primary-foreground">
+                    <View
+                      key={res.id}
+                      className="flex-row items-center justify-between px-4 py-3 bg-primary-foreground">
                       <TouchableOpacity className="flex-1" onPress={() => triggerGlassesPairingGuide(res)}>
                         <View className="flex-1 px-2.5 flex-col">
                           <Text text={deviceTitle} className="flex-wrap text-sm font-semibold" numberOfLines={2} />

--- a/mobile/src/app/pairing/select-glasses-model.tsx
+++ b/mobile/src/app/pairing/select-glasses-model.tsx
@@ -1,4 +1,5 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
+import {useRef} from "react"
 import {View, TouchableOpacity, Platform, ScrollView, Image} from "react-native"
 
 import {EvenRealitiesLogo} from "@/components/brands/EvenRealitiesLogo"
@@ -14,6 +15,7 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {SETTINGS, useSetting} from "@mentra/engine"
 import {AR99_MODEL_OPTIONS, type Ar99ProjectName, getGlassesImage} from "@/utils/getGlassesImage"
+import {preparePairingScan} from "@/utils/pairing/preparePairingScan"
 import GlassView from "@/components/ui/GlassView"
 
 type GlassesOption = {
@@ -29,6 +31,7 @@ export default function SelectGlassesModelScreen() {
   const {theme} = useAppTheme()
   const {push, goBack} = useNavigationStore.getState()
   const [superMode] = useSetting(SETTINGS.super_mode.key)
+  const pairingStartPending = useRef(false)
 
   const getManufacturerLogo = (option: GlassesOption) => {
     if (option.manufacturerName) {
@@ -83,6 +86,20 @@ export default function SelectGlassesModelScreen() {
   const glassesOptions = Platform.OS === "ios" ? sharedOptions : sharedOptions
 
   const triggerGlassesPairingGuide = async (option: GlassesOption) => {
+    if (option.deviceModel === DeviceTypes.LIVE) {
+      if (pairingStartPending.current) return
+      pairingStartPending.current = true
+      try {
+        const readyToScan = await preparePairingScan(option.deviceModel)
+        if (readyToScan) {
+          push("/pairing/scan", {deviceModel: option.deviceModel})
+        }
+      } finally {
+        pairingStartPending.current = false
+      }
+      return
+    }
+
     push("/pairing/prep", {
       deviceModel: option.deviceModel,
       ar99ProjectName: option.projectName,
@@ -105,7 +122,10 @@ export default function SelectGlassesModelScreen() {
           {glassesOptions
             .filter((glasses) => !SUPER_MODE_ONLY_MODELS.has(glasses.deviceModel) || superMode)
             .map((glasses) => (
-              <TouchableOpacity key={glasses.key} onPress={() => triggerGlassesPairingGuide(glasses)}>
+              <TouchableOpacity
+                key={glasses.key}
+                testID={`pairing-model-${glasses.key}`}
+                onPress={() => triggerGlassesPairingGuide(glasses)}>
                 <GlassView className="bg-primary-foreground flex-col items-center justify-center p-6 rounded-2xl overflow-hidden">
                   <View className="flex-row gap-4">
                     <View className="flex-col flex-1 justify-center">

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -156,6 +156,15 @@ const en = {
     livePairingModeSubtitle: "Put your glasses into pairing mode before you scan.",
     livePairingModeInfo:
       "Press the power button 5 times quickly. The LED flashes and the glasses speak a 4-character code (0–9, A–F). Match that code on the scan list if more than one unit appears.",
+    liveScanTitle: "Turn on your glasses",
+    liveScanSubtitle: "We're looking for your Mentra Live.",
+    livePairingFoundTitle: "Glasses found",
+    livePairingFoundSubtitle: "Put them in pairing mode to continue.",
+    liveScanHelpTitle: "Not showing up?",
+    liveScanHelpInfo: "Make sure your glasses are charged and powered on.",
+    liveUpdatedGlassesHint: "Already updated your glasses?",
+    liveChooseGlassesTitle: "Choose your glasses",
+    scanAgain: "Scan Again",
     noGlassesFound: "No glasses found",
     noGlassesFoundHint: "Make sure you pressed the power button 5 times quickly, then try again.",
     nearbyNotInPairingModeHint:
@@ -432,9 +441,11 @@ const en = {
     versionChangeVerifying: "Verifying your glasses\u2026",
     versionChangeKeepNearby: "Keep your glasses nearby and connected. They will restart on their own.",
     versionChangeComplete: "Version Change Complete",
-    versionChangeCompleteMessage: "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
+    versionChangeCompleteMessage:
+      "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
     versionChangeFirmwarePassComplete: "Firmware updated",
-    versionChangeFirmwarePassCompleteMessage: "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
+    versionChangeFirmwarePassCompleteMessage:
+      "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
     updateComplete: "Update Complete",
     updateCompleteMessage: "Your glasses have been updated successfully.",
     updateFailed: "Update Failed",
@@ -745,8 +756,7 @@ const en = {
     defaultHint: "Point the camera at a QR code",
     checkingPermission: "Checking camera permission\u2026",
     permissionTitle: "Camera access needed",
-    permissionBody:
-      "We need your camera to scan QR codes. The camera is only used while this screen is open.",
+    permissionBody: "We need your camera to scan QR codes. The camera is only used while this screen is open.",
     grantAccess: "Grant Camera Access",
     openSettings: "Open Settings",
     permissionDeniedTitle: "Permission Denied",

--- a/mobile/src/utils/pairing/preparePairingScan.test.ts
+++ b/mobile/src/utils/pairing/preparePairingScan.test.ts
@@ -1,0 +1,104 @@
+import {PermissionsAndroid, Platform} from "react-native"
+
+import {engine} from "@mentra/engine"
+
+import {showAlert} from "@/utils/AlertUtils"
+import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
+
+import {preparePairingScan} from "./preparePairingScan"
+
+jest.mock("@mentra/engine", () => ({
+  engine: {miniapps: {stopAll: jest.fn()}},
+}))
+
+jest.mock("@/../../cloud/packages/types/src", () => ({
+  DeviceTypes: {SIMULATED: "Simulated"},
+}))
+
+jest.mock("@/i18n", () => ({translate: (key: string) => key}))
+
+jest.mock("@/utils/AlertUtils", () => ({showAlert: jest.fn()}))
+
+jest.mock("@/utils/PermissionsUtils", () => ({
+  PermissionFeatures: {
+    BLUETOOTH: "bluetooth",
+    LOCATION: "location",
+    MICROPHONE: "microphone",
+    PHONE_STATE: "phone_state",
+  },
+  checkConnectivityRequirementsUI: jest.fn(),
+  requestFeaturePermissions: jest.fn(),
+}))
+
+const originalPlatformOS = Platform.OS
+const originalPlatformVersion = Platform.Version
+
+describe("preparePairingScan", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.defineProperty(Platform, "OS", {value: "ios", configurable: true})
+    ;(checkConnectivityRequirementsUI as jest.Mock).mockResolvedValue(true)
+    ;(requestFeaturePermissions as jest.Mock).mockResolvedValue(true)
+    ;(engine.miniapps.stopAll as jest.Mock).mockResolvedValue(undefined)
+  })
+
+  afterAll(() => {
+    Object.defineProperty(Platform, "OS", {value: originalPlatformOS, configurable: true})
+    Object.defineProperty(Platform, "Version", {value: originalPlatformVersion, configurable: true})
+  })
+
+  it("checks iOS connectivity and permissions before allowing the scan", async () => {
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(true)
+
+    expect(checkConnectivityRequirementsUI).toHaveBeenCalledTimes(1)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(1, PermissionFeatures.BLUETOOTH)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(2, PermissionFeatures.MICROPHONE)
+    expect(engine.miniapps.stopAll).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not stop miniapps or continue when connectivity is unavailable", async () => {
+    ;(checkConnectivityRequirementsUI as jest.Mock).mockResolvedValue(false)
+
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(false)
+
+    expect(requestFeaturePermissions).not.toHaveBeenCalled()
+    expect(engine.miniapps.stopAll).not.toHaveBeenCalled()
+  })
+
+  it("surfaces a Bluetooth denial and leaves pairing where it started", async () => {
+    ;(requestFeaturePermissions as jest.Mock).mockResolvedValueOnce(false)
+
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(false)
+
+    expect(showAlert).toHaveBeenCalledWith(
+      "pairing:bluetoothPermissionRequiredTitle",
+      "pairing:bluetoothPermissionRequiredMessageAlt",
+      [{text: "common:ok"}],
+    )
+    expect(engine.miniapps.stopAll).not.toHaveBeenCalled()
+  })
+
+  it("preserves the Android permission order before checking connectivity", async () => {
+    Object.defineProperty(Platform, "OS", {value: "android", configurable: true})
+    Object.defineProperty(Platform, "Version", {value: 33, configurable: true})
+    const requestMultiple = jest.spyOn(PermissionsAndroid, "requestMultiple").mockResolvedValue({
+      [PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN]: PermissionsAndroid.RESULTS.GRANTED,
+      [PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT]: PermissionsAndroid.RESULTS.GRANTED,
+      [PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE]: PermissionsAndroid.RESULTS.GRANTED,
+    })
+
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(true)
+
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(1, PermissionFeatures.PHONE_STATE)
+    expect(requestMultiple).toHaveBeenCalledWith([
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
+    ])
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(2, PermissionFeatures.BLUETOOTH)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(3, PermissionFeatures.MICROPHONE)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(4, PermissionFeatures.LOCATION)
+    expect(checkConnectivityRequirementsUI).toHaveBeenCalledTimes(1)
+    requestMultiple.mockRestore()
+  })
+})

--- a/mobile/src/utils/pairing/preparePairingScan.ts
+++ b/mobile/src/utils/pairing/preparePairingScan.ts
@@ -1,0 +1,117 @@
+import {engine} from "@mentra/engine"
+import {Linking, PermissionsAndroid, Platform} from "react-native"
+import type {Permission} from "react-native"
+
+import {DeviceTypes} from "@/../../cloud/packages/types/src"
+import {translate} from "@/i18n"
+import {showAlert} from "@/utils/AlertUtils"
+import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
+
+type BluetoothPermission = Permission | "android.permission.BLUETOOTH" | "android.permission.BLUETOOTH_ADMIN"
+
+/**
+ * Requests the permissions and connectivity needed before opening a pairing scan.
+ * Returns false when the user or device blocks setup, leaving navigation to the caller.
+ */
+export async function preparePairingScan(deviceModel: string): Promise<boolean> {
+  if (!deviceModel) {
+    console.error("Cannot prepare pairing scan without a device model")
+    return false
+  }
+
+  const needsBluetoothPermissions = !deviceModel.startsWith(DeviceTypes.SIMULATED) || Platform.OS !== "ios"
+
+  try {
+    if (Platform.OS === "android") {
+      const phoneStateGranted = await requestFeaturePermissions(PermissionFeatures.PHONE_STATE)
+      if (!phoneStateGranted) return false
+
+      if (needsBluetoothPermissions) {
+        const bluetoothPermissions: BluetoothPermission[] = []
+
+        if (typeof Platform.Version === "number" && Platform.Version < 31) {
+          bluetoothPermissions.push("android.permission.BLUETOOTH")
+          bluetoothPermissions.push("android.permission.BLUETOOTH_ADMIN")
+        }
+        if (typeof Platform.Version === "number" && Platform.Version >= 31) {
+          bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN)
+          bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT)
+          bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE)
+        }
+
+        if (bluetoothPermissions.length > 0) {
+          const results = await PermissionsAndroid.requestMultiple(bluetoothPermissions as Permission[])
+          const allGranted = Object.values(results).every((value) => value === PermissionsAndroid.RESULTS.GRANTED)
+
+          if (!allGranted) {
+            const anyNeverAskAgain = Object.values(results).some(
+              (value) => value === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN,
+            )
+
+            if (anyNeverAskAgain) {
+              showAlert(
+                translate("pairing:permissionRequired"),
+                translate("pairing:bluetoothPermissionPreviouslyDenied"),
+                [
+                  {
+                    text: translate("pairing:openSettings"),
+                    onPress: () => Linking.openSettings(),
+                  },
+                  {
+                    text: translate("common:cancel"),
+                    style: "cancel",
+                  },
+                ],
+              )
+            } else {
+              showAlert(
+                translate("pairing:bluetoothPermissionRequiredTitle"),
+                translate("pairing:bluetoothPermissionRequiredMessage"),
+                [{text: translate("common:ok")}],
+              )
+            }
+            return false
+          }
+        }
+      }
+    }
+
+    if (needsBluetoothPermissions && Platform.OS === "ios") {
+      const requirementsMet = await checkConnectivityRequirementsUI()
+      if (!requirementsMet) return false
+    }
+
+    if (needsBluetoothPermissions) {
+      const bluetoothGranted = await requestFeaturePermissions(PermissionFeatures.BLUETOOTH)
+      if (!bluetoothGranted) {
+        showAlert(
+          translate("pairing:bluetoothPermissionRequiredTitle"),
+          translate("pairing:bluetoothPermissionRequiredMessageAlt"),
+          [{text: translate("common:ok")}],
+        )
+        return false
+      }
+    }
+
+    const microphoneGranted = await requestFeaturePermissions(PermissionFeatures.MICROPHONE)
+    if (!microphoneGranted) return false
+
+    if (Platform.OS === "android") {
+      const locationGranted = await requestFeaturePermissions(PermissionFeatures.LOCATION)
+      if (!locationGranted) return false
+
+      if (needsBluetoothPermissions) {
+        const requirementsMet = await checkConnectivityRequirementsUI()
+        if (!requirementsMet) return false
+      }
+    }
+  } catch (error) {
+    console.error("Error requesting pairing permissions:", error)
+    showAlert(translate("pairing:errorTitle"), translate("pairing:permissionsError"), [{text: translate("common:ok")}])
+    return false
+  }
+
+  // Pairing owns the microphone. Backend app shutdown can be slow, so do not block navigation.
+  void engine.miniapps.stopAll()
+  return true
+}


### PR DESCRIPTION
## Summary

- start scanning immediately after Mentra Live is selected and pairing prerequisites are satisfied
- keep legacy firmware eligible for automatic connection without requiring pairing mode
- pause on a detected secure idle unit and surface the five-press pairing instructions immediately
- show in-place recovery guidance after a 15-second empty scan and retain the coded picker for multiple pairable units
- share the existing permission/connectivity preparation between the direct Live flow and other glasses prep flows

## Test evidence

- `npm test -- --runInBand --silent src/__tests__/app/pairing/scan.test.tsx src/__tests__/app/pairing/select-glasses-model.test.tsx src/utils/pairing/preparePairingScan.test.ts` (25 tests passed)
- scoped ESLint on all changed TypeScript files (0 errors; existing warnings only)
- `bun run compile` reaches the existing unrelated `BuiltInMiniappCatalog.ts:80` callback type error

## Stack

This is intentionally stacked on #3791 so the adaptive UX remains separate from the native scanner correctness fix. Retarget to `dev` after #3791 merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pairing navigation and permission gating for Mentra Live plus BLE scan timeout/stop logic; mistakes could block pairing or regress other glasses flows, though prep is refactored rather than rewritten for non-Live paths.
> 
> **Overview**
> **Mentra Live** pairing now skips the prep/onboarding screen: choosing Live runs shared **`preparePairingScan`** (permissions, connectivity, `stopAll`) and navigates straight to **`/pairing/scan`**. Other models still go through **`/pairing/prep`**, which now delegates the same prep logic instead of inlining it.
> 
> The **Live scan screen** adapts to what BLE reports: context-specific titles and subtitles while scanning; a dedicated help state after timeout or when permissions block connect, with **Scan Again** restarting scan in place; and **immediate pause** when a secure-but-idle Live is nearby (stop scan, show five-press pairing guidance) instead of spinning until the 15s timeout. Legacy units without secure pairing remain auto-connect eligible; multiple pairable units still show the code-labeled picker.
> 
> New **i18n** strings back the Live-specific copy. **Tests** cover the model picker routing, `preparePairingScan`, and updated scan behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4224730f27f9dd127bb21d20b120cc1938c04dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->