### PR TITLE
Make Mentra Live pairing discovery adaptive

### DIFF
--- a/mobile/.maestro/README.md
+++ b/mobile/.maestro/README.md
@@ -43,6 +43,7 @@ npm run test:maestro:ci
 
 ### Simulated Hardware Tests
 
+- `04b-mentra-live-adaptive-scan.yaml` - Direct Mentra Live scan, timeout help, and in-place retry
 - `04-simulated-glasses-pairing.yaml` - Pairing flow with simulated glasses (built-in feature)
 - `06-launch-app-simulated-glasses.yaml` - Launch Mira app on simulated glasses
 

--- a/mobile/.maestro/config.yaml
+++ b/mobile/.maestro/config.yaml
@@ -20,6 +20,7 @@ includedFlows:
   - flows/01-auth-flow.yaml
   - flows/02-tab-navigation.yaml
   - flows/03-app-store.yaml
+  - flows/04b-mentra-live-adaptive-scan.yaml
   - flows/04-simulated-glasses-pairing.yaml
   - flows/05-no-internet-connection.yaml
   - flows/06-launch-app-simulated-glasses.yaml

--- a/mobile/.maestro/flows/04b-mentra-live-adaptive-scan.yaml
+++ b/mobile/.maestro/flows/04b-mentra-live-adaptive-scan.yaml
@@ -1,0 +1,66 @@
+appId: ${MAESTRO_APP_ID}
+---
+# Test: Mentra Live adaptive pairing scan
+# Description: Verifies that Mentra Live skips the redundant prep screen and
+# that a no-result scan exposes pairing-mode help plus an in-place retry.
+
+- launchApp
+
+- tapOn: "Glasses"
+- tapOn: "Connect Glasses"
+
+- assertVisible: "Before you begin"
+- tapOn: "Continue"
+
+- assertVisible: "Select your glasses"
+- tapOn:
+    id: "pairing-model-mentra_live"
+
+# Accommodate clean Android/iOS devices while remaining a no-op when the suite
+# has already granted pairing permissions.
+- tapOn:
+    text: "Allow"
+    optional: true
+- tapOn:
+    text: "While using the app"
+    optional: true
+- tapOn:
+    text: "Only this time"
+    optional: true
+- tapOn:
+    text: "OK"
+    optional: true
+- tapOn:
+    text: "Allow"
+    optional: true
+- tapOn:
+    text: "While using the app"
+    optional: true
+- tapOn:
+    text: "Only this time"
+    optional: true
+- tapOn:
+    text: "OK"
+    optional: true
+
+# Mentra Live should navigate directly to the adaptive scanner, not the old
+# "Ready to pair" prep screen.
+- extendedWaitUntil:
+    visible: "Turn on your glasses"
+    timeout: 20000
+- assertVisible: "We're looking for your Mentra Live."
+- assertNotVisible: "Ready to pair"
+
+# With no physical glasses in the test environment, the same screen should
+# reveal the five-press instructions and restart discovery in place.
+- extendedWaitUntil:
+    visible: "Not showing up?"
+    timeout: 20000
+- assertVisible: "Already updated your glasses?"
+- assertVisible: "Scan Again"
+- tapOn: "Scan Again"
+
+- assertVisible: "Turn on your glasses"
+- assertVisible: "We're looking for your Mentra Live."
+- assertNotVisible: "Ready to pair"
+- takeScreenshot: "mentra-live-adaptive-scan"

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -284,6 +284,7 @@ class MentraBluetoothSdk private constructor(
             DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "project_name", device.projectName ?: "")
             DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_name", "")
             DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_address", "")
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_secure_pairing_capable", "")
         } finally {
             suppressDefaultDeviceEvents = false
         }
@@ -299,6 +300,7 @@ class MentraBluetoothSdk private constructor(
             DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "project_name", "")
             DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_name", "")
             DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_address", "")
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_secure_pairing_capable", "")
         } finally {
             suppressDefaultDeviceEvents = false
         }
@@ -428,6 +430,11 @@ class MentraBluetoothSdk private constructor(
                         "pending_device_address",
                         device.address ?: "",
                 )
+                DeviceStore.apply(
+                        ObservableStore.BLUETOOTH_CATEGORY,
+                        "pending_device_secure_pairing_capable",
+                        device.securePairingCapable ?: "",
+                )
             }
         }
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_wearable", device.model.deviceType)
@@ -454,6 +461,7 @@ class MentraBluetoothSdk private constructor(
     fun cancelConnectionAttempt() {
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_name", "")
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_address", "")
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_secure_pairing_capable", "")
         deviceManager.disconnect()
     }
 
@@ -464,6 +472,7 @@ class MentraBluetoothSdk private constructor(
     fun disconnect() {
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_name", "")
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_address", "")
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_device_secure_pairing_capable", "")
         deviceManager.disconnect()
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -1265,11 +1265,9 @@ class MentraLive : SGCManager() {
             val generation = ++scanGeneration
             isScanning = true
             bluetoothScanner!!.startScan(filters, settings, scanCallback)
-            // Connected glasses stop advertising (BLE_CONNECTION_MAX=1). Pairing scan
-            // would otherwise return empty even though GATT is already up.
-            if (!isReconnecting) {
-                handler.post { emitConnectedDeviceForPairingScan() }
-            }
+            // Pairing discovery must stay advertisement-driven. An already-connected
+            // device has no current pairing-mode advertisement, so surfacing it here
+            // would make RN treat the owner's glasses as pairable and auto-select them.
 
             // Set a timeout to stop scanning
             handler.postDelayed(
@@ -1349,33 +1347,6 @@ class MentraLive : SGCManager() {
         val body = HashMap<String, Any>()
         body["deviceModel"] = DeviceTypes.LIVE
         Bridge.sendTypedMessage("compatible_glasses_search_stop", body)
-    }
-
-    /**
-     * Pairing scan listens for advertisements. A unit that is already GATT-connected
-     * (typical after a CTKD retry / back-out on field firmware) has stopped ADV, so
-     * emit it as pairable or the scan list stays empty.
-     */
-    private fun emitConnectedDeviceForPairingScan() {
-        if (!isConnected || isReconnecting || pairingYieldActive) {
-            return
-        }
-        val device = connectedDevice ?: bluetoothGatt?.device ?: return
-        val name = safeBondedDeviceName(device)
-        if (!isMentraLiveBluetoothName(name)) {
-            return
-        }
-        Bridge.log(
-                "LIVE: Pairing scan: already GATT-connected to $name — emitting as pairable (ADV off while connected)"
-        )
-        Bridge.sendDiscoveredDevice(
-                DeviceTypes.LIVE,
-                name,
-                device.address ?: "",
-                pairingMode = true,
-                pairingCode = null,
-                securePairingCapable = false,
-        )
     }
 
     var seenDevices: MutableSet<String> = HashSet()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -2110,6 +2110,7 @@ class MentraLive : SGCManager() {
                             isConnecting = false
                             isConnected = true
                             connectedDevice = gatt.device
+                            emitConnectedPendingDeviceForPairingScan()
 
                             DeviceStore.apply("glasses", "bluetoothName", connectedDevice!!.name)
                             // Persist MAC so reconnection can use direct GATT instead of scanning

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -1387,6 +1387,8 @@ class MentraLive : SGCManager() {
         val pendingName = DeviceStore.get("bluetooth", "pending_device_name") as? String ?: ""
         val pendingAddress =
                 DeviceStore.get("bluetooth", "pending_device_address") as? String ?: ""
+        val pendingSecurePairingCapable =
+                DeviceStore.get("bluetooth", "pending_device_secure_pairing_capable") as? Boolean
         val address = device.address ?: ""
         if (
                 !shouldRecoverConnectedMentraLivePairingTarget(
@@ -1409,7 +1411,7 @@ class MentraLive : SGCManager() {
                 address,
                 pairingMode = true,
                 pairingCode = null,
-                securePairingCapable = false,
+                securePairingCapable = pendingSecurePairingCapable,
         )
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -82,6 +82,18 @@ internal fun hasRequiredMentraLiveCoreCharacteristics(
         hasTxCharacteristic: Boolean,
 ): Boolean = hasRxCharacteristic && hasTxCharacteristic
 
+internal fun isPendingMentraLivePairingTarget(
+        connectedName: String,
+        connectedAddress: String,
+        pendingName: String,
+        pendingAddress: String,
+): Boolean {
+    if (pendingAddress.isNotEmpty()) {
+        return connectedAddress.equals(pendingAddress, ignoreCase = true)
+    }
+    return pendingName.isNotEmpty() && connectedName == pendingName
+}
+
 /**
  * Smart Glasses Communicator for Mentra Live (K900) glasses Uses BLE to communicate with the
  * glasses
@@ -1265,9 +1277,6 @@ class MentraLive : SGCManager() {
             val generation = ++scanGeneration
             isScanning = true
             bluetoothScanner!!.startScan(filters, settings, scanCallback)
-            // Pairing discovery must stay advertisement-driven. An already-connected
-            // device has no current pairing-mode advertisement, so surfacing it here
-            // would make RN treat the owner's glasses as pairable and auto-select them.
 
             // Set a timeout to stop scanning
             handler.postDelayed(
@@ -1347,6 +1356,36 @@ class MentraLive : SGCManager() {
         val body = HashMap<String, Any>()
         body["deviceModel"] = DeviceTypes.LIVE
         Bridge.sendTypedMessage("compatible_glasses_search_stop", body)
+    }
+
+    /**
+     * A selected pairing target can stop advertising once its GATT link comes up, before
+     * readiness promotes it to the default device. Re-emit only that explicit pending target;
+     * an established owner's connected glasses have no pending name/address and stay hidden.
+     */
+    private fun emitConnectedPendingDeviceForPairingScan() {
+        if (!manualDiscoveryActive || isReconnecting || pairingYieldActive) return
+        val device = connectedDevice ?: bluetoothGatt?.device ?: return
+        val name = safeBondedDeviceName(device)
+        if (!isMentraLiveBluetoothName(name)) return
+
+        val pendingName = DeviceStore.get("bluetooth", "pending_device_name") as? String ?: ""
+        val pendingAddress =
+                DeviceStore.get("bluetooth", "pending_device_address") as? String ?: ""
+        val address = device.address ?: ""
+        if (!isPendingMentraLivePairingTarget(name, address, pendingName, pendingAddress)) return
+
+        Bridge.log(
+                "LIVE: Pairing scan: recovering connected pending target $name ($address)"
+        )
+        Bridge.sendDiscoveredDevice(
+                DeviceTypes.LIVE,
+                name,
+                address,
+                pairingMode = true,
+                pairingCode = null,
+                securePairingCapable = false,
+        )
     }
 
     var seenDevices: MutableSet<String> = HashSet()
@@ -5890,6 +5929,7 @@ class MentraLive : SGCManager() {
 
         // Start scanning for BLE devices
         startScan()
+        handler.post { emitConnectedPendingDeviceForPairingScan() }
     }
 
     private fun releaseStaleClassicForDiscovery() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -94,6 +94,21 @@ internal fun isPendingMentraLivePairingTarget(
     return pendingName.isNotEmpty() && connectedName == pendingName
 }
 
+internal fun shouldRecoverConnectedMentraLivePairingTarget(
+        isConnected: Boolean,
+        connectedName: String,
+        connectedAddress: String,
+        pendingName: String,
+        pendingAddress: String,
+): Boolean =
+        isConnected &&
+                isPendingMentraLivePairingTarget(
+                        connectedName,
+                        connectedAddress,
+                        pendingName,
+                        pendingAddress,
+                )
+
 /**
  * Smart Glasses Communicator for Mentra Live (K900) glasses Uses BLE to communicate with the
  * glasses
@@ -1373,7 +1388,17 @@ class MentraLive : SGCManager() {
         val pendingAddress =
                 DeviceStore.get("bluetooth", "pending_device_address") as? String ?: ""
         val address = device.address ?: ""
-        if (!isPendingMentraLivePairingTarget(name, address, pendingName, pendingAddress)) return
+        if (
+                !shouldRecoverConnectedMentraLivePairingTarget(
+                        isConnected,
+                        name,
+                        address,
+                        pendingName,
+                        pendingAddress,
+                )
+        ) {
+            return
+        }
 
         Bridge.log(
                 "LIVE: Pairing scan: recovering connected pending target $name ($address)"

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisementParserTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisementParserTest.kt
@@ -44,6 +44,28 @@ class MentraLivePairingAdvertisementParserTest {
     }
 
     @Test
+    fun connectedPairingRecoveryRequiresActiveGattConnection() {
+        assertFalse(
+                shouldRecoverConnectedMentraLivePairingTarget(
+                        isConnected = false,
+                        connectedName = "MENTRA_LIVE_BLE_TARGET",
+                        connectedAddress = "AA:BB:CC:DD:EE:FF",
+                        pendingName = "MENTRA_LIVE_BLE_TARGET",
+                        pendingAddress = "AA:BB:CC:DD:EE:FF",
+                )
+        )
+        assertTrue(
+                shouldRecoverConnectedMentraLivePairingTarget(
+                        isConnected = true,
+                        connectedName = "MENTRA_LIVE_BLE_TARGET",
+                        connectedAddress = "AA:BB:CC:DD:EE:FF",
+                        pendingName = "MENTRA_LIVE_BLE_TARGET",
+                        pendingAddress = "AA:BB:CC:DD:EE:FF",
+                )
+        )
+    }
+
+    @Test
     fun parsesMarkedSecurePairingAdvertisement() {
         val result = MentraLivePairingAdvertisementParser.parse(securePayload(pairingFlag = 1))
 

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisementParserTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLivePairingAdvertisementParserTest.kt
@@ -8,6 +8,42 @@ import org.junit.Test
 
 class MentraLivePairingAdvertisementParserTest {
     @Test
+    fun connectedPairingRecoveryRequiresExplicitPendingTarget() {
+        assertFalse(
+                isPendingMentraLivePairingTarget(
+                        connectedName = "MENTRA_LIVE_BLE_OWNER",
+                        connectedAddress = "AA:BB:CC:DD:EE:FF",
+                        pendingName = "",
+                        pendingAddress = "",
+                )
+        )
+        assertTrue(
+                isPendingMentraLivePairingTarget(
+                        connectedName = "MENTRA_LIVE_BLE_TARGET",
+                        connectedAddress = "AA:BB:CC:DD:EE:FF",
+                        pendingName = "MENTRA_LIVE_BLE_TARGET",
+                        pendingAddress = "",
+                )
+        )
+        assertTrue(
+                isPendingMentraLivePairingTarget(
+                        connectedName = "MENTRA_LIVE_BLE_TARGET",
+                        connectedAddress = "AA:BB:CC:DD:EE:FF",
+                        pendingName = "OTHER",
+                        pendingAddress = "aa:bb:cc:dd:ee:ff",
+                )
+        )
+        assertFalse(
+                isPendingMentraLivePairingTarget(
+                        connectedName = "MENTRA_LIVE_BLE_TARGET",
+                        connectedAddress = "AA:BB:CC:DD:EE:FF",
+                        pendingName = "MENTRA_LIVE_BLE_TARGET",
+                        pendingAddress = "11:22:33:44:55:66",
+                )
+        )
+    }
+
+    @Test
     fun parsesMarkedSecurePairingAdvertisement() {
         val result = MentraLivePairingAdvertisementParser.parse(securePayload(pairingFlag = 1))
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -311,6 +311,7 @@ public final class MentraBluetoothSDK {
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "project_name", device.projectName ?? "")
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_name", "")
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_address", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_secure_pairing_capable", "")
         finishDefaultDeviceApply(generation: generation)
     }
 
@@ -324,6 +325,7 @@ public final class MentraBluetoothSDK {
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "project_name", "")
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_name", "")
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_address", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_secure_pairing_capable", "")
         finishDefaultDeviceApply(generation: generation)
     }
 
@@ -401,6 +403,11 @@ public final class MentraBluetoothSDK {
         } else if !isController {
             DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_name", device.name)
             DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_address", device.identifier ?? "")
+            DeviceStore.shared.apply(
+                ObservableStore.bluetoothCategory,
+                "pending_device_secure_pairing_capable",
+                device.securePairingCapable ?? ""
+            )
         }
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_wearable", device.model.deviceType)
         DeviceManager.shared.connectByName(device.name)
@@ -427,6 +434,7 @@ public final class MentraBluetoothSDK {
         clearBluetoothRestoreIntent()
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_name", "")
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_address", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_secure_pairing_capable", "")
         DeviceManager.shared.disconnect()
     }
 
@@ -439,6 +447,7 @@ public final class MentraBluetoothSDK {
         clearBluetoothRestoreIntent()
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_name", "")
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_address", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_device_secure_pairing_capable", "")
         DeviceManager.shared.disconnect()
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1805,7 +1805,6 @@ class MentraLive: NSObject, SGCManager {
 
             manualDiscoveryActive = true
             startScan()
-            manualDiscoveryActive = isScanning
             emitConnectedPendingDeviceForPairingScan()
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -5556,7 +5556,10 @@ class MentraLive: NSObject, SGCManager {
             identifier: peripheral.identifier.uuidString,
             pairingMode: true,
             pairingCode: nil,
-            securePairingCapable: discoveredAdvPairing[name]?.securePairingCapable ?? false
+            securePairingCapable: DeviceStore.shared.get(
+                "bluetooth",
+                "pending_device_secure_pairing_capable"
+            ) as? Bool
         )
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -25,6 +25,20 @@ struct MentraLiveDevice {
     let address: String
 }
 
+enum MentraLivePendingPairingTarget {
+    static func matches(
+        connectedName: String,
+        connectedIdentifier: String,
+        pendingName: String,
+        pendingIdentifier: String
+    ) -> Bool {
+        if !pendingIdentifier.isEmpty {
+            return connectedIdentifier.caseInsensitiveCompare(pendingIdentifier) == .orderedSame
+        }
+        return !pendingName.isEmpty && connectedName == pendingName
+    }
+}
+
 // MARK: - BlePhotoUploadService
 
 class BlePhotoUploadService {
@@ -1773,6 +1787,7 @@ class MentraLive: NSObject, SGCManager {
             UserDefaults.standard.set("", forKey: PREFS_DEVICE_NAME)
 
             startScan()
+            emitConnectedPendingDeviceForPairingScan()
         }
     }
 
@@ -2363,10 +2378,6 @@ class MentraLive: NSObject, SGCManager {
         // }
 
         centralManager?.scanForPeripherals(withServices: nil, options: scanOptions)
-
-        // Pairing discovery must stay advertisement-driven. An already-connected
-        // peripheral has no current pairing-mode advertisement, so surfacing it here
-        // would make RN treat the owner's glasses as pairable and auto-select them.
 
         // var dName = DeviceManager.shared.deviceName
         // if dName.isEmpty {
@@ -5501,6 +5512,31 @@ class MentraLive: NSObject, SGCManager {
     }
 
     // MARK: - Event Emission
+
+    /// A selected pairing target can stop advertising once GATT connects, before readiness
+    /// promotes it to the default device. Re-emit only that explicit pending target; an
+    /// established owner's connected glasses have no pending identity and remain hidden.
+    private func emitConnectedPendingDeviceForPairingScan() {
+        guard !pairingYieldActive, let peripheral = connectedPeripheral, let name = peripheral.name,
+              MentraLivePendingPairingTarget.matches(
+                  connectedName: name,
+                  connectedIdentifier: peripheral.identifier.uuidString,
+                  pendingName: DeviceStore.shared.get("bluetooth", "pending_device_name") as? String ?? "",
+                  pendingIdentifier: DeviceStore.shared.get("bluetooth", "pending_device_address") as? String ?? ""
+              )
+        else {
+            return
+        }
+
+        Bridge.log("LIVE: Pairing scan: recovering connected pending target \(name) (\(peripheral.identifier))")
+        emitDiscoveredDevice(
+            name,
+            identifier: peripheral.identifier.uuidString,
+            pairingMode: true,
+            pairingCode: nil,
+            securePairingCapable: discoveredAdvPairing[name]?.securePairingCapable ?? false
+        )
+    }
 
     private func cacheAdvPairing(
         _ name: String,

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2364,9 +2364,9 @@ class MentraLive: NSObject, SGCManager {
 
         centralManager?.scanForPeripherals(withServices: nil, options: scanOptions)
 
-        // Fresh advertisements refill pairing metadata. Re-emitting the last scan's
-        // cache would keep a unit pairable after it left pairing mode.
-        emitConnectedDeviceForPairingScan()
+        // Pairing discovery must stay advertisement-driven. An already-connected
+        // peripheral has no current pairing-mode advertisement, so surfacing it here
+        // would make RN treat the owner's glasses as pairable and auto-select them.
 
         // var dName = DeviceManager.shared.deviceName
         // if dName.isEmpty {
@@ -5501,25 +5501,6 @@ class MentraLive: NSObject, SGCManager {
     }
 
     // MARK: - Event Emission
-
-    /// Pairing scan listens for advertisements. A unit that is already GATT-connected
-    /// has stopped ADV, so emit it as pairable or the scan list stays empty.
-    private func emitConnectedDeviceForPairingScan() {
-        guard connected, let peripheral = connectedPeripheral, let name = peripheral.name,
-              name == "Xy_A" || name.hasPrefix("XyBLE_") || name.hasPrefix("MENTRA_LIVE_BLE")
-              || name.hasPrefix("MENTRA_LIVE_BT") || name.lowercased().hasPrefix("mentra_live")
-        else {
-            return
-        }
-        Bridge.log("LIVE: Pairing scan: already GATT-connected to \(name) — emitting as pairable (ADV off while connected)")
-        emitDiscoveredDevice(
-            name,
-            identifier: peripheral.identifier.uuidString,
-            pairingMode: true,
-            pairingCode: nil,
-            securePairingCapable: discoveredAdvPairing[name]?.securePairingCapable ?? false
-        )
-    }
 
     private func cacheAdvPairing(
         _ name: String,

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -37,6 +37,21 @@ enum MentraLivePendingPairingTarget {
         }
         return !pendingName.isEmpty && connectedName == pendingName
     }
+
+    static func shouldRecover(
+        isConnected: Bool,
+        connectedName: String,
+        connectedIdentifier: String,
+        pendingName: String,
+        pendingIdentifier: String
+    ) -> Bool {
+        isConnected && matches(
+            connectedName: connectedName,
+            connectedIdentifier: connectedIdentifier,
+            pendingName: pendingName,
+            pendingIdentifier: pendingIdentifier
+        )
+    }
 }
 
 // MARK: - BlePhotoUploadService
@@ -5518,7 +5533,8 @@ class MentraLive: NSObject, SGCManager {
     /// established owner's connected glasses have no pending identity and remain hidden.
     private func emitConnectedPendingDeviceForPairingScan() {
         guard !pairingYieldActive, let peripheral = connectedPeripheral, let name = peripheral.name,
-              MentraLivePendingPairingTarget.matches(
+              MentraLivePendingPairingTarget.shouldRecover(
+                  isConnected: peripheral.state == .connected,
                   connectedName: name,
                   connectedIdentifier: peripheral.identifier.uuidString,
                   pendingName: DeviceStore.shared.get("bluetooth", "pending_device_name") as? String ?? "",

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -996,6 +996,7 @@ extension MentraLive: CBCentralManagerDelegate {
             self.isConnecting = false
             self.connectingPeripheral = nil
             self.connectedPeripheral = peripheral
+            self.emitConnectedPendingDeviceForPairingScan()
 
             // Save device name and address for future reconnection
             if let name = peripheral.name {
@@ -1647,6 +1648,7 @@ class MentraLive: NSObject, SGCManager {
 
     // State Tracking
     private var isScanning = false
+    private var manualDiscoveryActive = false
     private var isConnecting = false
     private var isKilled = false
     /// Glasses opened pairing window — stand down without forgetting identity/bonds.
@@ -1801,7 +1803,9 @@ class MentraLive: NSObject, SGCManager {
             // clear the saved device name:
             UserDefaults.standard.set("", forKey: PREFS_DEVICE_NAME)
 
+            manualDiscoveryActive = true
             startScan()
+            manualDiscoveryActive = isScanning
             emitConnectedPendingDeviceForPairingScan()
         }
     }
@@ -2411,6 +2415,7 @@ class MentraLive: NSObject, SGCManager {
     }
 
     func stopScan() {
+        manualDiscoveryActive = false
         guard isScanning else { return }
 
         centralManager?.stopScan()
@@ -5532,7 +5537,8 @@ class MentraLive: NSObject, SGCManager {
     /// promotes it to the default device. Re-emit only that explicit pending target; an
     /// established owner's connected glasses have no pending identity and remain hidden.
     private func emitConnectedPendingDeviceForPairingScan() {
-        guard !pairingYieldActive, let peripheral = connectedPeripheral, let name = peripheral.name,
+        guard manualDiscoveryActive, !pairingYieldActive, let peripheral = connectedPeripheral,
+              let name = peripheral.name,
               MentraLivePendingPairingTarget.shouldRecover(
                   isConnected: peripheral.state == .connected,
                   connectedName: name,

--- a/mobile/modules/bluetooth-sdk/ios/Tests/MentraLivePairingAdvertisementTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/MentraLivePairingAdvertisementTests.swift
@@ -38,6 +38,27 @@ final class MentraLivePairingAdvertisementTests: XCTestCase {
         )
     }
 
+    func testConnectedPairingRecoveryRequiresActiveGattConnection() {
+        XCTAssertFalse(
+            MentraLivePendingPairingTarget.shouldRecover(
+                isConnected: false,
+                connectedName: "MENTRA_LIVE_BLE_TARGET",
+                connectedIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                pendingName: "MENTRA_LIVE_BLE_TARGET",
+                pendingIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+            )
+        )
+        XCTAssertTrue(
+            MentraLivePendingPairingTarget.shouldRecover(
+                isConnected: true,
+                connectedName: "MENTRA_LIVE_BLE_TARGET",
+                connectedIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                pendingName: "MENTRA_LIVE_BLE_TARGET",
+                pendingIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+            )
+        )
+    }
+
     func testConnectionCallbackPolicyRejectsPairingYieldAndStaleAttempts() {
         XCTAssertFalse(
             MentraLiveConnectionAttemptPolicy.shouldAcceptDidConnect(

--- a/mobile/modules/bluetooth-sdk/ios/Tests/MentraLivePairingAdvertisementTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/MentraLivePairingAdvertisementTests.swift
@@ -3,6 +3,41 @@ import Foundation
 import XCTest
 
 final class MentraLivePairingAdvertisementTests: XCTestCase {
+    func testConnectedPairingRecoveryRequiresExplicitPendingTarget() {
+        XCTAssertFalse(
+            MentraLivePendingPairingTarget.matches(
+                connectedName: "MENTRA_LIVE_BLE_OWNER",
+                connectedIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                pendingName: "",
+                pendingIdentifier: ""
+            )
+        )
+        XCTAssertTrue(
+            MentraLivePendingPairingTarget.matches(
+                connectedName: "MENTRA_LIVE_BLE_TARGET",
+                connectedIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                pendingName: "MENTRA_LIVE_BLE_TARGET",
+                pendingIdentifier: ""
+            )
+        )
+        XCTAssertTrue(
+            MentraLivePendingPairingTarget.matches(
+                connectedName: "MENTRA_LIVE_BLE_TARGET",
+                connectedIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                pendingName: "OTHER",
+                pendingIdentifier: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+            )
+        )
+        XCTAssertFalse(
+            MentraLivePendingPairingTarget.matches(
+                connectedName: "MENTRA_LIVE_BLE_TARGET",
+                connectedIdentifier: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                pendingName: "MENTRA_LIVE_BLE_TARGET",
+                pendingIdentifier: "11111111-2222-3333-4444-555555555555"
+            )
+        )
+    }
+
     func testConnectionCallbackPolicyRejectsPairingYieldAndStaleAttempts() {
         XCTAssertFalse(
             MentraLiveConnectionAttemptPolicy.shouldAcceptDidConnect(

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -194,6 +194,9 @@ describe("pairing loading screen", () => {
   })
 
   it("navigates to success when firmware never emits pairing_info (legacy fallback)", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_LEGACY", securePairingCapable: false},
+    })
     render(<GlassesPairingLoadingScreen />)
 
     act(() => {
@@ -213,6 +216,19 @@ describe("pairing loading screen", () => {
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
     })
+  })
+
+  it("fails closed when recovered target capability is unknown", () => {
+    render(<GlassesPairingLoadingScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    })
+    act(() => {
+      jest.advanceTimersByTime(60_000)
+    })
+
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it("uses the legacy pairing_info fallback when scan already reported non-secure firmware", async () => {

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -593,7 +593,7 @@ describe("pairing scan screen", () => {
     expect(push).toHaveBeenCalledTimes(1)
   })
 
-  it("shows pairing-mode instructions immediately when a newer idle Mentra Live is nearby", async () => {
+  it("shows pairing-mode help but keeps scanning for a pairable Mentra Live", async () => {
     setPlatformOS("android")
     useCoreStore.setState({
       searchResults: [
@@ -617,9 +617,46 @@ describe("pairing scan screen", () => {
       expect(getByText("pairing:scanAgain")).toBeTruthy()
     })
     const {bluetoothSdkMock} = require("@/test-utils/mockBluetoothSdk")
-    expect(bluetoothSdkMock.stopScan).toHaveBeenCalled()
+    expect(bluetoothSdkMock.stopScan).not.toHaveBeenCalled()
     expect(queryByText(/IDLE/)).toBeNull()
     expect(push).not.toHaveBeenCalled()
+    ;(engine.pairing.scan as jest.Mock).mockClear()
+    fireEvent.press(getByText("pairing:scanAgain"))
+    await waitFor(() => {
+      expect(bluetoothSdkMock.stopScan).toHaveBeenCalled()
+      expect(engine.pairing.scan).toHaveBeenCalledWith("Mentra Live")
+    })
+
+    act(() => {
+      useCoreStore.setState({
+        searchResults: [
+          {
+            id: "idle",
+            model: "Mentra Live",
+            name: "MENTRA_LIVE_BLE_IDLE",
+            address: "idle",
+            pairingMode: false,
+            securePairingCapable: true,
+          },
+          {
+            id: "target",
+            model: "Mentra Live",
+            name: "MENTRA_LIVE_BLE_TARGET",
+            address: "target",
+            pairingMode: true,
+            pairingCode: "A1B2",
+            securePairingCapable: true,
+          },
+        ],
+      })
+    })
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith(
+        "/pairing/loading",
+        expect.objectContaining({deviceName: "MENTRA_LIVE_BLE_TARGET"}),
+      )
+    })
   })
 
   it("filters AR99 scan results to the selected AR99 project", async () => {

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -145,6 +145,8 @@ import {useNavigationStore} from "@/stores/navigation"
 import {requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import SelectGlassesBluetoothScreen from "@/app/pairing/scan"
 import {useCoreStore} from "@mentra/engine-host-internal"
+// The glasses store is private to the local engine workspace and has no public test export.
+// eslint-disable-next-line no-restricted-imports
 import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
 import {SETTINGS} from "@mentra/engine"
 import {useSettingsStore} from "@mentra/engine-host-internal"
@@ -170,9 +172,7 @@ describe("pairing scan screen", () => {
     useSettingsStore.getState().resetAllSettingsLocally()
     // The screen reads scan results through the pairing facade now; delegate the
     // mocked facade to the real core store this test seeds via setState().
-    ;(engine.pairing.searchResults as jest.Mock).mockImplementation(() => [
-      ...useCoreStore.getState().searchResults,
-    ])
+    ;(engine.pairing.searchResults as jest.Mock).mockImplementation(() => [...useCoreStore.getState().searchResults])
     ;(engine.pairing.onFound as jest.Mock).mockImplementation((cb: (results: unknown) => void) =>
       useCoreStore.subscribe((s) => s.searchResults, cb),
     )
@@ -228,11 +228,13 @@ describe("pairing scan screen", () => {
   })
 
   it("marks the chosen model pending on entry", async () => {
-    render(<SelectGlassesBluetoothScreen />)
+    const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
       expect(useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key)).toBe("Mentra Live")
     })
+    expect(getByText("pairing:liveScanTitle")).toBeTruthy()
+    expect(getByText("pairing:liveScanSubtitle")).toBeTruthy()
   })
 
   it("back-out delegates cleanup to the live abandonAttempt and keeps the pending marker", async () => {
@@ -355,8 +357,8 @@ describe("pairing scan screen", () => {
       const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
       await waitFor(() => {
-        expect(getByText("pairing:noGlassesFound")).toBeTruthy()
-        expect(getByText("pairing:tryAgain")).toBeTruthy()
+        expect(getByText("pairing:liveScanHelpTitle")).toBeTruthy()
+        expect(getByText("pairing:scanAgain")).toBeTruthy()
       })
       const {bluetoothSdkMock} = require("@/test-utils/mockBluetoothSdk")
       expect(bluetoothSdkMock.stopScan).toHaveBeenCalled()
@@ -377,13 +379,16 @@ describe("pairing scan screen", () => {
         jest.advanceTimersByTime(15_000)
       })
 
-      expect(getByText("pairing:noGlassesFound")).toBeTruthy()
+      expect(getByText("pairing:liveScanHelpTitle")).toBeTruthy()
+      expect(getByText("pairing:liveScanHelpInfo")).toBeTruthy()
+      expect(getByText("pairing:liveUpdatedGlassesHint")).toBeTruthy()
+      expect(getByText("pairing:livePairingModeInfo")).toBeTruthy()
     } finally {
       jest.useRealTimers()
     }
   })
 
-  it("Try Again restarts scan in place without navigating back", async () => {
+  it("Scan Again restarts scan in place without navigating back", async () => {
     jest.useFakeTimers()
     try {
       setPlatformOS("android")
@@ -393,10 +398,10 @@ describe("pairing scan screen", () => {
       act(() => {
         jest.advanceTimersByTime(15_000)
       })
-      expect(getByText("pairing:noGlassesFound")).toBeTruthy()
+      expect(getByText("pairing:liveScanHelpTitle")).toBeTruthy()
       ;(engine.pairing.scan as jest.Mock).mockClear()
 
-      fireEvent.press(getByText("pairing:tryAgain"))
+      fireEvent.press(getByText("pairing:scanAgain"))
 
       await waitFor(() => {
         expect(engine.pairing.scan).toHaveBeenCalledWith("Mentra Live")
@@ -434,6 +439,7 @@ describe("pairing scan screen", () => {
     const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
+      expect(getByText("pairing:liveChooseGlassesTitle")).toBeTruthy()
       expect(getByText(/pairing:pairingCodeLabel:A1B2/)).toBeTruthy()
       expect(getByText(/pairing:pairingCodeLabel:C3D4/)).toBeTruthy()
     })
@@ -587,38 +593,33 @@ describe("pairing scan screen", () => {
     expect(push).toHaveBeenCalledTimes(1)
   })
 
-  it("keeps scanning without a list when only non-pairing Mentra Live units are nearby", async () => {
-    jest.useFakeTimers()
-    try {
-      setPlatformOS("android")
-      useCoreStore.setState({
-        searchResults: [
-          {
-            id: "idle",
-            model: "Mentra Live",
-            name: "MENTRA_LIVE_BLE_IDLE",
-            address: "idle",
-            pairingMode: false,
-            securePairingCapable: true,
-          },
-        ],
-      })
+  it("shows pairing-mode instructions immediately when a newer idle Mentra Live is nearby", async () => {
+    setPlatformOS("android")
+    useCoreStore.setState({
+      searchResults: [
+        {
+          id: "idle",
+          model: "Mentra Live",
+          name: "MENTRA_LIVE_BLE_IDLE",
+          address: "idle",
+          pairingMode: false,
+          securePairingCapable: true,
+        },
+      ],
+    })
 
-      const {getByText, queryByText} = render(<SelectGlassesBluetoothScreen />)
+    const {getByText, queryByText} = render(<SelectGlassesBluetoothScreen />)
 
-      expect(queryByText(/IDLE/)).toBeNull()
-      expect(push).not.toHaveBeenCalled()
-
-      act(() => {
-        jest.advanceTimersByTime(15_000)
-      })
-
-      expect(getByText("pairing:noGlassesFound")).toBeTruthy()
-      expect(getByText("pairing:nearbyNotInPairingModeHint")).toBeTruthy()
-      expect(queryByText(/IDLE/)).toBeNull()
-    } finally {
-      jest.useRealTimers()
-    }
+    await waitFor(() => {
+      expect(getByText("pairing:livePairingFoundTitle")).toBeTruthy()
+      expect(getByText("pairing:livePairingFoundSubtitle")).toBeTruthy()
+      expect(getByText("pairing:livePairingModeInfo")).toBeTruthy()
+      expect(getByText("pairing:scanAgain")).toBeTruthy()
+    })
+    const {bluetoothSdkMock} = require("@/test-utils/mockBluetoothSdk")
+    expect(bluetoothSdkMock.stopScan).toHaveBeenCalled()
+    expect(queryByText(/IDLE/)).toBeNull()
+    expect(push).not.toHaveBeenCalled()
   })
 
   it("filters AR99 scan results to the selected AR99 project", async () => {

--- a/mobile/src/__tests__/app/pairing/select-glasses-model.test.tsx
+++ b/mobile/src/__tests__/app/pairing/select-glasses-model.test.tsx
@@ -1,0 +1,118 @@
+import {act, fireEvent, render} from "@testing-library/react-native"
+import type {ReactNode} from "react"
+
+import SelectGlassesModelScreen from "@/app/pairing/select-glasses-model"
+import {useNavigationStore} from "@/stores/navigation"
+import {preparePairingScan} from "@/utils/pairing/preparePairingScan"
+
+jest.mock("@/../../cloud/packages/types/src", () => ({
+  DeviceTypes: {
+    LIVE: "Mentra Live",
+    G1: "Even Realities G1",
+    G2: "Even Realities G2",
+    AR99: "AR99",
+    MACH1: "Mentra Mach1",
+    Z100: "Vuzix Z100",
+    NEX: "Mentra Nex",
+    NIMO: "Nimo",
+  },
+}))
+
+jest.mock("@mentra/engine", () => ({
+  SETTINGS: {super_mode: {key: "super_mode"}},
+  useSetting: () => [false],
+}))
+
+jest.mock("@/stores/navigation", () => ({
+  useNavigationStore: {getState: jest.fn()},
+}))
+
+jest.mock("@/utils/pairing/preparePairingScan", () => ({
+  preparePairingScan: jest.fn(),
+}))
+
+jest.mock("@/contexts/ThemeContext", () => ({
+  useAppTheme: () => ({theme: {colors: {text: "#000"}, spacing: {s4: 16}}}),
+}))
+
+jest.mock("@/utils/getGlassesImage", () => ({
+  AR99_MODEL_OPTIONS: [],
+  getGlassesImage: jest.fn(() => 1),
+}))
+
+jest.mock("@/components/ignite", () => {
+  const {Text: RNText, View} = require("react-native")
+  return {
+    Header: () => <View />,
+    Text: ({text}: {text?: string}) => <RNText>{text}</RNText>,
+  }
+})
+
+jest.mock("@/components/ignite/Screen", () => {
+  const {View} = require("react-native")
+  return {Screen: ({children}: {children: ReactNode}) => <View>{children}</View>}
+})
+
+jest.mock("@/components/ui/GlassView", () => {
+  const {View} = require("react-native")
+  function MockGlassView({children}: {children: ReactNode}) {
+    return <View>{children}</View>
+  }
+  return MockGlassView
+})
+
+jest.mock("@/components/ui/Spacer", () => ({
+  Spacer: () => null,
+}))
+
+jest.mock("@/components/brands/EvenRealitiesLogo", () => ({EvenRealitiesLogo: () => null}))
+jest.mock("@/components/brands/MentraLogo", () => ({MentraLogo: () => null}))
+jest.mock("@/components/brands/MentraLogoStandalone", () => ({MentraLogoStandalone: () => null}))
+jest.mock("@/components/brands/NimoLogo", () => ({NimoLogo: () => null}))
+jest.mock("@/components/brands/VuzixLogo", () => ({VuzixLogo: () => null}))
+jest.mock("@/components/brands/XingyiLogo", () => ({XingyiLogo: () => null}))
+
+describe("glasses model selection", () => {
+  const push = jest.fn()
+  const goBack = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useNavigationStore.getState as jest.Mock).mockReturnValue({push, goBack})
+    ;(preparePairingScan as jest.Mock).mockResolvedValue(true)
+  })
+
+  it("prepares permissions and opens the scan directly for Mentra Live", async () => {
+    const {getByTestId} = render(<SelectGlassesModelScreen />)
+
+    await act(async () => {
+      fireEvent.press(getByTestId("pairing-model-mentra_live"))
+    })
+
+    expect(preparePairingScan).toHaveBeenCalledWith("Mentra Live")
+    expect(push).toHaveBeenCalledWith("/pairing/scan", {deviceModel: "Mentra Live"})
+  })
+
+  it("keeps the existing prep flow for other glasses", () => {
+    const {getByTestId} = render(<SelectGlassesModelScreen />)
+
+    fireEvent.press(getByTestId("pairing-model-evenrealities_g1"))
+
+    expect(preparePairingScan).not.toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith("/pairing/prep", {
+      deviceModel: "Even Realities G1",
+      ar99ProjectName: undefined,
+    })
+  })
+
+  it("stays on model selection when pairing prerequisites are denied", async () => {
+    ;(preparePairingScan as jest.Mock).mockResolvedValue(false)
+    const {getByTestId} = render(<SelectGlassesModelScreen />)
+
+    await act(async () => {
+      fireEvent.press(getByTestId("pairing-model-mentra_live"))
+    })
+
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -15,7 +15,7 @@ import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {useNavigationStore} from "@/stores/navigation"
 
-// Legacy ads without secure_pairing_capable use this timeout. Secure firmware must not.
+// Only ads explicitly identified as legacy use this timeout. Unknown capability fails closed.
 const PAIRING_INFO_FALLBACK_MS = 5_000
 
 /**
@@ -141,7 +141,7 @@ export default function GlassesPairingLoadingScreen() {
     }
     // Secure-capable firmware must not use the legacy pairing_info timeout fallback.
     // Wait for the pairing_info readiness signal (not for ownership transfer).
-    if (securePairingCapable === true || pairingInfoRef.current?.secure_pairing_capable) {
+    if (securePairingCapable !== false || pairingInfoRef.current?.secure_pairing_capable) {
       return
     }
     const timer = setTimeout(() => {
@@ -165,7 +165,7 @@ export default function GlassesPairingLoadingScreen() {
     }
 
     if (isMentraLive) {
-      const secure = securePairingCapable === true || pairingInfoRef.current?.secure_pairing_capable === true
+      const secure = securePairingCapable !== false || pairingInfoRef.current?.secure_pairing_capable === true
       if (!pairingInfoReceived && !pairingInfoTimedOut) {
         logPairingTiming("waiting_pairing_info")
         return

--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -1,15 +1,13 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
 import {useRoute} from "@react-navigation/native"
-import {Linking, PermissionsAndroid, Image, Platform, ScrollView, View} from "react-native"
-import type {ImageStyle, Permission, ViewStyle} from "react-native"
+import {Image, Platform, ScrollView, View} from "react-native"
+import type {ImageStyle, ViewStyle} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
 import {Button, Header, Icon, Screen, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import {showAlert} from "@/utils/AlertUtils"
-import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import GlassesDisplayMirror from "@/components/mirror/GlassesDisplayMirror"
 import {useState} from "react"
 import GlassesTroubleshootingModal from "@/components/glasses/GlassesTroubleshootingModal"
@@ -18,8 +16,7 @@ import {CDN_BASE_URL} from "@/constants/appConfig"
 import {engine} from "@mentra/engine"
 import {getAr99DisplayName, getAr99ImageSource} from "@/utils/getGlassesImage"
 import {ThemedStyle} from "@/theme"
-
-type BluetoothPermission = Permission | "android.permission.BLUETOOTH" | "android.permission.BLUETOOTH_ADMIN"
+import {preparePairingScan} from "@/utils/pairing/preparePairingScan"
 
 export default function PairingPrepScreen() {
   const route = useRoute()
@@ -29,179 +26,8 @@ export default function PairingPrepScreen() {
   const {themed} = useAppTheme()
 
   const advanceToPairing = async () => {
-    if (deviceModel == null || deviceModel == "") {
-      console.log("SOME WEIRD ERROR HERE")
-      return
-    }
-
-    // Always request Bluetooth permissions - required for Android 14+ foreground service
-    let needsBluetoothPermissions = true
-    // we don't need bluetooth permissions for simulated glasses
-    if (deviceModel.startsWith(DeviceTypes.SIMULATED) && Platform.OS === "ios") {
-      needsBluetoothPermissions = false
-    }
-
-    try {
-      // Check for Android-specific permissions
-      if (Platform.OS === "android") {
-        // Android-specific Phone State permission - request for ALL glasses including simulated
-        console.log("Requesting PHONE_STATE permission...")
-        const phoneStateGranted = await requestFeaturePermissions(PermissionFeatures.PHONE_STATE)
-        console.log("PHONE_STATE permission result:", phoneStateGranted)
-
-        if (!phoneStateGranted) {
-          // The specific alert for previously denied permission is already handled in requestFeaturePermissions
-          // We just need to stop the flow here
-          return
-        }
-
-        // Bluetooth permissions only for physical glasses
-        if (needsBluetoothPermissions) {
-          const bluetoothPermissions: BluetoothPermission[] = []
-
-          // Bluetooth permissions based on Android version
-          if (typeof Platform.Version === "number" && Platform.Version < 31) {
-            // For Android 9, 10, and 11 (API 28-30), use legacy Bluetooth permissions
-            bluetoothPermissions.push("android.permission.BLUETOOTH")
-            bluetoothPermissions.push("android.permission.BLUETOOTH_ADMIN")
-          }
-          if (typeof Platform.Version === "number" && Platform.Version >= 31) {
-            bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN)
-            bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT)
-            bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE)
-          }
-
-          // Request Bluetooth permissions directly
-          if (bluetoothPermissions.length > 0) {
-            console.log("RIGHT BEFORE ASKING FOR PERMS")
-            console.log("Bluetooth permissions array:", bluetoothPermissions)
-            console.log(
-              "Bluetooth permission values:",
-              bluetoothPermissions.map((p) => `${p} (${typeof p})`),
-            )
-
-            const results = await PermissionsAndroid.requestMultiple(bluetoothPermissions as Permission[])
-            const allGranted = Object.values(results).every((value) => value === PermissionsAndroid.RESULTS.GRANTED)
-
-            // Since we now handle NEVER_ASK_AGAIN in requestFeaturePermissions,
-            // we just need to check if all are granted
-            if (!allGranted) {
-              // Check if any are NEVER_ASK_AGAIN to show proper dialog
-              const anyNeverAskAgain = Object.values(results).some(
-                (value) => value === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN,
-              )
-
-              if (anyNeverAskAgain) {
-                // Show "previously denied" dialog for Bluetooth
-                showAlert(
-                  translate("pairing:permissionRequired"),
-                  translate("pairing:bluetoothPermissionPreviouslyDenied"),
-                  [
-                    {
-                      text: translate("pairing:openSettings"),
-                      onPress: () => Linking.openSettings(),
-                    },
-                    {
-                      text: translate("common:cancel"),
-                      style: "cancel",
-                    },
-                  ],
-                )
-              } else {
-                // Show standard permission required dialog
-                showAlert(
-                  translate("pairing:bluetoothPermissionRequiredTitle"),
-                  translate("pairing:bluetoothPermissionRequiredMessage"),
-                  [{text: translate("common:ok")}],
-                )
-              }
-              return
-            }
-          }
-
-          // Phone state permission already requested above for all Android devices
-        } // End of Bluetooth permissions block
-      } // End of Android-specific permissions block
-
-      // Check connectivity early for iOS (permissions work differently)
-      console.log("DEBUG: needsBluetoothPermissions:", needsBluetoothPermissions, "Platform.OS:", Platform.OS)
-      if (needsBluetoothPermissions && Platform.OS === "ios") {
-        console.log("DEBUG: Running iOS connectivity check early")
-        const requirementsCheck = await checkConnectivityRequirementsUI()
-        if (!requirementsCheck) {
-          return
-        }
-      }
-
-      // Cross-platform permissions needed for both iOS and Android (only if connectivity check passed)
-      if (needsBluetoothPermissions) {
-        const hasBluetoothPermission = await requestFeaturePermissions(PermissionFeatures.BLUETOOTH)
-        if (!hasBluetoothPermission) {
-          showAlert(
-            translate("pairing:bluetoothPermissionRequiredTitle"),
-            translate("pairing:bluetoothPermissionRequiredMessageAlt"),
-            [{text: translate("common:ok")}],
-          )
-          return // Stop the connection process
-        }
-      }
-
-      // Request microphone permission (needed for both platforms)
-      console.log("Requesting microphone permission...")
-
-      // This now handles showing alerts for previously denied permissions internally
-      const micGranted = await requestFeaturePermissions(PermissionFeatures.MICROPHONE)
-
-      console.log("Microphone permission result:", micGranted)
-
-      if (!micGranted) {
-        // The specific alert for previously denied permission is already handled in requestFeaturePermissions
-        // We just need to stop the flow here
-        return
-      }
-
-      // Request location permission (needed for Android BLE scanning)
-      if (Platform.OS === "android") {
-        console.log("Requesting location permission for Android BLE scanning...")
-
-        // This now handles showing alerts for previously denied permissions internally
-        const locGranted = await requestFeaturePermissions(PermissionFeatures.LOCATION)
-
-        console.log("Location permission result:", locGranted)
-
-        if (!locGranted) {
-          // The specific alert for previously denied permission is already handled in requestFeaturePermissions
-          // We just need to stop the flow here
-          return
-        }
-
-        // Check connectivity for Android AFTER all permissions are granted
-        // This must be done after location permission is granted to avoid premature "Connection issue" popup
-        if (needsBluetoothPermissions) {
-          const requirementsCheck = await checkConnectivityRequirementsUI()
-          if (!requirementsCheck) {
-            return
-          }
-        }
-      } else {
-        console.log("Skipping location permission on iOS - not needed after BLE fix")
-      }
-    } catch (error) {
-      console.error("Error requesting permissions:", error)
-      showAlert(translate("pairing:errorTitle"), translate("pairing:permissionsError"), [
-        {text: translate("common:ok")},
-      ])
-      return
-    }
-
-    console.log("needsBluetoothPermissions", needsBluetoothPermissions)
-
-    // Stop any running apps from previous sessions to prevent mic race conditions.
-    // This is symmetric with the logic in DeviceSettings that stops apps when unpairing.
-    // Fire-and-forget: stopAll() awaits a per-app backend stop call that can take many
-    // seconds (or hang with no internet / NO_ACTIVE_SESSION). We don't need it to finish
-    // before navigating to the scan screen, so don't block pairing on it.
-    void engine.miniapps.stopAll()
+    const readyToScan = await preparePairingScan(deviceModel)
+    if (!readyToScan) return
 
     // skip pairing for simulated glasses:
     if (deviceModel.startsWith(DeviceTypes.SIMULATED)) {

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -163,20 +163,8 @@ export default function SelectGlassesBluetoothScreen() {
   const shouldShowDeviceList = isMentraLivePairingScan ? listResults.length >= 2 : listResults.length > 0
 
   useEffect(() => {
-    // A secure Mentra Live advertisement tells us the glasses are nearby but idle.
-    // Pause immediately so the required five-press action is visible and the next
-    // scan gets a fresh advertisement carrying the pairing-mode flag and code.
-    if (!hasNearbyNotInPairingMode || pairableResults.length > 0 || scanTimedOut) {
-      return
-    }
-
-    setScanTimedOut(true)
-    void BluetoothSdk.stopScan()
-  }, [hasNearbyNotInPairingMode, pairableResults.length, scanTimedOut])
-
-  useEffect(() => {
-    // Timeout only when no pairable Mentra Live appeared; non-pairing nearby units still count
-    // as "seen" for the empty-state hint but must not auto-connect.
+    // Keep scanning after an idle secure unit appears. Advertisements arrive one
+    // at a time, so another nearby unit may still be pairable or legacy firmware.
     if (!isMentraLivePairingScan || scanTimedOut || pairableResults.length > 0) {
       return
     }
@@ -330,9 +318,11 @@ export default function SelectGlassesBluetoothScreen() {
     void triggerGlassesPairingGuide(pairableResults[0])
   }, [isMentraLivePairingScan, scanTimedOut, pairableResults])
 
-  const handleTryAgain = () => {
-    // Restart scan in place — do not pop back to prep.
-    void startScanAttempt()
+  const handleTryAgain = async () => {
+    // Restart scan in place — do not pop back to prep. Explicitly stop first so
+    // iOS forgets the prior allowDuplicates=false result after pairing mode changes.
+    await BluetoothSdk.stopScan()
+    await startScanAttempt()
   }
 
   const scanTitle = (() => {
@@ -341,15 +331,20 @@ export default function SelectGlassesBluetoothScreen() {
         ? translate("pairing:noGlassesFound")
         : translate("pairing:scanningForGlassesModel", {model: selectedDisplayName})
     }
-    if (scanTimedOut) {
-      return hasNearbyNotInPairingMode
-        ? translate("pairing:livePairingFoundTitle")
-        : translate("pairing:liveScanHelpTitle")
+    if (shouldShowDeviceList) {
+      return translate("pairing:liveChooseGlassesTitle")
     }
-    return shouldShowDeviceList ? translate("pairing:liveChooseGlassesTitle") : translate("pairing:liveScanTitle")
+    if (hasNearbyNotInPairingMode) {
+      return translate("pairing:livePairingFoundTitle")
+    }
+    if (scanTimedOut) {
+      return translate("pairing:liveScanHelpTitle")
+    }
+    return translate("pairing:liveScanTitle")
   })()
 
-  const showLivePairingHelp = isMentraLivePairingScan && scanTimedOut
+  const showLivePairingHelp =
+    isMentraLivePairingScan && (scanTimedOut || (pairableResults.length === 0 && hasNearbyNotInPairingMode))
 
   return (
     <Screen preset="fixed" safeAreaEdges={["bottom"]} extraAndroidInsets>
@@ -379,6 +374,7 @@ export default function SelectGlassesBluetoothScreen() {
                 className="text-center text-sm leading-5 text-muted-foreground"
                 text={translate("pairing:livePairingModeInfo")}
               />
+              {!scanTimedOut ? <ActivityIndicator size="small" color={theme.colors.foreground} /> : null}
               <Button preset="primary" tx="pairing:scanAgain" onPress={handleTryAgain} className="w-full mt-2" />
             </View>
           ) : scanTimedOut ? (

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -35,9 +35,7 @@ export default function SelectGlassesBluetoothScreen() {
   const bluetoothClassicConnected = useEngineSnapshot(engine.pairing.readiness, (onChange) =>
     engine.pairing.onReadiness(onChange),
   ).bluetoothClassicConnected
-  const searchResults = useEngineSnapshot(engine.pairing.searchResults, (onChange) =>
-    engine.pairing.onFound(onChange),
-  )
+  const searchResults = useEngineSnapshot(engine.pairing.searchResults, (onChange) => engine.pairing.onFound(onChange))
   const [rememberedSearchResults, setRememberedSearchResults] = useState<Device[]>(searchResults)
   const [scanTimedOut, setScanTimedOut] = useState(false)
   const connectingRef = useRef(false)
@@ -131,9 +129,7 @@ export default function SelectGlassesBluetoothScreen() {
   // Secure Mentra Live ads with pairingMode=false are nearby but not pairable yet.
   // Legacy firmware (no secure flag) stays pairable even when pairingMode is unset/false.
   const isLivePairable = (device: Device) =>
-    !isMentraLivePairingScan ||
-    device.pairingMode !== false ||
-    device.securePairingCapable === false
+    !isMentraLivePairingScan || device.pairingMode !== false || device.securePairingCapable === false
 
   useEffect(() => {
     void startScanAttempt()
@@ -153,10 +149,7 @@ export default function SelectGlassesBluetoothScreen() {
   const pairableResults = useMemo(
     () =>
       visibleResults.filter(
-        (device) =>
-          !isMentraLivePairingScan ||
-          device.pairingMode !== false ||
-          device.securePairingCapable === false,
+        (device) => !isMentraLivePairingScan || device.pairingMode !== false || device.securePairingCapable === false,
       ),
     [visibleResults, isMentraLivePairingScan],
   )
@@ -167,9 +160,19 @@ export default function SelectGlassesBluetoothScreen() {
     [isMentraLivePairingScan, visibleResults],
   )
   const listResults = isMentraLivePairingScan ? pairableResults : visibleResults
-  const shouldShowDeviceList = isMentraLivePairingScan
-    ? listResults.length >= 2
-    : listResults.length > 0
+  const shouldShowDeviceList = isMentraLivePairingScan ? listResults.length >= 2 : listResults.length > 0
+
+  useEffect(() => {
+    // A secure Mentra Live advertisement tells us the glasses are nearby but idle.
+    // Pause immediately so the required five-press action is visible and the next
+    // scan gets a fresh advertisement carrying the pairing-mode flag and code.
+    if (!hasNearbyNotInPairingMode || pairableResults.length > 0 || scanTimedOut) {
+      return
+    }
+
+    setScanTimedOut(true)
+    void BluetoothSdk.stopScan()
+  }, [hasNearbyNotInPairingMode, pairableResults.length, scanTimedOut])
 
   useEffect(() => {
     // Timeout only when no pairable Mentra Live appeared; non-pairing nearby units still count
@@ -194,11 +197,9 @@ export default function SelectGlassesBluetoothScreen() {
 
   const triggerGlassesPairingGuide = async (device: Device) => {
     if (isMentraLivePairingScan && !isLivePairable(device)) {
-      showAlert(
-        translate("pairing:notInPairingModeAlertTitle"),
-        translate("pairing:notInPairingModeAlertMessage"),
-        [{text: "OK"}],
-      )
+      showAlert(translate("pairing:notInPairingModeAlertTitle"), translate("pairing:notInPairingModeAlertMessage"), [
+        {text: "OK"},
+      ])
       return
     }
 
@@ -236,8 +237,12 @@ export default function SelectGlassesBluetoothScreen() {
 
   const startPairing = async (device: Device) => {
     const deviceTypesWithBtClassic = [DeviceTypes.LIVE]
-    const resolvedProjectName = deviceModel === DeviceTypes.AR99 ? device.projectName ?? ar99ProjectName : undefined
-    if (Platform.OS === "android" || bluetoothClassicConnected || !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)) {
+    const resolvedProjectName = deviceModel === DeviceTypes.AR99 ? (device.projectName ?? ar99ProjectName) : undefined
+    if (
+      Platform.OS === "android" ||
+      bluetoothClassicConnected ||
+      !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)
+    ) {
       setTimeout(() => {
         engine.pairing.pair(device).catch((error) => {
           console.error("Failed to connect to glasses:", error)
@@ -330,22 +335,53 @@ export default function SelectGlassesBluetoothScreen() {
     void startScanAttempt()
   }
 
+  const scanTitle = (() => {
+    if (!isMentraLivePairingScan) {
+      return scanTimedOut
+        ? translate("pairing:noGlassesFound")
+        : translate("pairing:scanningForGlassesModel", {model: selectedDisplayName})
+    }
+    if (scanTimedOut) {
+      return hasNearbyNotInPairingMode
+        ? translate("pairing:livePairingFoundTitle")
+        : translate("pairing:liveScanHelpTitle")
+    }
+    return shouldShowDeviceList ? translate("pairing:liveChooseGlassesTitle") : translate("pairing:liveScanTitle")
+  })()
+
+  const showLivePairingHelp = isMentraLivePairingScan && scanTimedOut
+
   return (
     <Screen preset="fixed" safeAreaEdges={["bottom"]} extraAndroidInsets>
       <Header leftIcon="chevron-left" onLeftPress={handleBackOut} RightActionComponent={<MentraLogoStandalone />} />
       <View className="flex-1 justify-center">
         <GlassView className="gap-6 rounded-3xl p-6 bg-primary-foreground" transparent={false}>
           <Image source={selectedImage} className="h-[90px] w-[156px] mx-auto" resizeMode="contain" />
-          <Text
-            className="text-center text-xl font-semibold text-text-dim"
-            text={
-              scanTimedOut
-                ? translate("pairing:noGlassesFound")
-                : translate("pairing:scanningForGlassesModel", {model: selectedDisplayName})
-            }
-          />
+          <Text className="text-center text-xl font-semibold text-text-dim" text={scanTitle} />
 
-          {scanTimedOut ? (
+          {showLivePairingHelp ? (
+            <View className="gap-3 py-2">
+              <Text
+                className="text-center text-base font-medium text-foreground"
+                text={
+                  hasNearbyNotInPairingMode
+                    ? translate("pairing:livePairingFoundSubtitle")
+                    : translate("pairing:liveScanHelpInfo")
+                }
+              />
+              {!hasNearbyNotInPairingMode ? (
+                <Text
+                  className="text-center text-base font-semibold text-foreground"
+                  text={translate("pairing:liveUpdatedGlassesHint")}
+                />
+              ) : null}
+              <Text
+                className="text-center text-sm leading-5 text-muted-foreground"
+                text={translate("pairing:livePairingModeInfo")}
+              />
+              <Button preset="primary" tx="pairing:scanAgain" onPress={handleTryAgain} className="w-full mt-2" />
+            </View>
+          ) : scanTimedOut ? (
             <View className="gap-4 py-4">
               <Text
                 className="text-center text-sm text-muted-foreground"
@@ -391,14 +427,21 @@ export default function SelectGlassesBluetoothScreen() {
               <ActivityIndicator size="large" color={theme.colors.foreground} />
             </View>
           ) : !shouldShowDeviceList ? (
-            <View className="justify-center min-h-20 py-4">
+            <View className="justify-center items-center gap-3 min-h-20 py-4">
+              {isMentraLivePairingScan ? (
+                <Text
+                  className="text-center text-sm text-muted-foreground"
+                  text={translate("pairing:liveScanSubtitle")}
+                />
+              ) : null}
               <ActivityIndicator size="large" color={theme.colors.foreground} />
             </View>
           ) : (
             <ScrollView className="max-h-[300px] -mr-4 pr-4" contentContainerClassName="my-4">
               <Group>
                 {listResults.map((res: Device) => {
-                  const deviceTitle = deviceModel === DeviceTypes.AR99 ? getAr99ResultDisplayName(res) : selectedDisplayName
+                  const deviceTitle =
+                    deviceModel === DeviceTypes.AR99 ? getAr99ResultDisplayName(res) : selectedDisplayName
                   const deviceSubtitle =
                     deviceModel === DeviceTypes.AR99
                       ? formatAr99Subtitle(res)
@@ -406,7 +449,9 @@ export default function SelectGlassesBluetoothScreen() {
                         ? formatLiveSubtitle(res)
                         : filterDeviceName(res.name)
                   return (
-                    <View key={res.id} className="flex-row items-center justify-between px-4 py-3 bg-primary-foreground">
+                    <View
+                      key={res.id}
+                      className="flex-row items-center justify-between px-4 py-3 bg-primary-foreground">
                       <TouchableOpacity className="flex-1" onPress={() => triggerGlassesPairingGuide(res)}>
                         <View className="flex-1 px-2.5 flex-col">
                           <Text text={deviceTitle} className="flex-wrap text-sm font-semibold" numberOfLines={2} />

--- a/mobile/src/app/pairing/select-glasses-model.tsx
+++ b/mobile/src/app/pairing/select-glasses-model.tsx
@@ -1,4 +1,5 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
+import {useRef} from "react"
 import {View, TouchableOpacity, Platform, ScrollView, Image} from "react-native"
 
 import {EvenRealitiesLogo} from "@/components/brands/EvenRealitiesLogo"
@@ -14,6 +15,7 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {SETTINGS, useSetting} from "@mentra/engine"
 import {AR99_MODEL_OPTIONS, type Ar99ProjectName, getGlassesImage} from "@/utils/getGlassesImage"
+import {preparePairingScan} from "@/utils/pairing/preparePairingScan"
 import GlassView from "@/components/ui/GlassView"
 
 type GlassesOption = {
@@ -29,6 +31,7 @@ export default function SelectGlassesModelScreen() {
   const {theme} = useAppTheme()
   const {push, goBack} = useNavigationStore.getState()
   const [superMode] = useSetting(SETTINGS.super_mode.key)
+  const pairingStartPending = useRef(false)
 
   const getManufacturerLogo = (option: GlassesOption) => {
     if (option.manufacturerName) {
@@ -83,6 +86,20 @@ export default function SelectGlassesModelScreen() {
   const glassesOptions = Platform.OS === "ios" ? sharedOptions : sharedOptions
 
   const triggerGlassesPairingGuide = async (option: GlassesOption) => {
+    if (option.deviceModel === DeviceTypes.LIVE) {
+      if (pairingStartPending.current) return
+      pairingStartPending.current = true
+      try {
+        const readyToScan = await preparePairingScan(option.deviceModel)
+        if (readyToScan) {
+          push("/pairing/scan", {deviceModel: option.deviceModel})
+        }
+      } finally {
+        pairingStartPending.current = false
+      }
+      return
+    }
+
     push("/pairing/prep", {
       deviceModel: option.deviceModel,
       ar99ProjectName: option.projectName,
@@ -105,7 +122,10 @@ export default function SelectGlassesModelScreen() {
           {glassesOptions
             .filter((glasses) => !SUPER_MODE_ONLY_MODELS.has(glasses.deviceModel) || superMode)
             .map((glasses) => (
-              <TouchableOpacity key={glasses.key} onPress={() => triggerGlassesPairingGuide(glasses)}>
+              <TouchableOpacity
+                key={glasses.key}
+                testID={`pairing-model-${glasses.key}`}
+                onPress={() => triggerGlassesPairingGuide(glasses)}>
                 <GlassView className="bg-primary-foreground flex-col items-center justify-center p-6 rounded-2xl overflow-hidden">
                   <View className="flex-row gap-4">
                     <View className="flex-col flex-1 justify-center">

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -156,6 +156,15 @@ const en = {
     livePairingModeSubtitle: "Put your glasses into pairing mode before you scan.",
     livePairingModeInfo:
       "Press the power button 5 times quickly. The LED flashes and the glasses speak a 4-character code (0–9, A–F). Match that code on the scan list if more than one unit appears.",
+    liveScanTitle: "Turn on your glasses",
+    liveScanSubtitle: "We're looking for your Mentra Live.",
+    livePairingFoundTitle: "Glasses found",
+    livePairingFoundSubtitle: "Put them in pairing mode to continue.",
+    liveScanHelpTitle: "Not showing up?",
+    liveScanHelpInfo: "Make sure your glasses are charged and powered on.",
+    liveUpdatedGlassesHint: "Already updated your glasses?",
+    liveChooseGlassesTitle: "Choose your glasses",
+    scanAgain: "Scan Again",
     noGlassesFound: "No glasses found",
     noGlassesFoundHint: "Make sure you pressed the power button 5 times quickly, then try again.",
     nearbyNotInPairingModeHint:
@@ -432,9 +441,11 @@ const en = {
     versionChangeVerifying: "Verifying your glasses\u2026",
     versionChangeKeepNearby: "Keep your glasses nearby and connected. They will restart on their own.",
     versionChangeComplete: "Version Change Complete",
-    versionChangeCompleteMessage: "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
+    versionChangeCompleteMessage:
+      "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
     versionChangeFirmwarePassComplete: "Firmware updated",
-    versionChangeFirmwarePassCompleteMessage: "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
+    versionChangeFirmwarePassCompleteMessage:
+      "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
     updateComplete: "Update Complete",
     updateCompleteMessage: "Your glasses have been updated successfully.",
     updateFailed: "Update Failed",
@@ -745,8 +756,7 @@ const en = {
     defaultHint: "Point the camera at a QR code",
     checkingPermission: "Checking camera permission\u2026",
     permissionTitle: "Camera access needed",
-    permissionBody:
-      "We need your camera to scan QR codes. The camera is only used while this screen is open.",
+    permissionBody: "We need your camera to scan QR codes. The camera is only used while this screen is open.",
     grantAccess: "Grant Camera Access",
     openSettings: "Open Settings",
     permissionDeniedTitle: "Permission Denied",

--- a/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
+++ b/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
@@ -72,9 +72,10 @@ class BuiltInMiniappCatalog {
       void this.syncGlassesMenuApps()
     })
 
-    const syncMiniappDeveloperVisibility = (showOnHomeScreen: boolean) => {
-      appRegistry.setOfflineAppHidden(miniappDeveloperPackageName, !showOnHomeScreen)
-      engine.miniapps.setHiddenStatus(miniappDeveloperPackageName, !showOnHomeScreen)
+    const syncMiniappDeveloperVisibility = (showOnHomeScreen: boolean | undefined) => {
+      const visible = Boolean(showOnHomeScreen)
+      appRegistry.setOfflineAppHidden(miniappDeveloperPackageName, !visible)
+      engine.miniapps.setHiddenStatus(miniappDeveloperPackageName, !visible)
     }
     syncMiniappDeveloperVisibility(Boolean(engine.settings.get(SETTINGS.miniapp_dev_mode.key)))
     engine.settings.onChanged<boolean>(SETTINGS.miniapp_dev_mode.key, syncMiniappDeveloperVisibility)

--- a/mobile/src/utils/pairing/preparePairingScan.test.ts
+++ b/mobile/src/utils/pairing/preparePairingScan.test.ts
@@ -81,11 +81,14 @@ describe("preparePairingScan", () => {
   it("preserves the Android permission order before checking connectivity", async () => {
     Object.defineProperty(Platform, "OS", {value: "android", configurable: true})
     Object.defineProperty(Platform, "Version", {value: 33, configurable: true})
-    const requestMultiple = jest.spyOn(PermissionsAndroid, "requestMultiple").mockResolvedValue({
+    const grantedBluetoothPermissions = {
       [PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN]: PermissionsAndroid.RESULTS.GRANTED,
       [PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT]: PermissionsAndroid.RESULTS.GRANTED,
       [PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE]: PermissionsAndroid.RESULTS.GRANTED,
-    })
+    } as Awaited<ReturnType<typeof PermissionsAndroid.requestMultiple>>
+    const requestMultiple = jest
+      .spyOn(PermissionsAndroid, "requestMultiple")
+      .mockResolvedValue(grantedBluetoothPermissions)
 
     await expect(preparePairingScan("Mentra Live")).resolves.toBe(true)
 

--- a/mobile/src/utils/pairing/preparePairingScan.test.ts
+++ b/mobile/src/utils/pairing/preparePairingScan.test.ts
@@ -1,0 +1,104 @@
+import {PermissionsAndroid, Platform} from "react-native"
+
+import {engine} from "@mentra/engine"
+
+import {showAlert} from "@/utils/AlertUtils"
+import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
+
+import {preparePairingScan} from "./preparePairingScan"
+
+jest.mock("@mentra/engine", () => ({
+  engine: {miniapps: {stopAll: jest.fn()}},
+}))
+
+jest.mock("@/../../cloud/packages/types/src", () => ({
+  DeviceTypes: {SIMULATED: "Simulated"},
+}))
+
+jest.mock("@/i18n", () => ({translate: (key: string) => key}))
+
+jest.mock("@/utils/AlertUtils", () => ({showAlert: jest.fn()}))
+
+jest.mock("@/utils/PermissionsUtils", () => ({
+  PermissionFeatures: {
+    BLUETOOTH: "bluetooth",
+    LOCATION: "location",
+    MICROPHONE: "microphone",
+    PHONE_STATE: "phone_state",
+  },
+  checkConnectivityRequirementsUI: jest.fn(),
+  requestFeaturePermissions: jest.fn(),
+}))
+
+const originalPlatformOS = Platform.OS
+const originalPlatformVersion = Platform.Version
+
+describe("preparePairingScan", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.defineProperty(Platform, "OS", {value: "ios", configurable: true})
+    ;(checkConnectivityRequirementsUI as jest.Mock).mockResolvedValue(true)
+    ;(requestFeaturePermissions as jest.Mock).mockResolvedValue(true)
+    ;(engine.miniapps.stopAll as jest.Mock).mockResolvedValue(undefined)
+  })
+
+  afterAll(() => {
+    Object.defineProperty(Platform, "OS", {value: originalPlatformOS, configurable: true})
+    Object.defineProperty(Platform, "Version", {value: originalPlatformVersion, configurable: true})
+  })
+
+  it("checks iOS connectivity and permissions before allowing the scan", async () => {
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(true)
+
+    expect(checkConnectivityRequirementsUI).toHaveBeenCalledTimes(1)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(1, PermissionFeatures.BLUETOOTH)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(2, PermissionFeatures.MICROPHONE)
+    expect(engine.miniapps.stopAll).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not stop miniapps or continue when connectivity is unavailable", async () => {
+    ;(checkConnectivityRequirementsUI as jest.Mock).mockResolvedValue(false)
+
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(false)
+
+    expect(requestFeaturePermissions).not.toHaveBeenCalled()
+    expect(engine.miniapps.stopAll).not.toHaveBeenCalled()
+  })
+
+  it("surfaces a Bluetooth denial and leaves pairing where it started", async () => {
+    ;(requestFeaturePermissions as jest.Mock).mockResolvedValueOnce(false)
+
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(false)
+
+    expect(showAlert).toHaveBeenCalledWith(
+      "pairing:bluetoothPermissionRequiredTitle",
+      "pairing:bluetoothPermissionRequiredMessageAlt",
+      [{text: "common:ok"}],
+    )
+    expect(engine.miniapps.stopAll).not.toHaveBeenCalled()
+  })
+
+  it("preserves the Android permission order before checking connectivity", async () => {
+    Object.defineProperty(Platform, "OS", {value: "android", configurable: true})
+    Object.defineProperty(Platform, "Version", {value: 33, configurable: true})
+    const requestMultiple = jest.spyOn(PermissionsAndroid, "requestMultiple").mockResolvedValue({
+      [PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN]: PermissionsAndroid.RESULTS.GRANTED,
+      [PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT]: PermissionsAndroid.RESULTS.GRANTED,
+      [PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE]: PermissionsAndroid.RESULTS.GRANTED,
+    })
+
+    await expect(preparePairingScan("Mentra Live")).resolves.toBe(true)
+
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(1, PermissionFeatures.PHONE_STATE)
+    expect(requestMultiple).toHaveBeenCalledWith([
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
+    ])
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(2, PermissionFeatures.BLUETOOTH)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(3, PermissionFeatures.MICROPHONE)
+    expect(requestFeaturePermissions).toHaveBeenNthCalledWith(4, PermissionFeatures.LOCATION)
+    expect(checkConnectivityRequirementsUI).toHaveBeenCalledTimes(1)
+    requestMultiple.mockRestore()
+  })
+})

--- a/mobile/src/utils/pairing/preparePairingScan.ts
+++ b/mobile/src/utils/pairing/preparePairingScan.ts
@@ -1,0 +1,117 @@
+import {engine} from "@mentra/engine"
+import {Linking, PermissionsAndroid, Platform} from "react-native"
+import type {Permission} from "react-native"
+
+import {DeviceTypes} from "@/../../cloud/packages/types/src"
+import {translate} from "@/i18n"
+import {showAlert} from "@/utils/AlertUtils"
+import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
+
+type BluetoothPermission = Permission | "android.permission.BLUETOOTH" | "android.permission.BLUETOOTH_ADMIN"
+
+/**
+ * Requests the permissions and connectivity needed before opening a pairing scan.
+ * Returns false when the user or device blocks setup, leaving navigation to the caller.
+ */
+export async function preparePairingScan(deviceModel: string): Promise<boolean> {
+  if (!deviceModel) {
+    console.error("Cannot prepare pairing scan without a device model")
+    return false
+  }
+
+  const needsBluetoothPermissions = !deviceModel.startsWith(DeviceTypes.SIMULATED) || Platform.OS !== "ios"
+
+  try {
+    if (Platform.OS === "android") {
+      const phoneStateGranted = await requestFeaturePermissions(PermissionFeatures.PHONE_STATE)
+      if (!phoneStateGranted) return false
+
+      if (needsBluetoothPermissions) {
+        const bluetoothPermissions: BluetoothPermission[] = []
+
+        if (typeof Platform.Version === "number" && Platform.Version < 31) {
+          bluetoothPermissions.push("android.permission.BLUETOOTH")
+          bluetoothPermissions.push("android.permission.BLUETOOTH_ADMIN")
+        }
+        if (typeof Platform.Version === "number" && Platform.Version >= 31) {
+          bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN)
+          bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT)
+          bluetoothPermissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE)
+        }
+
+        if (bluetoothPermissions.length > 0) {
+          const results = await PermissionsAndroid.requestMultiple(bluetoothPermissions as Permission[])
+          const allGranted = Object.values(results).every((value) => value === PermissionsAndroid.RESULTS.GRANTED)
+
+          if (!allGranted) {
+            const anyNeverAskAgain = Object.values(results).some(
+              (value) => value === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN,
+            )
+
+            if (anyNeverAskAgain) {
+              showAlert(
+                translate("pairing:permissionRequired"),
+                translate("pairing:bluetoothPermissionPreviouslyDenied"),
+                [
+                  {
+                    text: translate("pairing:openSettings"),
+                    onPress: () => Linking.openSettings(),
+                  },
+                  {
+                    text: translate("common:cancel"),
+                    style: "cancel",
+                  },
+                ],
+              )
+            } else {
+              showAlert(
+                translate("pairing:bluetoothPermissionRequiredTitle"),
+                translate("pairing:bluetoothPermissionRequiredMessage"),
+                [{text: translate("common:ok")}],
+              )
+            }
+            return false
+          }
+        }
+      }
+    }
+
+    if (needsBluetoothPermissions && Platform.OS === "ios") {
+      const requirementsMet = await checkConnectivityRequirementsUI()
+      if (!requirementsMet) return false
+    }
+
+    if (needsBluetoothPermissions) {
+      const bluetoothGranted = await requestFeaturePermissions(PermissionFeatures.BLUETOOTH)
+      if (!bluetoothGranted) {
+        showAlert(
+          translate("pairing:bluetoothPermissionRequiredTitle"),
+          translate("pairing:bluetoothPermissionRequiredMessageAlt"),
+          [{text: translate("common:ok")}],
+        )
+        return false
+      }
+    }
+
+    const microphoneGranted = await requestFeaturePermissions(PermissionFeatures.MICROPHONE)
+    if (!microphoneGranted) return false
+
+    if (Platform.OS === "android") {
+      const locationGranted = await requestFeaturePermissions(PermissionFeatures.LOCATION)
+      if (!locationGranted) return false
+
+      if (needsBluetoothPermissions) {
+        const requirementsMet = await checkConnectivityRequirementsUI()
+        if (!requirementsMet) return false
+      }
+    }
+  } catch (error) {
+    console.error("Error requesting pairing permissions:", error)
+    showAlert(translate("pairing:errorTitle"), translate("pairing:permissionsError"), [{text: translate("common:ok")}])
+    return false
+  }
+
+  // Pairing owns the microphone. Backend app shutdown can be slow, so do not block navigation.
+  void engine.miniapps.stopAll()
+  return true
+}


### PR DESCRIPTION
## Summary

- keep Mentra Live discovery advertisement-driven so an established connected owner is never auto-selected as a new pairing target
- preserve recovery for an explicitly selected pending target that connected before native pairing promotion
- scan immediately after prerequisites instead of showing two near-duplicate instruction screens
- let legacy firmware connect normally without pairing mode
- surface five-press guidance as soon as a newer idle unit appears while continuing to scan for other pairable or legacy units
- show in-place timeout recovery and retain the coded picker for multiple pairable units
- fix the existing Miniapp Developer setting callback type mismatch that blocked the mobile quality job

## Review findings already addressed

- #3791 Codex finding: connected recovery is now restricted by pending device name/address, with Android and iOS policy coverage
- #3792 Codex/Bugbot finding: an idle advertisement no longer stops the scan; a later pairable device can still auto-connect
- scanning is explicitly restarted when the user taps Scan Again so iOS refreshes an allowDuplicates=false advertisement after pairing mode changes

## Test evidence

- focused React Native pairing tests: 25 passed
- mobile TypeScript compile: passed
- scoped ESLint: 0 errors (existing warnings only)
- Bluetooth SDK Android compile: passed
- Android pending-target policy unit tests: passed
- exported iOS Swift package device build: passed

Supersedes #3791 and #3792.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch native Mentra Live discovery/pairing recovery and pairing success gating; regressions could block pairing or mis-classify secure vs legacy firmware, though behavior is covered by new tests and Maestro.
> 
> **Overview**
> **Mentra Live pairing** now skips the redundant prep screen: choosing Mentra Live runs shared `preparePairingScan` (permissions, connectivity, miniapp stop) and goes straight to the adaptive scan UI with new copy, five-press guidance when a nearby unit isn’t pairable, and **Scan Again** that stops then restarts discovery (important on iOS). The loading step only uses the legacy `pairing_info` timeout when scan explicitly marked firmware as non-secure; unknown capability **fails closed**.
> 
> **Bluetooth SDK (Android/iOS)** persists `pending_device_secure_pairing_capable` with the pending GATT target and only re-emits a connected device during manual discovery when it matches that pending name/address—so an already-paired owner is never surfaced as a new pairing candidate, while a selected unit that connected before promotion can still appear in the list.
> 
> Adds Maestro flow `04b-mentra-live-adaptive-scan`, unit tests for pending-target policy, and a small fix so the Miniapp Developer settings callback accepts an optional boolean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73acfe7a130603b2c478d39b2e7f79a8064f1a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Mentra Live pairing discovery adaptive and advertisement-driven: only an explicitly selected pending unit with an active GATT connection is re-emitted as a pairing target, never an established connected owner, and the scan screen now guides users through pairing in place instead of pushing a second instruction screen.

**Refactors**
- Connected recovery runs only during a manual scan, including right after GATT connects, so a pending target that connected before promotion is still re-emitted; iOS now tracks manual discovery intent to enforce this.
- The pending target’s secure-capable flag is stored and reused during recovery so a promoted unit isn’t downgraded to legacy behavior.
- `preparePairingScan` now owns the permission, connectivity, and miniapp-stop flow; Mentra Live runs it from the model screen and goes straight to scanning, while other models keep the prep screen.
- The scan screen keeps scanning when a newer idle unit is nearby, shows five-press pairing help, and no longer dead-ends at timeout, so a later pairable or legacy unit still auto-connects.
- Scan Again explicitly stops the prior scan before restarting so iOS refreshes its advertisement results after pairing mode changes.
- A new Maestro flow verifies direct Mentra Live scanning, no-result pairing help, and in-place retry.

**Bug Fixes**
- The pairing loading screen now fails closed when a recovered target’s secure capability is unknown, instead of running the legacy timeout.
- The Miniapp Developer setting callback now accepts an optional boolean, unblocking the mobile quality job.

<sup>Written for commit 73acfe7a130603b2c478d39b2e7f79a8064f1a3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

