### PR TITLE
Update live BES firmware to 26.8.26.0

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.8.19.4",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.19.4.bin",
-    "sha256": "3a878f3825e3ddfb9a1c7112852ff86aa07baac7d9860e2ee23057e80d8856a9"
+    "version": "26.8.26.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.26.0.bin",
+    "sha256": "94e2f657c6917934ef979fd20e96440230da2020e38153425ad953c6fd9300e3"
   }
 }


### PR DESCRIPTION
## Summary

- update firmware_live.json to BES 26.8.26.0
- use the URL and SHA-256 published by firmwarecdn.mentraglass.com/latest.json
- preserve the existing MTK patch list

## Validation

- downloaded the published BES binary and verified size 1,148,931 bytes
- verified SHA-256: 94e2f657c6917934ef979fd20e96440230da2020e38153425ad953c6fd9300e3
- jq empty asg_client/ota_manifests/firmware_live.json
- git diff --check
- confirmed only firmware_live.json changed and MTK patches are unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which binary the live OTA channel serves to glasses; incorrect URL or hash would break or mis-deliver firmware updates, though scope is limited to one manifest field.
> 
> **Overview**
> Updates the **live** OTA manifest so devices pull **BES firmware 26.8.26.0** instead of **26.8.19.4**, with the matching `firmwarecdn.mentraglass.com` download URL and SHA-256.
> 
> The **MTK patch list** in `firmware_live.json` is unchanged; only the `bes_firmware` block is replaced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7fbe2c9dfc4faff8751def58f022fc79021a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->