### PR TITLE
Harden iOS CI cache fallback

### DIFF
--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -102,10 +102,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: mobile/ios/build-device
-          key: xcode-derived-device-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/ios/Podfile.lock', 'mobile/package.json') }}
-          restore-keys: |
-            xcode-derived-device-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
-            xcode-derived-device-${{ runner.os }}-
+          # DerivedData and SwiftPM artifacts embed absolute workspace paths.
+          # Keep this cache runner-local and exact: restoring another runner's
+          # cache produced references to missing Mapbox XCFrameworks.
+          key: xcode-derived-device-${{ runner.name }}-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/ios/Podfile.lock', 'mobile/package.json', 'mobile/bun.lock') }}
 
       - name: Install dependencies
         id: bun-install
@@ -411,14 +411,19 @@ jobs:
           # sufficient. We intentionally do NOT `rm -rf ~/Library/.../DerivedData/Mentra-*`:
           # that global glob would delete other branches' in-flight DerivedData on this
           # shared runner, which was contributing to the cross-build failures.
-          rm -rf Pods Podfile.lock build-device
+          # Keep Podfile.lock so the retry resolves the same dependency graph as
+          # the first attempt rather than drifting to newer pod versions.
+          rm -rf Pods build-device
 
           # Reinstall pods from scratch with fresh repo
           pod install --repo-update
 
-          # Retry the build
+          # Retry serially. The fallback only runs after a failed cached build,
+          # and limiting concurrency avoids the observed CocoaPods VFS overlay
+          # disappearing while parallel compile and XCFramework copy jobs run.
           xcodebuild -workspace Mentra.xcworkspace \
                      -scheme Mentra \
+                     -jobs 1 \
                      -configuration Release \
                      -destination 'generic/platform=iOS' \
                      -derivedDataPath build-device \


### PR DESCRIPTION
## Summary

- scope the iOS DerivedData cache to the self-hosted runner and require an exact key match
- include mobile/bun.lock in DerivedData cache invalidation
- preserve Podfile.lock when retrying a failed device build
- serialize only the clean fallback build to avoid the CocoaPods VFS overlay race

## Context

The failed dev build restored DerivedData created under actions-runner-3 into actions-runner-2, leaving absolute SwiftPM paths that referenced missing Mapbox XCFrameworks. Its clean retry then failed while parallel build operations lost the CocoaPods all-product-headers.yaml VFS overlay.

Failing job: https://github.com/Mentra-Community/MentraOS/actions/runs/32995000601/job/98261922883

## Validation

- parsed the workflow successfully with Ruby YAML
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the iOS CI cache fallback to prevent stale DerivedData from other runners and avoid the CocoaPods VFS overlay race.

- DerivedData cache now uses an exact key scoped to the runner name instead of wildcard restores.
- Includes `mobile/bun.lock` in the cache key.
- Fallback retry now keeps `Podfile.lock` and runs `xcodebuild` serially.

<sup>Written for commit dda11b69e3f1ce094e38b5a36a079f2d41b93af2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; no app runtime, auth, or data-handling impact.
> 
> **Overview**
> **Hardens the self-hosted iOS workflow** so DerivedData/SwiftPM caches are not shared across runners and the post-failure clean retry is less flaky.
> 
> The **Xcode DerivedData cache** now keys on `runner.name`, drops `restore-keys` (exact match only), and folds `mobile/bun.lock` into the hash so stale cross-runner restores cannot leave absolute paths to missing Mapbox XCFrameworks.
> 
> On **clean retry after a failed device build**, the workflow keeps `Podfile.lock` when wiping `Pods` and `build-device`, and runs the fallback `xcodebuild` with **`-jobs 1`** to avoid CocoaPods VFS overlay races during parallel compile/XCFramework copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda11b69e3f1ce094e38b5a36a079f2d41b93af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->