### PR TITLE
Clarify legacy Wi-Fi OTA bootstrap

### DIFF
--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -15,12 +15,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
-| iOS `MentraBluetoothSDK` version `0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| React Native `@mentra/bluetooth-sdk@3.1.0-beta.23` | Mentra Live software `3.1.0-beta.23` |
+| Android `com.mentraglass:bluetooth-sdk:3.1.0-beta.23` | Mentra Live software `3.1.0-beta.23` |
+| iOS `MentraBluetoothSDK` version `3.1.0-beta.23` | Mentra Live software `3.1.0-beta.23` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.5`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.5` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `3.1.0-beta.23`, but SDK features may fail or behave incorrectly. Install the matching `3.1.0-beta.23` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -33,7 +33,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-beta.5`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.5/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `3.1.0-beta.23`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-3.1.0-beta.23/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -59,20 +59,29 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 
 1. Pair and connect the example app to Mentra Live.
 2. The full-screen update flow checks the glasses automatically.
-3. If an update is available, tap **Update Now**. Configure glasses Wi-Fi only if the flow asks for it; supported releases can use the Mentra Live hotspot instead.
+3. If an update is available, tap **Update Now**. Factory-stock glasses require
+   glasses Wi-Fi for their first update; after they run Mentra Live software 3.1
+   or newer, supported phones can use the Mentra Live hotspot instead.
 4. Keep the app connected and avoid using other glasses features while the update is running.
 5. Wait while the flow installs every required component and rechecks the glasses. They may restart during installation.
 6. Continue when the flow reports that the glasses are up to date.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.5`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `3.1.0-beta.23`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
 Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
 
-All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
+Each coordinated version has an immutable MentraOS release containing its
+complete OTA bundle. For `3.1.0-beta.23`, open the
+[Mentra 3.1.0-beta.23 release](https://github.com/Mentra-Community/MentraOS/releases/tag/mentra-v3.1.0-beta.23)
+and download `mentra-live-ota-bundle-3.1.0-beta.23.zip`. Extract the archive;
+its `artifacts` directory contains the matching ASG client APK.
 
-For the latest `0.1.21-beta.5` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.5-`.
+```bash
+unzip "$HOME/Downloads/mentra-live-ota-bundle-3.1.0-beta.23.zip" \
+  -d "$HOME/Downloads/mentra-live-ota-3.1.0-beta.23"
+```
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -80,17 +89,18 @@ Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to t
 adb devices
 ```
 
-Install the ASG client using the glasses serial shown by that command:
+Install the extracted ASG client using the glasses serial shown by that
+command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.5-build>.apk"
+  "$HOME/Downloads/mentra-live-ota-3.1.0-beta.23/artifacts/<asg-client-hash>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-beta.5` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.5` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `3.1.0-beta.23` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `3.1.0-beta.23` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App
@@ -103,6 +113,15 @@ version verification.
 
 Do not reproduce that sequencing with `checkForOtaUpdate()`,
 `startOtaUpdate()`, and `ota_status` listeners in React Native application code.
+
+<Warning>
+`wifi_required` is only a legacy bootstrap state. Mentra Live software earlier
+than 3.1 does not support hotspot OTA. Factory-stock glasses are delivered in
+this state, so their first update must use a Wi-Fi network configured on the
+glasses. After that update installs Mentra Live software 3.1 or newer,
+subsequent updates can use hotspot OTA and the flow should not require glasses
+Wi-Fi.
+</Warning>
 
 ## Use The Exact Mentra App OTA Pages
 

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -15,12 +15,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@3.1.0-beta.23` | Mentra Live software `3.1.0-beta.23` |
-| Android `com.mentraglass:bluetooth-sdk:3.1.0-beta.23` | Mentra Live software `3.1.0-beta.23` |
-| iOS `MentraBluetoothSDK` version `3.1.0-beta.23` | Mentra Live software `3.1.0-beta.23` |
+| React Native `@mentra/bluetooth-sdk@0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| iOS `MentraBluetoothSDK` version `0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `3.1.0-beta.23`, but SDK features may fail or behave incorrectly. Install the matching `3.1.0-beta.23` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.5`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.5` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -33,7 +33,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `3.1.0-beta.23`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-3.1.0-beta.23/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `0.1.21-beta.5`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.5/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -66,22 +66,15 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 5. Wait while the flow installs every required component and rechecks the glasses. They may restart during installation.
 6. Continue when the flow reports that the glasses are up to date.
 
-The example app uses the release-specific OTA manifest selected by SDK `3.1.0-beta.23`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.5`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
 Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
 
-Each coordinated version has an immutable MentraOS release containing its
-complete OTA bundle. For `3.1.0-beta.23`, open the
-[Mentra 3.1.0-beta.23 release](https://github.com/Mentra-Community/MentraOS/releases/tag/mentra-v3.1.0-beta.23)
-and download `mentra-live-ota-bundle-3.1.0-beta.23.zip`. Extract the archive;
-its `artifacts` directory contains the matching ASG client APK.
+All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
 
-```bash
-unzip "$HOME/Downloads/mentra-live-ota-bundle-3.1.0-beta.23.zip" \
-  -d "$HOME/Downloads/mentra-live-ota-3.1.0-beta.23"
-```
+For the latest `0.1.21-beta.5` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.5-`.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -89,18 +82,17 @@ Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to t
 adb devices
 ```
 
-Install the extracted ASG client using the glasses serial shown by that
-command:
+Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/mentra-live-ota-3.1.0-beta.23/artifacts/<asg-client-hash>.apk"
+  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.5-build>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `3.1.0-beta.23` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `3.1.0-beta.23` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `0.1.21-beta.5` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.5` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App


### PR DESCRIPTION
## Summary

- explain that `wifi_required` is the legacy bootstrap path for Mentra Live software earlier than 3.1
- call out that factory-stock glasses require glasses Wi-Fi for their first update
- explain that hotspot OTA becomes available after the glasses run Mentra Live software 3.1 or newer
- retain the current published `0.1.21-beta.5` release references instead of forecasting a future coordinated identity

## Release identity

The coordinated staging identity is allocated from `github.run_number` only after the staging push. It cannot be guaranteed by a preceding source commit. The documentation should move to the 3.1 beta only after that release has completed and its exact package, example APK, MentraOS release, and OTA bundle coordinates are known.

## Verification

- `git diff --check`
- `cd mintlify-docs && bunx --bun mint export --output /tmp/mentraos-pre31-wifi-docs.zip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to OTA/Wi-Fi guidance; no application or firmware behavior changes.
> 
> **Overview**
> **Clarifies when glasses Wi-Fi is required vs when hotspot OTA is allowed** in the Mentra Live software-update guide.
> 
> Step 3 of the example-app glasses install flow now states that **factory-stock** units must use **glasses Wi-Fi for the first update**, and that **Mentra Live software 3.1+** enables the **Mentra Live hotspot** path on supported phones for later updates.
> 
> A new **Warning** documents that **`wifi_required` is a legacy bootstrap state** for software **before 3.1** (no hotspot OTA), ties that to factory-stock delivery, and notes that **post-3.1** updates should not depend on configuring glasses Wi-Fi when hotspot OTA applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58dde37501dd9731a9017d1e4378c8e107297b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->