### PR TITLE
Wait for OTA hotspot teardown before rechecking

### DIFF
--- a/mobile/modules/engine/src/facades/ota.ts
+++ b/mobile/modules/engine/src/facades/ota.ts
@@ -135,9 +135,9 @@ export const ota = {
     detach: () => otaInstallCoordinator.detach(),
     /** Retry after a failure: clear state and re-send ota_start (if connected). */
     retry: () => otaInstallCoordinator.retry(),
-    /** Terminal cleanup for Continue/Done (navigation stays in the screen). */
+    /** Terminal cleanup for Continue/Done, including hotspot route teardown. */
     finish: () => otaInstallCoordinator.finish(),
-    /** Abandon an interrupted session (super-mode skip): finish() + drop the session's status/progress. */
+    /** Abandon an interrupted session: await finish() then drop the session's status/progress. */
     discard: () => otaInstallCoordinator.discard(),
     /** Current install read model (displayState/errorMsg/lockout + glasses OTA data). */
     snapshot: (): OtaInstallSnapshot => otaInstallCoordinator.snapshot(),

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -65,8 +65,10 @@ const prepare = mock(() => "hotspot" as const)
 const attach = mock(() => {})
 const detach = mock(() => {})
 const retry = mock(() => {})
-const finish = mock(() => {})
+let finishPromise = Promise.resolve()
+const finish = mock(() => finishPromise)
 const discard = mock(() => {})
+let autoChainActive = false
 
 const fakeOta = {
   initialize: mock(() => Promise.resolve()),
@@ -97,7 +99,7 @@ mock.module("../../facades/ota", () => ({ota: fakeOta}))
 mock.module("../../services/OtaAutoChain", () => ({
   beginOtaAutoChain: mock(() => {}),
   clearOtaAutoChainReconnectWait: mock(() => {}),
-  isOtaAutoChainActive: () => false,
+  isOtaAutoChainActive: () => autoChainActive,
   otaAutoChainFingerprint: () => "fingerprint",
   otaAutoChainReconnectWaitRemaining: () => null,
   stopOtaAutoChain: mock(() => {}),
@@ -137,6 +139,9 @@ describe("useMentraLiveOta", () => {
     retry.mockClear()
     finish.mockClear()
     discard.mockClear()
+    fakeOta.checkForUpdates.mockClear()
+    autoChainActive = false
+    finishPromise = Promise.resolve()
     installSnapshot = {
       displayState: "starting",
       errorMsg: "",
@@ -208,6 +213,37 @@ describe("useMentraLiveOta", () => {
     })
     latestController.retryInstall()
     expect(retry).toHaveBeenCalledTimes(1)
+    await act(async () => renderer.unmount())
+  })
+
+  test("keeps confirmed completion visible until hotspot teardown finishes", async () => {
+    autoChainActive = true
+    let resolveFinish!: () => void
+    finishPromise = new Promise<void>((resolve) => {
+      resolveFinish = resolve
+    })
+    const renderer = await renderProbe()
+    installSnapshot = {...installSnapshot, displayState: "complete"}
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+
+    expect(latestController.state.screen).toBe("complete")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 800))
+    })
+
+    expect(finish).toHaveBeenCalledTimes(1)
+    expect(fakeOta.checkForUpdates).not.toHaveBeenCalled()
+    expect(latestController.state.screen).toBe("complete")
+
+    await act(async () => {
+      resolveFinish()
+      await finishPromise
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(fakeOta.checkForUpdates).toHaveBeenCalledTimes(1)
     await act(async () => renderer.unmount())
   })
 })

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -387,10 +387,10 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     ) {
       return
     }
-    const timeout = setTimeout(() => {
+    const timeout = setTimeout(async () => {
       if (!isOtaAutoChainActive()) return
       autoChainAdvancedRef.current = true
-      ota.installSession.finish()
+      await ota.installSession.finish()
       returnToCheck()
     }, AUTO_CHAIN_COMPLETE_DELAY_MS)
     return () => clearTimeout(timeout)
@@ -430,7 +430,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     ota.installSession.retry()
   }, [page])
 
-  const finish = useCallback(() => {
+  const finish = useCallback(async () => {
     if (page === "check") {
       onFinishedRef.current?.()
       return
@@ -442,14 +442,14 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       installSnapshot.errorMsg,
     )
     if (requiresGlassesReboot) stopOtaAutoChain()
-    ota.installSession.finish()
+    await ota.installSession.finish()
     returnToCheck()
   }, [installSnapshot, page, returnToCheck])
 
-  const discard = useCallback(() => {
+  const discard = useCallback(async () => {
     if (page !== "progress") return
     stopOtaAutoChain()
-    ota.installSession.discard()
+    await ota.installSession.discard()
     returnToCheck()
   }, [page, returnToCheck])
 

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -450,7 +450,7 @@ class OtaInstallCoordinator {
    * stays in the screen): clear the selected update, and after an APK step
    * clear the stale build number so the next check re-reads version_info.
    */
-  finish(): void {
+  async finish(): Promise<void> {
     if (this.otaStartOwnership?.outcome !== "pending") {
       this.otaStartOwnership = null
     }
@@ -458,7 +458,9 @@ class OtaInstallCoordinator {
     if (this.apkStepSeen) {
       useGlassesStore.getState().setGlassesInfo({buildNumber: ""})
     }
-    void this.teardownHotspotTransport()
+    // The post-install check needs internet again. Do not let callers leave the
+    // terminal screen while Android still owns the no-internet hotspot route.
+    await this.teardownHotspotTransport()
   }
 
   /**
@@ -467,8 +469,8 @@ class OtaInstallCoordinator {
    * deriveDisplayState doesn't resurrect the stale install when the host
    * navigates away and back through /ota routes.
    */
-  discard(): void {
-    this.finish()
+  async discard(): Promise<void> {
+    await this.finish()
     const store = useGlassesStore.getState()
     store.setOtaStatus(null)
     store.setOtaProgress(null)

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -669,6 +669,35 @@ describe("OtaInstallCoordinator MTK completion", () => {
 })
 
 describe("OtaInstallCoordinator finish()", () => {
+  it("does not resolve until hotspot transport teardown finishes", async () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      hotspotOtaVersion: 1,
+      wifi: {state: "disconnected"},
+    })
+    otaInstallCoordinator.prepare(checkResult())
+    let resolveTeardown!: () => void
+    mockHotspotTeardown.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTeardown = resolve
+        }),
+    )
+
+    let finished = false
+    const finishPromise = otaInstallCoordinator.finish().then(() => {
+      finished = true
+    })
+    await Promise.resolve()
+
+    expect(mockHotspotTeardown).toHaveBeenCalledTimes(1)
+    expect(finished).toBe(false)
+
+    resolveTeardown()
+    await finishPromise
+    expect(finished).toBe(true)
+  })
+
   it("after an APK step clears the update prompt and the stale build number", () => {
     setGlassesConnected()
     useGlassesStore.getState().setGlassesInfo({buildNumber: "40"})

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import {render, act, fireEvent} from "@testing-library/react-native"
+import {render, act, fireEvent, waitFor} from "@testing-library/react-native"
 
 import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
 import {useNavigationStore} from "@/stores/navigation"
@@ -437,7 +437,7 @@ describe("progress.tsx display states", () => {
     expect(getByText("Glasses disconnected")).toBeDefined()
   })
 
-  it("shows Skip (super) when disconnected in super mode", () => {
+  it("shows Skip (super) when disconnected in super mode", async () => {
     setSuperMode(true)
     setGlassesDisconnected()
     useGlassesStore.getState().setOtaStatus({
@@ -454,7 +454,7 @@ describe("progress.tsx display states", () => {
     const {getByText, getByTestId} = render(<OtaProgressScreen />)
     expect(getByText("Skip (super)")).toBeDefined()
     fireEvent.press(getByTestId("button-Skip (super)"))
-    expect(replaceSpy).toHaveBeenCalled()
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalled())
     replaceSpy.mockRestore()
   })
 


### PR DESCRIPTION
## Summary

- await hotspot transport teardown before leaving a terminal OTA state
- keep the confirmed completion screen visible until Android releases the no-internet glasses hotspot route
- make manual finish and discard follow the same cleanup contract
- cover the coordinator and React auto-chain race with regression tests
- await the now-asynchronous discard navigation in the existing super-mode UI test

## Why

Connected-hardware verification of the public custom OTA UI completed a hotspot update successfully: the phone served the manifest and 109,479,201-byte APK over the glasses hotspot, ASG advanced from 100000012 to 100000015, the ASG session changed, and the controller reached `complete`.

Immediately afterward, the auto-chain called `finish()` and rechecked the remote manifest while hotspot teardown was still running. Android still routed through the no-internet glasses hotspot, so the successful terminal screen was replaced by `Update check failed`.

This fixes the ordering in Mentra Engine instead of requiring host apps to latch or special-case success.

## Verification

- `cd mobile && bun run test --runInBand` — 706 passed, 2 skipped
- `bun test mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx` — 3 passed
- `cd mobile && bun run test --runInBand src/__tests__/otaInstallCoordinator.test.ts` — 84 passed
- `cd mobile && bun run compile` — passed
- `git diff --check` — passed

## Hardware evidence

- Z Fold Android phone
- Mentra Live 023B
- custom UI using published Engine/Bluetooth SDK packages
- local hotspot manifest and APK requests returned HTTP 200
- exact APK response bytes: 109,479,201
- ASG version after replacement: `asg.100000015.5bae766f5708`
- OTA status reached `complete`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering in the OTA terminal/auto-chain path (hotspot teardown vs update recheck); scope is narrow and covered by new tests, but failures would still affect post-install UX and networking.
> 
> **Overview**
> Fixes a race where **hotspot OTA auto-chain** called `finish()` and immediately re-ran the manifest check while Android still held the glasses **no-internet hotspot route**, flipping a successful **complete** screen to **Update check failed**.
> 
> **`OtaInstallCoordinator.finish()`** and **`discard()`** are now **`async`** and **`await`** **`teardownHotspotTransport()`** so terminal cleanup does not return until the phone can use normal internet again. **`useMentraLiveOta`** awaits that cleanup in the auto-chain delay path and in manual **finish** / **discard** before **`returnToCheck()`**, so the UI stays on **complete** until teardown finishes and **`checkForUpdates`** runs afterward.
> 
> Facade comments were updated to document hotspot teardown on **finish** and async **discard**. Regression tests cover coordinator **`finish`** resolution vs teardown and the React hook keeping **complete** visible until **`finish`** resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b1ddb32fdf501f0e98e7a08166a61a5bb4dc0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->