### PR TITLE
Avoid OTA completion console errors

### DIFF
--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -1068,7 +1068,7 @@ class OtaInstallCoordinator {
     if (this.otaStartOwnership?.outcome === "pending") {
       void this.sendOtaStartWithWatchdogs()
     }
-    void BluetoothSdk.queryOtaStatus()
+    void BluetoothSdk.queryOtaStatus().catch(() => {})
     this.armQueryReplyFallback("reconnect")
     return true
   }
@@ -1128,7 +1128,7 @@ class OtaInstallCoordinator {
       void this.sendOtaStartWithWatchdogs()
     } else {
       console.log("[OTA_PROGRESS] initial mount, session exists, sending ota_query_status")
-      void BluetoothSdk.queryOtaStatus()
+      void BluetoothSdk.queryOtaStatus().catch(() => {})
       this.armQueryReplyFallback("initial-mount")
     }
   }
@@ -1157,7 +1157,7 @@ class OtaInstallCoordinator {
     this.clearProgressTimeout()
     this.onFirstActivity()
     this.onFirstNonZeroProgress()
-    void BluetoothSdk.queryOtaStatus()
+    void BluetoothSdk.queryOtaStatus().catch(() => {})
     useGlassesStore.getState().setMtkUpdatedThisSession(true)
   }
 

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -121,7 +121,7 @@ async function fetchVersionInfoDetailed(url: string): Promise<ManifestFetchResul
   try {
     const response = await fetch(url)
     if (!response.ok) {
-      console.error("Failed to fetch version info:", response.status)
+      console.warn("Failed to fetch version info:", response.status)
       // 4xx: the manifest does not exist (or is gone) — permanent for this app
       // build, retrying cannot help. Everything else is transient server/network
       // trouble and retryable.
@@ -133,11 +133,11 @@ async function fetchVersionInfoDetailed(url: string): Promise<ManifestFetchResul
     try {
       return {json: await response.json()}
     } catch (parseError) {
-      console.error("OTA: manifest is not valid JSON:", parseError)
+      console.warn("OTA: manifest is not valid JSON:", parseError)
       return {json: null, failureReason: "pin_unavailable"}
     }
   } catch (error) {
-    console.error("OTA: Error fetching version info:", error)
+    console.warn("OTA: Error fetching version info:", error)
     return {json: null, failureReason: "network"}
   }
 }

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -910,6 +910,19 @@ describe("OtaInstallCoordinator legacy ota_progress normalization (WP 8C-a)", ()
     expect(bluetoothSdkMock.startOtaUpdate).not.toHaveBeenCalled()
   })
 
+  it("swallows a concurrent status-query rejection after an ASG session restart", async () => {
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 0, overallPercent: 100}))
+    bluetoothSdkMock.queryOtaStatus.mockClear().mockRejectedValueOnce(new Error("request_in_flight"))
+
+    GlobalEventEmitter.emit("glasses_session_changed", {previousSid: "old", sid: "new"})
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(bluetoothSdkMock.queryOtaStatus).toHaveBeenCalledTimes(1)
+  })
+
   it("glasses_session_changed after APK completion queries the ASG-owned session without sending ota_start", async () => {
     // The ASG persists and auto-resumes a unified multi-step session after its APK
     // process restart. The phone observes that session; it must not start a second

--- a/mobile/src/__tests__/otaUpdateCheckService.test.ts
+++ b/mobile/src/__tests__/otaUpdateCheckService.test.ts
@@ -147,6 +147,26 @@ describe("OtaUpdateCheckService", () => {
     expect(result.checkFailureReason).toBe("network")
   })
 
+  it("keeps a handled network check failure out of the error console", async () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {})
+    global.fetch = jest.fn(() => Promise.reject(new Error("network switching"))) as unknown as typeof fetch
+
+    const result = await checkCurrentGlassesForUpdate({
+      refreshVersionInfo: false,
+      fixClockBeforeCheck: false,
+      waitForBesVersionMs: 0,
+      waitForMtkVersionMs: 0,
+    })
+
+    expect(result.hasCheckCompleted).toBe(false)
+    expect(result.checkFailureReason).toBe("network")
+    expect(consoleWarn).toHaveBeenCalledWith("OTA: Error fetching version info:", expect.any(Error))
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+    consoleWarn.mockRestore()
+  })
+
   it("skips (missing_build) for an unparseable or zero glasses build number", async () => {
     useGlassesStore.getState().setGlassesInfo({buildNumber: "0"})
     global.fetch = jest.fn() as unknown as typeof fetch


### PR DESCRIPTION
## Summary

- absorb expected best-effort OTA status-query rejections during ASG restart reconciliation
- log handled manifest-fetch failures as warnings so customer development builds do not show a red Expo error screen
- cover both behaviors with focused regression tests

## Hardware finding

On a Z Fold and Mentra Live 023B, the public 3.1.0-dev.22 custom OTA flow successfully transferred the 109,479,201-byte ASG artifact over the glasses hotspot, upgraded ASG 100000012 to 100000015, observed the new ASG session, shut down the hotspot, restored the normal phone network, and reached the up-to-date page. During completion, the install poll and session-reconnect reconciliation briefly overlapped, producing the native request_in_flight rejection. The post-hotspot manifest retry also logged its handled first network miss with console.error. Together those opened Expo LogBox despite a successful update.

## Verification

- 96 focused OTA Jest tests pass
- mobile TypeScript compile passes
- git diff check passes
- hardware reproduction and successful OTA end state captured on Z Fold plus Mentra Live 023B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and promise-rejection handling only; OTA control flow and failure classification are unchanged aside from swallowing already-ignored query rejections.
> 
> **Overview**
> Stops **false-positive Expo error UI** during otherwise successful OTA flows by treating two expected failure paths as non-fatal at the logging/promise layer.
> 
> **Install coordinator:** Fire-and-forget `BluetoothSdk.queryOtaStatus()` calls on reconnect, initial mount, and MTK complete now use `.catch(() => {})`, so native `request_in_flight` rejections when install polling overlaps ASG session restarts no longer surface as unhandled promise rejections.
> 
> **Update check:** Manifest fetch paths that already return structured `checkFailureReason` (HTTP errors, bad JSON, network errors) log with **`console.warn`** instead of **`console.error`**, so handled post-hotspot or transient network misses do not trigger the red LogBox in dev builds.
> 
> Regression tests cover a concurrent query rejection after `glasses_session_changed` and assert network check failures warn without calling `console.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6465b4f7423d3ca2d369521d3fa4d9b3895f4891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->