### PR TITLE
Use coordinated semver for ASG version names

### DIFF
--- a/.github/scripts/compute-asg-build-identity.mjs
+++ b/.github/scripts/compute-asg-build-identity.mjs
@@ -51,13 +51,13 @@ export function computeAsgBuildFingerprint({entries, latestInputCommitTimestamp,
   }
 }
 
-export function finalizeAsgBuildIdentity({buildFingerprint, versionCode}) {
+export function finalizeAsgBuildIdentity({buildFingerprint, versionCode, versionName}) {
   const {fingerprint} = buildFingerprint
   if (!/^[0-9a-f]{64}$/.test(fingerprint)) throw new Error("Invalid ASG build fingerprint")
   if (!Number.isSafeInteger(versionCode) || versionCode <= 0 || versionCode > 2_100_000_000) {
     throw new Error(`Allocated ASG versionCode ${versionCode} is outside the Android-safe range`)
   }
-  const versionName = `asg.${versionCode}.${fingerprint.slice(0, 12)}`
+  if (!versionName) throw new Error("ASG versionName is required")
   return {
     ...buildFingerprint,
     versionCode,
@@ -67,10 +67,11 @@ export function finalizeAsgBuildIdentity({buildFingerprint, versionCode}) {
   }
 }
 
-export function computeAsgBuildIdentity({entries, latestInputCommitTimestamp, versionCode, contract = BUILD_CONTRACT}) {
+export function computeAsgBuildIdentity({entries, latestInputCommitTimestamp, versionCode, versionName, contract = BUILD_CONTRACT}) {
   return finalizeAsgBuildIdentity({
     buildFingerprint: computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, contract}),
     versionCode,
+    versionName,
   })
 }
 
@@ -122,7 +123,11 @@ function main() {
   const output = path.resolve(repoRoot, args.output || "asg-build-identity.json")
   const buildFingerprint = computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit})
   const identity = args["version-code"]
-    ? finalizeAsgBuildIdentity({buildFingerprint, versionCode: Number(args["version-code"])})
+    ? finalizeAsgBuildIdentity({
+        buildFingerprint,
+        versionCode: Number(args["version-code"]),
+        versionName: args["version-name"],
+      })
     : buildFingerprint
   mkdirSync(path.dirname(output), {recursive: true})
   writeFileSync(output, `${JSON.stringify(identity, null, 2)}\n`)

--- a/.github/scripts/compute-asg-build-identity.test.mjs
+++ b/.github/scripts/compute-asg-build-identity.test.mjs
@@ -11,33 +11,37 @@ const entries = [
   {mode: "100644", object: "a".repeat(40), path: "asg_client/app/build.gradle"},
   {mode: "160000", object: "b".repeat(40), path: "asg_client/StreamPackLite"},
 ]
+const versionName = "3.1.0-beta.57"
 
 test("derives a deterministic content-addressed ASG identity", () => {
-  const first = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057})
+  const first = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057, versionName})
   const reordered = computeAsgBuildIdentity({
     entries: [...entries].reverse(),
     latestInputCommitTimestamp: 1_782_000_000,
     versionCode: 100_057,
+    versionName,
   })
 
   assert.deepEqual(first, reordered)
   assert.match(first.fingerprint, /^[0-9a-f]{64}$/)
   assert.equal(first.versionCode, 100_057)
-  assert.equal(first.versionName, `asg.100057.${first.fingerprint.slice(0, 12)}`)
+  assert.equal(first.versionName, versionName)
   assert.equal(first.apkAsset, `mentra-live-asg-${first.versionCode}-${first.fingerprint}.apk`)
 })
 
 test("changes identity when an effective source or build contract changes", () => {
-  const baseline = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057})
+  const baseline = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057, versionName})
   const sourceChange = computeAsgBuildIdentity({
     entries: [{...entries[0], object: "c".repeat(40)}, entries[1]],
     latestInputCommitTimestamp: 1_782_000_100,
     versionCode: 100_058,
+    versionName,
   })
   const contractChange = computeAsgBuildIdentity({
     entries,
     latestInputCommitTimestamp: 1_782_000_000,
     versionCode: 100_057,
+    versionName,
     contract: {androidBuildVariant: "release", javaVersion: "21"},
   })
 
@@ -48,8 +52,8 @@ test("changes identity when an effective source or build contract changes", () =
 
 test("allocates the externally selected version code without changing the content fingerprint", () => {
   const fingerprint = computeAsgBuildFingerprint({entries, latestInputCommitTimestamp: 1_782_000_000})
-  const first = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_057})
-  const later = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_099})
+  const first = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_057, versionName})
+  const later = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_099, versionName})
 
   assert.equal(first.fingerprint, later.fingerprint)
   assert.equal(first.versionCode, 100_057)
@@ -58,7 +62,7 @@ test("allocates the externally selected version code without changing the conten
 
 test("rejects malformed input entries, timestamps, and version codes", () => {
   assert.throws(
-    () => computeAsgBuildIdentity({entries: [], latestInputCommitTimestamp: 1, versionCode: 100_001}),
+    () => computeAsgBuildIdentity({entries: [], latestInputCommitTimestamp: 1, versionCode: 100_001, versionName}),
     /must not be empty/,
   )
   assert.throws(
@@ -67,11 +71,12 @@ test("rejects malformed input entries, timestamps, and version codes", () => {
         entries: [{mode: "bad", object: "x", path: "asg"}],
         latestInputCommitTimestamp: 1,
         versionCode: 100_001,
+        versionName,
       }),
     /Invalid ASG build input/,
   )
   assert.throws(
-    () => computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1, versionCode: 0}),
+    () => computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1, versionCode: 0, versionName}),
     /outside the Android-safe range/,
   )
 })

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -155,12 +155,27 @@ jobs:
             echo "provenance_asset=$(jq -r .provenanceAsset coordinated-ota-work/asg-allocation.json)"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve ASG version name
+        id: asg-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROVENANCE_ASSET: ${{ steps.existing-asg.outputs.provenance_asset }}
+        run: |
+          version_name=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          if [[ "${{ steps.existing-asg.outputs.exists }}" == "true" ]]; then
+            gh release download "$ASG_RELEASE_TAG" --pattern "$PROVENANCE_ASSET" --dir coordinated-ota-work
+            mv "coordinated-ota-work/$PROVENANCE_ASSET" coordinated-ota-work/asg-provenance.json
+            version_name=$(jq -er .versionName coordinated-ota-work/asg-provenance.json)
+          fi
+          echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
+
       - name: Finalize effective ASG build identity
         id: asg-identity
         run: >-
           node .github/scripts/compute-asg-build-identity.mjs
           --source-commit "${{ github.sha }}"
           --version-code "${{ steps.existing-asg.outputs.version_code }}"
+          --version-name "${{ steps.asg-version.outputs.version_name }}"
           --output coordinated-ota-work/asg-build-identity.json
 
       - name: Prepare immutable asset names
@@ -199,16 +214,14 @@ jobs:
             echo "result_artifact=coordinated-ota-${release_set_id}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Download reusable ASG artifact and provenance
+      - name: Download reusable ASG artifact
         if: steps.existing-asg.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           APK_ASSET: ${{ steps.names.outputs.apk_asset }}
-          PROVENANCE_ASSET: ${{ steps.names.outputs.provenance_asset }}
         run: |
-          gh release download "$ASG_RELEASE_TAG" --pattern "$APK_ASSET" --pattern "$PROVENANCE_ASSET" --dir coordinated-ota-work
+          gh release download "$ASG_RELEASE_TAG" --pattern "$APK_ASSET" --dir coordinated-ota-work
           mv "coordinated-ota-work/$APK_ASSET" coordinated-ota-work/asg.apk
-          mv "coordinated-ota-work/$PROVENANCE_ASSET" coordinated-ota-work/asg-provenance.json
 
       - name: Setup Java for ASG build and APK verification
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary

- give each newly built ASG APK the coordinated release semver, such as `3.1.0-dev.23`, as its Android `versionName`
- preserve the embedded version name recorded in provenance when an unchanged ASG APK is reused by later release sets
- fail identity generation when no version name is supplied instead of synthesizing `asg.<versionCode>.<fingerprint>`

This intentionally does not repackage or rebuild an unchanged ASG APK just to rename it. A reused APK continues to display the semver of the release that originally built it. Full version alignment during production promotion remains future release-design work.

## Verification

- `node --test .github/scripts/compute-asg-build-identity.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs`
- `actionlint .github/workflows/reusable-coordinated-ota.yml`
- `git diff --check`
- generated identity smoke check: `versionCode=100000023`, `versionName=3.1.0-dev.23`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated OTA release identity and version resolution; mis-resolved names could fail APK verification or mislabel reused artifacts, but scope is CI/packaging only.
> 
> **Overview**
> ASG build identity now takes an explicit **Android `versionName`** (coordinated release semver from `release-plan.json`) instead of auto-generating `asg.<versionCode>.<fingerprint>`. **`finalizeAsgBuildIdentity` errors if `versionName` is missing**, and the identity CLI gains **`--version-name`**.
> 
> The coordinated OTA workflow adds **Resolve ASG version name**: new builds use `releaseIdentity`; when an existing APK is reused, the name is read from the downloaded **provenance** so metadata matches the binary that was actually built. Provenance is fetched in that step; the reuse download step now pulls **only the APK**.
> 
> Tests assert the supplied semver is stored unchanged on the identity object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb98a51cb61634ac499aaeea4a275f25bfecfc9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->