### PR TITLE
Skip pairing info wait for existing Mentra Live firmware

### DIFF
--- a/agents/OS-1615-mentra-live-pairing-ux-plan.md
+++ b/agents/OS-1615-mentra-live-pairing-ux-plan.md
@@ -160,7 +160,7 @@ Retired. MentraOS must not send `wipe_media`, `pairing_finalize`, `pairing_abort
 | Adv | Mentra manufacturer `0xB822`: existing pairing flag byte + versioned trailer (capability + code) |
 | Vs transfer_id | Distinct; code for UX, transfer_id for transaction correlation |
 
-Legacy ads without the Mentra company/flag remain pairable during the compatibility window with clear labeling and mandatory OTA after pair.
+Advertisements without the secure-pairing capability represent existing customer firmware. They remain pairable without the five-tap gate or a compatibility label; normal post-pair OTA policy applies independently.
 
 ---
 
@@ -190,7 +190,7 @@ Capability: protocol version + capability bitmask for mixed-version rollout.
 ## 9. Mobile UX (engine.pairing)
 
 - Prep: five taps, flashing LED, spoken code, match code in app.
-- Scan: filter secure firmware by pairing mode; saved-device reconnect bypasses filter; legacy labeled and OTA-forced; auto-connect when exactly one eligible; multi-result list shows four-char codes; 15 s timeout only when zero eligible; Try Again restarts in place; generation-based stale-callback protection.
+- Scan: filter secure firmware by pairing mode; saved-device reconnect bypasses filter; existing customer firmware remains pairable under its current behavior and uses its normal device name; auto-connect when exactly one eligible; multi-result list shows four-char codes; 15 s timeout only when zero eligible; Try Again restarts in place; generation-based stale-callback protection.
 - Loading: `pairing_info` is a readiness signal only. Ignore `had_previous_bond` for UI gating. Do not confirm, wipe, finalize, or abort a pairing transfer. Secure-capable firmware does not use the legacy pairing_info timeout fallback.
 
 ---

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -330,6 +330,7 @@ const mockIslandEntries = () => {
   // implementation (pure: settings store + types only) so host screens/tests
   // exercise the actual three-state read-model, not a parallel stub.
   const realPairingIdentity = jest.requireActual("./modules/engine/src/services/PairingIdentity")
+  const realPairingFacade = jest.requireActual("./modules/engine/src/facades/pairing")
   // Clock-skew utils moved into island; the host gallery sync + OTA checker import them
   // from @mentra/engine, so expose the real (pure) implementations through the mock.
   const realGlassesClockSync = jest.requireActual("./modules/engine/src/services/glassesClockSync")
@@ -558,6 +559,8 @@ const mockIslandEntries = () => {
             cb(readiness)
           })
         }),
+        targetReady: jest.fn((options) => realPairingFacade.pairing.targetReady(options)),
+        onTargetReady: jest.fn((options, cb) => realPairingFacade.pairing.onTargetReady(options, cb)),
         // Identity lifecycle: real projection/writes over the real settings store,
         // so tests observe the same none/pending/paired snapshots the app does.
         identity: jest.fn(() => realPairingIdentity.projectPairingIdentity()),

--- a/mobile/modules/engine/src/facades/pairing.ts
+++ b/mobile/modules/engine/src/facades/pairing.ts
@@ -13,6 +13,7 @@ import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
 import type {ConnectOptions, Device, DeviceModel, PairFailureEvent, GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
 import {useCoreStore} from "../stores/core"
 import {useGlassesStore} from "../stores/glasses"
+import {SETTINGS, useSettingsStore} from "../stores/settings"
 import {hasDefaultDevice} from "../services/DeviceStoreHydration"
 import {
   markPendingSelection,
@@ -20,18 +21,14 @@ import {
   subscribePairingIdentity,
   type IdentitySnapshot,
 } from "../services/PairingIdentity"
-import {
-  isGlassesConnected,
-  isGlassesLinkLayerBusy,
-  isGlassesReady,
-  waitForGlassesReady,
-} from "../services/GlassesReadiness"
+import {isGlassesConnected, isGlassesLinkLayerBusy, isGlassesReady} from "../services/GlassesReadiness"
 import {
   logAutomaticReportSubmissionStatus,
   toAutomaticReportSubmissionStatus,
   type AutomaticReportSubmissionStatus,
 } from "../services/AutomaticReportResult"
 import {pushAllBluetoothSettings} from "../services/GlassesSettingsSync"
+import {ControllerTypes} from "../types"
 import {submitAutomaticReport} from "./reports"
 
 export type {IdentitySnapshot} from "../services/PairingIdentity"
@@ -58,6 +55,82 @@ function projectReadiness() {
     bluetoothClassicConnected: s.bluetoothClassicConnected,
     nativeLinkBusy: isGlassesLinkLayerBusy(s.connection),
   }
+}
+
+function projectTargetReady(options: Pick<PairingReadyWaitOptions, "deviceModel" | "deviceName">): boolean {
+  const {deviceModel, deviceName} = options
+  const glasses = useGlassesStore.getState()
+
+  if (deviceModel === ControllerTypes.R1) {
+    if (!glasses.controllerConnected || !glasses.controllerFullyBooted) return false
+    const settings = useSettingsStore.getState()
+    const pairedModel = settings.getSetting(SETTINGS.default_controller.key)
+    const pairedName = settings.getSetting(SETTINGS.controller_device_name.key)
+    return (!deviceModel || pairedModel === deviceModel) && (!deviceName || pairedName === deviceName)
+  }
+
+  if (!isGlassesReady(glasses.connection)) return false
+  const identity = projectPairingIdentity()
+  if (!deviceModel && !deviceName) return true
+  return (
+    identity.kind === "paired" &&
+    (!deviceModel || identity.model === deviceModel) &&
+    (!deviceName || identity.name === deviceName)
+  )
+}
+
+function subscribeTargetReady(
+  options: Pick<PairingReadyWaitOptions, "deviceModel" | "deviceName">,
+  cb: (ready: boolean) => void,
+): () => void {
+  let last = projectTargetReady(options)
+  const notify = () => {
+    const ready = projectTargetReady(options)
+    if (ready === last) return
+    last = ready
+    cb(ready)
+  }
+  const unsubscribeGlasses = useGlassesStore.subscribe(notify)
+  const unsubscribeSettings = useSettingsStore.subscribe(notify)
+  return () => {
+    unsubscribeGlasses()
+    unsubscribeSettings()
+  }
+}
+
+async function waitForTargetReady(options: PairingReadyWaitOptions, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (options.signal?.aborted) {
+      resolve(false)
+      return
+    }
+    if (projectTargetReady(options)) {
+      resolve(true)
+      return
+    }
+
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    let unsubscribe: (() => void) | null = null
+    let onAbort: (() => void) | null = null
+    const finish = (ready: boolean) => {
+      if (settled) return
+      settled = true
+      if (timeout) clearTimeout(timeout)
+      if (unsubscribe) unsubscribe()
+      if (onAbort && options.signal) options.signal.removeEventListener("abort", onAbort)
+      resolve(ready)
+    }
+
+    unsubscribe = subscribeTargetReady(options, (ready) => {
+      if (ready) finish(true)
+    })
+    if (options.signal) {
+      onAbort = () => finish(false)
+      options.signal.addEventListener("abort", onAbort)
+    }
+    timeout = setTimeout(() => finish(projectTargetReady(options)), timeoutMs)
+  })
 }
 
 export type PairingReadinessSnapshot = ReturnType<typeof projectReadiness>
@@ -108,12 +181,7 @@ async function waitForReadyDuringPairing(options: PairingReadyWaitOptions = {}):
   })
 
   try {
-    const ready = await waitForGlassesReady({
-      getConnection: () => useGlassesStore.getState().connection,
-      subscribe: (listener) => useGlassesStore.subscribe((state) => state.connection, listener),
-      timeoutMs,
-      signal: options.signal,
-    })
+    const ready = await waitForTargetReady(options, timeoutMs)
 
     if (!ready && !options.signal?.aborted) {
       void submitPairingBootTimeoutReport({
@@ -193,6 +261,14 @@ export const pairing = {
       cb(snap)
     })
   },
+  /** Whether the exact wearable or controller selected on the scan screen is ready. */
+  targetReady: (options: Pick<PairingReadyWaitOptions, "deviceModel" | "deviceName">): boolean =>
+    projectTargetReady(options),
+  /** Subscribe to readiness for the exact selected target, excluding stale devices. */
+  onTargetReady: (
+    options: Pick<PairingReadyWaitOptions, "deviceModel" | "deviceName">,
+    cb: (ready: boolean) => void,
+  ): (() => void) => subscribeTargetReady(options, cb),
 
   // --- pairing-identity lifecycle (the PairingIdentity read-model + the JS-owned
   // identity writes; promotion to `paired` only ever happens natively) ---

--- a/mobile/src/__tests__/app/pairing/btclassic.test.tsx
+++ b/mobile/src/__tests__/app/pairing/btclassic.test.tsx
@@ -90,7 +90,7 @@ describe("btclassic pairing screen", () => {
     ;(usePushPrevious as jest.Mock).mockReturnValue(pushPrevious)
   })
 
-  it("kicks off the connect and reveals loading once Bluetooth Classic links", async () => {
+  it("reveals loading once Bluetooth Classic links and lets loading own the connect", async () => {
     render(<BtClassicPairingScreen />)
 
     act(() => {
@@ -98,34 +98,10 @@ describe("btclassic pairing screen", () => {
     })
 
     await waitFor(() => {
-      expect(engine.glasses.connect).toHaveBeenCalledWith(device, {saveAsDefault: false})
       expect(pushPrevious).toHaveBeenCalled()
     })
-
-    // The resolved kickoff must not trigger the failure route.
-    await act(async () => {})
+    expect(engine.glasses.connect).not.toHaveBeenCalled()
     expect(replace).not.toHaveBeenCalled()
-  })
-
-  it("routes a connect kickoff rejection to the failure screen", async () => {
-    ;(engine.glasses.connect as jest.Mock).mockRejectedValueOnce(new Error("bluetooth powered off"))
-
-    render(<BtClassicPairingScreen />)
-
-    act(() => {
-      useGlassesStore.getState().setGlassesInfo({bluetoothClassicConnected: true})
-    })
-
-    await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith("/pairing/failure", {
-        error: "errors:pairingCouldNotStart",
-        deviceModel: "Mentra Live",
-      })
-    })
-    expect(pushPrevious).toHaveBeenCalled()
-    // Parity with loading.tsx's handlePairFailure: the failed attempt is
-    // cleared before the failure screen shows.
-    expect(engine.pairing.abandonAttempt).toHaveBeenCalled()
   })
 
   it("routes a connectDefault rejection to the failure screen while loading is on top", async () => {

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -2,7 +2,7 @@ import {act, fireEvent, render, waitFor} from "@testing-library/react-native"
 import type {ReactNode} from "react"
 
 import {engine} from "@mentra/engine"
-import {useRoute} from "@react-navigation/native"
+import {useIsFocused, useRoute} from "@react-navigation/native"
 import {useNavigationStore} from "@/stores/navigation"
 import GlassesPairingLoadingScreen from "@/app/pairing/loading"
 // The glasses store is private to the local engine workspace and has no public test export.
@@ -21,6 +21,7 @@ jest.mock("@mentra/bluetooth-sdk", () => {
 })
 
 jest.mock("@react-navigation/native", () => ({
+  useIsFocused: jest.fn(() => true),
   useRoute: jest.fn(),
 }))
 
@@ -107,6 +108,20 @@ jest.mock("@/components/glasses/GlassesPairingLoader", () => {
 describe("pairing loading screen", () => {
   const replace = jest.fn()
   const goBack = jest.fn()
+  const makeDevice = (model: string, name: string) => ({id: name, model, name})
+  const makeRouteParams = (model: string, name: string, extra: Record<string, unknown> = {}) => ({
+    device: JSON.stringify(makeDevice(model, name)),
+    deviceModel: model,
+    deviceName: name,
+    ...extra,
+  })
+
+  const startPairingKickoff = async () => {
+    act(() => {
+      jest.advanceTimersByTime(2_000)
+    })
+    await act(async () => {})
+  }
 
   beforeEach(() => {
     jest.useFakeTimers()
@@ -114,8 +129,9 @@ describe("pairing loading screen", () => {
     jest.clearAllMocks()
     useGlassesStore.getState().reset()
     useSettingsStore.getState().resetAllSettingsLocally()
+    ;(useIsFocused as jest.Mock).mockReturnValue(true)
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_001"},
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_001"),
     })
     ;(useNavigationStore.getState as jest.Mock).mockReturnValue({replace, goBack})
     ;(engine.pairing.waitForBluetoothClassic as jest.Mock)?.mockResolvedValue?.(true)
@@ -137,6 +153,7 @@ describe("pairing loading screen", () => {
 
   it("shows booting after glasses_not_ready and routes pair failures to the failure screen", async () => {
     const {getByText} = render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     expect(getByText("waiting")).toBeTruthy()
 
@@ -160,8 +177,24 @@ describe("pairing loading screen", () => {
     })
   })
 
+  it("routes a selected-device kickoff rejection instead of leaving loading stuck", async () => {
+    ;(engine.pairing.pair as jest.Mock).mockRejectedValueOnce(new Error("bluetooth powered off"))
+    render(<GlassesPairingLoadingScreen />)
+
+    await startPairingKickoff()
+
+    await waitFor(() => {
+      expect(engine.pairing.abandonAttempt).toHaveBeenCalled()
+      expect(replace).toHaveBeenCalledWith("/pairing/failure", {
+        error: "errors:pairingCouldNotStart",
+        deviceModel: "Mentra Live",
+      })
+    })
+  })
+
   it("navigates to success after boot and files a timeout report after 35 seconds", async () => {
     const first = render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       emitBluetoothSdkEvent("pairing_info", {had_previous_bond: false})
@@ -192,6 +225,7 @@ describe("pairing loading screen", () => {
     replace.mockClear()
     useGlassesStore.getState().reset()
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       jest.advanceTimersByTime(35_000)
@@ -210,9 +244,10 @@ describe("pairing loading screen", () => {
 
   it("does not wait for pairing_info when the advertisement reports existing pairing behavior", async () => {
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_EXISTING", securePairingCapable: false},
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_EXISTING", {securePairingCapable: false}),
     })
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_EXISTING")
@@ -231,9 +266,50 @@ describe("pairing loading screen", () => {
     })
   })
 
+  it("starts the selected-device kickoff before an already-ready target can navigate", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_EXISTING", {securePairingCapable: false}),
+    })
+    promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_EXISTING")
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+
+    render(<GlassesPairingLoadingScreen />)
+    act(() => {
+      jest.advanceTimersByTime(1_999)
+    })
+    expect(engine.pairing.pair).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
+
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+    await act(async () => {})
+    expect(engine.pairing.pair).toHaveBeenCalledWith(makeDevice("Mentra Live", "MENTRA_LIVE_BLE_EXISTING"))
+    expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
+
+    act(() => {
+      jest.advanceTimersByTime(1_000)
+    })
+    expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
+  })
+
+  it("does not start the selected-device kickoff while loading is under Bluetooth Classic", async () => {
+    ;(useIsFocused as jest.Mock).mockReturnValue(false)
+    const screen = render(<GlassesPairingLoadingScreen />)
+
+    act(() => {
+      jest.advanceTimersByTime(10_000)
+    })
+    expect(engine.pairing.pair).not.toHaveBeenCalled()
+    ;(useIsFocused as jest.Mock).mockReturnValue(true)
+    screen.rerender(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
+    expect(engine.pairing.pair).toHaveBeenCalledWith(makeDevice("Mentra Live", "MENTRA_LIVE_BLE_001"))
+  })
+
   it("ignores readiness from previously connected glasses until the selected attempt reconnects", async () => {
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_NEW", securePairingCapable: false},
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_NEW", {securePairingCapable: false}),
     })
     promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_OLD")
     useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
@@ -242,9 +318,7 @@ describe("pairing loading screen", () => {
 
     // The scan screen does not start the selected connection until two seconds
     // after navigation. The previous glasses' ready state must not win first.
-    act(() => {
-      jest.advanceTimersByTime(2_000)
-    })
+    await startPairingKickoff()
     expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
     expect(engine.pairing.waitForReady).toHaveBeenCalled()
 
@@ -264,6 +338,7 @@ describe("pairing loading screen", () => {
 
   it("fails closed when recovered target capability is unknown instead of loading forever", async () => {
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
@@ -284,6 +359,7 @@ describe("pairing loading screen", () => {
 
   it("does not use pairing_info timeout when secure firmware already reported capable", async () => {
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       emitBluetoothSdkEvent("pairing_info", {
@@ -306,9 +382,10 @@ describe("pairing loading screen", () => {
 
   it("fails secure-capable firmware when pairing_info never arrives", async () => {
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_001", securePairingCapable: true},
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_001", {securePairingCapable: true}),
     })
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
@@ -340,14 +417,13 @@ describe("pairing loading screen", () => {
 
   it("ignores pairing_info carrying another glasses' pairing code", async () => {
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {
-        deviceModel: "Mentra Live",
-        deviceName: "MENTRA_LIVE_BLE_001",
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_001", {
         securePairingCapable: true,
         pairingCode: "ABCD",
-      },
+      }),
     })
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       emitBluetoothSdkEvent("pairing_info", {
@@ -370,10 +446,36 @@ describe("pairing loading screen", () => {
     })
   })
 
+  it("accepts pairing_info with an omitted optional code after the exact target connects", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_001", {
+        securePairingCapable: true,
+        pairingCode: "ABCD",
+      }),
+    })
+    render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
+
+    act(() => {
+      emitBluetoothSdkEvent("pairing_info", {
+        had_previous_bond: false,
+        secure_pairing_capable: true,
+      })
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+      jest.advanceTimersByTime(1_000)
+    })
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
+    })
+  })
+
   it("ignores had_previous_bond and navigates to success under Design A open reclaim", async () => {
     const showAlert = require("@/utils/AlertUtils").default as jest.Mock
 
     render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
 
     act(() => {
       emitBluetoothSdkEvent("pairing_info", {
@@ -398,15 +500,13 @@ describe("pairing loading screen", () => {
 
   it("uses controller readiness without being blocked by already-connected glasses", async () => {
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Even Realities R1", deviceName: "CEC5BA"},
+      params: makeRouteParams("Even Realities R1", "CEC5BA"),
     })
     promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_OLD")
     useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
 
     render(<GlassesPairingLoadingScreen />)
-    act(() => {
-      jest.advanceTimersByTime(2_000)
-    })
+    await startPairingKickoff()
     expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
 
     act(() => {
@@ -433,7 +533,13 @@ describe("pairing loading screen", () => {
 
     fireEvent.press(getByText("cancel-pairing"))
 
+    act(() => {
+      jest.advanceTimersByTime(3_000)
+    })
+
     expect(goBack).toHaveBeenCalled()
+    expect(engine.pairing.abandonAttempt).toHaveBeenCalled()
+    expect(engine.pairing.pair).not.toHaveBeenCalled()
     expect(replace).not.toHaveBeenCalledWith("/pairing/prep", {deviceModel: "Mentra Live"})
   })
 })

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -8,6 +8,7 @@ import GlassesPairingLoadingScreen from "@/app/pairing/loading"
 // The glasses store is private to the local engine workspace and has no public test export.
 // eslint-disable-next-line no-restricted-imports
 import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
+import {SETTINGS, useSettingsStore} from "../../../../modules/engine/src/stores/settings"
 import {emitBluetoothSdkEvent, resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
 
 jest.mock("@mentra/bluetooth-sdk", () => {
@@ -112,6 +113,7 @@ describe("pairing loading screen", () => {
     resetBluetoothSdkMock()
     jest.clearAllMocks()
     useGlassesStore.getState().reset()
+    useSettingsStore.getState().resetAllSettingsLocally()
     ;(useRoute as jest.Mock).mockReturnValue({
       params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_001"},
     })
@@ -122,6 +124,16 @@ describe("pairing loading screen", () => {
   afterEach(() => {
     jest.useRealTimers()
   })
+
+  const promoteWearable = (model: string, name: string) => {
+    void useSettingsStore.getState().setSetting(SETTINGS.default_wearable.key, model, false)
+    void useSettingsStore.getState().setSetting(SETTINGS.device_name.key, name, false)
+  }
+
+  const promoteController = (model: string, name: string) => {
+    void useSettingsStore.getState().setSetting(SETTINGS.default_controller.key, model, false)
+    void useSettingsStore.getState().setSetting(SETTINGS.controller_device_name.key, name, false)
+  }
 
   it("shows booting after glasses_not_ready and routes pair failures to the failure screen", async () => {
     const {getByText} = render(<GlassesPairingLoadingScreen />)
@@ -155,6 +167,7 @@ describe("pairing loading screen", () => {
       emitBluetoothSdkEvent("pairing_info", {had_previous_bond: false})
     })
     act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
     act(() => {
@@ -202,6 +215,7 @@ describe("pairing loading screen", () => {
     render(<GlassesPairingLoadingScreen />)
 
     act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_EXISTING")
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
 
@@ -221,6 +235,7 @@ describe("pairing loading screen", () => {
     ;(useRoute as jest.Mock).mockReturnValue({
       params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_NEW", securePairingCapable: false},
     })
+    promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_OLD")
     useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
 
     render(<GlassesPairingLoadingScreen />)
@@ -231,17 +246,12 @@ describe("pairing loading screen", () => {
       jest.advanceTimersByTime(2_000)
     })
     expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
-    expect(engine.pairing.waitForReady).not.toHaveBeenCalled()
+    expect(engine.pairing.waitForReady).toHaveBeenCalled()
 
-    // A real attempt drops the old link, then reports ready for the selected
-    // glasses. Existing customer firmware can succeed immediately from that
-    // attempt-scoped readiness without waiting for pairing_info.
+    // Native promotion identifies the selected glasses. No global disconnect
+    // edge is required, so a same-link handoff cannot leave the UI spinning.
     act(() => {
-      useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
-      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
-    })
-    await waitFor(() => {
-      expect(engine.pairing.waitForReady).toHaveBeenCalled()
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_NEW")
     })
     act(() => {
       jest.advanceTimersByTime(1_000)
@@ -256,6 +266,7 @@ describe("pairing loading screen", () => {
     render(<GlassesPairingLoadingScreen />)
 
     act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
     act(() => {
@@ -281,6 +292,7 @@ describe("pairing loading screen", () => {
       })
     })
     act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
     act(() => {
@@ -299,6 +311,7 @@ describe("pairing loading screen", () => {
     render(<GlassesPairingLoadingScreen />)
 
     act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
 
@@ -325,6 +338,38 @@ describe("pairing loading screen", () => {
     })
   })
 
+  it("ignores pairing_info carrying another glasses' pairing code", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: {
+        deviceModel: "Mentra Live",
+        deviceName: "MENTRA_LIVE_BLE_001",
+        securePairingCapable: true,
+        pairingCode: "ABCD",
+      },
+    })
+    render(<GlassesPairingLoadingScreen />)
+
+    act(() => {
+      emitBluetoothSdkEvent("pairing_info", {
+        had_previous_bond: false,
+        pairing_code: "1234",
+        secure_pairing_capable: true,
+      })
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    })
+    act(() => {
+      jest.advanceTimersByTime(5_000)
+    })
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/pairing/failure", {
+        error: "errors:pairingCouldNotStart",
+        deviceModel: "Mentra Live",
+      })
+    })
+  })
+
   it("ignores had_previous_bond and navigates to success under Design A open reclaim", async () => {
     const showAlert = require("@/utils/AlertUtils").default as jest.Mock
 
@@ -338,6 +383,7 @@ describe("pairing loading screen", () => {
       })
     })
     act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_001")
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
     act(() => {
@@ -348,6 +394,30 @@ describe("pairing loading screen", () => {
       expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
     })
     expect(showAlert).not.toHaveBeenCalled()
+  })
+
+  it("uses controller readiness without being blocked by already-connected glasses", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: {deviceModel: "Even Realities R1", deviceName: "CEC5BA"},
+    })
+    promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_OLD")
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+
+    render(<GlassesPairingLoadingScreen />)
+    act(() => {
+      jest.advanceTimersByTime(2_000)
+    })
+    expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
+
+    act(() => {
+      promoteController("Even Realities R1", "CEC5BA")
+      useGlassesStore.getState().setGlassesInfo({controllerConnected: true, controllerFullyBooted: true})
+      jest.advanceTimersByTime(1_000)
+    })
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Even Realities R1"})
+    })
   })
 
   it("cancels pairing with goBack", async () => {

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -217,6 +217,41 @@ describe("pairing loading screen", () => {
     })
   })
 
+  it("ignores readiness from previously connected glasses until the selected attempt reconnects", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_NEW", securePairingCapable: false},
+    })
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+
+    render(<GlassesPairingLoadingScreen />)
+
+    // The scan screen does not start the selected connection until two seconds
+    // after navigation. The previous glasses' ready state must not win first.
+    act(() => {
+      jest.advanceTimersByTime(2_000)
+    })
+    expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
+    expect(engine.pairing.waitForReady).not.toHaveBeenCalled()
+
+    // A real attempt drops the old link, then reports ready for the selected
+    // glasses. Existing customer firmware can succeed immediately from that
+    // attempt-scoped readiness without waiting for pairing_info.
+    act(() => {
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    })
+    await waitFor(() => {
+      expect(engine.pairing.waitForReady).toHaveBeenCalled()
+    })
+    act(() => {
+      jest.advanceTimersByTime(1_000)
+    })
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
+    })
+  })
+
   it("fails closed when recovered target capability is unknown instead of loading forever", async () => {
     render(<GlassesPairingLoadingScreen />)
 

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -293,6 +293,31 @@ describe("pairing loading screen", () => {
     expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
   })
 
+  it("cancels a pending success transition when the selected attempt fails", async () => {
+    ;(useRoute as jest.Mock).mockReturnValue({
+      params: makeRouteParams("Mentra Live", "MENTRA_LIVE_BLE_EXISTING", {securePairingCapable: false}),
+    })
+    render(<GlassesPairingLoadingScreen />)
+    await startPairingKickoff()
+
+    act(() => {
+      promoteWearable("Mentra Live", "MENTRA_LIVE_BLE_EXISTING")
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    })
+    expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
+
+    act(() => {
+      emitBluetoothSdkEvent("pair_failure", {error: "pairing:failed_after_kickoff"})
+      jest.advanceTimersByTime(1_000)
+    })
+
+    expect(replace).toHaveBeenCalledWith("/pairing/failure", {
+      error: "pairing:failed_after_kickoff",
+      deviceModel: "Mentra Live",
+    })
+    expect(replace).not.toHaveBeenCalledWith("/pairing/success", expect.anything())
+  })
+
   it("does not start the selected-device kickoff while loading is under Bluetooth Classic", async () => {
     ;(useIsFocused as jest.Mock).mockReturnValue(false)
     const screen = render(<GlassesPairingLoadingScreen />)

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -5,6 +5,8 @@ import {engine} from "@mentra/engine"
 import {useRoute} from "@react-navigation/native"
 import {useNavigationStore} from "@/stores/navigation"
 import GlassesPairingLoadingScreen from "@/app/pairing/loading"
+// The glasses store is private to the local engine workspace and has no public test export.
+// eslint-disable-next-line no-restricted-imports
 import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
 import {emitBluetoothSdkEvent, resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
 
@@ -193,9 +195,9 @@ describe("pairing loading screen", () => {
     )
   })
 
-  it("navigates to success when firmware never emits pairing_info (legacy fallback)", async () => {
+  it("does not wait for pairing_info when the advertisement reports existing pairing behavior", async () => {
     ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_LEGACY", securePairingCapable: false},
+      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_EXISTING", securePairingCapable: false},
     })
     render(<GlassesPairingLoadingScreen />)
 
@@ -203,12 +205,9 @@ describe("pairing loading screen", () => {
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
 
-    // No pairing_info event arrives (field firmware). Without the fallback, pairing hangs forever.
+    // The only remaining delay is the existing one-second transition to the success screen.
     expect(replace).not.toHaveBeenCalled()
 
-    act(() => {
-      jest.advanceTimersByTime(5_000)
-    })
     act(() => {
       jest.advanceTimersByTime(1_000)
     })
@@ -234,29 +233,6 @@ describe("pairing loading screen", () => {
         error: "errors:pairingCouldNotStart",
         deviceModel: "Mentra Live",
       })
-    })
-  })
-
-  it("uses the legacy pairing_info fallback when scan already reported non-secure firmware", async () => {
-    ;(useRoute as jest.Mock).mockReturnValue({
-      params: {deviceModel: "Mentra Live", deviceName: "MENTRA_LIVE_BLE_LEGACY", securePairingCapable: false},
-    })
-    render(<GlassesPairingLoadingScreen />)
-
-    act(() => {
-      useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
-    })
-    expect(replace).not.toHaveBeenCalled()
-
-    act(() => {
-      jest.advanceTimersByTime(5_000)
-    })
-    act(() => {
-      jest.advanceTimersByTime(1_000)
-    })
-
-    await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith("/pairing/success", {deviceModel: "Mentra Live"})
     })
   })
 

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -219,6 +219,7 @@ describe("pairing scan screen", () => {
         device: JSON.stringify({id: "a", model: "Mentra Live", name: "MENTRA_LIVE_BLE_001", address: "a"}),
       })
       expect(pushUnder).toHaveBeenCalledWith("/pairing/loading", {
+        device: JSON.stringify({id: "a", model: "Mentra Live", name: "MENTRA_LIVE_BLE_001", address: "a"}),
         deviceModel: "Mentra Live",
         deviceName: "MENTRA_LIVE_BLE_001",
       })
@@ -267,10 +268,9 @@ describe("pairing scan screen", () => {
     expect(goBack).not.toHaveBeenCalled()
   })
 
-  it("routes a pair kickoff rejection to the failure screen instead of leaving loading stuck", async () => {
+  it("hands the exact selected device to loading without connecting from the scan screen", async () => {
     jest.useFakeTimers()
     setPlatformOS("android")
-    ;(engine.pairing.pair as jest.Mock).mockRejectedValueOnce(new Error("bluetooth powered off"))
     useCoreStore.setState({
       searchResults: [{id: "a", model: "Mentra Live", name: "MENTRA_LIVE_BLE_001", address: "a"}],
     })
@@ -284,62 +284,16 @@ describe("pairing scan screen", () => {
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith("/pairing/loading", {
+        device: JSON.stringify({id: "a", model: "Mentra Live", name: "MENTRA_LIVE_BLE_001", address: "a"}),
         deviceModel: "Mentra Live",
         deviceName: "MENTRA_LIVE_BLE_001",
       })
     })
 
-    // The pair kickoff fires 2s after navigating to loading; its rejection
-    // must surface as a failure route, not just a console.error.
+    // Loading owns the delayed kickoff so leaving that route can cancel it.
     act(() => {
-      jest.advanceTimersByTime(2_000)
+      jest.advanceTimersByTime(3_000)
     })
-
-    await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith("/pairing/failure", {
-        error: "errors:pairingCouldNotStart",
-        deviceModel: "Mentra Live",
-      })
-    })
-    // Parity with loading.tsx's handlePairFailure: the failed attempt is
-    // cleared before the failure screen shows.
-    expect(engine.pairing.abandonAttempt).toHaveBeenCalled()
-  })
-
-  it("suppresses the kickoff-failure route when the user already left loading", async () => {
-    jest.useFakeTimers()
-    setPlatformOS("android")
-    // The user backed out of /pairing/loading during the 2s kickoff delay —
-    // the stale rejection must not yank them to the failure screen.
-    ;(useNavigationStore.getState as jest.Mock).mockReturnValue({
-      replace,
-      push,
-      goBack,
-      history: ["/pairing/scan"],
-    })
-    ;(engine.pairing.pair as jest.Mock).mockRejectedValueOnce(new Error("bluetooth powered off"))
-    useCoreStore.setState({
-      searchResults: [{id: "a", model: "Mentra Live", name: "MENTRA_LIVE_BLE_001", address: "a"}],
-    })
-
-    const {getByText} = render(<SelectGlassesBluetoothScreen />)
-
-    await waitFor(() => {
-      expect(getByText("001")).toBeTruthy()
-    })
-    fireEvent.press(getByText("001"))
-
-    await waitFor(() => {
-      expect(push).toHaveBeenCalled()
-    })
-
-    act(() => {
-      jest.advanceTimersByTime(2_000)
-    })
-    await act(async () => {})
-
-    expect(replace).not.toHaveBeenCalledWith("/pairing/failure", expect.anything())
-    expect(engine.pairing.abandonAttempt).not.toHaveBeenCalled()
     expect(engine.pairing.pair).not.toHaveBeenCalled()
   })
 
@@ -354,6 +308,7 @@ describe("pairing scan screen", () => {
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith("/pairing/loading", {
+        device: JSON.stringify({id: "skip", model: "Mentra Live", name: "NOTREQUIREDSKIP", address: "skip"}),
         deviceModel: "Mentra Live",
         deviceName: "NOTREQUIREDSKIP",
       })

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -550,15 +550,15 @@ describe("pairing scan screen", () => {
     })
   })
 
-  it("shows a single legacy Mentra Live and waits for the user to choose it", async () => {
+  it("shows existing customer firmware without labeling it as legacy", async () => {
     setPlatformOS("android")
     useCoreStore.setState({
       searchResults: [
         {
-          id: "legacy",
+          id: "existing",
           model: "Mentra Live",
-          name: "MENTRA_LIVE_BLE_LEGACY",
-          address: "legacy",
+          name: "MENTRA_LIVE_BLE_EXISTING",
+          address: "existing",
           pairingMode: false,
           securePairingCapable: false,
         },
@@ -569,25 +569,25 @@ describe("pairing scan screen", () => {
 
     await waitFor(() => {
       expect(getByText("pairing:liveChooseGlassesTitle")).toBeTruthy()
-      expect(getByText(/pairing:legacyFirmwareLabel/)).toBeTruthy()
+      expect(getByText("EXISTING")).toBeTruthy()
     })
     expect(push).not.toHaveBeenCalled()
 
-    fireEvent.press(getByText(/pairing:legacyFirmwareLabel/))
+    fireEvent.press(getByText("EXISTING"))
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(
         "/pairing/loading",
         expect.objectContaining({
           deviceModel: "Mentra Live",
-          deviceName: "MENTRA_LIVE_BLE_LEGACY",
+          deviceName: "MENTRA_LIVE_BLE_EXISTING",
           securePairingCapable: false,
         }),
       )
     })
   })
 
-  it("shows legacy Mentra Live beside an idle secure unit and waits for the user", async () => {
+  it("shows existing customer firmware beside an idle secure unit", async () => {
     setPlatformOS("android")
     useCoreStore.setState({
       searchResults: [
@@ -600,10 +600,10 @@ describe("pairing scan screen", () => {
           securePairingCapable: true,
         },
         {
-          id: "legacy",
+          id: "existing",
           model: "Mentra Live",
-          name: "MENTRA_LIVE_BLE_LEGACY",
-          address: "legacy",
+          name: "MENTRA_LIVE_BLE_EXISTING",
+          address: "existing",
           pairingMode: false,
           securePairingCapable: false,
         },
@@ -615,18 +615,18 @@ describe("pairing scan screen", () => {
     await waitFor(() => {
       expect(getByText("pairing:liveChooseGlassesTitle")).toBeTruthy()
       expect(getByText(/IDLE.*pairing:notInPairingModeLabel/)).toBeTruthy()
-      expect(getByText(/pairing:legacyFirmwareLabel/)).toBeTruthy()
+      expect(getByText("EXISTING")).toBeTruthy()
     })
     expect(push).not.toHaveBeenCalled()
 
-    fireEvent.press(getByText(/pairing:legacyFirmwareLabel/))
+    fireEvent.press(getByText("EXISTING"))
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(
         "/pairing/loading",
         expect.objectContaining({
           deviceModel: "Mentra Live",
-          deviceName: "MENTRA_LIVE_BLE_LEGACY",
+          deviceName: "MENTRA_LIVE_BLE_EXISTING",
           securePairingCapable: false,
         }),
       )

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -167,6 +167,7 @@ describe("pairing scan screen", () => {
   beforeEach(() => {
     resetBluetoothSdkMock()
     jest.clearAllMocks()
+    ;(engine.pairing.pair as jest.Mock).mockReset().mockResolvedValue(undefined)
     useCoreStore.getState().reset()
     useGlassesStore.getState().reset()
     useSettingsStore.getState().resetAllSettingsLocally()
@@ -339,6 +340,7 @@ describe("pairing scan screen", () => {
 
     expect(replace).not.toHaveBeenCalledWith("/pairing/failure", expect.anything())
     expect(engine.pairing.abandonAttempt).not.toHaveBeenCalled()
+    expect(engine.pairing.pair).not.toHaveBeenCalled()
   })
 
   it("auto-skips directly into pairing when NOTREQUIREDSKIP is discovered", async () => {
@@ -545,6 +547,7 @@ describe("pairing scan screen", () => {
         expect.objectContaining({
           deviceModel: "Mentra Live",
           deviceName: "MENTRA_LIVE_BLE_PAIR_A",
+          pairingCode: "ABCD",
         }),
       )
     })

--- a/mobile/src/app/pairing/btclassic.tsx
+++ b/mobile/src/app/pairing/btclassic.tsx
@@ -50,21 +50,21 @@ export default function BtClassicPairingScreen() {
 
   const handleSuccess = () => {
     if (device) {
-      engine.glasses.connect(device, {saveAsDefault: false}).catch((error) => {
-        console.error("Failed to connect glasses after Bluetooth Classic pairing:", error)
-        routePairingKickoffFailure(device.model)
-      })
-    } else {
-      // Paired contexts (success step stack / recovery alert): reconnect the
-      // saved default device.
-      engine.glasses.connectDefault().catch((error) => {
-        console.error("Failed to connect default glasses after Bluetooth Classic pairing:", error)
-        // Identity read-model, not raw keys: the failure copy names whatever
-        // identity model exists at rejection time (paired or pending).
-        const identity = engine.pairing.identity()
-        routePairingKickoffFailure(identity.kind === "none" ? undefined : identity.model)
-      })
+      // The loading screen owns the selected-device connect. Revealing it first
+      // keeps one cancellable kickoff path for Android, iOS, and controllers.
+      pushPrevious()
+      return
     }
+
+    // Paired contexts (success step stack / recovery alert): reconnect the
+    // saved default device.
+    engine.glasses.connectDefault().catch((error) => {
+      console.error("Failed to connect default glasses after Bluetooth Classic pairing:", error)
+      // Identity read-model, not raw keys: the failure copy names whatever
+      // identity model exists at rejection time (paired or pending).
+      const identity = engine.pairing.identity()
+      routePairingKickoffFailure(identity.kind === "none" ? undefined : identity.model)
+    })
     pushPrevious()
   }
 

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -1,8 +1,8 @@
-import {useRoute} from "@react-navigation/native"
-import BluetoothSdk, {type PairingInfoEvent} from "@mentra/bluetooth-sdk"
+import {useIsFocused, useRoute} from "@react-navigation/native"
+import BluetoothSdk, {type Device, type PairingInfoEvent} from "@mentra/bluetooth-sdk"
 import {engine} from "@mentra/engine"
 import type {PairFailureEvent} from "@mentra/engine"
-import {useCallback, useEffect, useRef, useState} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {View} from "react-native"
 
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
@@ -17,6 +17,7 @@ import {useNavigationStore} from "@/stores/navigation"
 // Secure pairing info should arrive immediately after Mentra Live finishes booting.
 // Secure or unknown firmware fails closed instead of spinning forever.
 const PAIRING_INFO_WAIT_MS = 5_000
+const PAIRING_KICKOFF_DELAY_MS = 2_000
 
 /**
  * Design A (open reclaim): five-tap clears prior owner/bonds on the glasses; the first
@@ -27,7 +28,15 @@ const PAIRING_INFO_WAIT_MS = 5_000
 export default function GlassesPairingLoadingScreen() {
   const {replace, goBack} = useNavigationStore.getState()
   const route = useRoute()
-  const {deviceModel, deviceName, ar99ProjectName, securePairingCapable, pairingCode} = route.params as {
+  const {
+    device: deviceJson,
+    deviceModel,
+    deviceName,
+    ar99ProjectName,
+    securePairingCapable,
+    pairingCode,
+  } = route.params as {
+    device?: string
     deviceModel: string
     deviceName?: string
     ar99ProjectName?: string
@@ -35,12 +44,27 @@ export default function GlassesPairingLoadingScreen() {
     securePairingCapable?: boolean
     pairingCode?: string
   }
+  const isFocused = useIsFocused()
+  const selectedDevice = useMemo((): Device | null => {
+    if (!deviceJson) return null
+    try {
+      const device = JSON.parse(deviceJson) as Device
+      if (device.model !== deviceModel || (deviceName && device.name !== deviceName)) return null
+      return device
+    } catch {
+      return null
+    }
+  }, [deviceJson, deviceModel, deviceName])
   const [showTroubleshootingModal, setShowTroubleshootingModal] = useState(false)
   const hasNavigatedRef = useRef(false)
   const navigationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [selectedTargetReady, setSelectedTargetReady] = useState(false)
   const [showGlassesBooting, setShowGlassesBooting] = useState(false)
   const [pairingInfoReceived, setPairingInfoReceived] = useState(false)
+  const [pairingKickoffComplete, setPairingKickoffComplete] = useState(false)
+  const pairingKickoffStartedRef = useRef(false)
+  const pairingKickoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pairingCancelledRef = useRef(false)
   const isMentraLive = deviceModel === DeviceTypes.LIVE
   const pairingTimingStartRef = useRef(Date.now())
   const pairingTimingLastRef = useRef(Date.now())
@@ -67,7 +91,7 @@ export default function GlassesPairingLoadingScreen() {
       if (!ready && navigationTimerRef.current) {
         clearTimeout(navigationTimerRef.current)
         navigationTimerRef.current = null
-        hasNavigatedRef.current = false
+        if (!pairingCancelledRef.current) hasNavigatedRef.current = false
       }
     }
     const unsubscribe = engine.pairing.onTargetReady(target, observeReadiness)
@@ -92,7 +116,11 @@ export default function GlassesPairingLoadingScreen() {
     }
 
     const sub = BluetoothSdk.addListener("pairing_info", (event: PairingInfoEvent) => {
-      if (pairingCode && event.pairing_code !== pairingCode) {
+      if (!pairingKickoffStartedRef.current) return
+
+      const advertisedCode = pairingCode?.trim().toUpperCase()
+      const eventCode = typeof event.pairing_code === "string" ? event.pairing_code.trim().toUpperCase() : undefined
+      if (advertisedCode && eventCode && eventCode !== advertisedCode) {
         logPairingTiming("ignoring_pairing_info_for_other_device")
         return
       }
@@ -109,6 +137,19 @@ export default function GlassesPairingLoadingScreen() {
   }, [isMentraLive, securePairingCapable, pairingCode, logPairingTiming])
 
   const handleGoBack = useCallback(() => {
+    pairingCancelledRef.current = true
+    hasNavigatedRef.current = true
+    if (pairingKickoffTimerRef.current) {
+      clearTimeout(pairingKickoffTimerRef.current)
+      pairingKickoffTimerRef.current = null
+    }
+    if (navigationTimerRef.current) {
+      clearTimeout(navigationTimerRef.current)
+      navigationTimerRef.current = null
+    }
+    void engine.pairing.abandonAttempt().catch((cleanupError) => {
+      console.warn("Pairing cancellation cleanup failed:", cleanupError)
+    })
     goBack()
   }, [goBack])
 
@@ -136,6 +177,35 @@ export default function GlassesPairingLoadingScreen() {
   }, [handlePairFailure])
 
   useEffect(() => {
+    if (!isFocused || !selectedDevice || pairingKickoffStartedRef.current) return
+
+    const timer = setTimeout(() => {
+      pairingKickoffTimerRef.current = null
+      if (pairingCancelledRef.current) return
+      pairingKickoffStartedRef.current = true
+      logPairingTiming("pairing_kickoff")
+      void engine.pairing
+        .pair(selectedDevice)
+        .then(() => {
+          setPairingKickoffComplete(true)
+        })
+        .catch((error) => {
+          console.error("Failed to connect to selected device:", error)
+          if (pairingCancelledRef.current || hasNavigatedRef.current) return
+          hasNavigatedRef.current = true
+          handlePairFailure("errors:pairingCouldNotStart")
+        })
+    }, PAIRING_KICKOFF_DELAY_MS)
+    pairingKickoffTimerRef.current = timer
+
+    return () => {
+      clearTimeout(timer)
+      if (pairingKickoffTimerRef.current === timer) pairingKickoffTimerRef.current = null
+    }
+  }, [handlePairFailure, isFocused, logPairingTiming, selectedDevice])
+
+  useEffect(() => {
+    if (!isFocused || !pairingKickoffComplete) return
     const controller = new AbortController()
 
     void engine.pairing.waitForReady({
@@ -149,10 +219,18 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       controller.abort()
     }
-  }, [deviceModel, deviceName])
+  }, [deviceModel, deviceName, isFocused, pairingKickoffComplete])
 
   useEffect(() => {
-    if (!isMentraLive || securePairingCapable === false || !selectedTargetReady || pairingInfoReceived) {
+    if (
+      !isFocused ||
+      pairingCancelledRef.current ||
+      !pairingKickoffComplete ||
+      !isMentraLive ||
+      securePairingCapable === false ||
+      !selectedTargetReady ||
+      pairingInfoReceived
+    ) {
       return
     }
     const timer = setTimeout(() => {
@@ -165,6 +243,8 @@ export default function GlassesPairingLoadingScreen() {
     }
   }, [
     isMentraLive,
+    isFocused,
+    pairingKickoffComplete,
     securePairingCapable,
     selectedTargetReady,
     pairingInfoReceived,
@@ -173,7 +253,7 @@ export default function GlassesPairingLoadingScreen() {
   ])
 
   useEffect(() => {
-    if (!selectedTargetReady) {
+    if (pairingCancelledRef.current || !isFocused || !pairingKickoffComplete || !selectedTargetReady) {
       return
     }
     logPairingTiming(
@@ -197,6 +277,8 @@ export default function GlassesPairingLoadingScreen() {
     }, 1000)
   }, [
     selectedTargetReady,
+    isFocused,
+    pairingKickoffComplete,
     replace,
     deviceModel,
     isMentraLive,
@@ -205,6 +287,14 @@ export default function GlassesPairingLoadingScreen() {
     securePairingCapable,
     logPairingTiming,
   ])
+
+  useEffect(() => {
+    if (!isFocused && navigationTimerRef.current) {
+      clearTimeout(navigationTimerRef.current)
+      navigationTimerRef.current = null
+      hasNavigatedRef.current = false
+    }
+  }, [isFocused])
 
   useEffect(() => {
     return () => {

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -15,15 +15,15 @@ import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {useNavigationStore} from "@/stores/navigation"
 
-// Pairing info should arrive immediately after Mentra Live finishes booting. Legacy firmware
-// may continue without it; secure or unknown firmware fails closed instead of spinning forever.
+// Secure pairing info should arrive immediately after Mentra Live finishes booting.
+// Secure or unknown firmware fails closed instead of spinning forever.
 const PAIRING_INFO_WAIT_MS = 5_000
 
 /**
  * Design A (open reclaim): five-tap clears prior owner/bonds on the glasses; the first
  * successful pair wins. Mentra Live pairing does NOT run ownership-transfer finalize/wipe.
- * pairing_info is still used as a secure-firmware readiness signal, but had_previous_bond
- * is ignored for UI gating.
+ * pairing_info is used only as a secure-firmware readiness signal; the advertised capability
+ * lets existing customer firmware proceed without waiting for an event it does not emit.
  */
 export default function GlassesPairingLoadingScreen() {
   const {replace, goBack} = useNavigationStore.getState()
@@ -42,9 +42,7 @@ export default function GlassesPairingLoadingScreen() {
     engine.pairing.onReadiness(onChange),
   ).fullyBooted
   const [showGlassesBooting, setShowGlassesBooting] = useState(false)
-  const pairingInfoRef = useRef<PairingInfoEvent | null>(null)
   const [pairingInfoReceived, setPairingInfoReceived] = useState(false)
-  const [pairingInfoTimedOut, setPairingInfoTimedOut] = useState(false)
   const isMentraLive = deviceModel === DeviceTypes.LIVE
   const pairingTimingStartRef = useRef(Date.now())
   const pairingTimingLastRef = useRef(Date.now())
@@ -75,12 +73,11 @@ export default function GlassesPairingLoadingScreen() {
   }, [logPairingTiming])
 
   useEffect(() => {
-    if (!isMentraLive) {
+    if (!isMentraLive || securePairingCapable === false) {
       return
     }
 
     const sub = BluetoothSdk.addListener("pairing_info", (event: PairingInfoEvent) => {
-      pairingInfoRef.current = event
       setPairingInfoReceived(true)
       logPairingTiming(
         "pairing_info",
@@ -91,7 +88,7 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       sub.remove()
     }
-  }, [isMentraLive, logPairingTiming])
+  }, [isMentraLive, securePairingCapable, logPairingTiming])
 
   const handleGoBack = useCallback(() => {
     goBack()
@@ -137,15 +134,10 @@ export default function GlassesPairingLoadingScreen() {
   }, [deviceModel, deviceName])
 
   useEffect(() => {
-    if (!isMentraLive || !glassesFullyBooted || pairingInfoReceived || pairingInfoTimedOut) {
+    if (!isMentraLive || securePairingCapable === false || !glassesFullyBooted || pairingInfoReceived) {
       return
     }
     const timer = setTimeout(() => {
-      if (securePairingCapable === false && pairingInfoRef.current?.secure_pairing_capable !== true) {
-        setPairingInfoTimedOut(true)
-        return
-      }
-
       hasNavigatedRef.current = true
       logPairingTiming("pairing_info_timeout", `securePairingCapable=${String(securePairingCapable)}`)
       handlePairFailure("errors:pairingCouldNotStart")
@@ -153,15 +145,7 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       clearTimeout(timer)
     }
-  }, [
-    isMentraLive,
-    glassesFullyBooted,
-    pairingInfoReceived,
-    pairingInfoTimedOut,
-    securePairingCapable,
-    handlePairFailure,
-    logPairingTiming,
-  ])
+  }, [isMentraLive, securePairingCapable, glassesFullyBooted, pairingInfoReceived, handlePairFailure, logPairingTiming])
 
   useEffect(() => {
     if (!glassesFullyBooted) {
@@ -169,22 +153,15 @@ export default function GlassesPairingLoadingScreen() {
     }
     logPairingTiming(
       "glasses_fully_booted",
-      `pairingInfoReceived=${pairingInfoReceived} timedOut=${pairingInfoTimedOut}`,
+      `pairingInfoReceived=${pairingInfoReceived} securePairingCapable=${String(securePairingCapable)}`,
     )
     if (hasNavigatedRef.current) {
       return
     }
 
-    if (isMentraLive) {
-      const secure = securePairingCapable !== false || pairingInfoRef.current?.secure_pairing_capable === true
-      if (!pairingInfoReceived && !pairingInfoTimedOut) {
-        logPairingTiming("waiting_pairing_info")
-        return
-      }
-      if (secure && !pairingInfoReceived) {
-        logPairingTiming("waiting_secure_pairing_info")
-        return
-      }
+    if (isMentraLive && securePairingCapable !== false && !pairingInfoReceived) {
+      logPairingTiming("waiting_secure_pairing_info")
+      return
     }
 
     hasNavigatedRef.current = true
@@ -198,7 +175,6 @@ export default function GlassesPairingLoadingScreen() {
     deviceModel,
     isMentraLive,
     pairingInfoReceived,
-    pairingInfoTimedOut,
     ar99ProjectName,
     securePairingCapable,
     logPairingTiming,

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -12,7 +12,6 @@ import {Screen} from "@/components/ignite/Screen"
 import GlassesPairingLoader from "@/components/glasses/GlassesPairingLoader"
 import GlassesTroubleshootingModal from "@/components/glasses/GlassesTroubleshootingModal"
 import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
-import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {useNavigationStore} from "@/stores/navigation"
 
 // Secure pairing info should arrive immediately after Mentra Live finishes booting.
@@ -38,9 +37,14 @@ export default function GlassesPairingLoadingScreen() {
   const [showTroubleshootingModal, setShowTroubleshootingModal] = useState(false)
   const hasNavigatedRef = useRef(false)
   const navigationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const glassesFullyBooted = useEngineSnapshot(engine.pairing.readiness, (onChange) =>
-    engine.pairing.onReadiness(onChange),
-  ).fullyBooted
+  // A re-pair can enter this screen while the previously connected glasses are
+  // still fully booted. The selected connect attempt drops that link first, so
+  // only accept ready after this screen has observed a not-ready state. This
+  // makes the success signal belong to the selected attempt instead of a stale
+  // global readiness snapshot.
+  const hasObservedNotReadyRef = useRef(false)
+  const [selectedAttemptStarted, setSelectedAttemptStarted] = useState(false)
+  const [selectedAttemptFullyBooted, setSelectedAttemptFullyBooted] = useState(false)
   const [showGlassesBooting, setShowGlassesBooting] = useState(false)
   const [pairingInfoReceived, setPairingInfoReceived] = useState(false)
   const isMentraLive = deviceModel === DeviceTypes.LIVE
@@ -60,6 +64,39 @@ export default function GlassesPairingLoadingScreen() {
     pairingTimingStartRef.current = Date.now()
     pairingTimingLastRef.current = pairingTimingStartRef.current
     logPairingTiming("loading_mount", `deviceModel=${deviceModel} deviceName=${deviceName ?? ""}`)
+  }, [deviceModel, deviceName, logPairingTiming])
+
+  useEffect(() => {
+    const observeReadiness = (fullyBooted: boolean) => {
+      if (!fullyBooted) {
+        hasObservedNotReadyRef.current = true
+        setSelectedAttemptStarted(true)
+        setSelectedAttemptFullyBooted(false)
+        if (navigationTimerRef.current) {
+          clearTimeout(navigationTimerRef.current)
+          navigationTimerRef.current = null
+          hasNavigatedRef.current = false
+        }
+        return
+      }
+
+      if (!hasObservedNotReadyRef.current) {
+        logPairingTiming("ignoring_pre_attempt_readiness")
+        return
+      }
+
+      setSelectedAttemptFullyBooted(true)
+    }
+
+    hasObservedNotReadyRef.current = false
+    setSelectedAttemptStarted(false)
+    setSelectedAttemptFullyBooted(false)
+    const unsubscribe = engine.pairing.onReadiness((readiness) => {
+      observeReadiness(readiness.fullyBooted)
+    })
+    observeReadiness(engine.pairing.readiness().fullyBooted)
+
+    return unsubscribe
   }, [deviceModel, deviceName, logPairingTiming])
 
   useEffect(() => {
@@ -118,6 +155,10 @@ export default function GlassesPairingLoadingScreen() {
   }, [handlePairFailure])
 
   useEffect(() => {
+    if (!selectedAttemptStarted) {
+      return
+    }
+
     const controller = new AbortController()
 
     void engine.pairing.waitForReady({
@@ -131,10 +172,10 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       controller.abort()
     }
-  }, [deviceModel, deviceName])
+  }, [deviceModel, deviceName, selectedAttemptStarted])
 
   useEffect(() => {
-    if (!isMentraLive || securePairingCapable === false || !glassesFullyBooted || pairingInfoReceived) {
+    if (!isMentraLive || securePairingCapable === false || !selectedAttemptFullyBooted || pairingInfoReceived) {
       return
     }
     const timer = setTimeout(() => {
@@ -145,10 +186,17 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       clearTimeout(timer)
     }
-  }, [isMentraLive, securePairingCapable, glassesFullyBooted, pairingInfoReceived, handlePairFailure, logPairingTiming])
+  }, [
+    isMentraLive,
+    securePairingCapable,
+    selectedAttemptFullyBooted,
+    pairingInfoReceived,
+    handlePairFailure,
+    logPairingTiming,
+  ])
 
   useEffect(() => {
-    if (!glassesFullyBooted) {
+    if (!selectedAttemptFullyBooted) {
       return
     }
     logPairingTiming(
@@ -167,10 +215,11 @@ export default function GlassesPairingLoadingScreen() {
     hasNavigatedRef.current = true
     logPairingTiming("navigate_success_scheduled")
     navigationTimerRef.current = setTimeout(() => {
+      navigationTimerRef.current = null
       replace("/pairing/success", {deviceModel: deviceModel, ar99ProjectName})
     }, 1000)
   }, [
-    glassesFullyBooted,
+    selectedAttemptFullyBooted,
     replace,
     deviceModel,
     isMentraLive,

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -27,24 +27,18 @@ const PAIRING_INFO_WAIT_MS = 5_000
 export default function GlassesPairingLoadingScreen() {
   const {replace, goBack} = useNavigationStore.getState()
   const route = useRoute()
-  const {deviceModel, deviceName, ar99ProjectName, securePairingCapable} = route.params as {
+  const {deviceModel, deviceName, ar99ProjectName, securePairingCapable, pairingCode} = route.params as {
     deviceModel: string
     deviceName?: string
     ar99ProjectName?: string
     /** Known upfront from the scan result's advertised capability, before any pairing_info event. */
     securePairingCapable?: boolean
+    pairingCode?: string
   }
   const [showTroubleshootingModal, setShowTroubleshootingModal] = useState(false)
   const hasNavigatedRef = useRef(false)
   const navigationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // A re-pair can enter this screen while the previously connected glasses are
-  // still fully booted. The selected connect attempt drops that link first, so
-  // only accept ready after this screen has observed a not-ready state. This
-  // makes the success signal belong to the selected attempt instead of a stale
-  // global readiness snapshot.
-  const hasObservedNotReadyRef = useRef(false)
-  const [selectedAttemptStarted, setSelectedAttemptStarted] = useState(false)
-  const [selectedAttemptFullyBooted, setSelectedAttemptFullyBooted] = useState(false)
+  const [selectedTargetReady, setSelectedTargetReady] = useState(false)
   const [showGlassesBooting, setShowGlassesBooting] = useState(false)
   const [pairingInfoReceived, setPairingInfoReceived] = useState(false)
   const isMentraLive = deviceModel === DeviceTypes.LIVE
@@ -67,37 +61,20 @@ export default function GlassesPairingLoadingScreen() {
   }, [deviceModel, deviceName, logPairingTiming])
 
   useEffect(() => {
-    const observeReadiness = (fullyBooted: boolean) => {
-      if (!fullyBooted) {
-        hasObservedNotReadyRef.current = true
-        setSelectedAttemptStarted(true)
-        setSelectedAttemptFullyBooted(false)
-        if (navigationTimerRef.current) {
-          clearTimeout(navigationTimerRef.current)
-          navigationTimerRef.current = null
-          hasNavigatedRef.current = false
-        }
-        return
+    const target = {deviceModel, deviceName}
+    const observeReadiness = (ready: boolean) => {
+      setSelectedTargetReady(ready)
+      if (!ready && navigationTimerRef.current) {
+        clearTimeout(navigationTimerRef.current)
+        navigationTimerRef.current = null
+        hasNavigatedRef.current = false
       }
-
-      if (!hasObservedNotReadyRef.current) {
-        logPairingTiming("ignoring_pre_attempt_readiness")
-        return
-      }
-
-      setSelectedAttemptFullyBooted(true)
     }
-
-    hasObservedNotReadyRef.current = false
-    setSelectedAttemptStarted(false)
-    setSelectedAttemptFullyBooted(false)
-    const unsubscribe = engine.pairing.onReadiness((readiness) => {
-      observeReadiness(readiness.fullyBooted)
-    })
-    observeReadiness(engine.pairing.readiness().fullyBooted)
+    const unsubscribe = engine.pairing.onTargetReady(target, observeReadiness)
+    observeReadiness(engine.pairing.targetReady(target))
 
     return unsubscribe
-  }, [deviceModel, deviceName, logPairingTiming])
+  }, [deviceModel, deviceName])
 
   useEffect(() => {
     const unsub = engine.pairing.onGlassesNotReady(() => {
@@ -115,6 +92,10 @@ export default function GlassesPairingLoadingScreen() {
     }
 
     const sub = BluetoothSdk.addListener("pairing_info", (event: PairingInfoEvent) => {
+      if (pairingCode && event.pairing_code !== pairingCode) {
+        logPairingTiming("ignoring_pairing_info_for_other_device")
+        return
+      }
       setPairingInfoReceived(true)
       logPairingTiming(
         "pairing_info",
@@ -125,7 +106,7 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       sub.remove()
     }
-  }, [isMentraLive, securePairingCapable, logPairingTiming])
+  }, [isMentraLive, securePairingCapable, pairingCode, logPairingTiming])
 
   const handleGoBack = useCallback(() => {
     goBack()
@@ -155,10 +136,6 @@ export default function GlassesPairingLoadingScreen() {
   }, [handlePairFailure])
 
   useEffect(() => {
-    if (!selectedAttemptStarted) {
-      return
-    }
-
     const controller = new AbortController()
 
     void engine.pairing.waitForReady({
@@ -172,10 +149,10 @@ export default function GlassesPairingLoadingScreen() {
     return () => {
       controller.abort()
     }
-  }, [deviceModel, deviceName, selectedAttemptStarted])
+  }, [deviceModel, deviceName])
 
   useEffect(() => {
-    if (!isMentraLive || securePairingCapable === false || !selectedAttemptFullyBooted || pairingInfoReceived) {
+    if (!isMentraLive || securePairingCapable === false || !selectedTargetReady || pairingInfoReceived) {
       return
     }
     const timer = setTimeout(() => {
@@ -189,14 +166,14 @@ export default function GlassesPairingLoadingScreen() {
   }, [
     isMentraLive,
     securePairingCapable,
-    selectedAttemptFullyBooted,
+    selectedTargetReady,
     pairingInfoReceived,
     handlePairFailure,
     logPairingTiming,
   ])
 
   useEffect(() => {
-    if (!selectedAttemptFullyBooted) {
+    if (!selectedTargetReady) {
       return
     }
     logPairingTiming(
@@ -219,7 +196,7 @@ export default function GlassesPairingLoadingScreen() {
       replace("/pairing/success", {deviceModel: deviceModel, ar99ProjectName})
     }, 1000)
   }, [
-    selectedAttemptFullyBooted,
+    selectedTargetReady,
     replace,
     deviceModel,
     isMentraLive,

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -64,7 +64,7 @@ export default function GlassesPairingLoadingScreen() {
   const [pairingKickoffComplete, setPairingKickoffComplete] = useState(false)
   const pairingKickoffStartedRef = useRef(false)
   const pairingKickoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pairingCancelledRef = useRef(false)
+  const pairingStoppedRef = useRef(false)
   const isMentraLive = deviceModel === DeviceTypes.LIVE
   const pairingTimingStartRef = useRef(Date.now())
   const pairingTimingLastRef = useRef(Date.now())
@@ -91,7 +91,7 @@ export default function GlassesPairingLoadingScreen() {
       if (!ready && navigationTimerRef.current) {
         clearTimeout(navigationTimerRef.current)
         navigationTimerRef.current = null
-        if (!pairingCancelledRef.current) hasNavigatedRef.current = false
+        if (!pairingStoppedRef.current) hasNavigatedRef.current = false
       }
     }
     const unsubscribe = engine.pairing.onTargetReady(target, observeReadiness)
@@ -137,7 +137,7 @@ export default function GlassesPairingLoadingScreen() {
   }, [isMentraLive, securePairingCapable, pairingCode, logPairingTiming])
 
   const handleGoBack = useCallback(() => {
-    pairingCancelledRef.current = true
+    pairingStoppedRef.current = true
     hasNavigatedRef.current = true
     if (pairingKickoffTimerRef.current) {
       clearTimeout(pairingKickoffTimerRef.current)
@@ -155,6 +155,16 @@ export default function GlassesPairingLoadingScreen() {
 
   const handlePairFailure = useCallback(
     (error: string) => {
+      pairingStoppedRef.current = true
+      hasNavigatedRef.current = true
+      if (pairingKickoffTimerRef.current) {
+        clearTimeout(pairingKickoffTimerRef.current)
+        pairingKickoffTimerRef.current = null
+      }
+      if (navigationTimerRef.current) {
+        clearTimeout(navigationTimerRef.current)
+        navigationTimerRef.current = null
+      }
       void engine.pairing.abandonAttempt().catch((cleanupError) => {
         console.warn("Pairing failure cleanup failed:", cleanupError)
       })
@@ -181,7 +191,7 @@ export default function GlassesPairingLoadingScreen() {
 
     const timer = setTimeout(() => {
       pairingKickoffTimerRef.current = null
-      if (pairingCancelledRef.current) return
+      if (pairingStoppedRef.current) return
       pairingKickoffStartedRef.current = true
       logPairingTiming("pairing_kickoff")
       void engine.pairing
@@ -191,8 +201,7 @@ export default function GlassesPairingLoadingScreen() {
         })
         .catch((error) => {
           console.error("Failed to connect to selected device:", error)
-          if (pairingCancelledRef.current || hasNavigatedRef.current) return
-          hasNavigatedRef.current = true
+          if (pairingStoppedRef.current || hasNavigatedRef.current) return
           handlePairFailure("errors:pairingCouldNotStart")
         })
     }, PAIRING_KICKOFF_DELAY_MS)
@@ -224,7 +233,7 @@ export default function GlassesPairingLoadingScreen() {
   useEffect(() => {
     if (
       !isFocused ||
-      pairingCancelledRef.current ||
+      pairingStoppedRef.current ||
       !pairingKickoffComplete ||
       !isMentraLive ||
       securePairingCapable === false ||
@@ -253,7 +262,7 @@ export default function GlassesPairingLoadingScreen() {
   ])
 
   useEffect(() => {
-    if (pairingCancelledRef.current || !isFocused || !pairingKickoffComplete || !selectedTargetReady) {
+    if (pairingStoppedRef.current || !isFocused || !pairingKickoffComplete || !selectedTargetReady) {
       return
     }
     logPairingTiming(

--- a/mobile/src/app/pairing/scan-controller.tsx
+++ b/mobile/src/app/pairing/scan-controller.tsx
@@ -14,7 +14,6 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {translate} from "@/i18n"
 import showAlert from "@/utils/AlertUtils"
-import {schedulePairingKickoff} from "@/utils/PairingUtils"
 import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {getGlassesOpenImage} from "@/utils/getGlassesImage"
 import GlassView from "@/components/ui/GlassView"
@@ -95,8 +94,11 @@ export default function SelectGlassesBluetoothScreen() {
   }
 
   const startPairing = async (device: Device) => {
-    schedulePairingKickoff(device, "controller")
-    replace("/pairing/loading", {deviceModel: device.model, deviceName: device.name})
+    replace("/pairing/loading", {
+      device: JSON.stringify(device),
+      deviceModel: device.model,
+      deviceName: device.name,
+    })
   }
 
   const filterDeviceName = (deviceName: string) => {

--- a/mobile/src/app/pairing/scan-controller.tsx
+++ b/mobile/src/app/pairing/scan-controller.tsx
@@ -14,7 +14,7 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {translate} from "@/i18n"
 import showAlert from "@/utils/AlertUtils"
-import {routePairingKickoffFailure} from "@/utils/PairingUtils"
+import {schedulePairingKickoff} from "@/utils/PairingUtils"
 import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {getGlassesOpenImage} from "@/utils/getGlassesImage"
 import GlassView from "@/components/ui/GlassView"
@@ -95,12 +95,7 @@ export default function SelectGlassesBluetoothScreen() {
   }
 
   const startPairing = async (device: Device) => {
-    setTimeout(() => {
-      engine.pairing.pair(device).catch((error) => {
-        console.error("Failed to connect to controller:", error)
-        routePairingKickoffFailure(device.model)
-      })
-    }, 2000)
+    schedulePairingKickoff(device, "controller")
     replace("/pairing/loading", {deviceModel: device.model, deviceName: device.name})
   }
 

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -17,7 +17,6 @@ import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {translate} from "@/i18n"
 import {useNavigationStore} from "@/stores/navigation"
 import showAlert from "@/utils/AlertUtils"
-import {schedulePairingKickoff} from "@/utils/PairingUtils"
 import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {AR99_MODEL_OPTIONS, getAr99DisplayName, getAr99ImageSource, getGlassesOpenImage} from "@/utils/getGlassesImage"
 
@@ -237,8 +236,8 @@ export default function SelectGlassesBluetoothScreen() {
       bluetoothClassicConnected ||
       !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)
     ) {
-      schedulePairingKickoff(device, "glasses")
       push("/pairing/loading", {
+        device: JSON.stringify(device),
         deviceModel: device.model,
         deviceName: device.name,
         ar99ProjectName: resolvedProjectName,
@@ -250,6 +249,7 @@ export default function SelectGlassesBluetoothScreen() {
 
     replace("/pairing/btclassic", {device: JSON.stringify(device)})
     pushUnder("/pairing/loading", {
+      device: JSON.stringify(device),
       deviceModel: device.model,
       deviceName: device.name,
       ar99ProjectName: resolvedProjectName,

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -17,7 +17,7 @@ import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {translate} from "@/i18n"
 import {useNavigationStore} from "@/stores/navigation"
 import showAlert from "@/utils/AlertUtils"
-import {routePairingKickoffFailure} from "@/utils/PairingUtils"
+import {schedulePairingKickoff} from "@/utils/PairingUtils"
 import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {AR99_MODEL_OPTIONS, getAr99DisplayName, getAr99ImageSource, getGlassesOpenImage} from "@/utils/getGlassesImage"
 
@@ -237,17 +237,13 @@ export default function SelectGlassesBluetoothScreen() {
       bluetoothClassicConnected ||
       !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)
     ) {
-      setTimeout(() => {
-        engine.pairing.pair(device).catch((error) => {
-          console.error("Failed to connect to glasses:", error)
-          routePairingKickoffFailure(device.model)
-        })
-      }, 2000)
+      schedulePairingKickoff(device, "glasses")
       push("/pairing/loading", {
         deviceModel: device.model,
         deviceName: device.name,
         ar99ProjectName: resolvedProjectName,
         securePairingCapable: device.securePairingCapable,
+        pairingCode: device.pairingCode,
       })
       return
     }
@@ -258,6 +254,7 @@ export default function SelectGlassesBluetoothScreen() {
       deviceName: device.name,
       ar99ProjectName: resolvedProjectName,
       securePairingCapable: device.securePairingCapable,
+      pairingCode: device.pairingCode,
     })
   }
 

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -127,7 +127,7 @@ export default function SelectGlassesBluetoothScreen() {
   )
 
   // Secure Mentra Live ads with pairingMode=false are nearby but not pairable yet.
-  // Legacy firmware (no secure flag) stays pairable even when pairingMode is unset/false.
+  // Existing customer firmware (no secure flag) stays pairable when pairingMode is unset/false.
   const isLivePairable = (device: Device) =>
     !isMentraLivePairingScan || device.pairingMode !== false || device.securePairingCapable === false
 
@@ -165,7 +165,7 @@ export default function SelectGlassesBluetoothScreen() {
 
   useEffect(() => {
     // Keep scanning after an idle secure unit appears. Advertisements arrive one
-    // at a time, so another nearby unit may still be pairable or legacy firmware.
+    // at a time, so another nearby unit may still be pairable or use existing pairing behavior.
     if (!isMentraLivePairingScan || scanTimedOut || pairableResults.length > 0) {
       return
     }
@@ -231,7 +231,7 @@ export default function SelectGlassesBluetoothScreen() {
 
   const startPairing = async (device: Device) => {
     const deviceTypesWithBtClassic = [DeviceTypes.LIVE]
-    const resolvedProjectName = deviceModel === DeviceTypes.AR99 ? device.projectName ?? ar99ProjectName : undefined
+    const resolvedProjectName = deviceModel === DeviceTypes.AR99 ? (device.projectName ?? ar99ProjectName) : undefined
     if (
       Platform.OS === "android" ||
       bluetoothClassicConnected ||
@@ -291,9 +291,7 @@ export default function SelectGlassesBluetoothScreen() {
     if (device.pairingCode) {
       parts.push(translate("pairing:pairingCodeLabel", {code: device.pairingCode}))
     }
-    if (device.securePairingCapable === false) {
-      parts.push(translate("pairing:legacyFirmwareLabel"))
-    } else if (device.pairingMode === false) {
+    if (device.securePairingCapable !== false && device.pairingMode === false) {
       parts.push(translate("pairing:notInPairingModeLabel"))
     }
     return parts.join(" · ")
@@ -398,8 +396,8 @@ export default function SelectGlassesBluetoothScreen() {
                         deviceModel === DeviceTypes.AR99
                           ? formatAr99Subtitle(res)
                           : isMentraLivePairingScan
-                          ? formatLiveSubtitle(res)
-                          : filterDeviceName(res.name)
+                            ? formatLiveSubtitle(res)
+                            : filterDeviceName(res.name)
                       return (
                         <View
                           key={res.id}
@@ -439,8 +437,8 @@ export default function SelectGlassesBluetoothScreen() {
                     deviceModel === DeviceTypes.AR99
                       ? formatAr99Subtitle(res)
                       : isMentraLivePairingScan
-                      ? formatLiveSubtitle(res)
-                      : filterDeviceName(res.name)
+                        ? formatLiveSubtitle(res)
+                        : filterDeviceName(res.name)
                   return (
                     <View
                       key={res.id}

--- a/mobile/src/services/__tests__/pairingReadyReport.test.ts
+++ b/mobile/src/services/__tests__/pairingReadyReport.test.ts
@@ -3,6 +3,7 @@ import {act, waitFor} from "@testing-library/react-native"
 import {pairing, submitPairingBootTimeoutReport} from "../../../modules/engine/src/facades/pairing"
 import {submitAutomaticReport} from "../../../modules/engine/src/facades/reports"
 import {useGlassesStore} from "../../../modules/engine/src/stores/glasses"
+import {SETTINGS, useSettingsStore} from "../../../modules/engine/src/stores/settings"
 import {emitBluetoothSdkEvent, resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
 
 jest.mock("@mentra/bluetooth-sdk", () => {
@@ -26,6 +27,7 @@ describe("pairing ready timeout reports", () => {
     jest.useFakeTimers()
     resetBluetoothSdkMock()
     useGlassesStore.getState().reset()
+    useSettingsStore.getState().resetAllSettingsLocally()
     ;(submitAutomaticReport as jest.Mock).mockClear()
     ;(submitAutomaticReport as jest.Mock).mockResolvedValue({
       status: "submitted",
@@ -114,11 +116,47 @@ describe("pairing ready timeout reports", () => {
     })
 
     act(() => {
+      void useSettingsStore.getState().setSetting(SETTINGS.default_wearable.key, "Mentra Live", false)
+      void useSettingsStore.getState().setSetting(SETTINGS.device_name.key, "MENTRA_LIVE_BLE_001", false)
       useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
     })
 
     await expect(readyPromise).resolves.toBe(true)
     expect(submitAutomaticReport).not.toHaveBeenCalled()
+  })
+
+  it("does not accept readiness from a different paired wearable", async () => {
+    void useSettingsStore.getState().setSetting(SETTINGS.default_wearable.key, "Mentra Live", false)
+    void useSettingsStore.getState().setSetting(SETTINGS.device_name.key, "MENTRA_LIVE_BLE_OLD", false)
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+
+    const readyPromise = pairing.waitForReady({
+      deviceModel: "Mentra Live",
+      deviceName: "MENTRA_LIVE_BLE_NEW",
+      timeoutMs: 1000,
+    })
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    await expect(readyPromise).resolves.toBe(false)
+  })
+
+  it("waits for the selected controller instead of wearable readiness", async () => {
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    const readyPromise = pairing.waitForReady({
+      deviceModel: "Even Realities R1",
+      deviceName: "CEC5BA",
+      timeoutMs: 1000,
+    })
+
+    act(() => {
+      void useSettingsStore.getState().setSetting(SETTINGS.default_controller.key, "Even Realities R1", false)
+      void useSettingsStore.getState().setSetting(SETTINGS.controller_device_name.key, "CEC5BA", false)
+      useGlassesStore.getState().setGlassesInfo({controllerConnected: true, controllerFullyBooted: true})
+    })
+
+    await expect(readyPromise).resolves.toBe(true)
   })
 
   it("readiness() projects pairing state without exposing the raw glasses store", () => {

--- a/mobile/src/utils/PairingUtils.ts
+++ b/mobile/src/utils/PairingUtils.ts
@@ -1,33 +1,13 @@
 import {engine} from "@mentra/engine"
-import type {Device} from "@mentra/bluetooth-sdk"
-
 import {useNavigationStore} from "@/stores/navigation"
-
-const PAIRING_KICKOFF_DELAY_MS = 2_000
-
-/**
- * Starts the selected connection after the loading transition, but only if the
- * user is still on that flow. A plain delayed pair() survives a back action and
- * can connect glasses or a controller the user explicitly cancelled.
- */
-export function schedulePairingKickoff(device: Device, targetLabel: "glasses" | "controller") {
-  setTimeout(() => {
-    const {history} = useNavigationStore.getState()
-    if (history[history.length - 1] !== "/pairing/loading") return
-    engine.pairing.pair(device).catch((error) => {
-      console.error(`Failed to connect to ${targetLabel}:`, error)
-      routePairingKickoffFailure(device.model)
-    })
-  }, PAIRING_KICKOFF_DELAY_MS)
-}
 
 /**
  * Routes a pairing/connect KICKOFF rejection to the failure screen.
  *
  * A kickoff rejection (e.g. Bluetooth powered off, a native-bridge error)
  * emits no pair_failure event, so the loading screen would otherwise spin
- * until the user cancels. Because the rejection lands on a delay, the user
- * may also have cancelled already — so this fires only while /pairing/loading
+ * until the user cancels. Because the rejection can land asynchronously, the user
+ * may have cancelled already — so this fires only while /pairing/loading
  * is still the top route; a stale callback must not yank the user out of
  * whatever screen they navigated to instead.
  */

--- a/mobile/src/utils/PairingUtils.ts
+++ b/mobile/src/utils/PairingUtils.ts
@@ -1,6 +1,25 @@
 import {engine} from "@mentra/engine"
+import type {Device} from "@mentra/bluetooth-sdk"
 
 import {useNavigationStore} from "@/stores/navigation"
+
+const PAIRING_KICKOFF_DELAY_MS = 2_000
+
+/**
+ * Starts the selected connection after the loading transition, but only if the
+ * user is still on that flow. A plain delayed pair() survives a back action and
+ * can connect glasses or a controller the user explicitly cancelled.
+ */
+export function schedulePairingKickoff(device: Device, targetLabel: "glasses" | "controller") {
+  setTimeout(() => {
+    const {history} = useNavigationStore.getState()
+    if (history[history.length - 1] !== "/pairing/loading") return
+    engine.pairing.pair(device).catch((error) => {
+      console.error(`Failed to connect to ${targetLabel}:`, error)
+      routePairingKickoffFailure(device.model)
+    })
+  }, PAIRING_KICKOFF_DELAY_MS)
+}
 
 /**
  * Routes a pairing/connect KICKOFF rejection to the failure screen.


### PR DESCRIPTION
## Summary

- trust the advertised `securePairingCapable` value when deciding whether Mentra Live loading requires `pairing_info`
- let existing customer firmware proceed as soon as the glasses are fully booted instead of waiting five seconds for an event it does not emit
- stop labeling existing customer firmware as “Legacy software” in the pairing list
- retain the existing `pairing_info` readiness check and timeout for secure-capable or unknown development firmware

## Test plan

- `bun run test -- src/__tests__/app/pairing/loading.test.tsx src/__tests__/app/pairing/scan.test.tsx --runInBand --silent`
- `bun run compile`
- focused ESLint on the four touched pairing files (zero errors; existing warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the first-time pairing state machine (kickoff timing, success gating, and firmware branches); risk is mitigated by broad test updates but regressions could still strand users on loading or pair the wrong device.
> 
> **Overview**
> **Mentra Live pairing** now treats advertised `securePairingCapable: false` as existing customer firmware: loading skips the `pairing_info` wait, scan shows normal device names (no “legacy” label), and the UX plan doc matches that behavior.
> 
> **Connect kickoff** moves from scan / Bluetooth Classic into `/pairing/loading`: routes pass the serialized selected device (and optional `pairingCode`); after a 2s delay while focused, loading calls `engine.pairing.pair`, handles kickoff failures, and cancels timers on back or failure. BT Classic for a new selection only reveals loading instead of connecting immediately.
> 
> **Readiness** is scoped to the chosen target via new `engine.pairing.targetReady` / `onTargetReady`; `waitForReady` waits for that model/name (including R1 controller settings), so a previously connected pair cannot trigger success early. Secure Mentra Live still requires `pairing_info` after kickoff, with optional pairing-code filtering and fail-closed timeouts when capability is unknown or secure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5001672f64654ef0b64cfda11fd861479bee881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->