### PR TITLE
Restore dev and staging release notifications in Slack

### DIFF
--- a/.github/scripts/notify-coordinated-release-slack.sh
+++ b/.github/scripts/notify-coordinated-release-slack.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${BRANCH:-}" in
+  dev)
+    webhook_url="${DEV_SLACK_WEBHOOK_URL:-}"
+    channel_label="Dev"
+    webhook_secret="SLACK_WEBHOOK_DEV_BUILDS"
+    ;;
+  staging)
+    webhook_url="${STAGING_SLACK_WEBHOOK_URL:-}"
+    channel_label="Staging"
+    webhook_secret="SLACK_WEBHOOK_NIGHTLY_BUILDS"
+    ;;
+  *)
+    echo "::warning::No release Slack channel is configured for branch ${BRANCH:-<unknown>}."
+    exit 0
+    ;;
+esac
+
+if [[ -z "$webhook_url" ]]; then
+  echo "::warning::$webhook_secret is not set; skipping the $channel_label release notification."
+  exit 0
+fi
+
+run_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
+commit_url="https://github.com/${REPOSITORY}/commit/${SHA}"
+commit_short="${SHA:0:7}"
+commit_subject="${COMMIT_MESSAGE:-Commit metadata unavailable}"
+commit_subject="${commit_subject%%$'\n'*}"
+commit_author="${COMMIT_AUTHOR:-unknown}"
+release_identity="${RELEASE_IDENTITY:-unknown}"
+release_url="https://github.com/${REPOSITORY}/releases/tag/mentra-v${release_identity}"
+if [[ "$release_identity" == "unknown" ]]; then
+  release_text="*Release:* identity allocation failed"
+else
+  release_text="*Release:* <${release_url}|${release_identity}>"
+fi
+
+icon() {
+  case "$1" in
+    success) echo ":white_check_mark:" ;;
+    failure) echo ":x:" ;;
+    cancelled) echo ":no_entry:" ;;
+    skipped) echo ":fast_forward:" ;;
+    *) echo ":grey_question:" ;;
+  esac
+}
+
+label() {
+  case "$1" in
+    success) echo "passed" ;;
+    failure) echo "failed" ;;
+    cancelled) echo "cancelled" ;;
+    skipped) echo "skipped" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+artifact_link() {
+  local url="$1"
+  local name="$2"
+  if [[ -n "$url" && -n "$name" ]] && curl --fail --silent --head --location --retry 2 "$url" >/dev/null; then
+    printf '<%s|%s>' "$url" "$name"
+  else
+    printf '<%s|View run logs>' "$run_url"
+  fi
+}
+
+# If the reusable mobile workflow failed before exporting platform conclusions,
+# retain the useful combined conclusion instead of displaying "unknown".
+android_result="${ANDROID_RESULT:-${MOBILE_RESULT:-unknown}}"
+ios_result="${IOS_RESULT:-${MOBILE_RESULT:-unknown}}"
+
+apk_url=""
+ipa_url=""
+if [[ -n "${MOBILE_ASSET_BASE_URL:-}" ]]; then
+  [[ -z "${APK_NAME:-}" ]] || apk_url="${MOBILE_ASSET_BASE_URL}/${APK_NAME}"
+  [[ -z "${IPA_NAME:-}" ]] || ipa_url="${MOBILE_ASSET_BASE_URL}/${IPA_NAME}"
+fi
+
+android_detail=$(artifact_link "$apk_url" "${APK_NAME:-Android APK}")
+ios_detail=$(artifact_link "$ipa_url" "${IPA_NAME:-iOS IPA}")
+asg_detail=$(artifact_link "${ASG_APK_URL:-}" "${ASG_APK_NAME:-ASG APK}")
+
+if [[ "${FINALIZE_RESULT:-}" == "success" ]]; then
+  header_icon=":white_check_mark:"
+  header_text="$channel_label release complete"
+elif [[ "$android_result" == "success" || "$ios_result" == "success" || "${OTA_RESULT:-}" == "success" ]]; then
+  header_icon=":warning:"
+  header_text="$channel_label release incomplete"
+else
+  header_icon=":x:"
+  header_text="$channel_label release failed"
+fi
+
+newline=$'\n'
+android_line="*$(icon "$android_result") Android* - $(label "$android_result") - ${android_detail}${newline}Google Play: ${PLAY_TRACK:-unknown}"
+ios_line="*$(icon "$ios_result") iOS* - $(label "$ios_result") - ${ios_detail}${newline}TestFlight: ${TESTFLIGHT_GROUP:-unknown}"
+asg_line="*$(icon "${OTA_RESULT:-unknown}") ASG + OTA* - $(label "${OTA_RESULT:-unknown}") - ${asg_detail}"
+checks_line="*Release checks*${newline}Plan: $(icon "${PLAN_RESULT:-unknown}") $(label "${PLAN_RESULT:-unknown}") | Packages: $(icon "${NPM_RESULT:-unknown}") $(label "${NPM_RESULT:-unknown}") | Native SDK: $(icon "${SDK_NATIVE_RESULT:-unknown}") $(label "${SDK_NATIVE_RESULT:-unknown}") | Engine consumer: $(icon "${ENGINE_RESULT:-unknown}") $(label "${ENGINE_RESULT:-unknown}") | Finalize: $(icon "${FINALIZE_RESULT:-unknown}") $(label "${FINALIZE_RESULT:-unknown}")"
+
+payload=$(jq -n \
+  --arg header "$header_icon $header_text" \
+  --arg commit "$commit_subject" \
+  --arg release "$release_text" \
+  --arg android "$android_line" \
+  --arg ios "$ios_line" \
+  --arg asg "$asg_line" \
+  --arg checks "$checks_line" \
+  --arg context "Commit <${commit_url}|\`${commit_short}\`> by ${commit_author} - <${run_url}|View workflow>" \
+  '{
+    blocks: [
+      {type: "header", text: {type: "plain_text", text: $header, emoji: true}},
+      {type: "section", text: {type: "mrkdwn", text: $commit}},
+      {type: "section", text: {type: "mrkdwn", text: $release}},
+      {type: "divider"},
+      {type: "section", text: {type: "mrkdwn", text: $android}},
+      {type: "section", text: {type: "mrkdwn", text: $ios}},
+      {type: "section", text: {type: "mrkdwn", text: $asg}},
+      {type: "section", text: {type: "mrkdwn", text: $checks}},
+      {type: "context", elements: [{type: "mrkdwn", text: $context}]}
+    ]
+  }')
+
+if [[ "${SLACK_NOTIFY_DRY_RUN:-}" == "true" ]]; then
+  printf '%s\n' "$payload"
+  exit 0
+fi
+
+curl --fail --silent --show-error --retry 3 \
+  --header "Content-Type: application/json" \
+  --data "$payload" \
+  "$webhook_url"
+echo

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -403,3 +403,41 @@ jobs:
               echo "- GitHub release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ steps.results.outputs.tag }}"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-slack:
+    name: Notify release Slack channel
+    needs: [plan, ota, npm, sdk-native, mobile, engine-consumer, finalize]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post coordinated release result
+        continue-on-error: true
+        env:
+          STAGING_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_BUILDS }}
+          DEV_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_DEV_BUILDS }}
+          BRANCH: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
+          RELEASE_IDENTITY: ${{ needs.plan.outputs.release_identity }}
+          PLAY_TRACK: ${{ needs.plan.outputs.play_track }}
+          TESTFLIGHT_GROUP: ${{ needs.plan.outputs.testflight_group }}
+          PLAN_RESULT: ${{ needs.plan.result }}
+          OTA_RESULT: ${{ needs.ota.result }}
+          NPM_RESULT: ${{ needs.npm.result }}
+          SDK_NATIVE_RESULT: ${{ needs.sdk-native.result }}
+          MOBILE_RESULT: ${{ needs.mobile.result }}
+          ANDROID_RESULT: ${{ needs.mobile.outputs.android_result }}
+          IOS_RESULT: ${{ needs.mobile.outputs.ios_result }}
+          ENGINE_RESULT: ${{ needs.engine-consumer.result }}
+          FINALIZE_RESULT: ${{ needs.finalize.result }}
+          APK_NAME: ${{ needs.mobile.outputs.apk_name }}
+          IPA_NAME: ${{ needs.mobile.outputs.ipa_name }}
+          MOBILE_ASSET_BASE_URL: ${{ needs.mobile.outputs.asset_base_url }}
+          ASG_APK_NAME: ${{ needs.ota.outputs.asg_apk_name }}
+          ASG_APK_URL: ${{ needs.ota.outputs.asg_apk_url }}
+        run: .github/scripts/notify-coordinated-release-slack.sh

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -71,6 +71,16 @@ on:
         value: ${{ jobs.result.outputs.result_artifact }}
       release_tag:
         value: ${{ jobs.prepare.outputs.release_tag }}
+      android_result:
+        value: ${{ jobs.status.outputs.android_result }}
+      ios_result:
+        value: ${{ jobs.status.outputs.ios_result }}
+      apk_name:
+        value: ${{ jobs.status.outputs.apk_name }}
+      ipa_name:
+        value: ${{ jobs.status.outputs.ipa_name }}
+      asset_base_url:
+        value: ${{ jobs.status.outputs.asset_base_url }}
 
 permissions:
   contents: write
@@ -754,3 +764,32 @@ jobs:
           path: result
           if-no-files-found: error
           retention-days: 90
+
+  status:
+    name: Export mobile build status
+    needs: [prepare, android, ios]
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      android_result: ${{ steps.status.outputs.android_result }}
+      ios_result: ${{ steps.status.outputs.ios_result }}
+      apk_name: ${{ steps.status.outputs.apk_name }}
+      ipa_name: ${{ steps.status.outputs.ipa_name }}
+      asset_base_url: ${{ steps.status.outputs.asset_base_url }}
+    steps:
+      - name: Export platform conclusions and artifact coordinates
+        id: status
+        env:
+          ANDROID_RESULT: ${{ needs.android.result }}
+          IOS_RESULT: ${{ needs.ios.result }}
+          APK_NAME: ${{ needs.prepare.outputs.apk_name }}
+          IPA_NAME: ${{ needs.prepare.outputs.ipa_name }}
+          ASSET_BASE_URL: ${{ needs.prepare.outputs.asset_base_url }}
+        run: |
+          {
+            echo "android_result=$ANDROID_RESULT"
+            echo "ios_result=$IOS_RESULT"
+            echo "apk_name=$APK_NAME"
+            echo "ipa_name=$IPA_NAME"
+            echo "asset_base_url=$ASSET_BASE_URL"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -38,6 +38,12 @@ on:
       asg_fingerprint:
         description: Effective ASG build-input fingerprint
         value: ${{ jobs.ota.outputs.asg_fingerprint }}
+      asg_apk_name:
+        description: Selected ASG APK asset name
+        value: ${{ jobs.ota.outputs.asg_apk_name }}
+      asg_apk_url:
+        description: Selected ASG APK public URL
+        value: ${{ jobs.ota.outputs.asg_apk_url }}
 
 permissions:
   contents: write
@@ -65,6 +71,8 @@ jobs:
       manifest_sha256: ${{ steps.result.outputs.manifest_sha256 }}
       result_artifact: ${{ steps.names.outputs.result_artifact }}
       asg_fingerprint: ${{ steps.asg-identity.outputs.fingerprint }}
+      asg_apk_name: ${{ steps.names.outputs.apk_asset }}
+      asg_apk_url: ${{ steps.names.outputs.apk_url }}
     steps:
       - name: Clean persistent-runner build outputs
         run: rm -rf asg_client/app/build asg_client/.gradle asg_client/StreamPackLite coordinated-ota-work "$GRADLE_USER_HOME"


### PR DESCRIPTION
## Summary

Restore coordinated release status posts for both release branches:

- `dev` posts to the new `dev-builds` webhook
- `staging` continues posting to the existing `staging-builds` webhook
- successful Android posts include a direct APK download link
- successful iOS posts include the exact IPA artifact link and TestFlight group
- ASG/OTA, package, native SDK, Engine-consumer, and finalization conclusions are included in one terminal report
- failed or unavailable assets fall back to the workflow run instead of producing a broken link

## Configuration

Staging reuses the existing `SLACK_WEBHOOK_NIGHTLY_BUILDS` repository secret.

Dev expects a new repository secret named:

```text
SLACK_WEBHOOK_DEV_BUILDS
```

Until that secret is configured, dev releases emit a GitHub Actions warning and continue without failing the release. Slack delivery itself is also best effort and cannot turn a successful release red.

## Design

The notification runs once after every coordinated release pipeline reaches a terminal state. Reusable mobile and OTA workflows export their platform conclusions and exact published artifact coordinates to the top-level coordinator. A small shell script selects the branch-specific webhook and constructs the Slack Block Kit payload.

This preserves the coordinated pipeline's existing per-branch concurrency and does not introduce a separate workflow that could report before all release jobs have settled.

## Validation

- `actionlint` passes for all modified workflows, ignoring the repository's existing custom-runner-label warning
- `shellcheck` passes
- `bash -n` passes
- dry-run payload parses as JSON and contains the expected Slack blocks
- `git diff --check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only notification plumbing with best-effort Slack delivery; release success is not gated on notifications.
> 
> **Overview**
> **Restores terminal Slack status posts** for coordinated releases on **`dev`** and **`staging`** push runs, using a new **`notify-coordinated-release-slack.sh`** script and a **`notify-slack`** job that runs after plan, OTA, npm, SDK, mobile, engine-consumer, and finalize (`always()`, push-only, **`continue-on-error`**).
> 
> The message picks the webhook by branch (`SLACK_WEBHOOK_DEV_BUILDS` vs existing nightly/staging secret), summarizes Android/iOS/ASG outcomes with Play track and TestFlight group, rolls up plan/npm/SDK/engine/finalize job results, and links APK/IPA/ASG assets when URLs pass a HEAD check—otherwise it falls back to the workflow run. Missing dev webhook logs a warning and skips without failing the pipeline.
> 
> **Reusable workflows now export coordinates** for that report: mobile adds a **`status`** job and workflow outputs for per-platform conclusions plus APK/IPA names and release download base URL; OTA exposes **`asg_apk_name`** and **`asg_apk_url`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0499b1c7bd8fd325388a63e515b74aabaeb1d0f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->