### PR TITLE
Group prerelease artifacts by production base version

### DIFF
--- a/.github/scripts/assemble-coordinated-release-results.test.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.test.mjs
@@ -144,7 +144,7 @@ test("assembles every product target and finalizes one complete release manifest
     mobile,
     asgSelectionFile,
     enginePackage,
-    releaseAssetBaseUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v${plan.releaseIdentity}`,
+    releaseAssetBaseUrl: "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0",
   })
   const manifest = finalizeReleaseManifest({plan, results, completedAt: "2026-08-25T02:00:00.000Z"})
 

--- a/.github/scripts/coordinated-mobile-records.test.mjs
+++ b/.github/scripts/coordinated-mobile-records.test.mjs
@@ -27,7 +27,7 @@ test("records and merges exact mobile store and downloadable artifacts", () => {
   writeFileSync(apk, "apk")
   writeFileSync(aab, "aab")
   writeFileSync(ipa, "ipa")
-  const base = "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57"
+  const base = "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0"
   const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
   const android = createAndroidRecord({
     plan,

--- a/.github/scripts/coordinated-ota-records.test.mjs
+++ b/.github/scripts/coordinated-ota-records.test.mjs
@@ -127,10 +127,10 @@ test("creates a release result only for an exact ASG, MTK, and BES selection", (
     selectionUrl: "https://example.com/asg-selection.json",
     selectionStatus: "published",
     manifestPath: fixtureData.manifestPath,
-    manifestUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57/${releasePlan.artifactNames.otaManifest}`,
+    manifestUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/${releasePlan.artifactNames.otaManifest}`,
     bundlePath: fixtureData.bundlePath,
     bundleUrl:
-      "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57/mentra-live-ota-bundle-3.1.0-beta.57.zip",
+      "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-bundle-3.1.0-beta.57.zip",
     bundleStatus: "published",
     manifestStatus: "reused",
     reused: true,

--- a/.github/scripts/coordinated-sdk-native-records.test.mjs
+++ b/.github/scripts/coordinated-sdk-native-records.test.mjs
@@ -51,7 +51,7 @@ test("records exact Maven and SwiftPM artifacts and merges them", () => {
     plan,
     archive: files.archive,
     archiveUrl:
-      "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57/mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar",
+      "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar",
     tagUrl: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/3.1.0-beta.57",
     mirrorCommit: "b".repeat(40),
     provenanceUrl,
@@ -63,7 +63,7 @@ test("records exact Maven and SwiftPM artifacts and merges them", () => {
   assert.equal(merged.publications["@mentra/bluetooth-sdk"]["swift-package-manager"].status, "reused")
   assert.equal(
     merged.publications["@mentra/bluetooth-sdk"]["swift-package-manager"].url,
-    "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-v3.1.0-beta.57/mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar",
+    "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar",
   )
   assert.equal(
     merged.publications["@mentra/bluetooth-sdk"]["swift-package-manager"].sourceTagUrl,

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -25,7 +25,8 @@ test("coordinated OTA assets have bounded release ownership", () => {
   assert.match(ota, /for file in coordinated-ota-work\/asg-release-assets\/\*/)
   assert.match(ota, /for file in coordinated-ota-work\/release-assets\/\*/)
   assert.match(ota, /--release-id "\$\{\{ inputs\.release_id \}\}"/)
-  assert.match(ota, /\{draft: false, prerelease: true, body: \$body\}/)
+  assert.match(ota, /artifactContainerTag/)
+  assert.doesNotMatch(ota, /draft: false, prerelease: true, body:/)
   assert.doesNotMatch(ota, /OTA_RELEASE_TAG/)
 })
 

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -41,6 +41,7 @@ test("release finalization reads the preserved OTA artifact layout", () => {
 
 test("production validates before approval and proves packages before mobile promotion", () => {
   const production = workflow("coordinated-production-promotion.yml")
+  const sdkNative = jobBlock(workflow("reusable-coordinated-sdk-native.yml"), "prepare")
 
   assert.doesNotMatch(jobBlock(production, "plan"), /^    needs:/m)
   assert.match(jobBlock(production, "approve"), /^    needs: plan$/m)
@@ -52,6 +53,15 @@ test("production validates before approval and proves packages before mobile pro
   assert.match(
     jobBlock(production, "finalize"),
     /^    needs: \[plan, approve, npm, sdk-native, mobile, engine-consumer\]$/m,
+  )
+  assert.match(sdkNative, /channel=\$\(jq -er \.channel release-intent\/release-plan\.json\)/)
+  assert.match(
+    sdkNative,
+    /if \[\[ "\$channel" == "production" \]\]; then\s+\[\[ "\$\(jq -r \.draft <<< "\$release"\)" == "true" \]\]\s+\[\[ "\$\(jq -r \.prerelease <<< "\$release"\)" == "false" \]\]/,
+  )
+  assert.match(
+    sdkNative,
+    /else\s+\[\[ "\$\(jq -r \.draft <<< "\$release"\)" == "false" \]\]\s+\[\[ "\$\(jq -r \.prerelease <<< "\$release"\)" == "true" \]\]/,
   )
 })
 

--- a/.github/scripts/prepare-production-release.mjs
+++ b/.github/scripts/prepare-production-release.mjs
@@ -45,8 +45,11 @@ export function prepareProductionRelease({family, betaPlan, betaManifest, betaMa
     throw new Error("Selected beta has no valid native build number")
   }
 
-  const betaTag = `mentra-v${betaPlan.releaseIdentity}`
-  const betaAssetBaseUrl = `https://github.com/${repository}/releases/download/${betaTag}`
+  const betaArtifactTag = betaPlan.artifactContainerTag
+  if (betaArtifactTag !== `mentra-builds-v${betaPlan.familyBaseVersion}`) {
+    throw new Error("Selected beta plan does not name its base-version artifact container")
+  }
+  const betaAssetBaseUrl = `https://github.com/${repository}/releases/download/${betaArtifactTag}`
   const betaManifestUrl = `${betaAssetBaseUrl}/${betaPlan.artifactNames.releaseManifest}`
   const productionPlan = createReleasePlan({
     family,

--- a/.github/scripts/prepare-production-release.test.mjs
+++ b/.github/scripts/prepare-production-release.test.mjs
@@ -24,6 +24,8 @@ const betaPlan = {
   releaseSetId: "mentra-3.1.0-beta.57",
   familyBaseVersion: "3.1.0",
   releaseIdentity: "3.1.0-beta.57",
+  artifactContainerTag: "mentra-builds-v3.1.0",
+  artifactContainerName: "Mentra 3.1.0 development builds",
   channel: "beta",
   sequence: 57,
   sourceCommit: "a".repeat(40),
@@ -92,6 +94,10 @@ test("derives a stable plan while preserving the selected beta bytes and native 
   assert.equal(result.productionPlan.native.buildNumber, betaPlan.native.buildNumber)
   assert.equal(result.selection.mobileArtifacts.androidAab.coordinate, betaPlan.artifactNames.androidStoreApp)
   assert.equal(result.selection.otaManifest.sha256, "c".repeat(64))
+  assert.equal(
+    result.productionPlan.promotion.selectedBetaManifest.url,
+    "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-release-3.1.0-beta.57.json",
+  )
   assert.equal(result.selection.otaArtifacts.length, 3)
   assert.deepEqual(
     result.selection.otaArtifacts.map(({coordinate}) => coordinate),

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -245,6 +245,10 @@ export function createReleasePlan({family, channel, sequence, sourceCommit, nati
     releaseSetId: releaseSetId(releaseIdentity),
     familyBaseVersion: family.familyBaseVersion,
     releaseIdentity,
+    artifactContainerTag:
+      channel === "production" ? `mentra-v${releaseIdentity}` : `mentra-builds-v${family.familyBaseVersion}`,
+    artifactContainerName:
+      channel === "production" ? `Mentra ${releaseIdentity}` : `Mentra ${family.familyBaseVersion} development builds`,
     channel,
     sequence: channel === "production" ? null : sequence,
     sourceCommit,

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -70,6 +70,8 @@ test("creates a deterministic release plan with exact dependency versions", () =
   })
 
   assert.equal(plan.releaseSetId, "mentra-3.1.0-beta.57")
+  assert.equal(plan.artifactContainerTag, "mentra-builds-v3.1.0")
+  assert.equal(plan.artifactContainerName, "Mentra 3.1.0 development builds")
   assert.equal(plan.native.marketingVersion, "3.1.0")
   assert.equal(plan.native.buildNumber, 3100057)
   assert.equal(plan.products["@mentra/engine"], "3.1.0-beta.57")
@@ -81,6 +83,15 @@ test("creates a deterministic release plan with exact dependency versions", () =
   assert.equal(plan.artifactNames.androidStoreApp, "mentraos-3.1.0-beta.57-android.aab")
   assert.equal(plan.artifactNames.iosSdkArchive, "mentra-bluetooth-sdk-ios-3.1.0-beta.57.tar")
   assert.equal(plan.otaInputs.firmwareManifest, "firmware_live.json")
+
+  const productionPlan = createReleasePlan({
+    family,
+    channel: "production",
+    sourceCommit: "b".repeat(40),
+    nativeBuildNumber: 3100057,
+  })
+  assert.equal(productionPlan.artifactContainerTag, "mentra-v3.1.0")
+  assert.equal(productionPlan.artifactContainerName, "Mentra 3.1.0")
 })
 
 test("serializes records canonically and finalizes only complete release results", () => {

--- a/.github/workflows/coordinated-production-promotion.yml
+++ b/.github/workflows/coordinated-production-promotion.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$BETA_IDENTITY" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*$ ]]
-          tag="mentra-v$BETA_IDENTITY"
+          base_version="${BETA_IDENTITY%%-*}"
+          tag="mentra-builds-v$base_version"
           state=$(gh release view "$tag" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv')
           [[ "$state" == $'false\ttrue' ]]
           mkdir -p selected-beta
@@ -60,6 +61,8 @@ jobs:
             --dir selected-beta
           mv "selected-beta/mentra-release-plan-$BETA_IDENTITY.json" selected-beta/release-plan.json
           mv "selected-beta/mentra-release-$BETA_IDENTITY.json" selected-beta/release-manifest.json
+          [[ "$(jq -er .releaseIdentity selected-beta/release-plan.json)" == "$BETA_IDENTITY" ]]
+          [[ "$(jq -er .artifactContainerTag selected-beta/release-plan.json)" == "$tag" ]]
 
       - name: Require and select the beta source from main
         run: |

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -133,31 +133,32 @@ jobs:
           SOURCE_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
-          identity=$(jq -er .releaseIdentity release-plan.json)
-          tag="mentra-v$identity"
-          name="Mentra $identity"
-          releases=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq 'add')
-          matches=$(jq --arg tag "$tag" '[.[] | select(.tag_name == $tag)]' <<< "$releases")
-          [[ "$(jq 'length' <<< "$matches")" -le 1 ]]
-          if [[ "$(jq 'length' <<< "$matches")" == 0 ]]; then
+          tag=$(jq -er .artifactContainerTag release-plan.json)
+          name=$(jq -er .artifactContainerName release-plan.json)
+          if ! release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$tag" 2>/dev/null); then
             payload=$(jq -n \
               --arg tag "$tag" \
               --arg source "$SOURCE_COMMIT" \
               --arg name "$name" \
-              --arg body "Coordinated release $identity. Publication is incomplete until the release manifest is attached." \
-              '{tag_name: $tag, target_commitish: $source, name: $name, body: $body, draft: true, prerelease: true}')
-            release=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input - <<< "$payload")
-          else
-            release=$(jq '.[0]' <<< "$matches")
+              --arg body "Immutable development and beta artifacts for the Mentra $(jq -er .familyBaseVersion release-plan.json) release train. Exact source revisions are preserved by per-build tags." \
+              '{tag_name: $tag, target_commitish: $source, name: $name, body: $body, draft: false, prerelease: true}')
+            if ! release=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input - <<< "$payload" 2>/dev/null); then
+              # Dev and staging can allocate the same base-version bucket concurrently.
+              sleep 2
+              release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$tag")
+            fi
           fi
+          [[ "$(jq -r .tag_name <<< "$release")" == "$tag" ]]
           [[ "$(jq -r .name <<< "$release")" == "$name" ]]
-          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
-            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
-          else
-            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
+          [[ "$(jq -r .draft <<< "$release")" == "false" ]]
+          [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
+          release_id=$(jq -er .id <<< "$release")
+          asset_count=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$release_id/assets?per_page=100" | jq 'add | length')
+          if (( asset_count >= 900 )); then
+            echo "Release container $tag has $asset_count assets; advance the family base version before GitHub's 1000-asset limit." >&2
+            exit 1
           fi
-          echo "release_id=$(jq -er .id <<< "$release")" >> "$GITHUB_OUTPUT"
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -290,7 +291,7 @@ jobs:
           mkdir -p finalized-release
           plan=release-input/plan/release-plan.json
           identity=$(jq -er .releaseIdentity "$plan")
-          tag="mentra-v$identity"
+          tag=$(jq -er .artifactContainerTag "$plan")
           asg_selection="release-input/ota/release-assets/$(jq -er .artifactNames.asgSelection "$plan")"
           test -f "$asg_selection"
           engine_package=$(find release-input/npm -type f -name 'mentra-engine-*.tgz' -print -quit)
@@ -320,19 +321,14 @@ jobs:
         if: needs.plan.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          SOURCE_COMMIT: ${{ needs.plan.outputs.source_commit }}
         run: |
           set -euo pipefail
           tag="${{ steps.results.outputs.tag }}"
           release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${{ needs.plan.outputs.release_id }}")
           [[ "$(jq -r .tag_name <<< "$release")" == "$tag" ]]
-          [[ "$(jq -r .name <<< "$release")" == "Mentra ${{ steps.results.outputs.identity }}" ]]
-          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
-            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
-          else
-            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
-          fi
+          [[ "$(jq -r .name <<< "$release")" == "$(jq -er .artifactContainerName release-input/plan/release-plan.json)" ]]
+          [[ "$(jq -r .draft <<< "$release")" == "false" ]]
+          [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
           echo "release_id=${{ needs.plan.outputs.release_id }}" >> "$GITHUB_OUTPUT"
 
       - name: Finalize release manifest
@@ -361,24 +357,20 @@ jobs:
               --repository "${{ github.repository }}"
           done
 
-      - name: Publish completed release set
+      - name: Tag and verify the completed release set
         if: needs.plan.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          tag="${{ steps.results.outputs.tag }}"
-          payload=$(jq -n \
-            --arg name "Mentra ${{ steps.results.outputs.identity }}" \
-            --arg body "Coordinated Mentra release ${{ steps.results.outputs.identity }} from ${{ needs.plan.outputs.source_commit }}. Every required target is recorded in ${{ steps.results.outputs.manifest_name }}." \
-            '{draft: false, prerelease: true, name: $name, body: $body}')
-          gh api --method PATCH \
-            "repos/${GITHUB_REPOSITORY}/releases/${{ steps.release-container.outputs.release_id }}" \
-            --input - <<< "$payload" \
-            --jq '.draft == false and .prerelease == true' | grep -qx true
-          git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-          [[ "$(git rev-parse "$tag^{commit}")" == "${{ needs.plan.outputs.source_commit }}" ]]
-          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/${{ steps.results.outputs.manifest_name }}"
+          source_tag="mentra-v${{ steps.results.outputs.identity }}"
+          if ! ref=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/$source_tag" 2>/dev/null); then
+            ref=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/$source_tag" \
+              -f sha="${{ needs.plan.outputs.source_commit }}")
+          fi
+          [[ "$(jq -r .object.sha <<< "$ref")" == "${{ needs.plan.outputs.source_commit }}" ]]
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ steps.results.outputs.tag }}/${{ steps.results.outputs.manifest_name }}"
           node .github/scripts/verify-public-release-asset.mjs \
             --file "finalized-release/${{ steps.results.outputs.manifest_name }}" \
             --url "$url"

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -129,7 +129,7 @@ jobs:
           [[ "$source" == "$SOURCE_COMMIT" ]]
           identity=$(jq -er .releaseIdentity release-intent/release-plan.json)
           release_set_id=$(jq -er .releaseSetId release-intent/release-plan.json)
-          tag="mentra-v${identity}"
+          tag=$(jq -er .artifactContainerTag release-intent/release-plan.json)
           {
             echo "release_tag=$tag"
             echo "release_identity=$identity"
@@ -160,20 +160,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ inputs.release_id }}
-          SOURCE_COMMIT: ${{ inputs.source_commit }}
         run: |
           set -euo pipefail
           tag="${{ steps.release.outputs.release_tag }}"
           test -n "$RELEASE_ID"
           release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID")
           [[ "$(jq -r .tag_name <<< "$release")" == "$tag" ]]
-          [[ "$(jq -r .name <<< "$release")" == "Mentra ${{ steps.release.outputs.release_identity }}" ]]
-          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
-            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
-          else
-            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
-          fi
+          [[ "$(jq -r .name <<< "$release")" == "$(jq -er .artifactContainerName release-intent/release-plan.json)" ]]
+          [[ "$(jq -r .draft <<< "$release")" == "false" ]]
+          [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
 
           release_id="$RELEASE_ID"
           assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$release_id/assets?per_page=100" | jq 'add')

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -202,7 +202,7 @@ jobs:
           provenance_asset=$(jq -er .provenanceAsset coordinated-ota-work/asg-build-identity.json)
           [[ "$apk_asset" == "${{ steps.existing-asg.outputs.apk_asset }}" ]]
           [[ "$provenance_asset" == "${{ steps.existing-asg.outputs.provenance_asset }}" ]]
-          release_tag="mentra-v${release_identity}"
+          release_tag=$(jq -er .artifactContainerTag release-intent/release-plan.json)
           asg_release_base="https://github.com/${REPOSITORY}/releases/download/${ASG_RELEASE_TAG}"
           release_base="https://github.com/${REPOSITORY}/releases/download/${release_tag}"
 
@@ -451,20 +451,13 @@ jobs:
         if: inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
-          SOURCE_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
           release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${{ inputs.release_id }}")
           [[ "$(jq -r .tag_name <<< "$release")" == "${{ steps.names.outputs.release_tag }}" ]]
-          [[ "$(jq -r .name <<< "$release")" == "Mentra ${{ steps.names.outputs.release_identity }}" ]]
+          [[ "$(jq -r .name <<< "$release")" == "$(jq -er .artifactContainerName release-intent/release-plan.json)" ]]
           [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
-          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
-            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
-          else
-            tag="${{ steps.names.outputs.release_tag }}"
-            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
-          fi
+          [[ "$(jq -r .draft <<< "$release")" == "false" ]]
           for file in coordinated-ota-work/release-assets/*; do
             name=$(basename "$file")
             node .github/scripts/publish-immutable-release-asset.mjs \
@@ -473,16 +466,6 @@ jobs:
               --release-id "${{ inputs.release_id }}" \
               --repository "${{ github.repository }}"
           done
-
-          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
-            payload=$(jq -n \
-              --arg body "Coordinated Mentra release ${{ steps.names.outputs.release_identity }} is in progress. Its immutable OTA assets are available; the completed release manifest is published only after every target succeeds." \
-              '{draft: false, prerelease: true, body: $body}')
-            gh api --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/releases/${{ inputs.release_id }}" \
-              --input - <<< "$payload" \
-              --jq '.draft == false and .prerelease == true' | grep -qx true
-          fi
 
       - name: Verify published OTA manifest
         if: inputs.dry_run != true

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -69,18 +69,13 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$RELEASE_ID"
-          identity=$(jq -er .releaseIdentity release-intent/release-plan.json)
           [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "$SOURCE_COMMIT" ]]
-          tag="mentra-v$identity"
+          tag=$(jq -er .artifactContainerTag release-intent/release-plan.json)
           release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID")
           [[ "$(jq -r .tag_name <<< "$release")" == "$tag" ]]
-          [[ "$(jq -r .name <<< "$release")" == "Mentra $identity" ]]
-          if [[ "$(jq -r .draft <<< "$release")" == "true" ]]; then
-            [[ "$(jq -r .target_commitish <<< "$release")" == "$SOURCE_COMMIT" ]]
-          else
-            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-            [[ "$(git rev-parse "$tag^{commit}")" == "$SOURCE_COMMIT" ]]
-          fi
+          [[ "$(jq -r .name <<< "$release")" == "$(jq -er .artifactContainerName release-intent/release-plan.json)" ]]
+          [[ "$(jq -r .draft <<< "$release")" == "false" ]]
+          [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
           {
             echo "release_id=$RELEASE_ID"
             echo "release_tag=$tag"
@@ -437,13 +432,14 @@ jobs:
         run: |
           set -euo pipefail
           version=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          artifact_tag=$(jq -er .artifactContainerTag release-intent/release-plan.json)
           archive_name=$(jq -er .artifactNames.iosSdkArchive release-intent/release-plan.json)
           [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "$SOURCE_COMMIT" ]]
           {
             echo "version=$version"
             echo "archive_name=$archive_name"
             echo "release_tag=mentra-v$version"
-            echo "archive_url=https://github.com/${{ github.repository }}/releases/download/mentra-v$version/$archive_name"
+            echo "archive_url=https://github.com/${{ github.repository }}/releases/download/$artifact_tag/$archive_name"
             echo "tag_url=https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/$version"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -74,8 +74,14 @@ jobs:
           release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID")
           [[ "$(jq -r .tag_name <<< "$release")" == "$tag" ]]
           [[ "$(jq -r .name <<< "$release")" == "$(jq -er .artifactContainerName release-intent/release-plan.json)" ]]
-          [[ "$(jq -r .draft <<< "$release")" == "false" ]]
-          [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
+          channel=$(jq -er .channel release-intent/release-plan.json)
+          if [[ "$channel" == "production" ]]; then
+            [[ "$(jq -r .draft <<< "$release")" == "true" ]]
+            [[ "$(jq -r .prerelease <<< "$release")" == "false" ]]
+          else
+            [[ "$(jq -r .draft <<< "$release")" == "false" ]]
+            [[ "$(jq -r .prerelease <<< "$release")" == "true" ]]
+          fi
           {
             echo "release_id=$RELEASE_ID"
             echo "release_tag=$tag"


### PR DESCRIPTION
## Summary

Stop creating one visible GitHub Release for every `dev.N` and `beta.N` build. A release family now owns one prerelease artifact container:

```text
mentra-builds-v3.1.0
```

All coordinated `3.1.0-dev.N` and `3.1.0-beta.N` assets retain their exact immutable filenames and are uploaded into that shared container. Production still creates the normal stable `mentra-v3.1.0` release.

## Provenance

Grouping the GitHub Release objects does not weaken per-build provenance:

- every completed build still creates an immutable source tag such as `mentra-v3.1.0-dev.29`
- every release plan records the exact identity, source commit, channel, native build number, filenames, hashes, and publication results
- artifact filenames remain version-qualified and cannot overwrite another build
- the completed release manifest remains the authority for whether a coordinated build finished

The shared container tag points to the commit that first created the release train and is only an artifact namespace. It is not treated as the source revision of every asset in the bucket.

## Production promotion

Production selection now:

1. resolves `mentra-builds-v<base>` from the requested beta identity
2. downloads the exact beta plan and completed manifest by immutable filename
3. verifies that the plan identifies both the requested beta and the expected artifact container
4. verifies every published artifact and source commit as before
5. creates the separate stable `mentra-v<base>` release

No mobile or OTA bytes are rebuilt by this change.

## Concurrency and limits

Dev and staging may allocate the same base-version bucket concurrently. Allocation handles that race by retrying the canonical tag lookup after a competing create. Existing global publication locks continue serializing individual asset publishers.

GitHub permits 1,000 assets per release. The coordinator refuses to begin another release once the bucket reaches 900 assets, leaving headroom for in-flight jobs and producing a clear instruction to advance the family base version.

## Scope

This changes future coordinated releases. Existing per-build GitHub Release entries are intentionally not deleted or rewritten by CI; historical cleanup can be performed separately after the new container has been proven in a live release.

## Validation

- all 84 `.github/scripts/*.test.mjs` tests pass
- `actionlint` passes for every modified workflow, ignoring only the repository's existing custom-runner-label warning
- `git diff --check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core release CI and where artifacts live; misconfiguration could break downloads or promotion, but behavior is heavily contract-tested and production still uses a separate stable release.
> 
> **Overview**
> Dev and staging coordinated builds no longer get their own GitHub Release (`mentra-v3.1.0-beta.N`). They share one prerelease **artifact container** per train (`mentra-builds-v3.1.0`), with immutable per-build filenames unchanged. Release plans now carry `artifactContainerTag` and `artifactContainerName` (production still uses `mentra-vX.Y.Z`).
> 
> The coordinator allocates that bucket once as a **non-draft prerelease**, handles concurrent create races, and **fails near GitHub’s 1,000-asset cap** (900). OTA/mobile/SDK-native workflows upload and verify against the plan’s container instead of undrafting a per-build release. **Finalize** tags the exact source commit with `mentra-v{releaseIdentity}` and drops the old PATCH-to-publish step.
> 
> **Production promotion** pulls the selected beta plan/manifest from `mentra-builds-v{base}`, checks `artifactContainerTag` and identity, and builds beta manifest URLs from the shared bucket. SDK-native **prepare** enforces draft/prerelease expectations by channel (draft stable container vs open prerelease bucket).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f97bf524bc30dd2bfc612e7494fadfdca601fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->