### PR TITLE
Expose coordinated OTA changelogs

### DIFF
--- a/.github/scripts/generate-changelog-catalog.mjs
+++ b/.github/scripts/generate-changelog-catalog.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import {existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+const VERSION_FILE_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\.md$/
+
+function compareVersions(left, right) {
+  const a = left.split(".").map(Number)
+  const b = right.split(".").map(Number)
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] - b[index]
+  }
+  return 0
+}
+
+export function readChangelogCatalog(rootDir) {
+  const directory = path.join(rootDir, "changelogs")
+  const files = readdirSync(directory, {withFileTypes: true})
+  const entries = []
+  for (const file of files) {
+    if (!file.isFile() || !VERSION_FILE_PATTERN.test(file.name)) {
+      throw new Error(`changelogs/ may contain only X.Y.Z.md files; found ${file.name}`)
+    }
+    const version = file.name.slice(0, -3)
+    const markdown = readFileSync(path.join(directory, file.name), "utf8").trim()
+    if (!markdown) throw new Error(`${file.name} must not be empty`)
+    entries.push({version, markdown})
+  }
+  if (entries.length === 0) throw new Error("changelogs/ must contain at least one X.Y.Z.md file")
+  return entries.sort((left, right) => compareVersions(right.version, left.version))
+}
+
+function kotlinString(value) {
+  return JSON.stringify(value).replaceAll("$", "\\$")
+}
+
+export function renderChangelogCatalog(entries) {
+  const typescript = [
+    "/** Generated from /changelogs. Do not edit directly. */",
+    "export const GENERATED_RELEASE_CHANGELOGS = Object.freeze(",
+    `${JSON.stringify(entries, null, 2)} as const,`,
+    ")",
+    "",
+  ].join("\n")
+  const kotlin = [
+    "package com.mentra.bluetoothsdk",
+    "",
+    "/** Generated from /changelogs. Do not edit directly. */",
+    "internal val GENERATED_RELEASE_CHANGELOGS: List<ReleaseChangelog> =",
+    "    listOf(",
+    ...entries.map(
+      ({version, markdown}) =>
+        `        ReleaseChangelog(version = ${kotlinString(version)}, markdown = ${kotlinString(markdown)}),`,
+    ),
+    "    )",
+    "",
+  ].join("\n")
+  const swift = [
+    "import Foundation",
+    "",
+    "/// Generated from /changelogs. Do not edit directly.",
+    "let generatedReleaseChangelogs: [ReleaseChangelog] = [",
+    ...entries.map(
+      ({version, markdown}) =>
+        `    ReleaseChangelog(version: ${JSON.stringify(version)}, markdown: ${JSON.stringify(markdown)}),`,
+    ),
+    "]",
+    "",
+  ].join("\n")
+  return {typescript, kotlin, swift}
+}
+
+export function catalogOutputs(rootDir) {
+  return {
+    typescript: path.join(rootDir, "mobile/modules/bluetooth-sdk/src/generated/changelogCatalog.ts"),
+    kotlin: path.join(
+      rootDir,
+      "mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/GeneratedChangelogCatalog.kt",
+    ),
+    swift: path.join(rootDir, "mobile/modules/bluetooth-sdk/ios/Source/GeneratedChangelogCatalog.swift"),
+  }
+}
+
+export function generateChangelogCatalog(rootDir, {check = false} = {}) {
+  const rendered = renderChangelogCatalog(readChangelogCatalog(rootDir))
+  for (const [language, output] of Object.entries(catalogOutputs(rootDir))) {
+    if (check) {
+      if (!existsSync(output) || readFileSync(output, "utf8") !== rendered[language]) {
+        throw new Error(
+          `${path.relative(rootDir, output)} is stale; run node .github/scripts/generate-changelog-catalog.mjs`,
+        )
+      }
+      continue
+    }
+    mkdirSync(path.dirname(output), {recursive: true})
+    writeFileSync(output, rendered[language])
+  }
+}
+
+function main() {
+  const rootDir = path.resolve(process.cwd())
+  generateChangelogCatalog(rootDir, {check: process.argv.includes("--check")})
+  console.log(`${process.argv.includes("--check") ? "Verified" : "Generated"} release changelog catalog`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/generate-changelog-catalog.test.mjs
+++ b/.github/scripts/generate-changelog-catalog.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import {mkdirSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {catalogOutputs, generateChangelogCatalog, readChangelogCatalog} from "./generate-changelog-catalog.mjs"
+
+test("sorts root changelogs newest-first and generates every SDK language", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-changelogs-"))
+  mkdirSync(path.join(root, "changelogs"))
+  writeFileSync(path.join(root, "changelogs/3.1.0.md"), "First release\n")
+  writeFileSync(path.join(root, "changelogs/3.3.0.md"), "Newest release\n")
+  writeFileSync(path.join(root, "changelogs/3.2.0.md"), "Middle $release\n")
+
+  assert.deepEqual(
+    readChangelogCatalog(root).map(({version}) => version),
+    ["3.3.0", "3.2.0", "3.1.0"],
+  )
+  generateChangelogCatalog(root)
+  generateChangelogCatalog(root, {check: true})
+
+  const outputs = catalogOutputs(root)
+  assert.match(readFileSync(outputs.typescript, "utf8"), /Newest release/)
+  assert.match(readFileSync(outputs.kotlin, "utf8"), /Middle \\\$release/)
+  assert.match(readFileSync(outputs.swift, "utf8"), /First release/)
+})
+
+test("rejects non-version files and stale generated catalogs", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-changelogs-"))
+  mkdirSync(path.join(root, "changelogs"))
+  writeFileSync(path.join(root, "changelogs/README.md"), "not a release")
+  assert.throws(() => readChangelogCatalog(root), /only X.Y.Z.md/)
+
+  const validRoot = mkdtempSync(path.join(tmpdir(), "mentra-changelogs-"))
+  mkdirSync(path.join(validRoot, "changelogs"))
+  writeFileSync(path.join(validRoot, "changelogs/3.1.0.md"), "Release")
+  generateChangelogCatalog(validRoot)
+  writeFileSync(catalogOutputs(validRoot).typescript, "stale")
+  assert.throws(() => generateChangelogCatalog(validRoot, {check: true}), /is stale/)
+})

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -1,4 +1,4 @@
-import {readFileSync} from "node:fs"
+import {existsSync, readFileSync} from "node:fs"
 import {createHash} from "node:crypto"
 import path from "node:path"
 
@@ -102,6 +102,9 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
   requireString(definition.family, "family")
   const versionSource = requireString(definition.versionSource, "versionSource")
   const familyBaseVersion = validateFamilyBaseVersion(readJson(path.join(rootDir, versionSource)).version)
+  if (!existsSync(path.join(rootDir, "changelogs", `${familyBaseVersion}.md`))) {
+    fail(`missing changelogs/${familyBaseVersion}.md for the current family base version`)
+  }
 
   if (!Array.isArray(definition.members) || definition.members.length === 0) fail("members must not be empty")
   const members = []

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -19,8 +19,16 @@ import {
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 
+function writeChangelog(root, version = "3.1.0") {
+  mkdirSync(path.join(root, "changelogs"), {recursive: true})
+  writeFileSync(path.join(root, "changelogs", version + ".md"), "Release notes")
+}
+
 test("accepts only credential-free public HTTPS URLs without fragments", () => {
-  assert.equal(requirePublicHttpsUrl("https://artifacts.example.com/file?q=1", "artifact"), "https://artifacts.example.com/file?q=1")
+  assert.equal(
+    requirePublicHttpsUrl("https://artifacts.example.com/file?q=1", "artifact"),
+    "https://artifacts.example.com/file?q=1",
+  )
   assert.throws(() => requirePublicHttpsUrl("http://artifacts.example.com/file", "artifact"), /must use HTTPS/)
   assert.throws(
     () => requirePublicHttpsUrl("https://token@artifacts.example.com/file", "artifact"),
@@ -42,8 +50,37 @@ test("loads the repository release family and derives dependency-first publicati
   assert.ok(
     family.publicationOrder.indexOf("@mentra/bluetooth-sdk") < family.publicationOrder.indexOf("@mentra/engine"),
   )
-  assert.equal(family.members.some((member) => member.name === "@mentra/types"), false)
+  assert.equal(
+    family.members.some((member) => member.name === "@mentra/types"),
+    false,
+  )
   assert.ok(family.publicationOrder.indexOf("@mentra/engine") < family.publicationOrder.indexOf("mentraos"))
+})
+
+test("requires release notes for the active family base version", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-release-family-"))
+  mkdirSync(path.join(root, ".github"), {recursive: true})
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({name: "product", version: "3.1.0"}))
+  writeFileSync(
+    path.join(root, ".github/release-family.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      family: "mentra",
+      versionSource: "package.json",
+      products: ["product"],
+      members: [
+        {
+          name: "product",
+          manifest: "package.json",
+          kind: "product",
+          publishTargets: ["npm"],
+          dependencies: [],
+        },
+      ],
+    }),
+  )
+
+  assert.throws(() => loadReleaseFamily({rootDir: root}), /missing changelogs\/3\.1\.0\.md/)
 })
 
 test("maps release branches and derives one ecosystem-neutral identity", () => {
@@ -191,6 +228,7 @@ test("can require package manifests to mirror the family base during activation"
   const root = mkdtempSync(path.join(tmpdir(), "mentra-release-family-"))
   mkdirSync(path.join(root, ".github"), {recursive: true})
   mkdirSync(path.join(root, "packages/example"), {recursive: true})
+  writeChangelog(root)
   writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.1.0"}))
   writeFileSync(path.join(root, "packages/example/package.json"), JSON.stringify({name: "example", version: "3.0.0"}))
   writeFileSync(
@@ -220,6 +258,7 @@ test("requires exact regular dependencies between activated public family packag
   mkdirSync(path.join(root, ".github"), {recursive: true})
   mkdirSync(path.join(root, "packages/base"), {recursive: true})
   mkdirSync(path.join(root, "packages/product"), {recursive: true})
+  writeChangelog(root)
   writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.1.0"}))
   writeFileSync(path.join(root, "packages/base/package.json"), JSON.stringify({name: "base", version: "3.1.0"}))
   writeFileSync(
@@ -263,6 +302,7 @@ test("rejects family dependencies hidden from the configured graph or declared a
   mkdirSync(path.join(root, ".github"), {recursive: true})
   mkdirSync(path.join(root, "packages/base"), {recursive: true})
   mkdirSync(path.join(root, "packages/product"), {recursive: true})
+  writeChangelog(root)
   writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.1.0"}))
   writeFileSync(path.join(root, "packages/base/package.json"), JSON.stringify({name: "base", version: "3.1.0"}))
   writeFileSync(
@@ -319,7 +359,7 @@ test("rejects family dependencies hidden from the configured graph or declared a
     JSON.stringify({
       name: "product",
       version: "3.1.0",
-      dependencies: {base: "3.1.0", "@mentra/outside": "workspace:*"},
+      dependencies: {"base": "3.1.0", "@mentra/outside": "workspace:*"},
     }),
   )
   assert.throws(

--- a/.github/scripts/stage-release-family.test.mjs
+++ b/.github/scripts/stage-release-family.test.mjs
@@ -17,6 +17,7 @@ function fixture() {
     recursive: true,
   })
   cpSync(path.join(repositoryRoot, "package.json"), path.join(root, "package.json"))
+  cpSync(path.join(repositoryRoot, "changelogs"), path.join(root, "changelogs"), {recursive: true})
   const family = loadReleaseFamily({rootDir: repositoryRoot, requireVersionMirrors: true})
   for (const member of family.members) {
     const source = path.join(repositoryRoot, member.manifest)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Collect promoted firmware inputs
         run: node .github/scripts/collect-ota-release-inputs.mjs
 
+      - name: Verify generated changelog catalogs
+        run: node .github/scripts/generate-changelog-catalog.mjs --check
+
       - name: Create deterministic release plan
         run: |
           set -euo pipefail

--- a/.github/workflows/release-family-checks.yml
+++ b/.github/workflows/release-family-checks.yml
@@ -9,11 +9,15 @@ on:
       - ".github/workflows/coordinated-*.yml"
       - ".github/workflows/release-family-checks.yml"
       - ".github/workflows/reusable-coordinated-*.yml"
+      - "changelogs/*.md"
       - "asg_client/ota_manifests/firmware_live.json"
       - "package.json"
       - "mobile/package.json"
       - "mobile/modules/bluetooth-sdk/package.json"
       - "mobile/modules/bluetooth-sdk/scripts/*.mjs"
+      - "mobile/modules/bluetooth-sdk/src/generated/changelogCatalog.ts"
+      - "mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/GeneratedChangelogCatalog.kt"
+      - "mobile/modules/bluetooth-sdk/ios/Source/GeneratedChangelogCatalog.swift"
       - "mobile/modules/crust/package.json"
       - "mobile/modules/engine/package.json"
       - "mobile/modules/engine/scripts/*.mjs"
@@ -50,6 +54,8 @@ jobs:
           node --test "${tests[@]}"
       - name: Validate repository definition
         run: node .github/scripts/release-family-cli.mjs validate --require-version-mirrors
+      - name: Verify generated changelog catalogs
+        run: node .github/scripts/generate-changelog-catalog.mjs --check
       - name: Validate release plan inputs
         run: |
           set -euo pipefail

--- a/changelogs/3.1.0.md
+++ b/changelogs/3.1.0.md
@@ -1,0 +1,5 @@
+Software updates are more reliable, with clearer progress and recovery when the glasses restart.
+
+- MentraOS, Mentra Engine, the Bluetooth SDK, and the glasses client now share one coordinated release version.
+- Mentra Live updates can continue across APK, system, and firmware restarts without asking the user to start the same update again.
+- Bluetooth photo capture and transfer diagnostics are more precise and less disruptive to normal glasses traffic.

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/GeneratedChangelogCatalog.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/GeneratedChangelogCatalog.kt
@@ -1,0 +1,7 @@
+package com.mentra.bluetoothsdk
+
+/** Generated from /changelogs. Do not edit directly. */
+internal val GENERATED_RELEASE_CHANGELOGS: List<ReleaseChangelog> =
+    listOf(
+        ReleaseChangelog(version = "3.1.0", markdown = "Software updates are more reliable, with clearer progress and recovery when the glasses restart.\n\n- MentraOS, Mentra Engine, the Bluetooth SDK, and the glasses client now share one coordinated release version.\n- Mentra Live updates can continue across APK, system, and firmware restarts without asking the user to start the same update again.\n- Bluetooth photo capture and transfer diagnostics are more precise and less disruptive to normal glasses traffic."),
+    )

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1225,6 +1225,12 @@ class MentraBluetoothSdk private constructor(
         )
     }
 
+    /** Return bundled release changelogs crossed between two coordinated product versions, newest first. */
+    fun getReleaseChangelogs(
+        fromVersion: String? = null,
+        toVersion: String? = null,
+    ): List<ReleaseChangelog> = ReleaseChangelogCatalog.select(fromVersion, toVersion)
+
     /** Ask connected Mentra Live glasses to report the current OTA install/session status. */
     private suspend fun queryOtaStatus(): OtaQueryResult =
         performOtaQuery("OTA status query") {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/ReleaseChangelog.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/ReleaseChangelog.kt
@@ -1,0 +1,61 @@
+package com.mentra.bluetoothsdk
+
+/** One coordinated Mentra release note authored in /changelogs/<version>.md. */
+data class ReleaseChangelog(
+    val version: String,
+    val markdown: String,
+)
+
+internal object ReleaseChangelogCatalog {
+    private val baseVersionPattern = Regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:[-+].*)?$")
+
+    fun select(
+        fromVersion: String?,
+        toVersion: String?,
+    ): List<ReleaseChangelog> {
+        val fallbackTarget =
+            GeneratedReleaseMetadata.FAMILY_BASE_VERSION.ifBlank {
+                GENERATED_RELEASE_CHANGELOGS.firstOrNull()?.version.orEmpty()
+            }
+        if (fallbackTarget.isBlank() && toVersion == null) return emptyList()
+        val target = baseVersion(toVersion ?: fallbackTarget, "toVersion")
+        if (GENERATED_RELEASE_CHANGELOGS.none { it.version == target }) {
+            throw BluetoothSdkException("missing_changelog", "No changelog is bundled for target version $target.")
+        }
+        if (fromVersion == null) return GENERATED_RELEASE_CHANGELOGS.filter { it.version == target }
+
+        val source = baseVersion(fromVersion, "fromVersion")
+        val direction = compareVersions(target, source)
+        return GENERATED_RELEASE_CHANGELOGS.filter { entry ->
+            when {
+                direction == 0 -> entry.version == target
+                direction > 0 -> compareVersions(entry.version, source) > 0 && compareVersions(entry.version, target) <= 0
+                else -> compareVersions(entry.version, source) < 0 && compareVersions(entry.version, target) >= 0
+            }
+        }
+    }
+
+    private fun baseVersion(
+        version: String,
+        label: String,
+    ): String {
+        val match = baseVersionPattern.matchEntire(version.trim())
+            ?: throw BluetoothSdkException(
+                "invalid_changelog_version",
+                "$label must be a semantic version such as 3.1.0, 3.1.0-dev.4, or 3.1.0-beta.2.",
+            )
+        return "${match.groupValues[1]}.${match.groupValues[2]}.${match.groupValues[3]}"
+    }
+
+    private fun compareVersions(
+        left: String,
+        right: String,
+    ): Int {
+        val a = left.split(".").map(String::toInt)
+        val b = right.split(".").map(String::toInt)
+        for (index in 0..2) {
+            if (a[index] != b[index]) return a[index] - b[index]
+        }
+        return 0
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/ReleaseChangelogTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/ReleaseChangelogTest.kt
@@ -1,0 +1,13 @@
+package com.mentra.bluetoothsdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReleaseChangelogTest {
+    @Test
+    fun includesTargetNotesForTransitionWithinOneReleaseTrain() {
+        val changelogs = ReleaseChangelogCatalog.select("3.1.0-dev.2", "3.1.0-beta.8")
+
+        assertEquals(listOf("3.1.0"), changelogs.map { it.version })
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/GeneratedChangelogCatalog.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/GeneratedChangelogCatalog.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Generated from /changelogs. Do not edit directly.
+let generatedReleaseChangelogs: [ReleaseChangelog] = [
+    ReleaseChangelog(version: "3.1.0", markdown: "Software updates are more reliable, with clearer progress and recovery when the glasses restart.\n\n- MentraOS, Mentra Engine, the Bluetooth SDK, and the glasses client now share one coordinated release version.\n- Mentra Live updates can continue across APK, system, and firmware restarts without asking the user to start the same update again.\n- Bluetooth photo capture and transfer diagnostics are more precise and less disruptive to normal glasses traffic."),
+]

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1259,6 +1259,14 @@ public final class MentraBluetoothSDK {
         )
     }
 
+    /// Return bundled release changelogs crossed between two coordinated product versions, newest first.
+    public func getReleaseChangelogs(
+        fromVersion: String? = nil,
+        toVersion: String? = nil
+    ) throws -> [ReleaseChangelog] {
+        try ReleaseChangelogCatalog.select(fromVersion: fromVersion, toVersion: toVersion)
+    }
+
     /// Ask connected Mentra Live glasses to report the current OTA install/session status.
     private func queryOtaStatus() async throws -> OtaQueryResult {
         try await performOtaQuery(operation: "OTA status query") {

--- a/mobile/modules/bluetooth-sdk/ios/Source/ReleaseChangelog.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ReleaseChangelog.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// One coordinated Mentra release note authored in /changelogs/<version>.md.
+public struct ReleaseChangelog: Equatable, Sendable {
+    public let version: String
+    public let markdown: String
+
+    public init(version: String, markdown: String) {
+        self.version = version
+        self.markdown = markdown
+    }
+}
+
+enum ReleaseChangelogCatalog {
+    static func select(fromVersion: String?, toVersion: String?) throws -> [ReleaseChangelog] {
+        let fallbackTarget = GeneratedReleaseMetadata.familyBaseVersion.isEmpty
+            ? (generatedReleaseChangelogs.first?.version ?? "")
+            : GeneratedReleaseMetadata.familyBaseVersion
+        if fallbackTarget.isEmpty, toVersion == nil { return [] }
+        let target = try baseVersion(toVersion ?? fallbackTarget, label: "toVersion")
+        guard generatedReleaseChangelogs.contains(where: { $0.version == target }) else {
+            throw BluetoothSdkError(code: "missing_changelog", message: "No changelog is bundled for target version \(target).")
+        }
+        guard let fromVersion else {
+            return generatedReleaseChangelogs.filter { $0.version == target }
+        }
+
+        let source = try baseVersion(fromVersion, label: "fromVersion")
+        let direction = compareVersions(target, source)
+        return generatedReleaseChangelogs.filter { entry in
+            if direction == 0 { return entry.version == target }
+            if direction > 0 {
+                return compareVersions(entry.version, source) > 0 && compareVersions(entry.version, target) <= 0
+            }
+            return compareVersions(entry.version, source) < 0 && compareVersions(entry.version, target) >= 0
+        }
+    }
+
+    private static func baseVersion(_ version: String, label: String) throws -> String {
+        let value = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffixStart = value.firstIndex(where: { $0 == "-" || $0 == "+" }) ?? value.endIndex
+        let components = value[..<suffixStart].split(separator: ".", omittingEmptySubsequences: false)
+        let isValid = components.count == 3 && components.allSatisfy { component in
+            !component.isEmpty
+                && (component == "0" || !component.hasPrefix("0"))
+                && component.utf8.allSatisfy { byte in byte >= 48 && byte <= 57 }
+        }
+        guard isValid else {
+            throw BluetoothSdkError(
+                code: "invalid_changelog_version",
+                message: "\(label) must be a semantic version such as 3.1.0, 3.1.0-dev.4, or 3.1.0-beta.2."
+            )
+        }
+        return components.joined(separator: ".")
+    }
+
+    private static func compareVersions(_ left: String, _ right: String) -> Int {
+        let a = left.split(separator: ".").map { Int($0) ?? 0 }
+        let b = right.split(separator: ".").map { Int($0) ?? 0 }
+        for index in 0 ..< 3 where a[index] != b[index] {
+            return a[index] - b[index]
+        }
+        return 0
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Tests/ReleaseChangelogTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/ReleaseChangelogTests.swift
@@ -1,0 +1,13 @@
+@testable import MentraBluetoothSDK
+import XCTest
+
+final class ReleaseChangelogTests: XCTestCase {
+    func testIncludesTargetNotesForTransitionWithinOneReleaseTrain() throws {
+        let changelogs = try ReleaseChangelogCatalog.select(
+            fromVersion: "3.1.0-dev.2",
+            toVersion: "3.1.0-beta.8"
+        )
+
+        XCTAssertEqual(changelogs.map(\.version), ["3.1.0"])
+    }
+}

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -1199,6 +1199,8 @@ export interface BluetoothSdkPublicModule {
   getOtaVersionUrl(): string
   /** Fetch the configured OTA manifest and return whether any ASG/BES/MTK update is available. */
   checkForOtaUpdate(): Promise<boolean>
+  /** Return bundled release changelogs crossed between two coordinated product versions, newest first. */
+  getReleaseChangelogs(fromVersion?: string | null, toVersion?: string | null): ReleaseChangelog[]
   /** Start OTA from the configured or explicitly supplied manifest URL. */
   startOtaUpdate(otaVersionUrl?: string | null): Promise<OtaStartAckEvent>
   /** Query the active OTA session and return the correlated status response. */
@@ -1279,6 +1281,13 @@ export interface OtaUpdateInfo {
   besVersion?: string
   /** True when the APK step installs an older build than the glasses currently run (exact-pin manifests only). */
   isDowngrade?: boolean
+}
+
+export interface ReleaseChangelog {
+  /** Base production version, for example `3.1.0`. */
+  version: string
+  /** Markdown body authored in `/changelogs/<version>.md`. */
+  markdown: string
 }
 
 export interface OtaProgress {

--- a/mobile/modules/bluetooth-sdk/src/__tests__/changelogs.test.ts
+++ b/mobile/modules/bluetooth-sdk/src/__tests__/changelogs.test.ts
@@ -1,0 +1,16 @@
+import {getReleaseChangelogs} from "../changelogs"
+
+describe("getReleaseChangelogs", () => {
+  it("includes the target changelog for a transition within one release train", () => {
+    expect(getReleaseChangelogs("3.1.0-dev.2", "3.1.0-beta.8")).toEqual([expect.objectContaining({version: "3.1.0"})])
+  })
+
+  it("returns the target changelog when the starting version is unavailable", () => {
+    expect(getReleaseChangelogs(null, "3.1.0").map(({version}) => version)).toEqual(["3.1.0"])
+  })
+
+  it("rejects malformed and unauthored target versions", () => {
+    expect(() => getReleaseChangelogs("old", "3.1.0")).toThrow(/fromVersion must be a semantic version/)
+    expect(() => getReleaseChangelogs("3.1.0", "3.2.0")).toThrow(/No changelog is bundled/)
+  })
+})

--- a/mobile/modules/bluetooth-sdk/src/changelogs.ts
+++ b/mobile/modules/bluetooth-sdk/src/changelogs.ts
@@ -1,0 +1,44 @@
+import type {ReleaseChangelog} from "./BluetoothSdk.types"
+import {GENERATED_RELEASE_CHANGELOGS} from "./generated/changelogCatalog"
+import {BLUETOOTH_SDK_RELEASE_METADATA} from "./generated/releaseMetadata"
+
+const BASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+].*)?$/
+
+function baseVersion(version: string, label: string): string {
+  const match = BASE_VERSION_PATTERN.exec(version.trim())
+  if (!match) throw new Error(`${label} must be a semantic version such as 3.1.0, 3.1.0-dev.4, or 3.1.0-beta.2`)
+  return `${match[1]}.${match[2]}.${match[3]}`
+}
+
+function compareVersions(left: string, right: string): number {
+  const a = left.split(".").map(Number)
+  const b = right.split(".").map(Number)
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] - b[index]
+  }
+  return 0
+}
+
+/**
+ * Return authored release notes crossed between two product versions, newest first.
+ * The target release is always included, including transitions within one base train.
+ */
+export function getReleaseChangelogs(fromVersion?: string | null, toVersion?: string | null): ReleaseChangelog[] {
+  const fallbackTarget = BLUETOOTH_SDK_RELEASE_METADATA.familyBaseVersion ?? GENERATED_RELEASE_CHANGELOGS[0]?.version
+  if (!fallbackTarget && !toVersion) return []
+  const target = baseVersion(toVersion ?? fallbackTarget, "toVersion")
+  if (!GENERATED_RELEASE_CHANGELOGS.some(({version}) => version === target)) {
+    throw new Error(`No changelog is bundled for target version ${target}`)
+  }
+  if (!fromVersion) {
+    return GENERATED_RELEASE_CHANGELOGS.filter(({version}) => version === target).map((entry) => ({...entry}))
+  }
+
+  const source = baseVersion(fromVersion, "fromVersion")
+  const direction = compareVersions(target, source)
+  return GENERATED_RELEASE_CHANGELOGS.filter(({version}) => {
+    if (direction === 0) return version === target
+    if (direction > 0) return compareVersions(version, source) > 0 && compareVersions(version, target) <= 0
+    return compareVersions(version, source) < 0 && compareVersions(version, target) >= 0
+  }).map((entry) => ({...entry}))
+}

--- a/mobile/modules/bluetooth-sdk/src/generated/changelogCatalog.ts
+++ b/mobile/modules/bluetooth-sdk/src/generated/changelogCatalog.ts
@@ -1,0 +1,9 @@
+/** Generated from /changelogs. Do not edit directly. */
+export const GENERATED_RELEASE_CHANGELOGS = Object.freeze(
+[
+  {
+    "version": "3.1.0",
+    "markdown": "Software updates are more reliable, with clearer progress and recovery when the glasses restart.\n\n- MentraOS, Mentra Engine, the Bluetooth SDK, and the glasses client now share one coordinated release version.\n- Mentra Live updates can continue across APK, system, and firmware restarts without asking the user to start the same update again.\n- Bluetooth photo capture and transfer diagnostics are more precise and less disruptive to normal glasses traffic."
+  }
+] as const,
+)

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -7,6 +7,7 @@ import type {
   PublicGlassesStatus,
   VideoRecordingDefaults,
 } from "./BluetoothSdk.types"
+import {getReleaseChangelogs} from "./changelogs"
 
 const PUBLIC_EVENT_NAMES = new Set<BluetoothSdkEventName>([
   "log",
@@ -159,6 +160,7 @@ export const BluetoothSdk: BluetoothSdkPublicModule = Object.freeze({
   setOtaVersionUrl: bindPublicMethod("setOtaVersionUrl"),
   getOtaVersionUrl: bindPublicMethod("getOtaVersionUrl"),
   checkForOtaUpdate: bindPublicMethod("checkForOtaUpdate"),
+  getReleaseChangelogs,
   startOtaUpdate,
   queryOtaStatus,
   startAr99OtaFromFile: bindPublicMethod("startAr99OtaFromFile"),
@@ -246,6 +248,7 @@ export type {
   OtaStatusEvent,
   OtaQueryResult,
   OtaUpdateInfo,
+  ReleaseChangelog,
   MtkUpdateCompleteEvent,
   PairFailureEvent,
   PairingInfoEvent,

--- a/mobile/modules/engine/src/facades/ota.ts
+++ b/mobile/modules/engine/src/facades/ota.ts
@@ -9,7 +9,14 @@
  * progress screen is a pure renderer over its snapshot + attach/detach/retry/finish.
  */
 import BluetoothSdk from "@mentra/bluetooth-sdk"
-import type {OtaProgress, OtaProgressStatus, OtaStartAckEvent, OtaStatus, OtaUpdateInfo} from "@mentra/bluetooth-sdk"
+import type {
+  OtaProgress,
+  OtaProgressStatus,
+  OtaStartAckEvent,
+  OtaStatus,
+  OtaUpdateInfo,
+  ReleaseChangelog,
+} from "@mentra/bluetooth-sdk"
 import {isGlassesConnected, useGlassesStore} from "../stores/glasses"
 import {resolveOtaManifestUrl} from "../services/otaManifestUrl"
 import {otaInstallCoordinator, type OtaInstallSnapshot} from "../services/OtaInstallCoordinator"
@@ -26,6 +33,7 @@ function projectSnapshot() {
   return {
     connected: isGlassesConnected(s.connection),
     buildNumber: s.buildNumber || null,
+    appVersion: s.appVersion || null,
     mtkFirmwareVersion: s.mtkFirmwareVersion || null,
     besFirmwareVersion: s.besFirmwareVersion || null,
     hotspotOtaVersion: s.hotspotOtaVersion ?? 0,
@@ -46,6 +54,7 @@ export type {
   OtaProgressStatus,
   OtaStatus,
   OtaUpdateInfo,
+  ReleaseChangelog,
   OtaInstallSnapshot,
   OtaCheckCurrentGlassesOptions,
   OtaCheckCurrentGlassesResult,
@@ -84,6 +93,9 @@ export const ota = {
   ping: () => BluetoothSdk.ping(),
   /** Resolve and compare the current glasses against the OTA manifest, then update the OTA snapshot. */
   checkForUpdates: (options?: OtaCheckCurrentGlassesOptions) => checkCurrentGlassesForUpdate(options),
+  /** Return bundled release changelogs crossed between two coordinated product versions, newest first. */
+  getReleaseChangelogs: (fromVersion?: string | null, toVersion?: string | null): ReleaseChangelog[] =>
+    BluetoothSdk.getReleaseChangelogs(fromVersion, toVersion),
   /** Clear the available-update prompt state. */
   clearUpdateAvailable: () => useGlassesStore.getState().setOtaUpdateAvailable(null),
   /** Clear active progress/status before entering a fresh install flow. */

--- a/mobile/modules/engine/src/index.ts
+++ b/mobile/modules/engine/src/index.ts
@@ -98,6 +98,7 @@ export type {
   OtaProgressStatus,
   OtaStatus,
   OtaUpdateInfo,
+  ReleaseChangelog,
   OtaSnapshot,
   OtaInstallSnapshot,
 } from "./facades/ota"

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -233,6 +233,7 @@ function OtaFlowContent({
         icon="check"
         title={translate("ota:upToDate")}>
         <BodyText colors={colors}>{translate("ota:noUpdatesAvailable")}</BodyText>
+        <ChangelogList changelogs={state.changelogs} colors={colors} />
       </FlowPage>
     )
   }

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -1,6 +1,15 @@
 /* eslint-disable react-native/no-raw-text -- BodyText and PercentText are local Text wrappers. */
 import React, {useMemo} from "react"
-import {ActivityIndicator, Pressable, StyleSheet, Text, View, type StyleProp, type ViewStyle} from "react-native"
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native"
 import {SafeAreaView} from "react-native-safe-area-context"
 import Svg, {Path, Rect} from "react-native-svg"
 
@@ -279,10 +288,10 @@ function OtaFlowContent({
       state.hotspotPhase === "downloading"
         ? "Downloading update to phone..."
         : state.hotspotPhase === "starting_hotspot"
-          ? "Starting glasses hotspot..."
-          : state.hotspotPhase === "joining_hotspot"
-            ? "Connecting phone to glasses..."
-            : "Starting update..."
+        ? "Starting glasses hotspot..."
+        : state.hotspotPhase === "joining_hotspot"
+        ? "Connecting phone to glasses..."
+        : "Starting update..."
     return (
       <FlowPage colors={colors} icon="download" title={title}>
         {state.hotspotPhase === "downloading" && state.hotspotArtifactPercent !== null ? (
@@ -334,13 +343,13 @@ function OtaFlowContent({
     const title = state.versionChangeConverged
       ? translate("ota:versionChangeComplete")
       : state.versionChange
-        ? translate("ota:versionChangeFirmwarePassComplete")
-        : "Update complete!"
+      ? translate("ota:versionChangeFirmwarePassComplete")
+      : "Update complete!"
     const message = state.versionChangeConverged
       ? translate("ota:versionChangeCompleteMessage")
       : state.versionChange
-        ? translate("ota:versionChangeFirmwarePassCompleteMessage")
-        : "Your glasses are up to date."
+      ? translate("ota:versionChangeFirmwarePassCompleteMessage")
+      : "Your glasses are up to date."
     return (
       <FlowPage
         actions={
@@ -354,6 +363,7 @@ function OtaFlowContent({
         icon="check"
         title={title}>
         <BodyText colors={colors}>{message}</BodyText>
+        <ChangelogList changelogs={state.changelogs} colors={colors} />
       </FlowPage>
     )
   }
@@ -426,6 +436,30 @@ function PercentText({colors, percent}: {colors: MentraLiveOtaFlowTheme; percent
   return <Text style={[styles.percent, {color: colors.primary}]}>{Math.round(percent)}%</Text>
 }
 
+function ChangelogList({
+  changelogs,
+  colors,
+}: {
+  changelogs: MentraLiveOtaController["state"]["changelogs"]
+  colors: MentraLiveOtaFlowTheme
+}) {
+  if (changelogs.length === 0) return null
+  return (
+    <ScrollView contentContainerStyle={styles.changelogContent} style={styles.changelogList}>
+      {changelogs.map((entry) => (
+        <View key={entry.version} style={styles.changelogEntry}>
+          <Text selectable style={[styles.changelogVersion, {color: colors.foreground}]}>
+            {entry.version}
+          </Text>
+          <Text selectable style={[styles.changelogMarkdown, {color: colors.textDim}]}>
+            {entry.markdown}
+          </Text>
+        </View>
+      ))}
+    </ScrollView>
+  )
+}
+
 function FlowButton({
   colors,
   disabled = false,
@@ -494,6 +528,11 @@ const styles = StyleSheet.create({
   percent: {fontSize: 30, fontVariant: ["tabular-nums"], fontWeight: "700"},
   progressTrack: {borderRadius: 4, height: 8, maxWidth: 420, overflow: "hidden", width: "100%"},
   progressFill: {borderRadius: 4, height: 8},
+  changelogList: {flexShrink: 1, maxHeight: 260, maxWidth: 420, width: "100%"},
+  changelogContent: {gap: 18, paddingVertical: 4},
+  changelogEntry: {gap: 8},
+  changelogVersion: {fontSize: 16, fontWeight: "600"},
+  changelogMarkdown: {fontSize: 14, lineHeight: 20},
   button: {
     alignItems: "center",
     borderRadius: 50,

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -5,9 +5,10 @@ import TestRenderer, {act} from "react-test-renderer"
 import {beforeEach, describe, expect, mock, test} from "bun:test"
 
 import type {OtaInstallSnapshot} from "../../services/OtaInstallCoordinator"
+import type {OtaCheckCurrentGlassesResult} from "../../services/OtaUpdateCheckService"
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
-const checkResult = {
+const checkResult: OtaCheckCurrentGlassesResult = {
   hasCheckCompleted: true,
   updateAvailable: true,
   latestVersionInfo: {
@@ -26,6 +27,7 @@ const checkResult = {
   updateInfo: {available: true, versionCode: 40, versionName: "3.1.0-dev.8", updates: ["apk"], totalSize: 1},
   isRequired: true,
 }
+let currentCheckResult = checkResult
 
 let otaSnapshot = {
   connected: true,
@@ -71,6 +73,26 @@ const finish = mock(() => finishPromise)
 const discard = mock(() => {})
 const getReleaseChangelogs = mock(() => [{version: "3.1.0", markdown: "Release notes"}])
 let autoChainActive = false
+let autoChainRange: {fromVersion: string | null; toVersion: string | null} | null = null
+const beginAutoChain = mock(
+  (
+    _fingerprint: string,
+    _approvedDowngrade: boolean,
+    range: {fromVersion: string | null; toVersion: string | null},
+  ) => {
+    autoChainActive = true
+    autoChainRange = {...range}
+  },
+)
+const stopAutoChain = mock(() => {
+  autoChainActive = false
+  autoChainRange = null
+})
+const advanceAutoChain = mock((_fingerprint: string, _isDowngrade: boolean, targetVersion: string | null) => {
+  if (!autoChainRange) return {advance: false as const, reason: "inactive" as const}
+  if (targetVersion) autoChainRange.toVersion = targetVersion
+  return {advance: true as const, passCount: 2}
+})
 
 const fakeOta = {
   initialize: mock(() => Promise.resolve()),
@@ -79,7 +101,7 @@ const fakeOta = {
     otaListeners.add(listener)
     return () => otaListeners.delete(listener)
   },
-  checkForUpdates: mock(() => Promise.resolve(checkResult)),
+  checkForUpdates: mock(() => Promise.resolve(currentCheckResult)),
   getReleaseChangelogs,
   clearUpdateAvailable: mock(() => {}),
   clearProgress: mock(() => {}),
@@ -100,13 +122,14 @@ const fakeOta = {
 
 mock.module("../../facades/ota", () => ({ota: fakeOta}))
 mock.module("../../services/OtaAutoChain", () => ({
-  beginOtaAutoChain: mock(() => {}),
+  beginOtaAutoChain: beginAutoChain,
   clearOtaAutoChainReconnectWait: mock(() => {}),
   isOtaAutoChainActive: () => autoChainActive,
   otaAutoChainFingerprint: () => "fingerprint",
+  otaAutoChainReleaseRange: () => (autoChainRange ? {...autoChainRange} : null),
   otaAutoChainReconnectWaitRemaining: () => null,
-  stopOtaAutoChain: mock(() => {}),
-  tryAdvanceOtaAutoChain: () => ({advance: false}),
+  stopOtaAutoChain: stopAutoChain,
+  tryAdvanceOtaAutoChain: advanceAutoChain,
 }))
 mock.module("../../services/OtaErrorMapping", () => ({
   BES_INSTALL_RESTART_MESSAGE: "Restart the glasses",
@@ -144,7 +167,12 @@ describe("useMentraLiveOta", () => {
     discard.mockClear()
     getReleaseChangelogs.mockClear()
     fakeOta.checkForUpdates.mockClear()
+    beginAutoChain.mockClear()
+    stopAutoChain.mockClear()
+    advanceAutoChain.mockClear()
     autoChainActive = false
+    autoChainRange = null
+    currentCheckResult = checkResult
     finishPromise = Promise.resolve()
     installSnapshot = {
       displayState: "starting",
@@ -236,6 +264,44 @@ describe("useMentraLiveOta", () => {
     })
 
     expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
+    await act(async () => renderer.unmount())
+  })
+
+  test("keeps the release range across a progress-screen remount", async () => {
+    const checkRenderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+    await act(async () => latestController.install())
+    await act(async () => checkRenderer.unmount())
+
+    installSnapshot = {...installSnapshot, displayState: "complete"}
+    const progressRenderer = await renderProbe("progress")
+    expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
+    await act(async () => progressRenderer.unmount())
+  })
+
+  test("retains changelogs on the final up-to-date screen", async () => {
+    const renderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+    await act(async () => latestController.install())
+    currentCheckResult = {...checkResult, updateAvailable: false, updateInfo: null, updates: []}
+    installSnapshot = {...installSnapshot, displayState: "complete"}
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 800))
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(latestController.state.screen).toBe("up_to_date")
     expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
     await act(async () => renderer.unmount())
   })

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -12,7 +12,7 @@ const checkResult = {
   updateAvailable: true,
   latestVersionInfo: {
     versionCode: 40,
-    versionName: "40",
+    versionName: "3.1.0-dev.8",
     downloadUrl: "https://example.com/asg.apk",
     apkSize: 1,
     sha256: "a".repeat(64),
@@ -23,13 +23,14 @@ const checkResult = {
   besVersion: null,
   isApkDowngrade: false,
   manifestBody: "{}",
-  updateInfo: {available: true, versionCode: 40, versionName: "40", updates: ["apk"], totalSize: 1},
+  updateInfo: {available: true, versionCode: 40, versionName: "3.1.0-dev.8", updates: ["apk"], totalSize: 1},
   isRequired: true,
 }
 
 let otaSnapshot = {
   connected: true,
   buildNumber: "39",
+  appVersion: "3.0.0",
   mtkFirmwareVersion: "0801",
   besFirmwareVersion: "0808",
   hotspotOtaVersion: 1,
@@ -68,6 +69,7 @@ const retry = mock(() => {})
 let finishPromise = Promise.resolve()
 const finish = mock(() => finishPromise)
 const discard = mock(() => {})
+const getReleaseChangelogs = mock(() => [{version: "3.1.0", markdown: "Release notes"}])
 let autoChainActive = false
 
 const fakeOta = {
@@ -78,6 +80,7 @@ const fakeOta = {
     return () => otaListeners.delete(listener)
   },
   checkForUpdates: mock(() => Promise.resolve(checkResult)),
+  getReleaseChangelogs,
   clearUpdateAvailable: mock(() => {}),
   clearProgress: mock(() => {}),
   installSession: {
@@ -139,6 +142,7 @@ describe("useMentraLiveOta", () => {
     retry.mockClear()
     finish.mockClear()
     discard.mockClear()
+    getReleaseChangelogs.mockClear()
     fakeOta.checkForUpdates.mockClear()
     autoChainActive = false
     finishPromise = Promise.resolve()
@@ -213,6 +217,26 @@ describe("useMentraLiveOta", () => {
     })
     latestController.retryInstall()
     expect(retry).toHaveBeenCalledTimes(1)
+    await act(async () => renderer.unmount())
+  })
+
+  test("exposes crossed release changelogs when an install completes", async () => {
+    const renderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+    expect(latestController.state.screen).toBe("update_available")
+
+    await act(async () => {
+      latestController.install()
+    })
+    installSnapshot = {...installSnapshot, displayState: "complete"}
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+
+    expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
     await act(async () => renderer.unmount())
   })
 

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -166,6 +166,7 @@ describe("useMentraLiveOta", () => {
     finish.mockClear()
     discard.mockClear()
     getReleaseChangelogs.mockClear()
+    getReleaseChangelogs.mockImplementation(() => [{version: "3.1.0", markdown: "Release notes"}])
     fakeOta.checkForUpdates.mockClear()
     beginAutoChain.mockClear()
     stopAutoChain.mockClear()
@@ -173,6 +174,7 @@ describe("useMentraLiveOta", () => {
     autoChainActive = false
     autoChainRange = null
     currentCheckResult = checkResult
+    otaSnapshot = {...otaSnapshot, appVersion: "3.0.0"}
     finishPromise = Promise.resolve()
     installSnapshot = {
       displayState: "starting",
@@ -303,6 +305,38 @@ describe("useMentraLiveOta", () => {
 
     expect(latestController.state.screen).toBe("up_to_date")
     expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
+    await act(async () => renderer.unmount())
+  })
+
+  test("falls back to target notes when legacy glasses report a numeric version", async () => {
+    otaSnapshot = {...otaSnapshot, appVersion: "40"}
+    getReleaseChangelogs.mockImplementation((fromVersion) => {
+      if (fromVersion === "40") throw new Error("legacy version is not coordinated semver")
+      return [{version: "3.1.0", markdown: "Release notes"}]
+    })
+    const renderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+    await act(async () => latestController.install())
+    currentCheckResult = {...checkResult, updateAvailable: false, updateInfo: null, updates: []}
+    installSnapshot = {...installSnapshot, displayState: "complete"}
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 800))
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(getReleaseChangelogs).toHaveBeenCalledWith("40", "3.1.0-dev.8")
+    expect(getReleaseChangelogs).toHaveBeenCalledWith(null, "3.1.0-dev.8")
+    expect(latestController.state).toMatchObject({
+      screen: "up_to_date",
+      changelogs: [{version: "3.1.0", markdown: "Release notes"}],
+    })
     await act(async () => renderer.unmount())
   })
 

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -18,6 +18,7 @@ import {
 } from "../services/OtaErrorMapping"
 import type {OtaInstallSnapshot} from "../services/OtaInstallCoordinator"
 import type {OtaCheckCurrentGlassesResult} from "../services/OtaUpdateCheckService"
+import type {ReleaseChangelog} from "../facades/ota"
 import {useEngineSnapshot} from "./useEngineSnapshot"
 
 export type MentraLiveOtaFlowPage = "check" | "progress"
@@ -84,6 +85,8 @@ export type MentraLiveOtaState = {
   canDiscard: boolean
   canOpenWifiSetup: boolean
   continueDisabled: boolean
+  /** Release notes crossed by this update, newest first. Populated on completion. */
+  changelogs: ReleaseChangelog[]
 }
 
 export type UseMentraLiveOtaOptions = {
@@ -121,10 +124,10 @@ function installProgress(snapshot: OtaInstallSnapshot): number | null {
   const isDownload = otaStatus?.phase === "download"
   const totalSteps = otaStatus?.totalSteps ?? 1
   const rawPercent = isDownload
-    ? (otaStatus?.stepPercent ?? 0)
+    ? otaStatus?.stepPercent ?? 0
     : totalSteps >= 2
-      ? (otaStatus?.overallPercent ?? 0)
-      : (otaStatus?.stepPercent ?? 0)
+    ? otaStatus?.overallPercent ?? 0
+    : otaStatus?.stepPercent ?? 0
   return Math.min(Math.max(rawPercent, snapshot.mtkInstallStallSimulatedPercent ?? 0, 0), 100)
 }
 
@@ -177,6 +180,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const selectedCheckResultRef = useRef<OtaCheckCurrentGlassesResult | null>(null)
   const autoChainAdvancedRef = useRef(false)
   const installActionPendingRef = useRef(false)
+  const changelogStartVersionRef = useRef<string | null>(null)
+  const changelogTargetVersionRef = useRef<string | null>(null)
   const onFinishedRef = useRef(onFinished)
   const onOpenWifiSetupRef = useRef(onOpenWifiSetup)
   const onFirmwareRestartingChangeRef = useRef(onFirmwareRestartingChange)
@@ -420,6 +425,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return
     }
     ota.installSession.prepare(result)
+    changelogStartVersionRef.current ??= snapshot.appVersion
+    changelogTargetVersionRef.current = result.updateInfo?.versionName ?? result.latestVersionInfo?.versionName ?? null
     if (updateFingerprint) beginOtaAutoChain(updateFingerprint, isVersionChange)
     navigateToProgress()
   }, [check, isVersionChange, navigateToProgress, page, updateFingerprint])
@@ -443,6 +450,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     )
     if (requiresGlassesReboot) stopOtaAutoChain()
     await ota.installSession.finish()
+    changelogStartVersionRef.current = null
+    changelogTargetVersionRef.current = null
     returnToCheck()
   }, [installSnapshot, page, returnToCheck])
 
@@ -450,6 +459,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     if (page !== "progress") return
     stopOtaAutoChain()
     await ota.installSession.discard()
+    changelogStartVersionRef.current = null
+    changelogTargetVersionRef.current = null
     returnToCheck()
   }, [page, returnToCheck])
 
@@ -490,6 +501,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: false,
         continueDisabled: false,
+        changelogs: [],
       }
     }
 
@@ -499,22 +511,22 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         checkState === "checking"
           ? "checking"
           : checkState === "update_available"
-            ? wifiRequired
-              ? "wifi_required"
-              : "update_available"
-            : checkState === "no_update"
-              ? "up_to_date"
-              : checkState === "dev_build"
-                ? "dev_build"
-                : errorKind === "pin_unavailable"
-                  ? "update_info_unavailable"
-                  : "check_failed"
+          ? wifiRequired
+            ? "wifi_required"
+            : "update_available"
+          : checkState === "no_update"
+          ? "up_to_date"
+          : checkState === "dev_build"
+          ? "dev_build"
+          : errorKind === "pin_unavailable"
+          ? "update_info_unavailable"
+          : "check_failed"
       const error: MentraLiveOtaError | null =
         screen === "check_failed"
           ? {code: "check_failed", message: "Couldn't check for updates. Please check your connection and try again."}
           : screen === "update_info_unavailable"
-            ? {code: "update_info_unavailable", message: "Update information for this app version is unavailable."}
-            : null
+          ? {code: "update_info_unavailable", message: "Update information for this app version is unavailable."}
+          : null
       return {
         screen,
         connected: otaSnapshot.connected,
@@ -543,6 +555,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: screen === "wifi_required",
         continueDisabled: false,
+        changelogs: [],
       }
     }
 
@@ -568,6 +581,18 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
           }
         : null
     const totalSteps = installSnapshot.otaStatus?.totalSteps ?? null
+    let changelogs: ReleaseChangelog[] = []
+    if (screen === "complete") {
+      try {
+        changelogs = ota.getReleaseChangelogs(changelogStartVersionRef.current, changelogTargetVersionRef.current)
+      } catch {
+        try {
+          changelogs = ota.getReleaseChangelogs(null, changelogTargetVersionRef.current)
+        } catch {
+          changelogs = []
+        }
+      }
+    }
     return {
       screen,
       connected: installSnapshot.connected,
@@ -599,6 +624,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       canDiscard: screen === "disconnected",
       canOpenWifiSetup: screen === "failed" && showChangeWifi,
       continueDisabled: installSnapshot.continueButtonDisabled,
+      changelogs,
     }
   }, [
     checkState,

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -129,7 +129,11 @@ function releaseChangelogsForActiveChain(): ReleaseChangelog[] {
   try {
     return ota.getReleaseChangelogs(range.fromVersion, range.toVersion)
   } catch {
-    return []
+    try {
+      return ota.getReleaseChangelogs(null, range.toVersion)
+    } catch {
+      return []
+    }
   }
 }
 

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -6,6 +6,7 @@ import {
   clearOtaAutoChainReconnectWait,
   isOtaAutoChainActive,
   otaAutoChainFingerprint,
+  otaAutoChainReleaseRange,
   otaAutoChainReconnectWaitRemaining,
   stopOtaAutoChain,
   tryAdvanceOtaAutoChain,
@@ -118,6 +119,20 @@ type CheckState = "checking" | "update_available" | "no_update" | "dev_build" | 
 const AUTO_CHAIN_NETWORK_RETRY_DELAY_MS = 5000
 const AUTO_CHAIN_COMPLETE_DELAY_MS = 750
 
+function targetVersion(result: OtaCheckCurrentGlassesResult): string | null {
+  return result.updateInfo?.versionName ?? result.latestVersionInfo?.versionName ?? null
+}
+
+function releaseChangelogsForActiveChain(): ReleaseChangelog[] {
+  const range = otaAutoChainReleaseRange()
+  if (!range?.toVersion) return []
+  try {
+    return ota.getReleaseChangelogs(range.fromVersion, range.toVersion)
+  } catch {
+    return []
+  }
+}
+
 function installProgress(snapshot: OtaInstallSnapshot): number | null {
   if (snapshot.displayState !== "updating") return null
   const {otaStatus} = snapshot
@@ -172,6 +187,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const [isVersionChange, setIsVersionChange] = useState(false)
   const [errorKind, setErrorKind] = useState<"network" | "pin_unavailable">("network")
   const [updateFingerprint, setUpdateFingerprint] = useState<string | null>(null)
+  const [completedChangelogs, setCompletedChangelogs] = useState<ReleaseChangelog[]>([])
   const [checkGeneration, setCheckGeneration] = useState(0)
   const performCheckGenerationRef = useRef(0)
   const activeCheckKeyRef = useRef<string | null>(null)
@@ -180,8 +196,6 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const selectedCheckResultRef = useRef<OtaCheckCurrentGlassesResult | null>(null)
   const autoChainAdvancedRef = useRef(false)
   const installActionPendingRef = useRef(false)
-  const changelogStartVersionRef = useRef<string | null>(null)
-  const changelogTargetVersionRef = useRef<string | null>(null)
   const onFinishedRef = useRef(onFinished)
   const onOpenWifiSetupRef = useRef(onOpenWifiSetup)
   const onFirmwareRestartingChangeRef = useRef(onFirmwareRestartingChange)
@@ -324,7 +338,11 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
             if (!snapshot.wifiConnected && snapshot.hotspotOtaVersion !== 1) {
               stopOtaAutoChain()
             } else {
-              const admission = tryAdvanceOtaAutoChain(fingerprint, result.updateInfo.isDowngrade === true)
+              const admission = tryAdvanceOtaAutoChain(
+                fingerprint,
+                result.updateInfo.isDowngrade === true,
+                targetVersion(result),
+              )
               if (admission.advance) {
                 checkCompletedRef.current = true
                 ota.installSession.prepare(result)
@@ -337,6 +355,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
           setCheckState("update_available")
           return
         }
+        if (isOtaAutoChainActive()) setCompletedChangelogs(releaseChangelogsForActiveChain())
         stopOtaAutoChain()
         checkCompletedRef.current = true
         ota.clearUpdateAvailable()
@@ -402,6 +421,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   }, [installSnapshot.connected, installSnapshot.displayState, page, returnToCheck])
 
   const check = useCallback(() => {
+    setCompletedChangelogs([])
     setPage("check")
     setCheckState("checking")
     setCheckGeneration((generation) => generation + 1)
@@ -425,9 +445,13 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return
     }
     ota.installSession.prepare(result)
-    changelogStartVersionRef.current ??= snapshot.appVersion
-    changelogTargetVersionRef.current = result.updateInfo?.versionName ?? result.latestVersionInfo?.versionName ?? null
-    if (updateFingerprint) beginOtaAutoChain(updateFingerprint, isVersionChange)
+    setCompletedChangelogs([])
+    if (updateFingerprint) {
+      beginOtaAutoChain(updateFingerprint, isVersionChange, {
+        fromVersion: snapshot.appVersion,
+        toVersion: targetVersion(result),
+      })
+    }
     navigateToProgress()
   }, [check, isVersionChange, navigateToProgress, page, updateFingerprint])
 
@@ -450,8 +474,6 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     )
     if (requiresGlassesReboot) stopOtaAutoChain()
     await ota.installSession.finish()
-    changelogStartVersionRef.current = null
-    changelogTargetVersionRef.current = null
     returnToCheck()
   }, [installSnapshot, page, returnToCheck])
 
@@ -459,8 +481,6 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     if (page !== "progress") return
     stopOtaAutoChain()
     await ota.installSession.discard()
-    changelogStartVersionRef.current = null
-    changelogTargetVersionRef.current = null
     returnToCheck()
   }, [page, returnToCheck])
 
@@ -555,7 +575,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: screen === "wifi_required",
         continueDisabled: false,
-        changelogs: [],
+        changelogs: screen === "up_to_date" ? completedChangelogs : [],
       }
     }
 
@@ -581,18 +601,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
           }
         : null
     const totalSteps = installSnapshot.otaStatus?.totalSteps ?? null
-    let changelogs: ReleaseChangelog[] = []
-    if (screen === "complete") {
-      try {
-        changelogs = ota.getReleaseChangelogs(changelogStartVersionRef.current, changelogTargetVersionRef.current)
-      } catch {
-        try {
-          changelogs = ota.getReleaseChangelogs(null, changelogTargetVersionRef.current)
-        } catch {
-          changelogs = []
-        }
-      }
-    }
+    const changelogs = screen === "complete" ? releaseChangelogsForActiveChain() : []
     return {
       screen,
       connected: installSnapshot.connected,
@@ -628,6 +637,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     }
   }, [
     checkState,
+    completedChangelogs,
     errorKind,
     firmwareRestarting,
     installSnapshot,

--- a/mobile/modules/engine/src/services/OtaAutoChain.ts
+++ b/mobile/modules/engine/src/services/OtaAutoChain.ts
@@ -6,8 +6,14 @@ export const OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS = 120_000
 type OtaAutoChainSession = {
   approvedDowngrade: boolean
   passCount: number
+  releaseRange: OtaAutoChainReleaseRange
   reconnectDeadline: number | null
   seenFingerprints: Set<string>
+}
+
+export type OtaAutoChainReleaseRange = {
+  fromVersion: string | null
+  toVersion: string | null
 }
 
 export type OtaAutoChainAdvanceResult =
@@ -42,10 +48,15 @@ export function otaAutoChainFingerprint(result: OtaCheckCurrentGlassesResult): s
 }
 
 /** Start a chain after the user explicitly approves its first update pass. */
-export function beginOtaAutoChain(initialFingerprint: string, approvedDowngrade: boolean): void {
+export function beginOtaAutoChain(
+  initialFingerprint: string,
+  approvedDowngrade: boolean,
+  releaseRange: OtaAutoChainReleaseRange,
+): void {
   session = {
     approvedDowngrade,
     passCount: 1,
+    releaseRange: {...releaseRange},
     reconnectDeadline: null,
     seenFingerprints: new Set([initialFingerprint]),
   }
@@ -53,6 +64,10 @@ export function beginOtaAutoChain(initialFingerprint: string, approvedDowngrade:
 
 export function isOtaAutoChainActive(): boolean {
   return session !== null
+}
+
+export function otaAutoChainReleaseRange(): OtaAutoChainReleaseRange | null {
+  return session ? {...session.releaseRange} : null
 }
 
 /** End the current chain. Safe to call when no chain is active. */
@@ -80,7 +95,11 @@ export function clearOtaAutoChainReconnectWait(): void {
  * Admit the next pass of an active chain. Repeated offers, unexpectedly
  * destructive downgrades, and runaway chains fail closed and end automation.
  */
-export function tryAdvanceOtaAutoChain(fingerprint: string, isDowngrade: boolean): OtaAutoChainAdvanceResult {
+export function tryAdvanceOtaAutoChain(
+  fingerprint: string,
+  isDowngrade: boolean,
+  targetVersion: string | null,
+): OtaAutoChainAdvanceResult {
   if (!session) {
     return {advance: false, reason: "inactive"}
   }
@@ -102,5 +121,6 @@ export function tryAdvanceOtaAutoChain(fingerprint: string, isDowngrade: boolean
 
   session.seenFingerprints.add(fingerprint)
   session.passCount += 1
+  if (targetVersion) session.releaseRange.toVersion = targetVersion
   return {advance: true, passCount: session.passCount}
 }

--- a/mobile/modules/engine/src/services/__tests__/OtaAutoChain.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/OtaAutoChain.test.ts
@@ -1,0 +1,21 @@
+import {beforeEach, describe, expect, test} from "bun:test"
+
+import {beginOtaAutoChain, otaAutoChainReleaseRange, stopOtaAutoChain, tryAdvanceOtaAutoChain} from "../OtaAutoChain"
+
+describe("OtaAutoChain release range", () => {
+  beforeEach(() => stopOtaAutoChain())
+
+  test("retains the source and advances the target across OTA passes", () => {
+    beginOtaAutoChain("first", false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.4"})
+
+    expect(otaAutoChainReleaseRange()).toEqual({fromVersion: "3.0.0", toVersion: "3.1.0-dev.4"})
+    expect(tryAdvanceOtaAutoChain("second", false, "3.2.0-beta.2")).toEqual({advance: true, passCount: 2})
+    expect(otaAutoChainReleaseRange()).toEqual({fromVersion: "3.0.0", toVersion: "3.2.0-beta.2"})
+  })
+
+  test("clears the range with the rest of the session", () => {
+    beginOtaAutoChain("first", false, {fromVersion: "3.0.0", toVersion: "3.1.0"})
+    stopOtaAutoChain()
+    expect(otaAutoChainReleaseRange()).toBeNull()
+  })
+})

--- a/mobile/src/__tests__/otaAutoChain.test.ts
+++ b/mobile/src/__tests__/otaAutoChain.test.ts
@@ -51,24 +51,27 @@ it("advances through distinct update offers after the user approves the first pa
   const first = otaAutoChainFingerprint(result())
   const second = otaAutoChainFingerprint(result({buildNumber: "37", updates: ["mtk", "bes"]}))
 
-  beginOtaAutoChain(first, false)
+  beginOtaAutoChain(first, false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.1"})
 
-  expect(tryAdvanceOtaAutoChain(second, false)).toEqual({advance: true, passCount: 2})
+  expect(tryAdvanceOtaAutoChain(second, false, "3.1.0-dev.2")).toEqual({advance: true, passCount: 2})
   expect(isOtaAutoChainActive()).toBe(true)
 })
 
 it("stops instead of reinstalling the same offer twice", () => {
   const fingerprint = otaAutoChainFingerprint(result())
-  beginOtaAutoChain(fingerprint, false)
+  beginOtaAutoChain(fingerprint, false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.1"})
 
-  expect(tryAdvanceOtaAutoChain(fingerprint, false)).toEqual({advance: false, reason: "duplicate"})
+  expect(tryAdvanceOtaAutoChain(fingerprint, false, "3.1.0-dev.1")).toEqual({advance: false, reason: "duplicate"})
   expect(isOtaAutoChainActive()).toBe(false)
 })
 
 it("requires separate approval when an upgrade chain encounters a downgrade", () => {
-  beginOtaAutoChain(otaAutoChainFingerprint(result()), false)
+  beginOtaAutoChain(otaAutoChainFingerprint(result()), false, {
+    fromVersion: "3.0.0",
+    toVersion: "3.1.0-dev.1",
+  })
 
-  expect(tryAdvanceOtaAutoChain("downgrade", true)).toEqual({
+  expect(tryAdvanceOtaAutoChain("downgrade", true, "3.0.0")).toEqual({
     advance: false,
     reason: "downgrade_not_approved",
   })
@@ -76,23 +79,26 @@ it("requires separate approval when an upgrade chain encounters a downgrade", ()
 })
 
 it("allows subsequent downgrade passes when the user approved a downgrade initially", () => {
-  beginOtaAutoChain("firmware-first-downgrade", true)
+  beginOtaAutoChain("firmware-first-downgrade", true, {fromVersion: "3.1.0", toVersion: "3.0.1"})
 
-  expect(tryAdvanceOtaAutoChain("downgrade-handoff", true)).toEqual({advance: true, passCount: 2})
+  expect(tryAdvanceOtaAutoChain("downgrade-handoff", true, "3.0.0")).toEqual({advance: true, passCount: 2})
 })
 
 it("bounds the number of automatic passes", () => {
-  beginOtaAutoChain("pass-1", false)
+  beginOtaAutoChain("pass-1", false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.1"})
   for (let pass = 2; pass <= MAX_OTA_AUTO_CHAIN_PASSES; pass += 1) {
-    expect(tryAdvanceOtaAutoChain(`pass-${pass}`, false).advance).toBe(true)
+    expect(tryAdvanceOtaAutoChain(`pass-${pass}`, false, `3.1.0-dev.${pass}`).advance).toBe(true)
   }
 
-  expect(tryAdvanceOtaAutoChain("one-too-many", false)).toEqual({advance: false, reason: "max_passes"})
+  expect(tryAdvanceOtaAutoChain("one-too-many", false, "3.1.0-dev.9")).toEqual({
+    advance: false,
+    reason: "max_passes",
+  })
   expect(isOtaAutoChainActive()).toBe(false)
 })
 
 it("bounds a reboot reconnect wait without extending it on subsequent renders", () => {
-  beginOtaAutoChain("pass-1", false)
+  beginOtaAutoChain("pass-1", false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.1"})
 
   expect(otaAutoChainReconnectWaitRemaining(1_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS)
   expect(otaAutoChainReconnectWaitRemaining(2_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS - 1_000)
@@ -100,7 +106,7 @@ it("bounds a reboot reconnect wait without extending it on subsequent renders", 
 })
 
 it("starts a fresh bounded wait after a successful reconnect", () => {
-  beginOtaAutoChain("pass-1", false)
+  beginOtaAutoChain("pass-1", false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.1"})
   expect(otaAutoChainReconnectWaitRemaining(1_000)).toBe(OTA_AUTO_CHAIN_RECONNECT_TIMEOUT_MS)
 
   clearOtaAutoChainReconnectWait()

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -13,6 +13,7 @@ import {BES_INSTALL_RESTART_MESSAGE} from "@/utils/otaErrorMapping"
 import {beginOtaAutoChain, isOtaAutoChainActive, stopOtaAutoChain} from "@/services/otaAutoChain"
 
 const mockReplace = jest.fn()
+const AUTO_CHAIN_RELEASE_RANGE = {fromVersion: "3.0.0", toVersion: "3.1.0-dev.1"}
 
 // super_mode is controlled through the REAL settings store — the screen's
 // useSetting comes from the global @mentra/engine mock, which passes the real
@@ -196,7 +197,7 @@ describe("progress.tsx display states", () => {
 
   it("automatically returns to update checking after a chained pass completes", async () => {
     setGlassesConnected()
-    beginOtaAutoChain("initial-offer", false)
+    beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
     const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
     try {
       const {getByText} = render(<OtaProgressScreen />)
@@ -228,7 +229,7 @@ describe("progress.tsx display states", () => {
 
   it("waits for a rebooting chained pass to reconnect before checking again", async () => {
     setGlassesDisconnected()
-    beginOtaAutoChain("initial-offer", false)
+    beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
     useGlassesStore.getState().setOtaStatus({
       sessionId: "s1",
       totalSteps: 1,
@@ -263,7 +264,7 @@ describe("progress.tsx display states", () => {
 
   it("reschedules chained navigation when a reboot starts during the success delay", async () => {
     setGlassesConnected()
-    beginOtaAutoChain("initial-offer", false)
+    beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
     const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
     try {
       const {getByText} = render(<OtaProgressScreen />)
@@ -306,7 +307,7 @@ describe("progress.tsx display states", () => {
 
   it("stops automatic chaining when Continue bypasses BES reboot verification", async () => {
     setGlassesConnected()
-    beginOtaAutoChain("initial-offer", false)
+    beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
     const {getByTestId} = render(<OtaProgressScreen />)
 
     act(() => {
@@ -354,7 +355,7 @@ describe("progress.tsx display states", () => {
 
   it("stops automatic chaining when leaving a failed pass to change WiFi", () => {
     setGlassesConnected()
-    beginOtaAutoChain("initial-offer", false)
+    beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
     const pushSpy = jest.spyOn(useNavigationStore.getState(), "push")
     try {
       const {getByText} = render(<OtaProgressScreen />)


### PR DESCRIPTION
## Summary

- add root-level `changelogs/<base-version>.md` release notes as the authored source for the coordinated MentraOS, Engine, Bluetooth SDK, and ASG release family
- generate embedded TypeScript, Kotlin, and Swift catalogs so every shipped SDK can answer changelog queries without fetching repository files at runtime
- expose `getReleaseChangelogs(fromVersion, toVersion)` consistently from the React Native, Android, and iOS Bluetooth SDK APIs and through the Mentra Engine OTA facade
- capture the glasses version at OTA start and the selected target version, then expose all crossed base-version changelogs newest-first when the OTA flow reaches completion
- render those notes on the stock Engine OTA completion screen
- require a changelog for the active release-family base and fail CI when generated catalogs are stale

## Contract

Changelog filenames are stable production base versions such as `3.1.0.md`. Prerelease identities such as `3.1.0-dev.14` and `3.1.0-beta.8` map to that same base entry. A transition across multiple base versions returns every bundled changelog strictly after the source and through the target, newest first. A transition within one base train still returns that base's notes.

The root Markdown remains the only authored copy. Generated language catalogs are checked into the SDK artifacts because the standalone Android and Swift SDKs cannot read files from the MentraOS repository after publication.

## Validation

- 87 release-script tests passed, including generator freshness and release-family enforcement
- TypeScript Bluetooth SDK build and SDK changelog tests passed
- Mentra Engine build and OTA hook tests passed
- Android SDK compile and `ReleaseChangelogTest` passed
- iOS simulator build and `ReleaseChangelogTests` passed
- generated catalog check, Prettier check, affected-workflow `actionlint`, and `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OTA auto-chain session state and user-facing install completion UI; release tooling now blocks releases missing changelog files or stale generated artifacts.
> 
> **Overview**
> Introduces **`changelogs/<X.Y.Z>.md`** as the single authored release-notes source for the coordinated product family, with a Node generator that emits embedded **TypeScript, Kotlin, and Swift** catalogs checked into the Bluetooth SDK. CI and **`loadReleaseFamily`** now require a changelog for the active family base version and fail when generated files are stale.
> 
> The Bluetooth SDK and Engine **`ota`** facade expose **`getReleaseChangelogs(fromVersion, toVersion)`**, mapping prerelease identities to base versions and returning crossed notes newest-first. **`OtaAutoChain`** records the glasses **`appVersion`** and manifest target across multi-pass installs so the same range survives remounts.
> 
> **`useMentraLiveOta`** and **`MentraLiveOtaFlow`** surface those notes on install **complete** and final **up-to-date** screens, with a fallback when legacy glasses report numeric versions instead of coordinated semver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c181637bd84b9770c180f7c05c6d1112c85ed1fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->