### PR TITLE
Mentra Live improvements

### DIFF
--- a/asg_client/app/src/main/assets/index.html
+++ b/asg_client/app/src/main/assets/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AugmentOS Camera Server</title>
+    <title>Mentra Live Camera Gallery</title>
     <style>
       :root {
         --primary-color: #3498db;
@@ -550,7 +550,7 @@
   <body>
     <div class="container">
       <div class="header">
-        <h1>📸 AugmentOS Camera</h1>
+        <h1>📸 Mentra Live Camera Gallery</h1>
         <p>Smart Glasses Photo Gallery & Capture</p>
       </div>
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
@@ -100,8 +100,10 @@ public abstract class AsgServer extends NanoHTTPD {
 
     /**
      * Start the server with enhanced error handling and extended timeout for large files.
+     *
+     * @return true when the listener bound successfully, otherwise false
      */
-    public void startServer() {
+    public boolean startServer() {
         logger.info(getTag(), "🚀 =========================================");
         logger.info(getTag(), "🚀 STARTING " + config.getServerName());
         logger.info(getTag(), "🚀 =========================================");
@@ -123,8 +125,10 @@ public abstract class AsgServer extends NanoHTTPD {
             } catch (Exception e) {
                 logger.warn(getTag(), "🌐 Could not determine server URL: " + e.getMessage());
             }
+            return true;
         } catch (IOException e) {
             logger.error(getTag(), "❌ Failed to start " + config.getServerName() + ": " + e.getMessage(), e);
+            return false;
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
@@ -42,9 +42,20 @@ public abstract class AsgServer extends NanoHTTPD {
      * Constructor for ASG server with dependency injection.
      * Follows Dependency Inversion Principle by depending on abstractions.
      */
-    public AsgServer(ServerConfig config, NetworkProvider networkProvider, 
+    public AsgServer(ServerConfig config, NetworkProvider networkProvider,
                     CacheManager cacheManager, RateLimiter rateLimiter, Logger logger) {
-        super(config.getPort());
+        this(config, networkProvider, cacheManager, rateLimiter, logger, null);
+    }
+
+    /**
+     * Construct a server bound to one local address instead of every network interface.
+     *
+     * @param bindAddress local address to bind, or {@code null} to listen on all interfaces
+     */
+    public AsgServer(ServerConfig config, NetworkProvider networkProvider,
+                    CacheManager cacheManager, RateLimiter rateLimiter, Logger logger,
+                    String bindAddress) {
+        super(bindAddress, config.getPort());
         this.config = config;
         this.networkProvider = networkProvider;
         this.cacheManager = cacheManager;
@@ -71,7 +82,10 @@ public abstract class AsgServer extends NanoHTTPD {
      */
     public String getServerUrl() {
         try {
-            String ipAddress = networkProvider.getBestIpAddress();
+            String ipAddress = getHostname();
+            if (ipAddress == null || ipAddress.isEmpty()) {
+                ipAddress = networkProvider.getBestIpAddress();
+            }
             return "http://" + ipAddress + ":" + getListeningPort();
         } catch (Exception e) {
             logger.error(getTag(), "Error getting server URL: " + e.getMessage(), e);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/DefaultServerFactory.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/DefaultServerFactory.java
@@ -65,6 +65,29 @@ public class DefaultServerFactory {
         return new AsgCameraServer(config, networkProvider, cacheManager, rateLimiter, logger, fileManager);
     }
 
+    /** Create a camera web server reachable only through the active hotspot gateway address. */
+    public static AsgCameraServer createHotspotCameraWebServer(
+            int port,
+            String serverName,
+            Context context,
+            Logger logger,
+            FileManager fileManager,
+            String hotspotGatewayIp) {
+        ServerConfig config = createServerConfig(port, serverName, context);
+        NetworkProvider networkProvider = createNetworkProvider(logger);
+        CacheManager cacheManager = createCacheManager(logger);
+        RateLimiter rateLimiter = createRateLimiter(150, 60000, logger);
+
+        return new AsgCameraServer(
+                config,
+                networkProvider,
+                cacheManager,
+                rateLimiter,
+                logger,
+                fileManager,
+                hotspotGatewayIp);
+    }
+
     /**
      * Create a camera web server with custom rate limiting
      */
@@ -77,4 +100,4 @@ public class DefaultServerFactory {
 
         return new AsgCameraServer(config, networkProvider, cacheManager, rateLimiter, logger, fileManager);
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/managers/AsgServerManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/managers/AsgServerManager.java
@@ -94,7 +94,10 @@ public class AsgServerManager {
         }
 
         try {
-            server.startServer();
+            if (!server.startServer()) {
+                logger.error("ServerManager", "🚀 ❌ Server failed to start: " + serverName);
+                return false;
+            }
             logger.info("ServerManager", "🚀 ✅ Server started successfully: " + serverName);
             logger.info("ServerManager", "🚀 📍 Port: " + server.getListeningPort());
             logger.info("ServerManager", "🚀 🌐 URL: " + server.getServerUrl());
@@ -297,4 +300,4 @@ public class AsgServerManager {
         AsgServer server = servers.get(serverName);
         return server != null && server.isAlive();
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
@@ -104,7 +104,19 @@ public class AsgCameraServer extends AsgServer {
             RateLimiter rateLimiter,
             Logger logger,
             FileManager fileManager) {
-        super(config, networkProvider, cacheManager, rateLimiter, logger);
+        this(config, networkProvider, cacheManager, rateLimiter, logger, fileManager, null);
+    }
+
+    /** Construct a camera server restricted to a single local network address. */
+    public AsgCameraServer(
+            ServerConfig config,
+            NetworkProvider networkProvider,
+            CacheManager cacheManager,
+            RateLimiter rateLimiter,
+            Logger logger,
+            FileManager fileManager,
+            String bindAddress) {
+        super(config, networkProvider, cacheManager, rateLimiter, logger, bindAddress);
         this.fileManager = fileManager;
         this.galleryTrashManager =
                 new GalleryTrashManager(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -954,7 +954,10 @@ public class AsgClientService extends Service implements NetworkStateListener, T
         // Send hotspot status update to phone
         try {
             if (serviceInitializer != null && serviceInitializer.getServiceManager() != null) {
-                var networkManager = serviceInitializer.getServiceManager().getNetworkManager();
+                var serviceManager = serviceInitializer.getServiceManager();
+                serviceManager.setWebServerEnabled(isEnabled);
+
+                var networkManager = serviceManager.getNetworkManager();
                 var commManager = serviceInitializer.getCommunicationManager();
 
                 if (networkManager != null && commManager != null) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/GalleryCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/GalleryCommandHandler.java
@@ -71,11 +71,8 @@ public class GalleryCommandHandler implements ICommandHandler {
                 return sendEmptyGalleryStatus(cameraState);
             }
 
-            // Get FileManager from the camera server (same way HTTP server does it)
-            FileManager fileManager = null;
-            if (serviceManager != null && serviceManager.getCameraServer() != null) {
-                fileManager = serviceManager.getCameraServer().getFileManager();
-            }
+            // Gallery status travels over BLE and remains available before hotspot startup.
+            FileManager fileManager = serviceManager != null ? serviceManager.getFileManager() : null;
 
             if (fileManager == null) {
                 Log.e(TAG, "📸 FileManager not available");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -113,7 +113,6 @@ public class WifiCommandHandler implements ICommandHandler {
                 if (networkManager != null) {
                     Log.d(TAG, "📶 Initiating WiFi connection to: " + ssid);
                     networkManager.connectToWifi(ssid, password);
-                    serviceManager.initializeCameraWebServer();
 
                     // Schedule WiFi status check after connection attempt
                     // This ensures we send status even if broadcast receiver doesn't fire

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -57,7 +57,7 @@ public class AsgClientServiceManager {
 
     // State tracking
     private boolean isInitialized = false;
-    private boolean isWebServerEnabled = true;
+    private boolean isWebServerEnabled = false;
     private boolean isK900Device = false;
 
     // RGB LED command handler reference
@@ -136,7 +136,10 @@ public class AsgClientServiceManager {
             Log.d(TAG, "📸 Step 6: Initializing media capture service");
             initializeMediaCaptureService();
 
-            Log.d(TAG, "🌐 Step 7: Initializing camera web server");
+            // The gallery server is a hotspot-only service. Re-read the adopted/current state
+            // after the media dependencies are ready, then start it only if the AP is active.
+            isWebServerEnabled = networkManager != null && networkManager.isHotspotEnabled();
+            Log.d(TAG, "🌐 Step 7: Synchronizing camera web server with hotspot state");
             initializeCameraWebServer();
 
             isInitialized = true;
@@ -590,6 +593,22 @@ public class AsgClientServiceManager {
             return;
         }
 
+        if (networkManager == null || !networkManager.isHotspotEnabled()) {
+            Log.w(TAG, "🔒 Hotspot is inactive - refusing to start camera web server");
+            return;
+        }
+
+        if (mediaCaptureService == null) {
+            Log.d(TAG, "⏭️ Media capture service is not ready - deferring camera web server");
+            return;
+        }
+
+        String hotspotGatewayIp = networkManager.getHotspotGatewayIp();
+        if (hotspotGatewayIp == null || hotspotGatewayIp.isEmpty()) {
+            Log.e(TAG, "🔒 Hotspot gateway is unavailable - refusing to start camera web server");
+            return;
+        }
+
         if (serverManager == null) {
             Log.d(TAG, "📦 Creating new AsgServerManager instance");
             serverManager = AsgServerManager.getInstance(context);
@@ -606,8 +625,13 @@ public class AsgClientServiceManager {
                 Log.d(TAG, "📝 Logger created: " + logger.getClass().getSimpleName());
 
                 cameraServer =
-                        DefaultServerFactory.createCameraWebServer(
-                                8089, "CameraWebServer", context, logger, fileManager);
+                        DefaultServerFactory.createHotspotCameraWebServer(
+                                8089,
+                                "CameraWebServer",
+                                context,
+                                logger,
+                                fileManager,
+                                hotspotGatewayIp);
                 Log.d(
                         TAG,
                         "✅ Camera web server created: " + cameraServer.getClass().getSimpleName());
@@ -806,27 +830,27 @@ public class AsgClientServiceManager {
                             + isWebServerEnabled
                             + " to "
                             + enabled);
-            isWebServerEnabled = enabled;
+        }
+        isWebServerEnabled = enabled;
 
-            if (enabled && cameraServer == null) {
-                Log.d(TAG, "🚀 Enabling web server - initializing camera server");
-                initializeCameraWebServer();
-            } else if (!enabled && cameraServer != null) {
-                Log.d(TAG, "🛑 Disabling web server - stopping camera server");
-                if (serverManager != null) {
-                    Log.d(TAG, "📡 Using server manager to stop camera server");
-                    serverManager.stopServer("camera");
-                } else {
-                    Log.d(TAG, "🛑 Directly stopping camera server");
-                    cameraServer.stopServer();
-                }
-                cameraServer = null;
-                Log.d(TAG, "✅ Camera server stopped and nullified");
+        // Reconcile the actual server on every event, even if the cached state already matches.
+        // This keeps repeated hotspot-disable notifications fail-closed.
+        if (enabled && cameraServer == null) {
+            Log.d(TAG, "🚀 Enabling web server - initializing camera server");
+            initializeCameraWebServer();
+        } else if (!enabled && cameraServer != null) {
+            Log.d(TAG, "🛑 Disabling web server - stopping camera server");
+            if (serverManager != null) {
+                Log.d(TAG, "📡 Using server manager to stop camera server");
+                serverManager.stopServer("camera");
             } else {
-                Log.d(TAG, "⏭️ No action needed - web server state already matches desired state");
+                Log.d(TAG, "🛑 Directly stopping camera server");
+                cameraServer.stopServer();
             }
+            cameraServer = null;
+            Log.d(TAG, "✅ Camera server stopped and nullified");
         } else {
-            Log.d(TAG, "⏭️ Web server enabled state unchanged - no action needed");
+            Log.d(TAG, "⏭️ Camera server already matches the hotspot state");
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -673,7 +673,12 @@ public class AsgClientServiceManager {
                 serverManager.registerServer("camera", cameraServer);
                 Log.d(TAG, "📝 Camera server registered with server manager");
 
-                cameraServer.startServer();
+                if (!cameraServer.startServer()) {
+                    Log.e(TAG, "💥 Camera web server failed to bind; clearing it for retry");
+                    serverManager.stopServer("camera");
+                    cameraServer = null;
+                    return;
+                }
                 Log.d(TAG, "🚀 Camera web server started");
 
                 Log.i(TAG, "✅ Camera web server initialized and started successfully");
@@ -735,6 +740,11 @@ public class AsgClientServiceManager {
                 "📸 getMediaCaptureService() called - returning: "
                         + (mediaCaptureService != null ? "valid" : "null"));
         return mediaCaptureService;
+    }
+
+    /** Get the shared media file manager independently of the hotspot server lifecycle. */
+    public FileManager getFileManager() {
+        return fileManager;
     }
 
     public ImuManager getImuManager() {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/server/core/AsgServerHttpActivityTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/server/core/AsgServerHttpActivityTest.java
@@ -11,6 +11,8 @@ import com.mentra.asg_client.io.server.interfaces.ServerConfig;
 import com.mentra.asg_client.logging.Logger;
 import fi.iki.elonen.NanoHTTPD;
 import java.io.ByteArrayInputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
@@ -77,6 +79,30 @@ public class AsgServerHttpActivityTest {
                     .isEqualTo("http://127.0.0.1:" + server.getListeningPort());
         } finally {
             server.stopServer();
+        }
+    }
+
+    @Test
+    public void bindFailureIsReportedToCaller() throws Exception {
+        try (ServerSocket occupied = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            ServerConfig config = mock(ServerConfig.class);
+            NetworkProvider networkProvider = mock(NetworkProvider.class);
+            CacheManager cacheManager = mock(CacheManager.class);
+            RateLimiter rateLimiter = mock(RateLimiter.class);
+            Logger logger = mock(Logger.class);
+            when(config.getPort()).thenReturn(occupied.getLocalPort());
+
+            TestServer server =
+                    new TestServer(
+                            config,
+                            networkProvider,
+                            cacheManager,
+                            rateLimiter,
+                            logger,
+                            "127.0.0.1");
+
+            assertThat(server.startServer()).isFalse();
+            assertThat(server.isAlive()).isFalse();
         }
     }
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/server/core/AsgServerHttpActivityTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/server/core/AsgServerHttpActivityTest.java
@@ -50,6 +50,36 @@ public class AsgServerHttpActivityTest {
         assertThat(activityCount.get()).isEqualTo(2);
     }
 
+    @Test
+    public void bindAddressRestrictsServerAndDeterminesAdvertisedUrl() {
+        ServerConfig config = mock(ServerConfig.class);
+        NetworkProvider networkProvider = mock(NetworkProvider.class);
+        CacheManager cacheManager = mock(CacheManager.class);
+        RateLimiter rateLimiter = mock(RateLimiter.class);
+        Logger logger = mock(Logger.class);
+        when(config.getPort()).thenReturn(0);
+        when(networkProvider.getBestIpAddress()).thenReturn("10.0.0.25");
+
+        TestServer server =
+                new TestServer(
+                        config,
+                        networkProvider,
+                        cacheManager,
+                        rateLimiter,
+                        logger,
+                        "127.0.0.1");
+
+        server.startServer();
+        try {
+            assertThat(server.isAlive()).isTrue();
+            assertThat(server.getHostname()).isEqualTo("127.0.0.1");
+            assertThat(server.getServerUrl())
+                    .isEqualTo("http://127.0.0.1:" + server.getListeningPort());
+        } finally {
+            server.stopServer();
+        }
+    }
+
     private static final class TestServer extends AsgServer {
         TestServer(
                 ServerConfig config,
@@ -58,6 +88,16 @@ public class AsgServerHttpActivityTest {
                 RateLimiter rateLimiter,
                 Logger logger) {
             super(config, networkProvider, cacheManager, rateLimiter, logger);
+        }
+
+        TestServer(
+                ServerConfig config,
+                NetworkProvider networkProvider,
+                CacheManager cacheManager,
+                RateLimiter rateLimiter,
+                Logger logger,
+                String bindAddress) {
+            super(config, networkProvider, cacheManager, rateLimiter, logger, bindAddress);
         }
 
         @Override

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/GalleryCommandHandlerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/GalleryCommandHandlerTest.java
@@ -1,0 +1,56 @@
+package com.mentra.asg_client.service.core.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
+import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class GalleryCommandHandlerTest {
+    @Test
+    public void reportsGalleryFromSharedFileManagerWithoutCameraServer() {
+        AsgClientServiceManager serviceManager = mock(AsgClientServiceManager.class);
+        ICommunicationManager communicationManager = mock(ICommunicationManager.class);
+        FileManager fileManager = mock(FileManager.class);
+        AtomicReference<JSONObject> response = new AtomicReference<>();
+        when(serviceManager.getFileManager()).thenReturn(fileManager);
+        when(fileManager.getDefaultPackageName()).thenReturn("com.mentra");
+        when(fileManager.listFiles("com.mentra"))
+                .thenReturn(
+                        List.of(
+                                new FileManager.FileMetadata(
+                                        "IMG_1/photo.jpg",
+                                        "/gallery/IMG_1/photo.jpg",
+                                        123L,
+                                        1L,
+                                        "image/jpeg",
+                                        "com.mentra")));
+        when(communicationManager.sendBluetoothResponse(any(JSONObject.class)))
+                .thenAnswer(
+                        invocation -> {
+                            response.set(invocation.getArgument(0));
+                            return true;
+                        });
+
+        GalleryCommandHandler handler =
+                new GalleryCommandHandler(serviceManager, communicationManager);
+
+        assertThat(handler.handleCommand("query_gallery_status", new JSONObject())).isTrue();
+        assertThat(response.get().optInt("photos")).isEqualTo(1);
+        assertThat(response.get().optBoolean("has_content")).isTrue();
+        verify(serviceManager).getFileManager();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManagerCameraServerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManagerCameraServerTest.java
@@ -1,0 +1,72 @@
+package com.mentra.asg_client.service.legacy.managers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
+import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
+import com.mentra.asg_client.io.server.managers.AsgServerManager;
+import com.mentra.asg_client.io.server.services.AsgCameraServer;
+import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
+import com.mentra.asg_client.service.core.AsgClientService;
+import java.lang.reflect.Field;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class AsgClientServiceManagerCameraServerTest {
+    private INetworkManager networkManager;
+    private AsgClientServiceManager serviceManager;
+
+    @Before
+    public void setUp() {
+        networkManager = mock(INetworkManager.class);
+        serviceManager =
+                new AsgClientServiceManager(
+                        mock(Context.class),
+                        mock(AsgClientService.class),
+                        mock(ICommunicationManager.class),
+                        mock(FileManager.class),
+                        mock(IBesOtaRegistry.class),
+                        mock(ICompanionTransport.class),
+                        networkManager);
+    }
+
+    @Test
+    public void enablingServerWhileHotspotInactiveFailsClosed() {
+        when(networkManager.isHotspotEnabled()).thenReturn(false);
+
+        serviceManager.setWebServerEnabled(true);
+
+        assertThat(serviceManager.getCameraServer()).isNull();
+    }
+
+    @Test
+    public void repeatedDisableStopsUnexpectedServer() throws Exception {
+        AsgCameraServer cameraServer = mock(AsgCameraServer.class);
+        AsgServerManager serverManager = mock(AsgServerManager.class);
+        setField("cameraServer", cameraServer);
+        setField("serverManager", serverManager);
+        setField("isWebServerEnabled", false);
+
+        serviceManager.setWebServerEnabled(false);
+
+        verify(serverManager).stopServer("camera");
+        assertThat(serviceManager.getCameraServer()).isNull();
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = AsgClientServiceManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(serviceManager, value);
+    }
+}

--- a/asg_client/docs/features/camera-web-server.md
+++ b/asg_client/docs/features/camera-web-server.md
@@ -1,12 +1,14 @@
 # Camera web server
 
-ASG Client embeds a small HTTP server on the glasses (default port **8089**) that the phone uses to enumerate, sync, and download captured photos and videos. It also exposes endpoints for taking pictures, server status, and bulk file management.
+ASG Client embeds a small HTTP server on the glasses (default port **8089**) that the phone uses to enumerate, sync, and download captured photos and videos while connected to the Mentra Live hotspot. It also exposes endpoints for taking pictures, server status, and bulk file management.
 
 Source: `app/src/main/java/com/mentra/asg_client/io/server/`. Main class: `AsgCameraServer` (`io/server/services/AsgCameraServer.java`), built on the abstract `AsgServer` (`io/server/core/AsgServer.java`) which wraps NanoHTTPD.
 
 ## When the server runs
 
-The server is started by `AsgClientServiceManager.initializeCameraWebServer()` after WiFi credentials are accepted (see `WifiCommandHandler.handleSetWifiCredentials`). It listens on the local WiFi address only — it is not exposed beyond the network the glasses are joined to.
+The server starts only after the Mentra Live hotspot reports ready and stops as soon as the hotspot stops. `AsgClientService.onHotspotStateChanged()` drives the matching server lifecycle through `AsgClientServiceManager`. At process startup, an already-active hotspot is adopted before the service manager synchronizes the server state.
+
+NanoHTTPD binds specifically to the active hotspot gateway address, not to every interface. Ordinary station-mode WiFi connections never start the server and cannot reach it.
 
 `AsgClientServiceManager.getCameraServer()` exposes the running instance to other components. The gallery command handler, for example, reads counts from the server's `FileManager`.
 
@@ -27,7 +29,7 @@ CacheManager cache = new DefaultCacheManager(logger);
 RateLimiter rate = new DefaultRateLimiter(100, 60_000, logger);
 
 AsgCameraServer server = new AsgCameraServer(
-    config, network, cache, rate, logger, fileManager
+    config, network, cache, rate, logger, fileManager, hotspotGatewayIp
 );
 
 server.setOnPictureRequestListener(() -> mediaCaptureService.takePicture());
@@ -125,7 +127,7 @@ The capture ID is also stamped into the photo's EXIF `ImageUniqueID` tag at save
 
 ## Curl test recipes
 
-Replace `<GLASSES_IP>` with the WiFi IP of the glasses (visible in the phone app's pairing screen).
+Replace `<GLASSES_IP>` with the hotspot gateway IP reported by the glasses.
 
 ```bash
 # Health

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -112,7 +112,7 @@ Streaming endpoints on the active Mentra Live hotspot subnet are reachable witho
 
 ### Local media sync server
 
-`asg_client` runs an embedded HTTP server that lets the phone enumerate, download, ZIP, and delete captured media. This is used for gallery sync and avoids relying on cloud connectivity for local media transfer.
+While the Mentra Live hotspot is active, `asg_client` runs an embedded HTTP server that lets the phone enumerate, download, ZIP, and delete captured media. The server is stopped with the hotspot and binds only to the hotspot gateway address; it must never expose media through a WiFi network that the glasses join. This is used for gallery sync and avoids relying on cloud connectivity for local media transfer.
 
 ### Audio and microphone
 


### PR DESCRIPTION
## Summary

- align the local camera gallery with the Mentra Live connectivity lifecycle
- tighten the gallery server network binding
- refresh the gallery branding and supporting documentation
- add focused lifecycle and server coverage

## Testing

- targeted ASG unit tests
- ASG Android compile check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and where local media is reachable over HTTP (hotspot-only binding); mis-timed hotspot/gateway state could block gallery sync until retry, but reduces exposure on joined Wi‑Fi networks.
> 
> **Overview**
> **Mentra Live camera gallery** is now tied to the hotspot lifecycle instead of ordinary Wi‑Fi: the embedded HTTP gallery server starts only when the Mentra Live AP is active, stops when it turns off, and no longer starts when the phone sends Wi‑Fi credentials.
> 
> **Network exposure is tightened** by binding NanoHTTPD to the hotspot gateway IP (`createHotspotCameraWebServer`) rather than all interfaces, with `startServer()` returning success/failure so managers can fail closed and retry. Advertised URLs prefer the bind address.
> 
> **BLE gallery status** no longer depends on a running camera server: `GalleryCommandHandler` reads the shared `FileManager` via `AsgClientServiceManager.getFileManager()`, so counts work before the hotspot server is up.
> 
> **UX/docs**: static gallery HTML is rebranded to “Mentra Live Camera Gallery”; feature and Mentra Live spec docs describe hotspot-only sync. Unit tests cover bind behavior, gallery status without a server, and hotspot enable/disable reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be7f7262a2cd90de41f17ff3caebd574e2f2d40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->