### PR TITLE
Seed WHIP startup bitrate

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -43,6 +43,12 @@ public class AsgConstants {
     public static final long STREAM_METRICS_INTERVAL_MS = 1_000L;
 
     /**
+     * Initial WHIP/WebRTC send bitrate before congestion control has measured the network. This
+     * avoids libwebrtc's low default startup estimate while preserving room to adapt.
+     */
+    public static final int WHIP_INITIAL_VIDEO_BITRATE_BPS = 1_500_000;
+
+    /**
      * 1Hz encoder FPS/bitrate/dropped-frame telemetry ({@code [STREAM_QUALITY]} and BLE {@code
      * stream_status.stats}). Lifecycle {@code stream_status} (started/stopped/error) is unaffected.
      * Keep false in production; flip locally to debug the Mentra Call FPS ladder.

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicy.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicy.java
@@ -1,0 +1,18 @@
+package com.mentra.asg_client.io.streaming.services;
+
+import com.mentra.asg_client.AsgConstants;
+import org.webrtc.PeerConnection;
+
+/** Resolves WHIP bitrate constraints without exceeding the caller's configured ceiling. */
+final class WhipBitratePolicy {
+    private WhipBitratePolicy() {}
+
+    static int initialBitrateBps(int maximumBitrateBps) {
+        return Math.min(maximumBitrateBps, AsgConstants.WHIP_INITIAL_VIDEO_BITRATE_BPS);
+    }
+
+    static boolean applyTo(PeerConnection peerConnection, int maximumBitrateBps) {
+        return peerConnection.setBitrate(
+                null, initialBitrateBps(maximumBitrateBps), maximumBitrateBps);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -665,11 +665,14 @@ public class WhipStreamingService extends Service {
   }
 
   /**
-   * Cap the video encoder bitrate via RTP sender parameters and set degradation
-   * preference to MAINTAIN_FRAMERATE so WebRTC drops quality-per-frame instead of
+   * Seed WebRTC above its conservative startup default, cap the video encoder bitrate, and set
+   * degradation preference to MAINTAIN_FRAMERATE so WebRTC drops quality-per-frame instead of
    * frame rate when thermals get tight.
    */
   private void applyBitrateConstraints() {
+    int maximumBitrateBps = mStreamConfig.getVideoBitrate();
+    int initialBitrateBps = WhipBitratePolicy.initialBitrateBps(maximumBitrateBps);
+
     for (RtpSender sender : mPeerConnection.getSenders()) {
       if (sender.track() == null) continue;
       if (!"video".equals(sender.track().kind())) continue;
@@ -680,13 +683,20 @@ public class WhipStreamingService extends Service {
       params.degradationPreference = RtpParameters.DegradationPreference.MAINTAIN_FRAMERATE;
 
       for (RtpParameters.Encoding encoding : params.encodings) {
-        encoding.maxBitrateBps = mStreamConfig.getVideoBitrate();
+        encoding.maxBitrateBps = maximumBitrateBps;
       }
 
       sender.setParameters(params);
-      Log.i(TAG, "Applied video bitrate cap: " + (mStreamConfig.getVideoBitrate() / 1000)
-          + " kbps, degradation: MAINTAIN_FRAMERATE");
     }
+
+    boolean bitratePreferencesApplied =
+        WhipBitratePolicy.applyTo(mPeerConnection, maximumBitrateBps);
+    if (!bitratePreferencesApplied) {
+      Log.w(TAG, "Failed to apply WHIP initial/max bitrate preferences");
+    }
+    Log.i(TAG, "Applied video bitrate constraints: start=" + (initialBitrateBps / 1000)
+        + " kbps, max=" + (maximumBitrateBps / 1000)
+        + " kbps, degradation=MAINTAIN_FRAMERATE");
   }
 
   // -----------------------------------------------------------------------

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicyTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicyTest.java
@@ -1,0 +1,33 @@
+package com.mentra.asg_client.io.streaming.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.webrtc.PeerConnection;
+
+public class WhipBitratePolicyTest {
+
+    @Test
+    public void initialBitrateBps_usesConfiguredStartupSeedBelowMaximum() {
+        assertEquals(1_500_000, WhipBitratePolicy.initialBitrateBps(2_500_000));
+    }
+
+    @Test
+    public void initialBitrateBps_neverExceedsLowConfiguredMaximum() {
+        assertEquals(500_000, WhipBitratePolicy.initialBitrateBps(500_000));
+    }
+
+    @Test
+    public void applyTo_setsInitialAndMaximumPeerConnectionBitrates() {
+        PeerConnection peerConnection = mock(PeerConnection.class);
+        when(peerConnection.setBitrate(null, 1_500_000, 2_500_000)).thenReturn(true);
+
+        assertTrue(WhipBitratePolicy.applyTo(peerConnection, 2_500_000));
+
+        verify(peerConnection).setBitrate(null, 1_500_000, 2_500_000);
+    }
+}

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -108,6 +108,8 @@ Every camera-button press should still be forwarded to the phone as a `button_pr
 
 Mentra Live supports camera/microphone live streaming paths from `asg_client`, including RTMP, SRT, and WHIP services. Streaming behavior must coordinate camera ownership, microphone foreground-service requirements, reconnect/keep-alive handling, and privacy LED state.
 
+WHIP streams seed WebRTC with an explicit initial send bitrate capped by the caller's configured maximum. Congestion control remains enabled so the sender can still reduce bitrate on constrained networks instead of treating the configured bitrate as a fixed rate.
+
 Streaming endpoints on the active Mentra Live hotspot subnet are reachable without a separate STA WiFi connection. `asg_client` derives that subnet from the live hotspot interface rather than assuming fixed client addresses. For WHIP, the WebRTC network inventory must also expose the hotspot interface so ICE can gather a directly reachable local candidate.
 
 ### Local media sync server


### PR DESCRIPTION
## Summary

- seed WHIP WebRTC sessions at 1.5 Mbps instead of the conservative library default
- cap the initial seed at the caller configured maximum and preserve congestion adaptation
- document the behavior and cover default and low bitrate configurations

## Testing

- ./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.streaming.services.WhipBitratePolicyTest --tests com.mentra.asg_client.io.streaming.config.WhipStreamConfigTest
- ./scripts/check-android-compile.sh asg

## Manual verification

- Physical Mentra Live validation on strong and constrained WiFi is still required to measure startup quality and fallback behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds WHIP/WebRTC sessions at 1.5 Mbps instead of libwebrtc's conservative startup default, capped at the caller's configured maximum while preserving congestion adaptation.

- Adds `WhipBitratePolicy` to compute the startup seed and apply initial/max bitrate preferences on the peer connection.
- Updates `WhipStreamingService.applyBitrateConstraints` to seed via `setBitrate` and keep `MAINTAIN_FRAMERATE` degradation.
- Covers the seed logic with unit tests for the default and low-max configurations.
- Requires manual verification on strong and constrained WiFi to measure startup quality and fallback behavior.

<sup>Written for commit 1186c52f3ffd23b1c30b3fec44dcc798f808069e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WHIP/WebRTC send-path bitrate at stream start, which can affect startup quality and network behavior on real devices; max caps and congestion adaptation are preserved.
> 
> **Overview**
> WHIP live streams now **seed WebRTC send bitrate** at **1.5 Mbps** (`WHIP_INITIAL_VIDEO_BITRATE_BPS`) instead of relying on libwebrtc’s conservative startup estimate, while still honoring the caller’s configured **maximum** and existing RTP encoder caps plus `MAINTAIN_FRAMERATE`.
> 
> A new **`WhipBitratePolicy`** computes `min(maxConfigured, 1.5 Mbps)` and applies it via **`PeerConnection.setBitrate`**, with unit tests and a **mentra-live-spec** note that congestion control can still ramp down on bad networks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1186c52f3ffd23b1c30b3fec44dcc798f808069e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->