### PR TITLE
Show coordinated release versions in Mentra Live OTA

### DIFF
--- a/.github/scripts/build-bluetooth-sdk-ota-manifest.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-manifest.mjs
@@ -10,7 +10,7 @@ const requiredEnv = [
   'ASG_VERSION_NAME',
   'FIRMWARE_MANIFEST',
   'OUTPUT_PATH',
-  'SDK_VERSION',
+  'RELEASE_VERSION',
 ];
 
 for (const key of requiredEnv) {
@@ -19,9 +19,9 @@ for (const key of requiredEnv) {
   }
 }
 
-const sdkVersion = process.env.SDK_VERSION.trim();
-if (!/^[0-9A-Za-z][0-9A-Za-z._-]*$/.test(sdkVersion)) {
-  throw new Error(`Refusing unsafe SDK version for OTA path: ${sdkVersion}`);
+const releaseVersion = process.env.RELEASE_VERSION.trim();
+if (!/^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/.test(releaseVersion)) {
+  throw new Error(`Invalid coordinated release version: ${releaseVersion}`);
 }
 
 const versionCode = Number(process.env.ASG_VERSION_CODE);
@@ -43,6 +43,7 @@ if (!firmware.bes_firmware || typeof firmware.bes_firmware !== 'object' || Array
 }
 
 const manifest = {
+  releaseVersion,
   apps: {
     'com.mentra.asg_client': {
       versionCode,

--- a/.github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import {mkdtempSync, readFileSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {spawnSync} from 'node:child_process';
+import test from 'node:test';
+
+const script = path.resolve('.github/scripts/build-bluetooth-sdk-ota-manifest.mjs');
+
+function runManifestBuild(releaseVersion) {
+  const root = mkdtempSync(path.join(tmpdir(), 'mentra-ota-manifest-'));
+  const firmwarePath = path.join(root, 'firmware.json');
+  const outputPath = path.join(root, 'version.json');
+  writeFileSync(
+    firmwarePath,
+    JSON.stringify({
+      mtk_patches: [{start_firmware: 'A', end_firmware: 'B', url: 'https://example.com/mtk.zip'}],
+      bes_firmware: {version: '1.0.0', url: 'https://example.com/bes.bin'},
+    }),
+  );
+  const result = spawnSync(process.execPath, [script], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ASG_APK_SHA256: 'a'.repeat(64),
+      ASG_APK_SIZE: '123',
+      ASG_APK_URL: 'https://example.com/asg.apk',
+      ASG_VERSION_CODE: '40',
+      ASG_VERSION_NAME: 'asg.40',
+      FIRMWARE_MANIFEST: firmwarePath,
+      OUTPUT_PATH: outputPath,
+      RELEASE_VERSION: releaseVersion,
+    },
+  });
+  return {outputPath, result};
+}
+
+test('writes the coordinated release version independently of the ASG version', () => {
+  const {outputPath, result} = runManifestBuild('3.1.0-beta.3');
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(readFileSync(outputPath, 'utf8'));
+  assert.equal(manifest.releaseVersion, '3.1.0-beta.3');
+  assert.equal(manifest.apps['com.mentra.asg_client'].versionName, 'asg.40');
+});
+
+test('rejects a value outside the coordinated release identity format', () => {
+  const {result} = runManifestBuild('asg.40');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Invalid coordinated release version/);
+});

--- a/.github/scripts/coordinated-ota-records.mjs
+++ b/.github/scripts/coordinated-ota-records.mjs
@@ -136,13 +136,14 @@ export function createOtaReleaseResult({
   const manifest = readJson(manifestPath)
   const asg = manifest.apps?.["com.mentra.asg_client"]
   if (
+    manifest.releaseVersion !== releasePlan.releaseIdentity ||
     asg?.versionCode !== identity.versionCode ||
     asg?.versionName !== identity.versionName ||
     asg?.apkUrl !== provenance.apk.url ||
     asg?.sha256 !== provenance.apk.sha256 ||
     asg?.apkSize !== provenance.apk.size
   ) {
-    throw new Error("OTA manifest does not pin the selected ASG artifact exactly")
+    throw new Error("OTA manifest does not identify the release and selected ASG artifact exactly")
   }
   if (canonicalJson(manifest.mtk_patches) !== canonicalJson(releasePlan.otaInputs.mtkPatches)) {
     throw new Error("OTA manifest MTK inputs differ from the release plan")

--- a/.github/scripts/coordinated-ota-records.test.mjs
+++ b/.github/scripts/coordinated-ota-records.test.mjs
@@ -60,6 +60,7 @@ function fixture() {
     manifestPath,
     `${JSON.stringify(
       {
+        releaseVersion: releasePlan.releaseIdentity,
         apps: {
           "com.mentra.asg_client": {
             versionCode: identity.versionCode,
@@ -150,6 +151,40 @@ test("creates a release result only for an exact ASG, MTK, and BES selection", (
   assert.equal(result.asg.originatingReleaseSetId, releasePlan.releaseSetId)
   assert.equal(result.firmwareManifestSha256, releasePlan.otaInputs.firmwareManifest.sha256)
   assert.match(result.manifest.sha256, /^[0-9a-f]{64}$/)
+})
+
+test("rejects a manifest attributed to a different coordinated release", () => {
+  const fixtureData = fixture()
+  const manifest = JSON.parse(readFileSync(fixtureData.manifestPath, "utf8"))
+  manifest.releaseVersion = "3.1.0-beta.56"
+  writeFileSync(fixtureData.manifestPath, JSON.stringify(manifest))
+
+  assert.throws(
+    () =>
+      createOtaReleaseResult({
+        releasePlan,
+        identity,
+        provenance: fixtureData.provenance,
+        selectionPath: fixtureData.selectionPath,
+        selectionUrl: "https://example.com/asg-selection.json",
+        selectionStatus: "published",
+        manifestPath: fixtureData.manifestPath,
+        manifestUrl: "https://example.com/version.json",
+        bundlePath: fixtureData.bundlePath,
+        bundleUrl: "https://example.com/bundle.zip",
+        bundleStatus: "published",
+        manifestStatus: "published",
+        reused: false,
+        workflow: {
+          apkPath: fixtureData.apkPath,
+          signingCertificateSha256,
+          repository: "Mentra-Community/MentraOS",
+          runId: "123",
+          runAttempt: 1,
+        },
+      }),
+    /does not identify the release/,
+  )
 })
 
 test("rejects a substituted ASG selection record", () => {

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -323,7 +323,7 @@ jobs:
           ASG_VERSION_NAME: ${{ steps.asg-identity.outputs.version_name }}
           FIRMWARE_MANIFEST: asg_client/ota_manifests/firmware_live.json
           OUTPUT_PATH: coordinated-ota-work/release-assets/${{ steps.names.outputs.manifest_asset }}
-          SDK_VERSION: ${{ steps.names.outputs.release_identity }}
+          RELEASE_VERSION: ${{ steps.names.outputs.release_identity }}
         run: |
           ASG_APK_SHA256=$(jq -er .apk.sha256 coordinated-ota-work/asg-provenance.json)
           ASG_APK_SIZE=$(jq -er .apk.size coordinated-ota-work/asg-provenance.json)

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -205,9 +205,10 @@ export function CustomMentraLiveUpdate({onDone, onSetupWifi}: CustomMentraLiveUp
 coordinated Mentra release. `toVersion` is that exact release identity. The
 current `fromVersion` is the ASG client version reported by the glasses and may
 be `null` on older installations, so custom pages should keep an honest unknown
-fallback. This is an internal compatibility proxy until glasses report their
-coordinated release identity directly. Engine captures the pair before
-installation and retains it through restarts and final verification.
+fallback. When glasses report their coordinated release identity directly,
+Engine can replace this one source-version lookup without changing customer UI
+code. Engine captures the pair before installation and retains it through
+restarts and final verification.
 
 Start from the Starter Kit's
 [custom OTA presentation folder](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tree/main/examples/react-native/src/ota)

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -166,7 +166,16 @@ export function CustomMentraLiveUpdate({onDone, onSetupWifi}: CustomMentraLiveUp
     return <Text>Checking for updates…</Text>
   }
   if (state.screen === "update_available") {
-    return <Button title="Update now" onPress={ota.install} />
+    return (
+      <View>
+        {state.releaseTransition && (
+          <Text>
+            {state.releaseTransition.fromVersion ?? "Current version unknown"} → {state.releaseTransition.toVersion}
+          </Text>
+        )}
+        <Button title="Update now" onPress={ota.install} />
+      </View>
+    )
   }
   if (state.screen === "wifi_required") {
     return <Button title="Set up Wi-Fi" onPress={ota.openWifiSetup} />
@@ -180,12 +189,25 @@ export function CustomMentraLiveUpdate({onDone, onSetupWifi}: CustomMentraLiveUp
     )
   }
   if (state.screen === "up_to_date" || state.screen === "complete") {
-    return <Button title="Done" onPress={ota.finish} />
+    return (
+      <View>
+        {state.releaseTransition && <Text>Updated to {state.releaseTransition.toVersion}</Text>}
+        <Button title="Done" onPress={ota.finish} />
+      </View>
+    )
   }
 
   return <Text>{state.progress == null ? "Preparing update…" : `${state.progress}%`}</Text>
 }
 ```
+
+`state.releaseTransition` is present when the checked OTA manifest belongs to a
+coordinated Mentra release. `toVersion` is that exact release identity. The
+current `fromVersion` is the ASG client version reported by the glasses and may
+be `null` on older installations, so custom pages should keep an honest unknown
+fallback. This is an internal compatibility proxy until glasses report their
+coordinated release identity directly. Engine captures the pair before
+installation and retains it through restarts and final verification.
 
 Start from the Starter Kit's
 [custom OTA presentation folder](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tree/main/examples/react-native/src/ota)

--- a/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
+++ b/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
@@ -63,7 +63,9 @@ export function customActions(controller: MentraLiveOtaController) {
 
 export function CustomOtaConsumer({onDone, onSetupWifi}: {onDone: () => void; onSetupWifi: () => void}) {
   const controller = useMentraLiveOta({onFinished: onDone, onOpenWifiSetup: onSetupWifi})
-  return React.createElement(React.Fragment, null, screenLabel(controller.state.screen))
+  const transition = controller.state.releaseTransition
+  const releaseLabel = transition ? `${transition.fromVersion ?? "Unknown"} → ${transition.toVersion}` : ""
+  return React.createElement(React.Fragment, null, screenLabel(controller.state.screen), releaseLabel)
 }
 
 // Prove the curated low-level transport types resolve without a private import.

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -72,6 +72,9 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:updateConnectWifi": "Connect your {{deviceName}} to WiFi to install the update.",
   "ota:updateDescription":
     "A new update is available for your glasses. We recommend updating now for the best experience.",
+  "ota:releaseTransition": "{{fromVersion}} → {{toVersion}}",
+  "ota:releaseTransitionUnknown": "Current version unknown → {{toVersion}}",
+  "ota:updatedToVersion": "Updated to {{version}}",
   "ota:downgradeAvailable": "{{deviceName}} Version Change Required",
   "ota:downgradeDescription":
     "This app requires an earlier glasses software version. Your photos and videos will be preserved, but glasses settings will be reset and restored automatically after the change.",
@@ -204,6 +207,16 @@ function OtaFlowContent({
             ) : null}
           </>
         }>
+        {state.releaseTransition ? (
+          <BodyText colors={colors}>
+            {state.releaseTransition.fromVersion
+              ? translate("ota:releaseTransition", {
+                  fromVersion: state.releaseTransition.fromVersion,
+                  toVersion: state.releaseTransition.toVersion,
+                })
+              : translate("ota:releaseTransitionUnknown", {toVersion: state.releaseTransition.toVersion})}
+          </BodyText>
+        ) : null}
         <BodyText colors={colors}>
           {state.screen === "wifi_required"
             ? translate("ota:updateConnectWifi", {deviceName})
@@ -233,6 +246,11 @@ function OtaFlowContent({
         icon="check"
         title={translate("ota:upToDate")}>
         <BodyText colors={colors}>{translate("ota:noUpdatesAvailable")}</BodyText>
+        {state.releaseTransition ? (
+          <BodyText colors={colors}>
+            {translate("ota:updatedToVersion", {version: state.releaseTransition.toVersion})}
+          </BodyText>
+        ) : null}
         <ChangelogList changelogs={state.changelogs} colors={colors} />
       </FlowPage>
     )
@@ -364,6 +382,11 @@ function OtaFlowContent({
         icon="check"
         title={title}>
         <BodyText colors={colors}>{message}</BodyText>
+        {state.releaseTransition ? (
+          <BodyText colors={colors}>
+            {translate("ota:updatedToVersion", {version: state.releaseTransition.toVersion})}
+          </BodyText>
+        ) : null}
         <ChangelogList changelogs={state.changelogs} colors={colors} />
       </FlowPage>
     )

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -13,7 +13,7 @@ const checkResult: OtaCheckCurrentGlassesResult = {
   updateAvailable: true,
   latestVersionInfo: {
     versionCode: 40,
-    versionName: "3.1.0-dev.8",
+    versionName: "asg.40",
     downloadUrl: "https://example.com/asg.apk",
     apkSize: 1,
     sha256: "a".repeat(64),
@@ -24,7 +24,8 @@ const checkResult: OtaCheckCurrentGlassesResult = {
   besVersion: null,
   isApkDowngrade: false,
   manifestBody: "{}",
-  updateInfo: {available: true, versionCode: 40, versionName: "3.1.0-dev.8", updates: ["apk"], totalSize: 1},
+  releaseVersion: "3.1.0-dev.8",
+  updateInfo: {available: true, versionCode: 40, versionName: "asg.40", updates: ["apk"], totalSize: 1},
   isRequired: true,
 }
 let currentCheckResult = checkResult
@@ -73,12 +74,16 @@ const finish = mock(() => finishPromise)
 const discard = mock(() => {})
 const getReleaseChangelogs = mock(() => [{version: "3.1.0", markdown: "Release notes"}])
 let autoChainActive = false
-let autoChainRange: {fromVersion: string | null; toVersion: string | null} | null = null
+let autoChainRange: {
+  fromVersion: string | null
+  toVersion: string | null
+  releaseVersion?: string | null
+} | null = null
 const beginAutoChain = mock(
   (
     _fingerprint: string,
     _approvedDowngrade: boolean,
-    range: {fromVersion: string | null; toVersion: string | null},
+    range: {fromVersion: string | null; toVersion: string | null; releaseVersion?: string | null},
   ) => {
     autoChainActive = true
     autoChainRange = {...range}
@@ -88,11 +93,14 @@ const stopAutoChain = mock(() => {
   autoChainActive = false
   autoChainRange = null
 })
-const advanceAutoChain = mock((_fingerprint: string, _isDowngrade: boolean, targetVersion: string | null) => {
-  if (!autoChainRange) return {advance: false as const, reason: "inactive" as const}
-  if (targetVersion) autoChainRange.toVersion = targetVersion
-  return {advance: true as const, passCount: 2}
-})
+const advanceAutoChain = mock(
+  (_fingerprint: string, _isDowngrade: boolean, targetVersion: string | null, releaseVersion: string | null) => {
+    if (!autoChainRange) return {advance: false as const, reason: "inactive" as const}
+    if (targetVersion) autoChainRange.toVersion = targetVersion
+    if (releaseVersion) autoChainRange.releaseVersion = releaseVersion
+    return {advance: true as const, passCount: 2}
+  },
+)
 
 const fakeOta = {
   initialize: mock(() => Promise.resolve()),
@@ -256,6 +264,10 @@ describe("useMentraLiveOta", () => {
       await new Promise((resolve) => setTimeout(resolve, 1_150))
     })
     expect(latestController.state.screen).toBe("update_available")
+    expect(latestController.state.releaseTransition).toEqual({
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.8",
+    })
 
     await act(async () => {
       latestController.install()
@@ -266,6 +278,10 @@ describe("useMentraLiveOta", () => {
     })
 
     expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.releaseTransition).toEqual({
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.8",
+    })
     expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
     await act(async () => renderer.unmount())
   })
@@ -281,6 +297,7 @@ describe("useMentraLiveOta", () => {
     installSnapshot = {...installSnapshot, displayState: "complete"}
     const progressRenderer = await renderProbe("progress")
     expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.releaseTransition?.toVersion).toBe("3.1.0-dev.8")
     expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
     await act(async () => progressRenderer.unmount())
   })
@@ -304,7 +321,25 @@ describe("useMentraLiveOta", () => {
     })
 
     expect(latestController.state.screen).toBe("up_to_date")
+    expect(latestController.state.releaseTransition).toEqual({
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.8",
+    })
     expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
+    await act(async () => renderer.unmount())
+  })
+
+  test("does not invent a coordinated target for a legacy manifest", async () => {
+    currentCheckResult = {...checkResult, releaseVersion: null}
+    const renderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(latestController.state).toMatchObject({
+      screen: "update_available",
+      releaseTransition: null,
+    })
     await act(async () => renderer.unmount())
   })
 

--- a/mobile/modules/engine/src/react/index.ts
+++ b/mobile/modules/engine/src/react/index.ts
@@ -12,6 +12,7 @@ export {
   type MentraLiveOtaErrorCode,
   type MentraLiveOtaHotspotPhase,
   type MentraLiveOtaInstallPhase,
+  type MentraLiveOtaReleaseTransition,
   type MentraLiveOtaScreen,
   type MentraLiveOtaState,
   type MentraLiveOtaStep,

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -10,6 +10,7 @@ import {
   otaAutoChainReconnectWaitRemaining,
   stopOtaAutoChain,
   tryAdvanceOtaAutoChain,
+  type OtaAutoChainReleaseRange,
 } from "../services/OtaAutoChain"
 import {
   BES_INSTALL_RESTART_MESSAGE,
@@ -58,6 +59,13 @@ export type MentraLiveOtaHotspotPhase = "idle" | "downloading" | "starting_hotsp
 export type MentraLiveOtaInstallPhase = "download" | "install"
 export type MentraLiveOtaStep = "apk" | "mtk" | "bes"
 
+export type MentraLiveOtaReleaseTransition = {
+  /** Current glasses software label. Temporarily backed by the reported ASG app version. */
+  fromVersion: string | null
+  /** Exact coordinated release identity carried by the OTA manifest. */
+  toVersion: string
+}
+
 export type MentraLiveOtaState = {
   screen: MentraLiveOtaScreen
   connected: boolean
@@ -86,6 +94,8 @@ export type MentraLiveOtaState = {
   canDiscard: boolean
   canOpenWifiSetup: boolean
   continueDisabled: boolean
+  /** Release labels for the offered or just-completed coordinated update. */
+  releaseTransition: MentraLiveOtaReleaseTransition | null
   /** Release notes crossed by this update, newest first. Populated on completion. */
   changelogs: ReleaseChangelog[]
 }
@@ -119,8 +129,18 @@ type CheckState = "checking" | "update_available" | "no_update" | "dev_build" | 
 const AUTO_CHAIN_NETWORK_RETRY_DELAY_MS = 5000
 const AUTO_CHAIN_COMPLETE_DELAY_MS = 750
 
-function targetVersion(result: OtaCheckCurrentGlassesResult): string | null {
-  return result.updateInfo?.versionName ?? result.latestVersionInfo?.versionName ?? null
+function releaseRangeTargetVersion(result: OtaCheckCurrentGlassesResult): string | null {
+  return result.releaseVersion ?? result.updateInfo?.versionName ?? result.latestVersionInfo?.versionName ?? null
+}
+
+function currentReleaseVersion(appVersion: string | null): string | null {
+  const version = appVersion?.trim()
+  return version || null
+}
+
+function releaseTransitionFromRange(range: OtaAutoChainReleaseRange | null): MentraLiveOtaReleaseTransition | null {
+  if (!range?.releaseVersion) return null
+  return {fromVersion: range.fromVersion, toVersion: range.releaseVersion}
 }
 
 function releaseChangelogsForActiveChain(): ReleaseChangelog[] {
@@ -191,6 +211,10 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const [isVersionChange, setIsVersionChange] = useState(false)
   const [errorKind, setErrorKind] = useState<"network" | "pin_unavailable">("network")
   const [updateFingerprint, setUpdateFingerprint] = useState<string | null>(null)
+  const [offeredReleaseTransition, setOfferedReleaseTransition] = useState<MentraLiveOtaReleaseTransition | null>(null)
+  const [completedReleaseTransition, setCompletedReleaseTransition] = useState<MentraLiveOtaReleaseTransition | null>(
+    null,
+  )
   const [completedChangelogs, setCompletedChangelogs] = useState<ReleaseChangelog[]>([])
   const [checkGeneration, setCheckGeneration] = useState(0)
   const performCheckGenerationRef = useRef(0)
@@ -336,6 +360,10 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
           setIsVersionChange(result.updateInfo.isDowngrade === true)
           const fingerprint = otaAutoChainFingerprint(result)
           setUpdateFingerprint(fingerprint)
+          if (!isOtaAutoChainActive()) {
+            const fromVersion = currentReleaseVersion(ota.snapshot().appVersion)
+            setOfferedReleaseTransition(result.releaseVersion ? {fromVersion, toVersion: result.releaseVersion} : null)
+          }
           if (isOtaAutoChainActive()) {
             const snapshot = ota.snapshot()
             if (!snapshot.wifiStatusKnown) return
@@ -345,7 +373,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
               const admission = tryAdvanceOtaAutoChain(
                 fingerprint,
                 result.updateInfo.isDowngrade === true,
-                targetVersion(result),
+                releaseRangeTargetVersion(result),
+                result.releaseVersion,
               )
               if (admission.advance) {
                 checkCompletedRef.current = true
@@ -359,7 +388,10 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
           setCheckState("update_available")
           return
         }
-        if (isOtaAutoChainActive()) setCompletedChangelogs(releaseChangelogsForActiveChain())
+        if (isOtaAutoChainActive()) {
+          setCompletedChangelogs(releaseChangelogsForActiveChain())
+          setCompletedReleaseTransition(releaseTransitionFromRange(otaAutoChainReleaseRange()))
+        }
         stopOtaAutoChain()
         checkCompletedRef.current = true
         ota.clearUpdateAvailable()
@@ -425,6 +457,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   }, [installSnapshot.connected, installSnapshot.displayState, page, returnToCheck])
 
   const check = useCallback(() => {
+    setOfferedReleaseTransition(null)
+    setCompletedReleaseTransition(null)
     setCompletedChangelogs([])
     setPage("check")
     setCheckState("checking")
@@ -451,13 +485,17 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     ota.installSession.prepare(result)
     setCompletedChangelogs([])
     if (updateFingerprint) {
+      const fromVersion = offeredReleaseTransition
+        ? offeredReleaseTransition.fromVersion
+        : currentReleaseVersion(snapshot.appVersion)
       beginOtaAutoChain(updateFingerprint, isVersionChange, {
-        fromVersion: snapshot.appVersion,
-        toVersion: targetVersion(result),
+        fromVersion,
+        toVersion: releaseRangeTargetVersion(result),
+        releaseVersion: result.releaseVersion,
       })
     }
     navigateToProgress()
-  }, [check, isVersionChange, navigateToProgress, page, updateFingerprint])
+  }, [check, isVersionChange, navigateToProgress, offeredReleaseTransition, page, updateFingerprint])
 
   const retryInstall = useCallback(() => {
     if (page !== "progress") return
@@ -525,6 +563,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: false,
         continueDisabled: false,
+        releaseTransition: null,
         changelogs: [],
       }
     }
@@ -579,6 +618,12 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: screen === "wifi_required",
         continueDisabled: false,
+        releaseTransition:
+          screen === "update_available" || screen === "wifi_required"
+            ? offeredReleaseTransition
+            : screen === "up_to_date"
+              ? completedReleaseTransition
+              : null,
         changelogs: screen === "up_to_date" ? completedChangelogs : [],
       }
     }
@@ -637,17 +682,20 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       canDiscard: screen === "disconnected",
       canOpenWifiSetup: screen === "failed" && showChangeWifi,
       continueDisabled: installSnapshot.continueButtonDisabled,
+      releaseTransition: releaseTransitionFromRange(otaAutoChainReleaseRange()),
       changelogs,
     }
   }, [
     checkState,
     completedChangelogs,
+    completedReleaseTransition,
     errorKind,
     firmwareRestarting,
     installSnapshot,
     isUpdateRequired,
     isVersionChange,
     otaSnapshot,
+    offeredReleaseTransition,
     page,
     runtimeReady,
   ])

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -62,7 +62,7 @@ export type MentraLiveOtaStep = "apk" | "mtk" | "bes"
 export type MentraLiveOtaReleaseTransition = {
   /** Current glasses software label. Temporarily backed by the reported ASG app version. */
   fromVersion: string | null
-  /** Exact coordinated release identity carried by the OTA manifest. */
+  /** Exact coordinated release identity for the selected OTA pin. */
   toVersion: string
 }
 

--- a/mobile/modules/engine/src/services/OtaAutoChain.ts
+++ b/mobile/modules/engine/src/services/OtaAutoChain.ts
@@ -14,6 +14,8 @@ type OtaAutoChainSession = {
 export type OtaAutoChainReleaseRange = {
   fromVersion: string | null
   toVersion: string | null
+  /** Exact coordinated release identity, absent for legacy manifests. */
+  releaseVersion?: string | null
 }
 
 export type OtaAutoChainAdvanceResult =
@@ -99,6 +101,7 @@ export function tryAdvanceOtaAutoChain(
   fingerprint: string,
   isDowngrade: boolean,
   targetVersion: string | null,
+  releaseVersion: string | null = null,
 ): OtaAutoChainAdvanceResult {
   if (!session) {
     return {advance: false, reason: "inactive"}
@@ -122,5 +125,6 @@ export function tryAdvanceOtaAutoChain(
   session.seenFingerprints.add(fingerprint)
   session.passCount += 1
   if (targetVersion) session.releaseRange.toVersion = targetVersion
+  if (releaseVersion) session.releaseRange.releaseVersion = releaseVersion
   return {advance: true, passCount: session.passCount}
 }

--- a/mobile/modules/engine/src/services/OtaAutoChain.ts
+++ b/mobile/modules/engine/src/services/OtaAutoChain.ts
@@ -14,7 +14,7 @@ type OtaAutoChainSession = {
 export type OtaAutoChainReleaseRange = {
   fromVersion: string | null
   toVersion: string | null
-  /** Exact coordinated release identity, absent for legacy manifests. */
+  /** Exact coordinated release identity for the OTA pin, absent for legacy manifests. */
   releaseVersion?: string | null
 }
 

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -37,6 +37,7 @@ export interface BesFirmware {
 }
 
 export interface VersionJson {
+  releaseVersion?: string
   apps?: {
     [packageName: string]: VersionInfo
   }
@@ -65,6 +66,8 @@ export interface OtaCheckResult {
    * instead of racing it with a second fetch of the same URL.
    */
   manifestBody: string | null
+  /** Coordinated release identity carried by modern OTA manifests. */
+  releaseVersion: string | null
   /**
    * Why the check failed, when it did. "network" is retryable (connection/server
    * trouble); "pin_unavailable" is permanent for this app build (manifest 404/gone,
@@ -105,6 +108,7 @@ function emptyCheckResult(skippedReason?: OtaCheckSkippedReason): OtaCheckCurren
     besVersion: null,
     isApkDowngrade: false,
     manifestBody: null,
+    releaseVersion: null,
     updateInfo: null,
     isRequired: true,
     skippedReason,
@@ -116,6 +120,13 @@ function glassesConnectedNow(): boolean {
 }
 
 type ManifestFetchResult = {json: VersionJson | null; failureReason?: "network" | "pin_unavailable"}
+
+const COORDINATED_RELEASE_VERSION = /^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/
+
+function coordinatedReleaseVersion(versionJson: VersionJson): string | null {
+  const version = versionJson.releaseVersion?.trim()
+  return version && COORDINATED_RELEASE_VERSION.test(version) ? version : null
+}
 
 async function fetchVersionInfoDetailed(url: string): Promise<ManifestFetchResult> {
   try {
@@ -297,6 +308,7 @@ export async function checkForOtaUpdate(
         besVersion: null,
         isApkDowngrade: false,
         manifestBody: null,
+        releaseVersion: null,
         checkFailureReason: fetched.failureReason ?? "network",
       }
     }
@@ -328,6 +340,7 @@ export async function checkForOtaUpdate(
         besVersion: null,
         isApkDowngrade: false,
         manifestBody: null,
+        releaseVersion: null,
         checkFailureReason: "pin_unavailable",
       }
     }
@@ -366,6 +379,7 @@ export async function checkForOtaUpdate(
       besVersion: versionJson?.bes_firmware?.version || null,
       isApkDowngrade: apkDirection === "downgrade",
       manifestBody: versionJson ? JSON.stringify(versionJson) : null,
+      releaseVersion: coordinatedReleaseVersion(versionJson),
     }
   } catch (error) {
     console.error("Error checking for OTA update:", error)
@@ -378,6 +392,7 @@ export async function checkForOtaUpdate(
       besVersion: null,
       isApkDowngrade: false,
       manifestBody: null,
+      releaseVersion: null,
       checkFailureReason: "network",
     }
   }

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -68,7 +68,7 @@ export interface OtaCheckResult {
    * instead of racing it with a second fetch of the same URL.
    */
   manifestBody: string | null
-  /** Coordinated release identity carried by modern OTA manifests. */
+  /** Coordinated release identity for the selected OTA pin. */
   releaseVersion: string | null
   /**
    * Why the check failed, when it did. "network" is retryable (connection/server

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -1,7 +1,9 @@
 import BluetoothSdk, {type OtaUpdateInfo} from "@mentra/bluetooth-sdk"
+import {ENGINE_RELEASE_METADATA} from "../generated/releaseMetadata"
 import {getGlassesSystemTimeMs, isGlassesConnected, useGlassesStore, waitForGlassesState} from "../stores/glasses"
 import {maybeFixGlassesClockFromVersionInfo} from "./glassesClockSync"
 import {hasConfiguredModernOtaManifestPin, resolveOtaManifestUrl} from "./otaManifestUrl"
+import {resolveOtaReleaseVersion} from "./otaReleaseVersion"
 
 /**
  * Phone-side mirror of ASG's `DOWNGRADE_FLOOR_VERSION_CODE`. Set to the versionCode of the first
@@ -120,13 +122,6 @@ function glassesConnectedNow(): boolean {
 }
 
 type ManifestFetchResult = {json: VersionJson | null; failureReason?: "network" | "pin_unavailable"}
-
-const COORDINATED_RELEASE_VERSION = /^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/
-
-function coordinatedReleaseVersion(versionJson: VersionJson): string | null {
-  const version = versionJson.releaseVersion?.trim()
-  return version && COORDINATED_RELEASE_VERSION.test(version) ? version : null
-}
 
 async function fetchVersionInfoDetailed(url: string): Promise<ManifestFetchResult> {
   try {
@@ -379,7 +374,12 @@ export async function checkForOtaUpdate(
       besVersion: versionJson?.bes_firmware?.version || null,
       isApkDowngrade: apkDirection === "downgrade",
       manifestBody: versionJson ? JSON.stringify(versionJson) : null,
-      releaseVersion: coordinatedReleaseVersion(versionJson),
+      releaseVersion: resolveOtaReleaseVersion({
+        manifestReleaseVersion: versionJson.releaseVersion,
+        manifestUrl: otaVersionUrl,
+        packagedManifestUrl: ENGINE_RELEASE_METADATA.otaManifestUrl,
+        packagedReleaseIdentity: ENGINE_RELEASE_METADATA.releaseIdentity,
+      }),
     }
   } catch (error) {
     console.error("Error checking for OTA update:", error)

--- a/mobile/modules/engine/src/services/__tests__/OtaAutoChain.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/OtaAutoChain.test.ts
@@ -6,11 +6,26 @@ describe("OtaAutoChain release range", () => {
   beforeEach(() => stopOtaAutoChain())
 
   test("retains the source and advances the target across OTA passes", () => {
-    beginOtaAutoChain("first", false, {fromVersion: "3.0.0", toVersion: "3.1.0-dev.4"})
+    beginOtaAutoChain("first", false, {
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.4",
+      releaseVersion: "3.1.0-dev.4",
+    })
 
-    expect(otaAutoChainReleaseRange()).toEqual({fromVersion: "3.0.0", toVersion: "3.1.0-dev.4"})
-    expect(tryAdvanceOtaAutoChain("second", false, "3.2.0-beta.2")).toEqual({advance: true, passCount: 2})
-    expect(otaAutoChainReleaseRange()).toEqual({fromVersion: "3.0.0", toVersion: "3.2.0-beta.2"})
+    expect(otaAutoChainReleaseRange()).toEqual({
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.4",
+      releaseVersion: "3.1.0-dev.4",
+    })
+    expect(tryAdvanceOtaAutoChain("second", false, "3.2.0-beta.2", "3.2.0-beta.2")).toEqual({
+      advance: true,
+      passCount: 2,
+    })
+    expect(otaAutoChainReleaseRange()).toEqual({
+      fromVersion: "3.0.0",
+      toVersion: "3.2.0-beta.2",
+      releaseVersion: "3.2.0-beta.2",
+    })
   })
 
   test("clears the range with the rest of the session", () => {

--- a/mobile/modules/engine/src/services/__tests__/otaReleaseVersion.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/otaReleaseVersion.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from "bun:test"
+
+import {resolveOtaReleaseVersion} from "../otaReleaseVersion"
+
+describe("resolveOtaReleaseVersion", () => {
+  test("uses the packaged stable identity when production promotes exact beta OTA bytes", () => {
+    expect(
+      resolveOtaReleaseVersion({
+        manifestReleaseVersion: "3.1.0-beta.57",
+        manifestUrl: "https://example.com/ota.json",
+        packagedManifestUrl: "https://example.com/ota.json",
+        packagedReleaseIdentity: "3.1.0",
+      }),
+    ).toBe("3.1.0")
+  })
+
+  test("uses the manifest identity for a different host or developer pin", () => {
+    expect(
+      resolveOtaReleaseVersion({
+        manifestReleaseVersion: "3.2.0-beta.4",
+        manifestUrl: "https://example.com/override.json",
+        packagedManifestUrl: "https://example.com/packaged.json",
+        packagedReleaseIdentity: "3.1.0",
+      }),
+    ).toBe("3.2.0-beta.4")
+  })
+
+  test("does not expose an invalid release label", () => {
+    expect(
+      resolveOtaReleaseVersion({
+        manifestReleaseVersion: "asg.40",
+        manifestUrl: "https://example.com/ota.json",
+      }),
+    ).toBeNull()
+  })
+})

--- a/mobile/modules/engine/src/services/otaReleaseVersion.ts
+++ b/mobile/modules/engine/src/services/otaReleaseVersion.ts
@@ -1,0 +1,22 @@
+const COORDINATED_RELEASE_VERSION = /^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/
+
+type OtaReleaseVersionInput = {
+  manifestReleaseVersion?: string | null
+  manifestUrl: string
+  packagedManifestUrl?: string | null
+  packagedReleaseIdentity?: string | null
+}
+
+function validReleaseVersion(version: string | null | undefined): string | null {
+  const trimmed = version?.trim()
+  return trimmed && COORDINATED_RELEASE_VERSION.test(trimmed) ? trimmed : null
+}
+
+/** Resolve the label for the selected OTA pin, including stable promotion of exact beta OTA bytes. */
+export function resolveOtaReleaseVersion(input: OtaReleaseVersionInput): string | null {
+  const packagedRelease = validReleaseVersion(input.packagedReleaseIdentity)
+  if (packagedRelease && input.packagedManifestUrl?.trim() === input.manifestUrl.trim()) {
+    return packagedRelease
+  }
+  return validReleaseVersion(input.manifestReleaseVersion)
+}

--- a/mobile/src/__tests__/otaAutoChain.test.ts
+++ b/mobile/src/__tests__/otaAutoChain.test.ts
@@ -29,6 +29,7 @@ function result(overrides: Partial<OtaCheckCurrentGlassesResult> = {}): OtaCheck
     besVersion: null,
     isApkDowngrade: false,
     manifestBody: '{"version":37}',
+    releaseVersion: null,
     updateInfo: {
       available: true,
       versionCode: 37,

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -128,6 +128,7 @@ function checkResult(): OtaCheckCurrentGlassesResult {
     besVersion: null,
     isApkDowngrade: false,
     manifestBody: "{}",
+    releaseVersion: null,
     updateInfo: null,
     isRequired: true,
   }

--- a/mobile/src/__tests__/otaUpdateCheckService.test.ts
+++ b/mobile/src/__tests__/otaUpdateCheckService.test.ts
@@ -273,6 +273,7 @@ describe("OtaUpdateCheckService", () => {
         ok: true,
         json: () =>
           Promise.resolve({
+            releaseVersion: "3.1.0-beta.3",
             apps: {
               "com.mentra.asg_client": {
                 versionCode: 11,
@@ -312,6 +313,7 @@ describe("OtaUpdateCheckService", () => {
         hasCheckCompleted: true,
         updateAvailable: true,
         isRequired: false,
+        releaseVersion: "3.1.0-beta.3",
         updates: ["apk", "mtk", "bes"],
       }),
     )

--- a/mobile/src/app/ota/__tests__/shared-flow.test.tsx
+++ b/mobile/src/app/ota/__tests__/shared-flow.test.tsx
@@ -36,6 +36,7 @@ describe("MentraLiveOtaFlow", () => {
     useGlassesStore.getState().setGlassesInfo({
       connection: {state: "connected", fullyBooted: true},
       buildNumber: "37",
+      appVersion: "3.1.0-dev.7",
       hotspotOtaVersion: 1,
       wifi: {state: "disconnected"},
     })
@@ -48,6 +49,7 @@ describe("MentraLiveOtaFlow", () => {
       besVersion: null,
       isApkDowngrade: false,
       manifestBody: "{}",
+      releaseVersion: "3.1.0-dev.8",
       updateInfo: {isDowngrade: false, updates: [{type: "apk"}], versionName: "38"},
       isRequired: true,
       manifestUrl: "https://example.com/version.json",
@@ -63,6 +65,7 @@ describe("MentraLiveOtaFlow", () => {
       await jest.advanceTimersByTimeAsync(1_100)
     })
     expect(getByText("Mentra Live Update Available")).toBeDefined()
+    expect(getByText("3.1.0-dev.7 → 3.1.0-dev.8")).toBeDefined()
 
     fireEvent.press(getByTestId("button-Update Now"))
 
@@ -87,6 +90,7 @@ describe("MentraLiveOtaFlow", () => {
       besVersion: null,
       isApkDowngrade: false,
       manifestBody: "{}",
+      releaseVersion: null,
       updateInfo: {isDowngrade: false, updates: [{type: "apk"}], versionName: "37"},
       isRequired: false,
       manifestUrl: "https://example.com/version.json",
@@ -142,6 +146,7 @@ describe("MentraLiveOtaFlow", () => {
       besVersion: null,
       isApkDowngrade: false,
       manifestBody: "{}",
+      releaseVersion: null,
       updateInfo: null,
       isRequired: false,
       manifestUrl: "https://example.com/version.json",

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -411,6 +411,9 @@ const en = {
     updateReadyToInstall: "Version {{version}} for {{deviceName}} is ready to install.",
     updateConnectWifi: "Connect your {{deviceName}} to WiFi to install the update.",
     updateDescription: "A new update is available for your glasses. We recommend updating now for the best experience.",
+    releaseTransition: "{{fromVersion}} → {{toVersion}}",
+    releaseTransitionUnknown: "Current version unknown → {{toVersion}}",
+    updatedToVersion: "Updated to {{version}}",
     downgradeAvailable: "{{deviceName}} Version Change Required",
     downgradeDescriptionShort:
       "This app requires an earlier glasses software version. Photos and videos are kept; glasses settings will be reset and restored automatically.",


### PR DESCRIPTION
## Summary

- stamp coordinated OTA manifests with the exact release identity independently of the ASG artifact version
- expose one public `releaseTransition` value from `@mentra/engine/ota`, using the glasses-reported ASG client version as the temporary source-version proxy
- retain that transition through the existing APK/MTK/BES auto-chain and show it on the stock update-available and completion pages
- document the same state for custom OTA presentations without duplicating Engine sequencing

No BLE protocol, phone persistence, or second OTA state machine is added. Legacy manifests continue to use the existing UI without inventing a coordinated release label.

## Verification

- `node --test .github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs .github/scripts/coordinated-ota-records.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs` (17 passed)
- `cd mobile && bun run compile`
- focused Jest OTA suites (23 passed)
- Engine OTA hook and auto-chain suites (10 passed)
- `bun run test:public-ota-consumer`
- `bun run test:public-api` (3 passed)
- `git diff --check`

Hardware verification will follow after this change is included in a published Engine/SDK prerelease and consumed by the Starter Kit example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OTA manifest shape, release verification in CI, and user-visible update copy, but legacy manifests are unchanged and behavior is covered by new and updated tests.
> 
> **Overview**
> Coordinated OTA manifests now carry a **`releaseVersion`** field (semver release identity) separate from the ASG client **`versionName`**, with CI switching from `SDK_VERSION` to **`RELEASE_VERSION`** and stricter validation on both manifest generation and release-record verification.
> 
> **Engine** parses `releaseVersion` from fetched manifests via **`resolveOtaReleaseVersion`** (including stable promotion when production reuses exact beta OTA bytes), surfaces it on OTA check results, and exposes public **`state.releaseTransition`** (`fromVersion` → `toVersion`) from **`useMentraLiveOta`**. The APK/MTK/BES auto-chain retains **`releaseVersion`** across passes so stock **`MentraLiveOtaFlow`**, i18n, docs, and custom OTA UIs can show the coordinated upgrade path. Legacy manifests without a valid coordinated label keep prior behavior (**`releaseTransition` is null**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11f28ad2371c3a4a1400f24764221b4228bfd6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->