### PR TITLE
Clarify coordinated Mentra Live OTA setup

### DIFF
--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -11,16 +11,31 @@ packages, hosted OTA manifest, and portable OTA bundle selected for one release.
 See [Air-Gapped Bluetooth SDK Deployment](/mentra-live/air-gapped-deployment)
 for release-record resolution, checksum verification, and internal hosting.
 
-The latest matching pair is:
+Resolve the current coordinated beta identity, then pin that exact value in
+your app:
+
+```bash
+ENGINE_VERSION="$(npm view @mentra/engine@beta version)"
+SDK_VERSION="$(npm view @mentra/bluetooth-sdk@beta version)"
+test "$ENGINE_VERSION" = "$SDK_VERSION"
+echo "$SDK_VERSION"
+```
+
+The command prints the current `<release-version>`. If the equality check fails,
+the coordinated release is still publishing; wait for it to finish instead of
+mixing versions. Use that exact value across every platform:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
-| iOS `MentraBluetoothSDK` version `0.1.21-beta.5` | Mentra Live software `0.1.21-beta.5` |
+| React Native `@mentra/engine@<release-version>` and `@mentra/bluetooth-sdk@<release-version>` | Mentra Live software `<release-version>` |
+| Android `com.mentraglass:bluetooth-sdk:<release-version>` | Mentra Live software `<release-version>` |
+| iOS `MentraBluetoothSDK` version `<release-version>` | Mentra Live software `<release-version>` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.5`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.5` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses
+running an older software release may connect, but SDK features can fail or
+behave incorrectly. Install the exact glasses release matching your pinned SDK
+version before testing those features.
 </Warning>
 
 ## How Version Matching Works
@@ -33,9 +48,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-beta.5`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.5/mentra-example-react-native.apk)
-
-For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
+Open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the `sdk-<release-version>` tag matching the exact version you resolved above, and select **Downloads** to find its React Native example APK.
 
 ### Install A Prebuilt App On Android
 
@@ -59,20 +72,27 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 
 1. Pair and connect the example app to Mentra Live.
 2. The full-screen update flow checks the glasses automatically.
-3. If an update is available, tap **Update Now**. Configure glasses Wi-Fi only if the flow asks for it; supported releases can use the Mentra Live hotspot instead.
+3. If an update is available, tap **Update Now**. Configure glasses Wi-Fi only if the flow asks for it; Mentra Live software 3.1 and newer can use the glasses hotspot instead.
 4. Keep the app connected and avoid using other glasses features while the update is running.
 5. Wait while the flow installs every required component and rechecks the glasses. They may restart during installation.
 6. Continue when the flow reports that the glasses are up to date.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.5`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by its pinned
+SDK version, so it installs the glasses software components matching that
+release.
+
+<Note>
+`wifi_required` is the bootstrap path for Mentra Live software older than 3.1,
+which cannot host a hotspot OTA. Stock glasses are delivered with this older
+software, so their first update still requires glasses Wi-Fi. Once they run
+3.1 or newer, later updates can use hotspot OTA when glasses Wi-Fi is unset.
+</Note>
 
 ## Bootstrap The Update With ADB
 
 Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
 
-All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
-
-For the latest `0.1.21-beta.5` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.5-`.
+Open the [Mentra 3.1 prerelease artifacts](https://github.com/Mentra-Community/MentraOS/releases/tag/mentra-builds-v3.1.0) and download `mentra-live-ota-bundle-<release-version>.zip` for the exact version resolved above. Extract it and locate the single `.apk` file in its `artifacts` directory.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -84,13 +104,16 @@ Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.5-build>.apk"
+  "$HOME/Downloads/<extracted-bundle>/artifacts/<asg-client>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-beta.5` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.5` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the selected release's ASG client application. It
+does not necessarily install the matching MTK system software or BES firmware.
+After installing the APK, use the same release's example app OTA flow to install
+any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App
@@ -109,10 +132,15 @@ Do not reproduce that sequencing with `checkForOtaUpdate()`,
 This is the simplest and safest integration. `MentraLiveOtaFlow` provides the
 same full-page OTA screens and behavior as the Mentra App.
 
-Install matching Mentra Engine and Bluetooth SDK releases:
+Install the matching Mentra Engine and Bluetooth SDK releases. This example
+resolves the current beta again, verifies that publication is coordinated, and
+then pins the exact result in your lockfile:
 
 ```bash
-bun add @mentra/engine@VERSION @mentra/bluetooth-sdk@VERSION
+ENGINE_VERSION="$(npm view @mentra/engine@beta version)"
+SDK_VERSION="$(npm view @mentra/bluetooth-sdk@beta version)"
+test "$ENGINE_VERSION" = "$SDK_VERSION"
+bun add "@mentra/engine@$ENGINE_VERSION" "@mentra/bluetooth-sdk@$SDK_VERSION"
 ```
 
 Render the flow after Mentra Live connects. Your app owns only the surrounding

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -11,40 +11,26 @@ packages, hosted OTA manifest, and portable OTA bundle selected for one release.
 See [Air-Gapped Bluetooth SDK Deployment](/mentra-live/air-gapped-deployment)
 for release-record resolution, checksum verification, and internal hosting.
 
-Resolve the newest completed beta release record, then pin its exact identity
-in your app:
+Resolve the current beta candidate, require its completed release record, then
+pin that exact identity in your app:
 
 ```bash
 RELEASE_FAMILY="3.1.0"
-RELEASE_API="https://api.github.com/repos/Mentra-Community/MentraOS/releases/tags/mentra-builds-v${RELEASE_FAMILY}"
 RELEASE_RECORD="mentra-release-selected-beta.json"
-
-RELEASE_RECORD_URL="$(
-  curl --fail --silent --show-error --location "$RELEASE_API" |
-    jq -er --arg family "$RELEASE_FAMILY" '
-      [.assets[]
-        | select(.name | startswith("mentra-release-" + $family + "-beta."))
-        | select(.name | test("beta[.][0-9]+[.]json$"))
-        | {
-            url: .browser_download_url,
-            sequence: (.name | capture("beta[.](?<n>[0-9]+)[.]json$").n | tonumber)
-          }
-      ]
-      | if length == 0
-        then error("no completed beta release")
-        else max_by(.sequence).url
-        end
-    '
-)" &&
+RELEASE_VERSION="$(npm view @mentra/bluetooth-sdk@beta version)" &&
+RELEASE_RECORD_URL="https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v${RELEASE_FAMILY}/mentra-release-${RELEASE_VERSION}.json" &&
 curl --fail --location --output "$RELEASE_RECORD" "$RELEASE_RECORD_URL" &&
-RELEASE_VERSION="$(jq -er .releaseIdentity "$RELEASE_RECORD")" &&
+test "$(jq -er .releaseIdentity "$RELEASE_RECORD")" = "$RELEASE_VERSION" &&
 echo "$RELEASE_VERSION"
 ```
 
-The command considers only a `mentra-release-<release-version>.json` record,
-which is published after the SDK packages, native artifacts, OTA assets, example
-app, and release verification complete. It fails instead of selecting a release
-that is still publishing. Use the printed value across every platform:
+The npm tag proposes a candidate; it is not the readiness check. The command
+succeeds only when the matching `mentra-release-<release-version>.json` exists
+and identifies that same release. This record is published after the SDK
+packages, native artifacts, OTA assets, example app, and release verification
+complete. If the candidate is still publishing, the command fails; wait for it
+to finish instead of mixing versions. Use the printed value across every
+platform:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -11,19 +11,40 @@ packages, hosted OTA manifest, and portable OTA bundle selected for one release.
 See [Air-Gapped Bluetooth SDK Deployment](/mentra-live/air-gapped-deployment)
 for release-record resolution, checksum verification, and internal hosting.
 
-Resolve the current coordinated beta identity, then pin that exact value in
-your app:
+Resolve the newest completed beta release record, then pin its exact identity
+in your app:
 
 ```bash
-ENGINE_VERSION="$(npm view @mentra/engine@beta version)"
-SDK_VERSION="$(npm view @mentra/bluetooth-sdk@beta version)"
-test "$ENGINE_VERSION" = "$SDK_VERSION"
-echo "$SDK_VERSION"
+RELEASE_FAMILY="3.1.0"
+RELEASE_API="https://api.github.com/repos/Mentra-Community/MentraOS/releases/tags/mentra-builds-v${RELEASE_FAMILY}"
+RELEASE_RECORD="mentra-release-selected-beta.json"
+
+RELEASE_RECORD_URL="$(
+  curl --fail --silent --show-error --location "$RELEASE_API" |
+    jq -er --arg family "$RELEASE_FAMILY" '
+      [.assets[]
+        | select(.name | startswith("mentra-release-" + $family + "-beta."))
+        | select(.name | test("beta[.][0-9]+[.]json$"))
+        | {
+            url: .browser_download_url,
+            sequence: (.name | capture("beta[.](?<n>[0-9]+)[.]json$").n | tonumber)
+          }
+      ]
+      | if length == 0
+        then error("no completed beta release")
+        else max_by(.sequence).url
+        end
+    '
+)" &&
+curl --fail --location --output "$RELEASE_RECORD" "$RELEASE_RECORD_URL" &&
+RELEASE_VERSION="$(jq -er .releaseIdentity "$RELEASE_RECORD")" &&
+echo "$RELEASE_VERSION"
 ```
 
-The command prints the current `<release-version>`. If the equality check fails,
-the coordinated release is still publishing; wait for it to finish instead of
-mixing versions. Use that exact value across every platform:
+The command considers only a `mentra-release-<release-version>.json` record,
+which is published after the SDK packages, native artifacts, OTA assets, example
+app, and release verification complete. It fails instead of selecting a release
+that is still publishing. Use the printed value across every platform:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
@@ -132,15 +153,13 @@ Do not reproduce that sequencing with `checkForOtaUpdate()`,
 This is the simplest and safest integration. `MentraLiveOtaFlow` provides the
 same full-page OTA screens and behavior as the Mentra App.
 
-Install the matching Mentra Engine and Bluetooth SDK releases. This example
-resolves the current beta again, verifies that publication is coordinated, and
-then pins the exact result in your lockfile:
+Install the matching Mentra Engine and Bluetooth SDK releases from the completed
+record selected above. The `&&` guard prevents installation if the record is
+missing or invalid:
 
 ```bash
-ENGINE_VERSION="$(npm view @mentra/engine@beta version)"
-SDK_VERSION="$(npm view @mentra/bluetooth-sdk@beta version)"
-test "$ENGINE_VERSION" = "$SDK_VERSION"
-bun add "@mentra/engine@$ENGINE_VERSION" "@mentra/bluetooth-sdk@$SDK_VERSION"
+RELEASE_VERSION="$(jq -er .releaseIdentity mentra-release-selected-beta.json)" &&
+bun add "@mentra/engine@$RELEASE_VERSION" "@mentra/bluetooth-sdk@$RELEASE_VERSION"
 ```
 
 Render the flow after Mentra Live connects. Your app owns only the surrounding


### PR DESCRIPTION
## Summary

- replace the obsolete hardcoded `0.1.21-beta.5` pairing with a copyable, fail-closed resolver for the current `3.1.0` beta
- use the Bluetooth SDK beta tag only as a candidate, then require its matching finalized `mentra-release-<version>.json` before recommending or installing it
- pin that exact completed identity across React Native, Maven, SwiftPM, and Mentra Live software
- explain that `wifi_required` is expected for pre-3.1 firmware, including stock glasses, because those releases cannot host hotspot OTA
- point the ADB bootstrap path at the coordinated 3.1 OTA bundle rather than the legacy Bluetooth SDK OTA release

A literal `3.1.0-beta.N` would become stale whenever staging allocates another coordinated identity. A moving npm tag can also advance before native artifacts finish, so the finalized release record remains the cross-platform readiness authority.

## Validation

- `bunx --bun mint validate`
- `git diff --check`
- exercised the documented URL/identity guard against completed record `3.1.0-dev.33`
- confirmed the current beta candidate fails closed because no completed 3.1 beta record exists yet
- verified the published `mentra-live-ota-bundle-3.1.0-dev.37.zip` contains one ASG APK under `artifacts/` and the coordinated manifest reports release `3.1.0-dev.37`

## Related

- MentraOS public OTA API/UI: #3814
- Starter Kit custom OTA UI: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/50

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Mintlify; no runtime, auth, or deployment code is modified.
> 
> **Overview**
> Updates **Update Mentra Live** guidance so developers no longer pin a fixed `0.1.21-beta.5` SDK/glasses pair. It adds a **copyable resolver** that reads the `@mentra/bluetooth-sdk@beta` candidate, downloads `mentra-release-<version>.json` from the `3.1.0` build family, and **fails unless** `releaseIdentity` matches—treating the completed record as readiness, not the npm tag alone.
> 
> The dependency table and warnings now use **`<release-version>`** placeholders and call out **`@mentra/engine`** alongside the Bluetooth SDK. Starter Kit and example-app steps point at the tag matching the resolved version instead of a hardcoded APK URL.
> 
> **OTA behavior** is clarified for **3.1+ hotspot** vs **`wifi_required` on pre-3.1/stock glasses**. The **ADB bootstrap** path switches from legacy Bluetooth SDK OTA ASG APKs to **`mentra-live-ota-bundle-<version>.zip`** on `mentra-builds-v3.1.0`, with generic install paths and warnings.
> 
> **`bun add`** instructions pin Engine and Bluetooth SDK versions from the saved release record JSON with an **`&&` guard** when the record is missing or invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59bfa34eb9dde3bfbdd16eb87add67b59b0810b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->