### PR TITLE
Update live BES firmware to 26.8.27.0

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.8.26.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.26.0.bin",
-    "sha256": "94e2f657c6917934ef979fd20e96440230da2020e38153425ad953c6fd9300e3"
+    "version": "26.8.27.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.27.0.bin",
+    "sha256": "8d9e49569ba25e45d0b9c79b63244a3d413026b74523b63b7ebd1f84bf74c05e"
   }
 }


### PR DESCRIPTION
## Summary

- update firmware_live.json to BES 26.8.27.0
- use the URL and SHA-256 published by firmwarecdn.mentraglass.com/latest.json
- preserve the existing MTK patch list

## Validation

- downloaded the published BES binary and verified size 1,145,062 bytes
- verified SHA-256: 8d9e49569ba25e45d0b9c79b63244a3d413026b74523b63b7ebd1f84bf74c05e
- jq empty asg_client/ota_manifests/firmware_live.json
- git diff --check
- confirmed only firmware_live.json changed and all seven MTK patches are unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing live OTA metadata affects which BES binary clients download; incorrect hash or URL would break or mis-apply updates.
> 
> **Overview**
> Updates the **live OTA manifest** (`firmware_live.json`) so devices pull **BES firmware 26.8.27.0** instead of 26.8.26.0.
> 
> The `bes_firmware` block’s **version**, **CDN URL**, and **SHA-256** are aligned with the published `firmwarecdn.mentraglass.com` artifact. The **MTK patch list** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453f1608b53d50f7f7ec34d941932db18a73c581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->