### PR TITLE
Remove redundant Mentra Live pairing code label

### DIFF
--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -388,7 +388,7 @@ describe("pairing scan screen", () => {
     }
   })
 
-  it("shows pairing codes for multi-device Mentra Live results", async () => {
+  it("shows device identifiers without a separate pairing-code label", async () => {
     setPlatformOS("android")
     useCoreStore.setState({
       searchResults: [
@@ -412,13 +412,14 @@ describe("pairing scan screen", () => {
       ],
     })
 
-    const {getByText} = render(<SelectGlassesBluetoothScreen />)
+    const {getByText, queryByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
       expect(getByText("pairing:liveChooseGlassesTitle")).toBeTruthy()
-      expect(getByText(/pairing:pairingCodeLabel:A1B2/)).toBeTruthy()
-      expect(getByText(/pairing:pairingCodeLabel:C3D4/)).toBeTruthy()
+      expect(getByText("001")).toBeTruthy()
+      expect(getByText("002")).toBeTruthy()
     })
+    expect(queryByText(/pairing:pairingCodeLabel/)).toBeNull()
   })
 
   it("shows every Mentra Live and marks units that are not in pairing mode", async () => {
@@ -454,13 +455,14 @@ describe("pairing scan screen", () => {
       ],
     })
 
-    const {getByText} = render(<SelectGlassesBluetoothScreen />)
+    const {getByText, queryByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
       expect(getByText(/IDLE.*pairing:notInPairingModeLabel/)).toBeTruthy()
-      expect(getByText(/pairing:pairingCodeLabel:ABCD/)).toBeTruthy()
-      expect(getByText(/pairing:pairingCodeLabel:EF01/)).toBeTruthy()
+      expect(getByText("PAIR_A")).toBeTruthy()
+      expect(getByText("PAIR_B")).toBeTruthy()
     })
+    expect(queryByText(/pairing:pairingCodeLabel/)).toBeNull()
   })
 
   it("shows a single pairing-mode Mentra Live and waits for the user to choose it", async () => {
@@ -492,11 +494,11 @@ describe("pairing scan screen", () => {
     await waitFor(() => {
       expect(getByText("pairing:liveChooseGlassesTitle")).toBeTruthy()
       expect(getByText(/IDLE.*pairing:notInPairingModeLabel/)).toBeTruthy()
-      expect(getByText(/pairing:pairingCodeLabel:ABCD/)).toBeTruthy()
+      expect(getByText("PAIR_A")).toBeTruthy()
     })
     expect(push).not.toHaveBeenCalled()
 
-    fireEvent.press(getByText(/pairing:pairingCodeLabel:ABCD/))
+    fireEvent.press(getByText("PAIR_A"))
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(
@@ -654,11 +656,11 @@ describe("pairing scan screen", () => {
 
     await waitFor(() => {
       expect(getByText(/IDLE.*pairing:notInPairingModeLabel/)).toBeTruthy()
-      expect(getByText(/pairing:pairingCodeLabel:A1B2/)).toBeTruthy()
+      expect(getByText("TARGET")).toBeTruthy()
     })
     expect(push).not.toHaveBeenCalled()
 
-    fireEvent.press(getByText(/pairing:pairingCodeLabel:A1B2/))
+    fireEvent.press(getByText("TARGET"))
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -295,9 +295,6 @@ export default function SelectGlassesBluetoothScreen() {
   const formatLiveSubtitle = (device: Device) => {
     const base = filterDeviceName(device.name)
     const parts: string[] = [base]
-    if (device.pairingCode) {
-      parts.push(translate("pairing:pairingCodeLabel", {code: device.pairingCode}))
-    }
     if (securePairingEnabled && device.securePairingCapable !== false && device.pairingMode === false) {
       parts.push(translate("pairing:notInPairingModeLabel"))
     }


### PR DESCRIPTION
## Summary

- show the Mentra Live device identifier without appending a separate `Code X` suffix
- continue carrying the advertised pairing code into the selected pairing attempt for readiness and protocol correlation
- preserve the current secure-pairing feature-flag behavior and pairing-mode status label

## Test plan

- `bun run test --runInBand src/__tests__/app/pairing/scan.test.tsx` (19 passed)
- `bun run compile`
- focused ESLint on the changed scan files (zero errors; existing warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy change on the pairing scan screen only; pairing payload and secure-pairing gating logic are untouched.
> 
> **Overview**
> **Mentra Live Bluetooth scan** no longer appends a separate “Code …” line on each device row. List subtitles now show only the shortened device identifier (and, when secure pairing is on, the existing “not in pairing mode” suffix).
> 
> Pairing behavior is unchanged: tapping a device still navigates to loading with `pairingCode` (and related fields) in the route params. Tests were updated to assert the visible IDs, confirm `pairingCodeLabel` is absent, and keep pressing/selecting by those identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11dfe19423ffe38ea3e8fb826ffed5e15151db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->