### PR TITLE
Gate coordinated releases on matching example apps

### DIFF
--- a/.github/scripts/assemble-coordinated-release-results.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.mjs
@@ -44,12 +44,68 @@ function verifyAsgSelection(plan, ota, selectionFile) {
   return {sha256, size: bytes.length}
 }
 
+function verifyStarterKitResult(plan, starterKit, resultUrl) {
+  if (!starterKit) return undefined
+  if (
+    starterKit.schemaVersion !== 1 ||
+    starterKit.releaseSetId !== plan.releaseSetId ||
+    starterKit.releaseIdentity !== plan.releaseIdentity ||
+    starterKit.familyBaseVersion !== plan.familyBaseVersion ||
+    starterKit.channel !== plan.channel ||
+    starterKit.mentraos?.sourceCommit !== plan.sourceCommit
+  ) {
+    throw new Error("Starter Kit result does not match the release plan")
+  }
+  for (const packageName of ["@mentra/bluetooth-sdk", "@mentra/engine"]) {
+    if (starterKit.packages?.[packageName] !== plan.releaseIdentity) {
+      throw new Error(`Starter Kit ${packageName} version does not match the release plan`)
+    }
+  }
+  if (!/^https:\/\//.test(resultUrl || "")) throw new Error("Starter Kit result URL must be public HTTPS")
+  if (!/^https:\/\//.test(starterKit.starterKit?.validationRunUrl || "")) {
+    throw new Error("Starter Kit validation run URL must be public HTTPS")
+  }
+  if (!Array.isArray(starterKit.artifacts) || starterKit.artifacts.length !== 4) {
+    throw new Error("Starter Kit result must contain all four example artifacts")
+  }
+  const keys = new Set()
+  const artifacts = starterKit.artifacts.map((artifact) => {
+    if (
+      !artifact?.key ||
+      keys.has(artifact.key) ||
+      typeof artifact.name !== "string" ||
+      !artifact.name.includes(plan.releaseIdentity) ||
+      !/^https:\/\//.test(artifact.url || "") ||
+      !/^[0-9a-f]{64}$/.test(artifact.sha256 || "") ||
+      !Number.isSafeInteger(artifact.size) ||
+      artifact.size < 1
+    ) {
+      throw new Error("Starter Kit contains an invalid or duplicate example artifact")
+    }
+    keys.add(artifact.key)
+    return {
+      status: "published",
+      coordinate: artifact.name,
+      url: artifact.url,
+      sha256: artifact.sha256,
+      size: artifact.size,
+      provenanceUrl: starterKit.starterKit.validationRunUrl,
+    }
+  })
+  for (const key of ["android", "ios", "reactNative", "reactNativeElevenLabsAudio"]) {
+    if (!keys.has(key)) throw new Error(`Starter Kit result is missing ${key}`)
+  }
+  return {record: {...starterKit, resultUrl}, artifacts}
+}
+
 export function assembleCoordinatedReleaseResults({
   plan,
   ota,
   npmRecords,
   native,
   mobile,
+  starterKit,
+  starterKitResultUrl,
   asgSelectionFile,
   enginePackage,
   releaseAssetBaseUrl,
@@ -59,6 +115,7 @@ export function assembleCoordinatedReleaseResults({
   }
   const merged = mergeReleaseResultRecords({plan, records: [...npmRecords, native, mobile]})
   const selection = verifyAsgSelection(plan, ota, asgSelectionFile)
+  const verifiedStarterKit = verifyStarterKitResult(plan, starterKit, starterKitResultUrl)
   const otaProvenanceUrl = provenanceUrl(ota)
   const artifacts = [
     ...merged.artifacts,
@@ -99,6 +156,7 @@ export function assembleCoordinatedReleaseResults({
       }),
     )
   }
+  if (verifiedStarterKit) artifacts.push(...verifiedStarterKit.artifacts)
 
   return {
     schemaVersion: 1,
@@ -113,6 +171,7 @@ export function assembleCoordinatedReleaseResults({
       provenanceUrl: otaProvenanceUrl,
     },
     artifacts,
+    ...(verifiedStarterKit ? {starterKit: verifiedStarterKit.record} : {}),
   }
 }
 
@@ -135,6 +194,8 @@ function main() {
     npmRecords: [readJson(path.resolve(args.npm))],
     native: readJson(path.resolve(args.native)),
     mobile: readJson(path.resolve(args.mobile)),
+    starterKit: args["starter-kit"] ? readJson(path.resolve(args["starter-kit"])) : undefined,
+    starterKitResultUrl: args["starter-kit-result-url"],
     asgSelectionFile: path.resolve(args["asg-selection"]),
     enginePackage: args["engine-package"] ? path.resolve(args["engine-package"]) : undefined,
     releaseAssetBaseUrl: args["release-asset-base-url"],

--- a/.github/scripts/assemble-coordinated-release-results.test.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.test.mjs
@@ -135,6 +135,38 @@ test("assembles every product target and finalizes one complete release manifest
     },
     workflow: {repository: "Mentra-Community/MentraOS", runId: "123"},
   }
+  const starterKit = {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    familyBaseVersion: plan.familyBaseVersion,
+    channel: plan.channel,
+    mentraos: {sourceCommit: plan.sourceCommit, coordinatorRunUrl: provenanceUrl},
+    ota: {manifestUrl: ota.manifest.url, manifestSha256: ota.manifest.sha256},
+    starterKit: {
+      baseCommit: "1".repeat(40),
+      releaseCommit: "2".repeat(40),
+      mergeCommit: "3".repeat(40),
+      sourceTag: `sdk-${plan.releaseIdentity}`,
+      artifactContainerTag: `sdk-builds-v${plan.familyBaseVersion}`,
+      releaseUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/tag/sdk-builds-v3.1.0",
+      pullRequestUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/51",
+      validationRunUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/456",
+    },
+    packages: {
+      "@mentra/bluetooth-sdk": plan.releaseIdentity,
+      "@mentra/engine": plan.releaseIdentity,
+    },
+    artifacts: ["android", "ios", "reactNative", "reactNativeElevenLabsAudio"].map((key, index) => ({
+      key,
+      name: `mentra-example-${key}-${plan.releaseIdentity}.${key === "ios" ? "ipa" : "apk"}`,
+      url: `https://example.com/mentra-example-${key}-${plan.releaseIdentity}`,
+      size: index + 1,
+      sha256: String(index + 1).repeat(64),
+      contentType: "application/octet-stream",
+    })),
+    testflight: null,
+  }
 
   const results = assembleCoordinatedReleaseResults({
     plan,
@@ -142,6 +174,8 @@ test("assembles every product target and finalizes one complete release manifest
     npmRecords,
     native,
     mobile,
+    starterKit,
+    starterKitResultUrl: "https://example.com/starter-kit-result.json",
     asgSelectionFile,
     enginePackage,
     releaseAssetBaseUrl: "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0",
@@ -152,7 +186,8 @@ test("assembles every product target and finalizes one complete release manifest
   assert.equal(manifest.publications["@mentra/bluetooth-sdk"]["maven-central"].status, "published")
   assert.equal(manifest.publications.mentraos["app-store-connect"].status, "published")
   assert.ok(manifest.artifacts.some((artifact) => artifact.coordinate === plan.artifactNames.asgSelection))
-  assert.equal(manifest.artifacts.at(-1).coordinate, plan.artifactNames.enginePackage)
+  assert.equal(manifest.starterKit.resultUrl, "https://example.com/starter-kit-result.json")
+  assert.equal(manifest.artifacts.at(-1).coordinate, starterKit.artifacts.at(-1).name)
 
   assert.throws(
     () =>
@@ -167,6 +202,23 @@ test("assembles every product target and finalizes one complete release manifest
         releaseAssetBaseUrl: "https://example.com/release",
       }),
     /Duplicate publication record/,
+  )
+
+  assert.throws(
+    () =>
+      assembleCoordinatedReleaseResults({
+        plan,
+        ota,
+        npmRecords,
+        native,
+        mobile,
+        starterKit: {...starterKit, releaseSetId: "mentra-other"},
+        starterKitResultUrl: "https://example.com/starter-kit-result.json",
+        asgSelectionFile,
+        enginePackage,
+        releaseAssetBaseUrl: "https://example.com/release",
+      }),
+    /Starter Kit result does not match/,
   )
 
   writeFileSync(asgSelectionFile, `${JSON.stringify(asgSelection)}\n`)

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -84,6 +84,10 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native, engine-consumer\]$/m)
   assert.match(starterKit, /coordinated-example-release\.yml/)
   assert.match(starterKit, /starter-kit-release-\$identity\.json/)
+  assert.match(starterKit, /gh pr checks "\$pr_url"[^]*--required --json name,bucket/)
+  assert.match(starterKit, /gh pr merge "\$pr_url"[^]*--match-head-commit "\$candidate_sha"/)
+  assert.match(starterKit, /gh pr view "\$pull_request_url"[^]*--json url,state,headRefOid,baseRefName,mergeCommit/)
+  assert.match(starterKit, /git\/ref\/tags\/sdk-\$identity/)
   assert.match(starterKit, /\.digest <<< "\$asset"/)
   assert.match(jobBlock(coordinator, "finalize"), /needs\.starter-kit\.result == 'success'/)
   assert.match(docs, /^    needs: \[plan, starter-kit, finalize\]$/m)
@@ -103,6 +107,7 @@ test("coordinated docs publish only after finalization to the matching channel",
     /^    needs: \[plan, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, finalize, docs\]$/m,
   )
   assert.match(notify, /STARTER_KIT_RESULT: \$\{\{ needs\.starter-kit\.result \}\}/)
+  assert.match(notify, /STARTER_KIT_RUN_URL: \$\{\{ needs\.starter-kit\.outputs\.run_url \}\}/)
   assert.match(notify, /DOCS_RESULT: \$\{\{ needs\.docs\.result \}\}/)
 })
 

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -84,6 +84,8 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native, engine-consumer\]$/m)
   assert.match(starterKit, /coordinated-example-release\.yml/)
   assert.match(starterKit, /starter-kit-release-\$identity\.json/)
+  assert.match(starterKit, /select\(\.displayTitle == [^\n]+ and \.status != \\"completed\\"\)/)
+  assert.match(starterKit, /encoded_candidate_branch=\$\(jq -rn[^\n]+'\$value \| @uri'\)/)
   assert.match(starterKit, /gh pr checks "\$pr_url"[^]*--required --json name,bucket/)
   assert.match(starterKit, /gh pr merge "\$pr_url"[^]*--match-head-commit "\$candidate_sha"/)
   assert.match(starterKit, /gh pr view "\$pull_request_url"[^]*--json url,state,headRefOid,baseRefName,mergeCommit/)

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -77,10 +77,17 @@ test("mobile destinations use real TestFlight groups without changing the releas
 
 test("coordinated docs publish only after finalization to the matching channel", () => {
   const coordinator = workflow("coordinated-release.yml")
+  const starterKit = jobBlock(coordinator, "starter-kit")
   const docs = jobBlock(coordinator, "docs")
   const notify = jobBlock(coordinator, "notify-slack")
 
-  assert.match(docs, /^    needs: \[plan, finalize\]$/m)
+  assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native, engine-consumer\]$/m)
+  assert.match(starterKit, /coordinated-example-release\.yml/)
+  assert.match(starterKit, /starter-kit-release-\$identity\.json/)
+  assert.match(starterKit, /\.digest <<< "\$asset"/)
+  assert.match(jobBlock(coordinator, "finalize"), /needs\.starter-kit\.result == 'success'/)
+  assert.match(docs, /^    needs: \[plan, starter-kit, finalize\]$/m)
+  assert.match(docs, /needs\.starter-kit\.result == 'success'/)
   assert.match(docs, /needs\.finalize\.result == 'success'/)
   assert.match(docs, /needs\.plan\.outputs\.dry_run != 'true'/)
   assert.match(docs, /project=mentraos-docs-dev/)
@@ -88,9 +95,14 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(docs, /project=mentraos-docs-beta/)
   assert.match(docs, /docs_url=https:\/\/docs-beta\.mentraglass\.com/)
   assert.match(docs, /render-coordinated-docs\.mjs/)
+  assert.match(docs, /--starter-kit/)
   assert.match(docs, /X-Robots-Tag: noindex/)
   assert.match(docs, /grep --fixed-strings --quiet "\$RELEASE_IDENTITY" "\$body"/)
-  assert.match(notify, /^    needs: \[plan, ota, npm, sdk-native, mobile, engine-consumer, finalize, docs\]$/m)
+  assert.match(
+    notify,
+    /^    needs: \[plan, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, finalize, docs\]$/m,
+  )
+  assert.match(notify, /STARTER_KIT_RESULT: \$\{\{ needs\.starter-kit\.result \}\}/)
   assert.match(notify, /DOCS_RESULT: \$\{\{ needs\.docs\.result \}\}/)
 })
 

--- a/.github/scripts/notify-coordinated-release-slack.sh
+++ b/.github/scripts/notify-coordinated-release-slack.sh
@@ -60,10 +60,11 @@ label() {
 artifact_link() {
   local url="$1"
   local name="$2"
+  local fallback_url="${3:-$run_url}"
   if [[ -n "$url" && -n "$name" ]] && curl --fail --silent --head --location --retry 2 "$url" >/dev/null; then
     printf '<%s|%s>' "$url" "$name"
   else
-    printf '<%s|View run logs>' "$run_url"
+    printf '<%s|View run logs>' "$fallback_url"
   fi
 }
 
@@ -82,7 +83,10 @@ fi
 android_detail=$(artifact_link "$apk_url" "${APK_NAME:-Android APK}")
 ios_detail=$(artifact_link "$ipa_url" "${IPA_NAME:-iOS IPA}")
 asg_detail=$(artifact_link "${ASG_APK_URL:-}" "${ASG_APK_NAME:-ASG APK}")
-starter_detail=$(artifact_link "${STARTER_KIT_APK_URL:-}" "${STARTER_KIT_APK_NAME:-React Native example APK}")
+starter_detail=$(artifact_link \
+  "${STARTER_KIT_APK_URL:-}" \
+  "${STARTER_KIT_APK_NAME:-React Native example APK}" \
+  "${STARTER_KIT_RUN_URL:-$run_url}")
 if [[ -n "${STARTER_KIT_RELEASE_URL:-}" ]]; then
   starter_detail+=" - <${STARTER_KIT_RELEASE_URL}|All example builds>"
 fi

--- a/.github/scripts/notify-coordinated-release-slack.sh
+++ b/.github/scripts/notify-coordinated-release-slack.sh
@@ -82,6 +82,10 @@ fi
 android_detail=$(artifact_link "$apk_url" "${APK_NAME:-Android APK}")
 ios_detail=$(artifact_link "$ipa_url" "${IPA_NAME:-iOS IPA}")
 asg_detail=$(artifact_link "${ASG_APK_URL:-}" "${ASG_APK_NAME:-ASG APK}")
+starter_detail=$(artifact_link "${STARTER_KIT_APK_URL:-}" "${STARTER_KIT_APK_NAME:-React Native example APK}")
+if [[ -n "${STARTER_KIT_RELEASE_URL:-}" ]]; then
+  starter_detail+=" - <${STARTER_KIT_RELEASE_URL}|All example builds>"
+fi
 docs_detail="<${run_url}|View run logs>"
 if [[ -n "${DOCS_URL:-}" ]]; then
   docs_detail="<${DOCS_URL}|Open docs>"
@@ -102,8 +106,9 @@ newline=$'\n'
 android_line="*$(icon "$android_result") Android* - $(label "$android_result") - ${android_detail}${newline}Google Play: ${PLAY_TRACK:-unknown}"
 ios_line="*$(icon "$ios_result") iOS* - $(label "$ios_result") - ${ios_detail}${newline}TestFlight: ${TESTFLIGHT_GROUP:-unknown}"
 asg_line="*$(icon "${OTA_RESULT:-unknown}") ASG + OTA* - $(label "${OTA_RESULT:-unknown}") - ${asg_detail}"
+starter_line="*$(icon "${STARTER_KIT_RESULT:-unknown}") Starter Kit* - $(label "${STARTER_KIT_RESULT:-unknown}") - ${starter_detail}"
 docs_line="*$(icon "${DOCS_RESULT:-unknown}") Docs* - $(label "${DOCS_RESULT:-unknown}") - ${docs_detail}"
-checks_line="*Release checks*${newline}Plan: $(icon "${PLAN_RESULT:-unknown}") $(label "${PLAN_RESULT:-unknown}") | Packages: $(icon "${NPM_RESULT:-unknown}") $(label "${NPM_RESULT:-unknown}") | Native SDK: $(icon "${SDK_NATIVE_RESULT:-unknown}") $(label "${SDK_NATIVE_RESULT:-unknown}") | Engine consumer: $(icon "${ENGINE_RESULT:-unknown}") $(label "${ENGINE_RESULT:-unknown}") | Finalize: $(icon "${FINALIZE_RESULT:-unknown}") $(label "${FINALIZE_RESULT:-unknown}")"
+checks_line="*Release checks*${newline}Plan: $(icon "${PLAN_RESULT:-unknown}") $(label "${PLAN_RESULT:-unknown}") | Packages: $(icon "${NPM_RESULT:-unknown}") $(label "${NPM_RESULT:-unknown}") | Native SDK: $(icon "${SDK_NATIVE_RESULT:-unknown}") $(label "${SDK_NATIVE_RESULT:-unknown}") | Engine consumer: $(icon "${ENGINE_RESULT:-unknown}") $(label "${ENGINE_RESULT:-unknown}") | Examples: $(icon "${STARTER_KIT_RESULT:-unknown}") $(label "${STARTER_KIT_RESULT:-unknown}") | Finalize: $(icon "${FINALIZE_RESULT:-unknown}") $(label "${FINALIZE_RESULT:-unknown}")"
 
 payload=$(jq -n \
   --arg header "$header_icon $header_text" \
@@ -112,6 +117,7 @@ payload=$(jq -n \
   --arg android "$android_line" \
   --arg ios "$ios_line" \
   --arg asg "$asg_line" \
+  --arg starter "$starter_line" \
   --arg docs "$docs_line" \
   --arg checks "$checks_line" \
   --arg context "Commit <${commit_url}|\`${commit_short}\`> by ${commit_author} - <${run_url}|View workflow>" \
@@ -124,6 +130,7 @@ payload=$(jq -n \
       {type: "section", text: {type: "mrkdwn", text: $android}},
       {type: "section", text: {type: "mrkdwn", text: $ios}},
       {type: "section", text: {type: "mrkdwn", text: $asg}},
+      {type: "section", text: {type: "mrkdwn", text: $starter}},
       {type: "section", text: {type: "mrkdwn", text: $docs}},
       {type: "section", text: {type: "mrkdwn", text: $checks}},
       {type: "context", elements: [{type: "mrkdwn", text: $context}]}

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -359,6 +359,35 @@ function requiredArtifactCoordinates(plan) {
   })
 }
 
+function validateStarterKitEvidence(plan, starterKit, artifacts) {
+  if (starterKit === undefined) return undefined
+  if (
+    starterKit?.schemaVersion !== 1 ||
+    starterKit.releaseSetId !== plan.releaseSetId ||
+    starterKit.releaseIdentity !== plan.releaseIdentity ||
+    starterKit.familyBaseVersion !== plan.familyBaseVersion ||
+    starterKit.channel !== plan.channel ||
+    starterKit.mentraos?.sourceCommit !== plan.sourceCommit ||
+    !Array.isArray(starterKit.artifacts) ||
+    starterKit.artifacts.length !== 4
+  ) {
+    throw new Error("Starter Kit evidence does not match the release plan")
+  }
+  requirePublicHttpsUrl(starterKit.resultUrl, "starterKit.resultUrl")
+  requirePublicHttpsUrl(starterKit.starterKit?.releaseUrl, "starterKit.starterKit.releaseUrl")
+  requirePublicHttpsUrl(starterKit.starterKit?.pullRequestUrl, "starterKit.starterKit.pullRequestUrl")
+  requirePublicHttpsUrl(starterKit.starterKit?.validationRunUrl, "starterKit.starterKit.validationRunUrl")
+
+  const artifactByCoordinate = new Map(artifacts.map((artifact) => [artifact.coordinate, artifact]))
+  for (const example of starterKit.artifacts) {
+    const artifact = artifactByCoordinate.get(example.name)
+    if (!artifact || artifact.url !== example.url || artifact.sha256 !== example.sha256 || artifact.size !== example.size) {
+      throw new Error(`Starter Kit artifact ${example.name || "<unknown>"} differs from publication evidence`)
+    }
+  }
+  return starterKit
+}
+
 export function finalizeReleaseManifest({plan, results, completedAt}) {
   if (!plan?.releaseSetId || !plan?.members) throw new Error("A generated release plan is required")
   if (results?.releaseSetId !== plan.releaseSetId) throw new Error("Publication results do not match the release set")
@@ -411,6 +440,7 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
   for (const coordinate of requiredArtifactCoordinates(plan)) {
     if (!artifactCoordinates.has(coordinate)) throw new Error(`Missing required artifact ${coordinate}`)
   }
+  const starterKit = validateStarterKitEvidence(plan, results.starterKit, artifacts)
 
   let promotion
   if (plan.channel === "production") {
@@ -443,6 +473,7 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
     publications,
     otaManifest,
     artifacts,
+    ...(starterKit ? {starterKit} : {}),
     ...(promotion ? {promotion} : {}),
   }
 }

--- a/.github/scripts/render-coordinated-docs.mjs
+++ b/.github/scripts/render-coordinated-docs.mjs
@@ -16,7 +16,24 @@ function parseArgs(args) {
   return values
 }
 
-export function renderCoordinatedDocs({sourceDir, outputDir, releasePlan, repository}) {
+function validateStarterKitResult(releasePlan, starterKitResult) {
+  if (!starterKitResult) throw new Error("Coordinated prerelease docs require a Starter Kit result")
+  if (
+    starterKitResult.schemaVersion !== 1 ||
+    starterKitResult.releaseSetId !== releasePlan.releaseSetId ||
+    starterKitResult.releaseIdentity !== releasePlan.releaseIdentity ||
+    starterKitResult.mentraos?.sourceCommit !== releasePlan.sourceCommit
+  ) {
+    throw new Error("Starter Kit result does not match the coordinated release plan")
+  }
+  const reactNative = starterKitResult.artifacts?.find((artifact) => artifact.key === "reactNative")
+  if (!reactNative || !/^https:\/\//.test(reactNative.url || "")) {
+    throw new Error("Starter Kit result is missing the React Native APK")
+  }
+  return reactNative
+}
+
+export function renderCoordinatedDocs({sourceDir, outputDir, releasePlan, starterKitResult, repository}) {
   if (!RELEASE_IDENTITY_PATTERN.test(releasePlan?.releaseIdentity || "")) {
     throw new Error(`Invalid coordinated release identity ${JSON.stringify(releasePlan?.releaseIdentity)}`)
   }
@@ -51,6 +68,11 @@ export function renderCoordinatedDocs({sourceDir, outputDir, releasePlan, reposi
   config.variables["release-version"] = releasePlan.releaseIdentity
   config.variables["release-artifacts-url"] =
     `https://github.com/${repository}/releases/tag/${releasePlan.artifactContainerTag}`
+  if (releasePlan.releaseIdentity.includes("-")) {
+    const reactNative = validateStarterKitResult(releasePlan, starterKitResult)
+    config.variables["example-app-version"] = releasePlan.releaseIdentity
+    config.variables["example-app-url"] = reactNative.url
+  }
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
 
   return {releaseIdentity: releasePlan.releaseIdentity, outputDir: output}
@@ -60,10 +82,14 @@ const isMain = process.argv[1] && import.meta.url === pathToFileURL(path.resolve
 if (isMain) {
   const args = parseArgs(process.argv.slice(2))
   const plan = JSON.parse(readFileSync(path.resolve(args.plan), "utf8"))
+  const starterKitResult = args["starter-kit"]
+    ? JSON.parse(readFileSync(path.resolve(args["starter-kit"]), "utf8"))
+    : undefined
   const result = renderCoordinatedDocs({
     sourceDir: path.resolve(args.source),
     outputDir: path.resolve(args.output),
     releasePlan: plan,
+    starterKitResult,
     repository: args.repository,
   })
   console.log(`Rendered docs for ${result.releaseIdentity} in ${result.outputDir}`)

--- a/.github/scripts/render-coordinated-docs.test.mjs
+++ b/.github/scripts/render-coordinated-docs.test.mjs
@@ -34,9 +34,28 @@ test("renders exact coordinated release variables without changing source", (con
     releaseIdentity: "3.1.0-beta.57",
     releaseSetId: "mentra-3.1.0-beta.57",
     artifactContainerTag: "mentra-builds-v3.1.0",
+    sourceCommit: "a".repeat(40),
+  }
+  const starterKitResult = {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    mentraos: {sourceCommit: plan.sourceCommit},
+    artifacts: [
+      {
+        key: "reactNative",
+        url: "https://github.com/Mentra/Starter/releases/download/sdk-builds-v3.1.0/example.apk",
+      },
+    ],
   }
 
-  renderCoordinatedDocs({sourceDir: source, outputDir: output, releasePlan: plan, repository: "Mentra/MentraOS"})
+  renderCoordinatedDocs({
+    sourceDir: source,
+    outputDir: output,
+    releasePlan: plan,
+    starterKitResult,
+    repository: "Mentra/MentraOS",
+  })
 
   const rendered = JSON.parse(readFileSync(path.join(output, "docs.json"), "utf8"))
   const original = JSON.parse(readFileSync(path.join(source, "docs.json"), "utf8"))
@@ -45,7 +64,8 @@ test("renders exact coordinated release variables without changing source", (con
     rendered.variables["release-artifacts-url"],
     "https://github.com/Mentra/MentraOS/releases/tag/mentra-builds-v3.1.0",
   )
-  assert.equal(rendered.variables["example-app-version"], "0.1.21-beta.5")
+  assert.equal(rendered.variables["example-app-version"], "3.1.0-beta.57")
+  assert.equal(rendered.variables["example-app-url"], starterKitResult.artifacts[0].url)
   assert.equal(original.variables["release-version"], "3.1.0")
   assert.equal(readFileSync(path.join(output, "page.mdx"), "utf8"), "Release {{release-version}}")
 })
@@ -66,6 +86,26 @@ test("rejects an inconsistent release plan", (context) => {
         repository: "Mentra/MentraOS",
       }),
     /inconsistent release-set identity/,
+  )
+})
+
+test("rejects prerelease docs without matching example artifacts", (context) => {
+  const {root, source, output} = fixture()
+  context.after(() => rmSync(root, {recursive: true, force: true}))
+  assert.throws(
+    () =>
+      renderCoordinatedDocs({
+        sourceDir: source,
+        outputDir: output,
+        releasePlan: {
+          releaseIdentity: "3.1.0-dev.4",
+          releaseSetId: "mentra-3.1.0-dev.4",
+          artifactContainerTag: "mentra-builds-v3.1.0",
+          sourceCommit: "a".repeat(40),
+        },
+        repository: "Mentra/MentraOS",
+      }),
+    /require a Starter Kit result/,
   )
 })
 

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -337,14 +337,27 @@ jobs:
           if ! curl --fail --silent --show-error --location "$result_url" \
             --output "starter-kit-result/$result_name" 2>/dev/null; then
             rm -f "starter-kit-result/$result_name"
-            dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-            gh workflow run coordinated-example-release.yml \
-              --repo "$STARTER_KIT_REPOSITORY" \
-              --ref main \
-              -f "channel=$channel" \
-              -f "payload=$payload"
+            run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
+              --workflow coordinated-example-release.yml --event workflow_dispatch --limit 100 \
+              --json databaseId,displayTitle,status,url \
+              --jq ".[] | select(.displayTitle == \"$run_title\" and .status != \"completed\")" \
+              | head -1)
+            dispatched_at=""
+            if [[ -n "$run_json" ]]; then
+              run_id=$(jq -r .databaseId <<< "$run_json")
+              run_url=$(jq -r .url <<< "$run_json")
+              echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
+            else
+              dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+              gh workflow run coordinated-example-release.yml \
+                --repo "$STARTER_KIT_REPOSITORY" \
+                --ref main \
+                -f "channel=$channel" \
+                -f "payload=$payload"
+            fi
 
             candidate_branch="coordinated/$identity"
+            encoded_candidate_branch=$(jq -rn --arg value "$candidate_branch" '$value | @uri')
             candidate_sha=""
             for _ in {1..180}; do
               if [[ -z "$run_id" ]]; then
@@ -359,7 +372,7 @@ jobs:
                   echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
                 fi
               fi
-              candidate_sha=$(gh api "repos/$STARTER_KIT_REPOSITORY/branches/$candidate_branch" \
+              candidate_sha=$(gh api "repos/$STARTER_KIT_REPOSITORY/branches/$encoded_candidate_branch" \
                 --jq .commit.sha 2>/dev/null || true)
               [[ -n "$run_id" && -n "$candidate_sha" ]] && break
               if [[ -n "$run_id" ]]; then

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -326,13 +326,6 @@ jobs:
               expectedStarterKitHead: $expectedStarterKitHead
             }')
 
-          dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          gh workflow run coordinated-example-release.yml \
-            --repo "$STARTER_KIT_REPOSITORY" \
-            --ref main \
-            -f "channel=$channel" \
-            -f "payload=$payload"
-
           run_title="Coordinated example $channel $identity"
           run_id=""
           run_url=""
@@ -341,40 +334,132 @@ jobs:
           result_url="https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$container_tag/$result_name"
           mkdir -p starter-kit-result
 
-          for _ in {1..420}; do
-            if [[ -z "$run_id" ]]; then
-              run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
-                --workflow coordinated-example-release.yml --event workflow_dispatch --limit 30 \
-                --json databaseId,displayTitle,createdAt,status,conclusion,url \
-                --jq ".[] | select(.displayTitle == \"$run_title\" and .createdAt >= \"$dispatched_at\")" \
-                | head -1)
-              if [[ -n "$run_json" ]]; then
-                run_id=$(jq -r .databaseId <<< "$run_json")
-                run_url=$(jq -r .url <<< "$run_json")
+          if ! curl --fail --silent --show-error --location "$result_url" \
+            --output "starter-kit-result/$result_name" 2>/dev/null; then
+            rm -f "starter-kit-result/$result_name"
+            dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            gh workflow run coordinated-example-release.yml \
+              --repo "$STARTER_KIT_REPOSITORY" \
+              --ref main \
+              -f "channel=$channel" \
+              -f "payload=$payload"
+
+            candidate_branch="coordinated/$identity"
+            candidate_sha=""
+            for _ in {1..180}; do
+              if [[ -z "$run_id" ]]; then
+                run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
+                  --workflow coordinated-example-release.yml --event workflow_dispatch --limit 30 \
+                  --json databaseId,displayTitle,createdAt,url \
+                  --jq ".[] | select(.displayTitle == \"$run_title\" and .createdAt >= \"$dispatched_at\")" \
+                  | head -1)
+                if [[ -n "$run_json" ]]; then
+                  run_id=$(jq -r .databaseId <<< "$run_json")
+                  run_url=$(jq -r .url <<< "$run_json")
+                  echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
+                fi
+              fi
+              candidate_sha=$(gh api "repos/$STARTER_KIT_REPOSITORY/branches/$candidate_branch" \
+                --jq .commit.sha 2>/dev/null || true)
+              [[ -n "$run_id" && -n "$candidate_sha" ]] && break
+              if [[ -n "$run_id" ]]; then
+                status=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status --jq .status)
+                if [[ "$status" == "completed" ]]; then
+                  conclusion=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json conclusion --jq .conclusion)
+                  echo "Starter Kit run concluded $conclusion before creating $candidate_branch: $run_url" >&2
+                  exit 1
+                fi
+              fi
+              sleep 10
+            done
+            if [[ -z "$run_id" || -z "$candidate_sha" ]]; then
+              echo "Starter Kit did not create $candidate_branch for $identity within 30 minutes." >&2
+              exit 1
+            fi
+
+            pr_json=$(gh pr list --repo "$STARTER_KIT_REPOSITORY" --state all \
+              --base "$target_branch" --head "$candidate_branch" --limit 1 \
+              --json number,url,state,mergedAt,headRefOid)
+            if [[ "$(jq 'length' <<< "$pr_json")" == "0" ]]; then
+              pr_body=$(printf '%s\n\n%s\n%s\n' \
+                "Automated dependency synchronization for coordinated release \`$identity\`." \
+                "Coordinator: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+                "Starter Kit workflow: $run_url")
+              pr_url=$(gh pr create --repo "$STARTER_KIT_REPOSITORY" \
+                --base "$target_branch" \
+                --head "$candidate_branch" \
+                --title "chore(release): synchronize examples to $identity" \
+                --body "$pr_body")
+            else
+              pr_url=$(jq -r '.[0].url' <<< "$pr_json")
+              merged_at=$(jq -r '.[0].mergedAt // empty' <<< "$pr_json")
+              state=$(jq -r '.[0].state' <<< "$pr_json")
+              if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
+                echo "Existing coordinator PR $pr_url was closed without merging." >&2
+                exit 1
               fi
             fi
+            [[ "$(gh pr view "$pr_url" --repo "$STARTER_KIT_REPOSITORY" --json headRefOid --jq .headRefOid)" == "$candidate_sha" ]]
 
-            if curl --fail --silent --show-error --location "$result_url" \
-              --output "starter-kit-result/$result_name" 2>/dev/null; then
-              break
+            if [[ -z "${merged_at:-}" ]]; then
+              checks_ready=false
+              for _ in {1..540}; do
+                checks=$(gh pr checks "$pr_url" --repo "$STARTER_KIT_REPOSITORY" \
+                  --required --json name,bucket 2>/dev/null || true)
+                if [[ -n "$checks" && "$(jq 'length' <<< "$checks")" != "0" ]]; then
+                  if jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<< "$checks" >/dev/null; then
+                    jq -r '.[] | "\(.bucket)\t\(.name)"' <<< "$checks" >&2
+                    echo "Required Starter Kit validation failed for $pr_url." >&2
+                    exit 1
+                  fi
+                  if jq -e 'all(.[]; .bucket == "pass" or .bucket == "skipping")' <<< "$checks" >/dev/null; then
+                    checks_ready=true
+                    break
+                  fi
+                fi
+                sleep 10
+              done
+              if [[ "$checks_ready" != "true" ]]; then
+                echo "Required Starter Kit validation did not finish within 90 minutes: $pr_url" >&2
+                exit 1
+              fi
+
+              gh pr merge "$pr_url" --repo "$STARTER_KIT_REPOSITORY" \
+                --merge --match-head-commit "$candidate_sha"
             fi
 
-            if [[ -n "$run_id" ]]; then
+            for _ in {1..90}; do
+              if curl --fail --silent --show-error --location "$result_url" \
+                --output "starter-kit-result/$result_name" 2>/dev/null; then
+                break
+              fi
               status=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status --jq .status)
               if [[ "$status" == "completed" ]]; then
                 conclusion=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json conclusion --jq .conclusion)
                 echo "Starter Kit run concluded $conclusion before publishing $result_name: $run_url" >&2
                 exit 1
               fi
-            fi
-            sleep 20
-          done
+              sleep 10
+            done
+          fi
           result="starter-kit-result/$result_name"
           test -s "$result"
           [[ "$(jq -er .releaseSetId "$result")" == "$release_set_id" ]]
           [[ "$(jq -er .releaseIdentity "$result")" == "$identity" ]]
           [[ "$(jq -er .mentraos.sourceCommit "$result")" == "$source_commit" ]]
-          [[ "$(jq -er .starterKit.baseCommit "$result")" == "$expected_head" ]]
+          jq -er '.starterKit.baseCommit | select(test("^[0-9a-f]{40}$"))' "$result" >/dev/null
+          release_commit=$(jq -er '.starterKit.releaseCommit | select(test("^[0-9a-f]{40}$"))' "$result")
+          merge_commit=$(jq -er '.starterKit.mergeCommit | select(test("^[0-9a-f]{40}$"))' "$result")
+          pull_request_url=$(jq -er .starterKit.pullRequestUrl "$result")
+          [[ "$(jq -er .starterKit.sourceTag "$result")" == "sdk-$identity" ]]
+          pr_provenance=$(gh pr view "$pull_request_url" --repo "$STARTER_KIT_REPOSITORY" \
+            --json url,state,headRefOid,baseRefName,mergeCommit)
+          [[ "$(jq -r .url <<< "$pr_provenance")" == "$pull_request_url" ]]
+          [[ "$(jq -r .state <<< "$pr_provenance")" == "MERGED" ]]
+          [[ "$(jq -r .headRefOid <<< "$pr_provenance")" == "$release_commit" ]]
+          [[ "$(jq -r .baseRefName <<< "$pr_provenance")" == "$target_branch" ]]
+          [[ "$(jq -r .mergeCommit.oid <<< "$pr_provenance")" == "$merge_commit" ]]
+          [[ "$(gh api "repos/$STARTER_KIT_REPOSITORY/git/ref/tags/sdk-$identity" --jq .object.sha)" == "$release_commit" ]]
           [[ "$(jq -er '.artifacts | length' "$result")" == "4" ]]
           if [[ -z "$run_url" ]]; then
             run_url=$(jq -er .starterKit.validationRunUrl "$result")

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -248,9 +248,202 @@ jobs:
       dry_run: ${{ needs.plan.outputs.dry_run == 'true' }}
     secrets: inherit
 
+  starter-kit:
+    name: Build coordinated Starter Kit examples
+    needs: [plan, ota, npm, sdk-native, engine-consumer]
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    outputs:
+      result_artifact: ${{ steps.coordinates.outputs.result_artifact }}
+      result_url: ${{ steps.coordinates.outputs.result_url }}
+      release_url: ${{ steps.coordinates.outputs.release_url }}
+      run_url: ${{ steps.coordinates.outputs.run_url }}
+      react_native_apk_name: ${{ steps.coordinates.outputs.react_native_apk_name }}
+      react_native_apk_url: ${{ steps.coordinates.outputs.react_native_apk_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.source_commit }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.plan_artifact }}
+          path: release-input/plan
+
+      - name: Dispatch and wait for the exact Starter Kit release
+        id: coordinates
+        if: needs.plan.outputs.dry_run != 'true'
+        env:
+          STARTER_KIT_TOKEN: ${{ secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
+          OTA_MANIFEST_URL: ${{ needs.ota.outputs.manifest_url }}
+          OTA_MANIFEST_SHA256: ${{ needs.ota.outputs.manifest_sha256 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$STARTER_KIT_TOKEN" ]]; then
+            echo "A Starter Kit GitHub App token is required in STARTER_KIT_COORDINATOR_TOKEN." >&2
+            exit 1
+          fi
+          export GH_TOKEN="$STARTER_KIT_TOKEN"
+
+          plan=release-input/plan/release-plan.json
+          identity=$(jq -er .releaseIdentity "$plan")
+          release_set_id=$(jq -er .releaseSetId "$plan")
+          family_base=$(jq -er .familyBaseVersion "$plan")
+          channel=$(jq -er .channel "$plan")
+          source_commit=$(jq -er .sourceCommit "$plan")
+          case "$channel" in
+            dev) target_branch=dev ;;
+            beta) target_branch=staging ;;
+            *) echo "Unsupported prerelease Starter Kit channel $channel" >&2; exit 1 ;;
+          esac
+
+          expected_head=$(gh api "repos/$STARTER_KIT_REPOSITORY/branches/$target_branch" --jq .commit.sha)
+          payload=$(jq -cn \
+            --arg releaseSetId "$release_set_id" \
+            --arg releaseIdentity "$identity" \
+            --arg familyBaseVersion "$family_base" \
+            --arg channel "$channel" \
+            --arg sourceCommit "$source_commit" \
+            --arg coordinatorRunUrl "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --arg manifestUrl "$OTA_MANIFEST_URL" \
+            --arg manifestSha256 "$OTA_MANIFEST_SHA256" \
+            --arg expectedStarterKitHead "$expected_head" \
+            --arg correlationId "mentraos-${GITHUB_RUN_ID}" \
+            '{
+              schemaVersion: 1,
+              releaseSetId: $releaseSetId,
+              releaseIdentity: $releaseIdentity,
+              familyBaseVersion: $familyBaseVersion,
+              channel: $channel,
+              correlationId: $correlationId,
+              mentraos: {sourceCommit: $sourceCommit, coordinatorRunUrl: $coordinatorRunUrl},
+              ota: {manifestUrl: $manifestUrl, manifestSha256: $manifestSha256},
+              packages: {
+                "@mentra/bluetooth-sdk": $releaseIdentity,
+                "@mentra/engine": $releaseIdentity
+              },
+              expectedStarterKitHead: $expectedStarterKitHead
+            }')
+
+          dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run coordinated-example-release.yml \
+            --repo "$STARTER_KIT_REPOSITORY" \
+            --ref main \
+            -f "channel=$channel" \
+            -f "payload=$payload"
+
+          run_title="Coordinated example $channel $identity"
+          run_id=""
+          run_url=""
+          result_name="starter-kit-release-$identity.json"
+          container_tag="sdk-builds-v$family_base"
+          result_url="https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$container_tag/$result_name"
+          mkdir -p starter-kit-result
+
+          for _ in {1..420}; do
+            if [[ -z "$run_id" ]]; then
+              run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
+                --workflow coordinated-example-release.yml --event workflow_dispatch --limit 30 \
+                --json databaseId,displayTitle,createdAt,status,conclusion,url \
+                --jq ".[] | select(.displayTitle == \"$run_title\" and .createdAt >= \"$dispatched_at\")" \
+                | head -1)
+              if [[ -n "$run_json" ]]; then
+                run_id=$(jq -r .databaseId <<< "$run_json")
+                run_url=$(jq -r .url <<< "$run_json")
+              fi
+            fi
+
+            if curl --fail --silent --show-error --location "$result_url" \
+              --output "starter-kit-result/$result_name" 2>/dev/null; then
+              break
+            fi
+
+            if [[ -n "$run_id" ]]; then
+              status=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status --jq .status)
+              if [[ "$status" == "completed" ]]; then
+                conclusion=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json conclusion --jq .conclusion)
+                echo "Starter Kit run concluded $conclusion before publishing $result_name: $run_url" >&2
+                exit 1
+              fi
+            fi
+            sleep 20
+          done
+          result="starter-kit-result/$result_name"
+          test -s "$result"
+          [[ "$(jq -er .releaseSetId "$result")" == "$release_set_id" ]]
+          [[ "$(jq -er .releaseIdentity "$result")" == "$identity" ]]
+          [[ "$(jq -er .mentraos.sourceCommit "$result")" == "$source_commit" ]]
+          [[ "$(jq -er .starterKit.baseCommit "$result")" == "$expected_head" ]]
+          [[ "$(jq -er '.artifacts | length' "$result")" == "4" ]]
+          if [[ -z "$run_url" ]]; then
+            run_url=$(jq -er .starterKit.validationRunUrl "$result")
+          fi
+
+          release_id=$(gh api "repos/$STARTER_KIT_REPOSITORY/releases/tags/$container_tag" --jq .id)
+          assets_json=$(gh api --paginate --slurp \
+            "repos/$STARTER_KIT_REPOSITORY/releases/$release_id/assets?per_page=100" | jq -c add)
+          result_asset=$(jq -c --arg name "$result_name" '.[] | select(.name == $name)' <<< "$assets_json")
+          [[ -n "$result_asset" ]]
+          [[ "$(jq -r .browser_download_url <<< "$result_asset")" == "$result_url" ]]
+          [[ "$(jq -r .size <<< "$result_asset")" == "$(stat -c %s "$result")" ]]
+          [[ "$(jq -r .digest <<< "$result_asset")" == "sha256:$(sha256sum "$result" | cut -d' ' -f1)" ]]
+          while IFS= read -r artifact; do
+            name=$(jq -r .name <<< "$artifact")
+            url=$(jq -r .url <<< "$artifact")
+            size=$(jq -r .size <<< "$artifact")
+            digest="sha256:$(jq -r .sha256 <<< "$artifact")"
+            asset=$(jq -c --arg name "$name" '.[] | select(.name == $name)' <<< "$assets_json")
+            [[ -n "$asset" ]]
+            [[ "$(jq -r .browser_download_url <<< "$asset")" == "$url" ]]
+            [[ "$(jq -r .size <<< "$asset")" == "$size" ]]
+            [[ "$(jq -r .digest <<< "$asset")" == "$digest" ]]
+          done < <(jq -c '.artifacts[]' "$result")
+
+          react_native_apk_name=$(jq -er '.artifacts[] | select(.key == "reactNative") | .name' "$result")
+          react_native_apk_url=$(jq -er '.artifacts[] | select(.key == "reactNative") | .url' "$result")
+          release_url=$(jq -er .starterKit.releaseUrl "$result")
+          result_artifact="coordinated-starter-kit-$release_set_id"
+          {
+            echo "result_artifact=$result_artifact"
+            echo "result_url=$result_url"
+            echo "release_url=$release_url"
+            echo "run_url=$run_url"
+            echo "react_native_apk_name=$react_native_apk_name"
+            echo "react_native_apk_url=$react_native_apk_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        if: needs.plan.outputs.dry_run != 'true'
+        with:
+          name: ${{ steps.coordinates.outputs.result_artifact }}
+          path: starter-kit-result
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize Starter Kit release
+        if: needs.plan.outputs.dry_run != 'true'
+        run: |
+          {
+            echo "## Starter Kit"
+            echo
+            echo "- Result: ${{ steps.coordinates.outputs.result_url }}"
+            echo "- Validation: ${{ steps.coordinates.outputs.run_url }}"
+            echo "- React Native APK: ${{ steps.coordinates.outputs.react_native_apk_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   finalize:
     name: Finalize immutable release bill of materials
-    needs: [plan, ota, npm, sdk-native, mobile, engine-consumer]
+    needs: [plan, ota, npm, sdk-native, mobile, engine-consumer, starter-kit]
+    if: >-
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.ota.result == 'success' &&
+      needs.npm.result == 'success' &&
+      needs.sdk-native.result == 'success' &&
+      needs.mobile.result == 'success' &&
+      needs.engine-consumer.result == 'success' &&
+      needs.starter-kit.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -287,6 +480,12 @@ jobs:
           name: ${{ needs.mobile.outputs.result_artifact }}
           path: release-input/mobile
 
+      - uses: actions/download-artifact@v4
+        if: needs.plan.outputs.dry_run != 'true'
+        with:
+          name: ${{ needs.starter-kit.outputs.result_artifact }}
+          path: release-input/starter-kit
+
       - name: Assemble complete publication evidence
         id: results
         run: |
@@ -299,12 +498,22 @@ jobs:
           test -f "$asg_selection"
           engine_package=$(find release-input/npm -type f -name 'mentra-engine-*.tgz' -print -quit)
           test -n "$engine_package"
+          starter_kit_args=()
+          if [[ "${{ needs.plan.outputs.dry_run }}" != "true" ]]; then
+            starter_kit_result=$(find release-input/starter-kit -type f -name 'starter-kit-release-*.json' -print -quit)
+            test -n "$starter_kit_result"
+            starter_kit_args=(
+              --starter-kit "$starter_kit_result"
+              --starter-kit-result-url "${{ needs.starter-kit.outputs.result_url }}"
+            )
+          fi
           node .github/scripts/assemble-coordinated-release-results.mjs \
             --plan "$plan" \
             --ota release-input/ota/ota-result.json \
             --npm release-input/npm/npm-publications.json \
             --native release-input/sdk-native/sdk-native-publications.json \
             --mobile release-input/mobile/mobile-publications.json \
+            "${starter_kit_args[@]}" \
             --asg-selection "$asg_selection" \
             --engine-package "$engine_package" \
             --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag" \
@@ -401,8 +610,8 @@ jobs:
 
   docs:
     name: Publish release-matched documentation
-    needs: [plan, finalize]
-    if: needs.plan.result == 'success' && needs.finalize.result == 'success' && needs.plan.outputs.dry_run != 'true'
+    needs: [plan, starter-kit, finalize]
+    if: needs.plan.result == 'success' && needs.starter-kit.result == 'success' && needs.finalize.result == 'success' && needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -424,6 +633,11 @@ jobs:
         with:
           name: ${{ needs.plan.outputs.plan_artifact }}
           path: release-input/plan
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.starter-kit.outputs.result_artifact }}
+          path: release-input/starter-kit
 
       - name: Select the documentation channel
         id: target
@@ -454,6 +668,7 @@ jobs:
           --source mintlify-docs
           --output "$RUNNER_TEMP/mentraos-docs-source"
           --plan release-input/plan/release-plan.json
+          --starter-kit "$(find release-input/starter-kit -type f -name 'starter-kit-release-*.json' -print -quit)"
           --repository "${{ github.repository }}"
 
       - name: Export Mintlify docs
@@ -480,6 +695,7 @@ jobs:
             echo "Mintlify export contains an unresolved release-version variable." >&2
             exit 1
           fi
+          grep -R --fixed-strings --quiet "${{ needs.starter-kit.outputs.react_native_apk_url }}" "$export_dir/mentra-live"
 
       - name: Deploy to Cloudflare Pages
         env:
@@ -522,7 +738,7 @@ jobs:
 
   notify-slack:
     name: Notify release Slack channel
-    needs: [plan, ota, npm, sdk-native, mobile, engine-consumer, finalize, docs]
+    needs: [plan, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, finalize, docs]
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -550,6 +766,7 @@ jobs:
           ANDROID_RESULT: ${{ needs.mobile.outputs.android_result }}
           IOS_RESULT: ${{ needs.mobile.outputs.ios_result }}
           ENGINE_RESULT: ${{ needs.engine-consumer.result }}
+          STARTER_KIT_RESULT: ${{ needs.starter-kit.result }}
           FINALIZE_RESULT: ${{ needs.finalize.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
           DOCS_URL: ${{ needs.docs.outputs.docs_url }}
@@ -558,4 +775,8 @@ jobs:
           MOBILE_ASSET_BASE_URL: ${{ needs.mobile.outputs.asset_base_url }}
           ASG_APK_NAME: ${{ needs.ota.outputs.asg_apk_name }}
           ASG_APK_URL: ${{ needs.ota.outputs.asg_apk_url }}
+          STARTER_KIT_APK_NAME: ${{ needs.starter-kit.outputs.react_native_apk_name }}
+          STARTER_KIT_APK_URL: ${{ needs.starter-kit.outputs.react_native_apk_url }}
+          STARTER_KIT_RELEASE_URL: ${{ needs.starter-kit.outputs.release_url }}
+          STARTER_KIT_RUN_URL: ${{ needs.starter-kit.outputs.run_url }}
         run: .github/scripts/notify-coordinated-release-slack.sh

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -470,10 +470,10 @@ MentraOS retains one running release plus the newest pending head per channel.
 `dev` and `staging` have distinct concurrency groups and cannot cancel or
 replace each other.
 
-Starter Kit coordinated releases also serialize by channel. They do not cancel
-an already running publication. Because MentraOS dispatches only an active
-coordinated run, superseded pending MentraOS heads do not create Starter Kit
-releases.
+Starter Kit coordinated releases serialize by base-version family because dev
+and beta share one grouped release container. They do not cancel an already
+running publication. Because MentraOS dispatches only an active coordinated
+run, superseded pending MentraOS heads do not create Starter Kit releases.
 
 Every boundary uses exact identities and compare-and-swap behavior:
 

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -197,18 +197,21 @@ The workflow:
 4. updates every example and lockfile to the exact coordinated versions;
 5. embeds the exact release identity and OTA pin where the example runtime
    needs observable release metadata;
-6. calls the shared build workflow for the exact candidate commit;
-7. computes the filename, size, media type, and SHA-256 of every artifact;
-8. publishes an immutable Starter Kit source tag and uploads the artifacts to
-   the base version's release container;
-9. publishes `starter-kit-release-<identity>.json` alongside the binaries;
-10. advances the channel branch to the tested candidate only if its head still
-    equals the dispatch's expected head; and
-11. exposes a correlated success or failure result that MentraOS can poll.
+6. opens a version-synchronization pull request against the channel branch;
+7. explicitly dispatches the shared build workflow on the exact candidate SHA;
+8. merges the pull request only when the required checks belong to that same
+   head SHA and the target branch still contains the expected base;
+9. computes the filename, size, media type, and SHA-256 of every artifact;
+10. publishes an immutable Starter Kit source tag and uploads the artifacts to
+    the base version's release container;
+11. publishes `starter-kit-release-<identity>.json` alongside the binaries; and
+12. exposes a correlated success or failure result that MentraOS can poll.
 
-The branch compare-and-swap is required. A human commit that arrives during the
-build must not be overwritten. In that case, the coordinated example release
-fails clearly and the next coordinator run uses the new branch head.
+The synchronization pull request is the branch compare-and-swap boundary. A
+human commit that arrives during the build is never overwritten: a compatible
+base advance may merge normally, while a conflict or changed candidate head
+fails clearly. The published artifacts always identify the validated candidate
+commit, and the next coordinator run starts from the resulting channel head.
 
 ### Shared build workflow
 
@@ -244,10 +247,17 @@ releases.
 ## Cross-Repository Protocol
 
 MentraOS dispatches with a GitHub App installation token scoped to the two
-repositories. A personal access token is not part of the release architecture.
-The App receives only the permissions needed to dispatch workflows, read run
-state and artifacts, and create the Starter Kit's release commit, tag, and
-release.
+repositories. A personal access token is not part of the final release
+architecture. The App receives only the permissions needed to dispatch
+workflows and read run state in the Starter Kit. The Starter Kit's own
+`GITHUB_TOKEN` creates and merges its synchronization pull request and publishes
+its tag, release, and assets.
+
+During bootstrap, the implementation may fall back to the existing scoped SDK
+push credential while `STARTER_KIT_COORDINATOR_TOKEN` is being provisioned. The
+fallback is explicit migration debt: it is not copied into another secret, and
+it is removed after the GitHub App token has completed one dev and one beta
+dispatch.
 
 GitHub workflow dispatch does not return synchronous outputs. The protocol is:
 

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -153,11 +153,12 @@ must carry explicit machine-readable metadata so it cannot trigger a dispatch
 loop.
 
 If a human Starter Kit change reaches `dev` or `staging` without a concurrent
-MentraOS source change, the Starter Kit requests a coordinated release from
-MentraOS. MentraOS still allocates the identity and republishes the complete
-release family, subject to the channel's one-running/latest-pending coalescing
-policy. The callback to Starter Kit identifies the requesting head SHA, and the
-automation sync commit is excluded from generating another request.
+MentraOS source change, it remains validated source until the next coordinated
+Mentra release consumes that branch head. When an example-only change must be
+published immediately, an operator manually dispatches the MentraOS coordinated
+workflow on the corresponding branch. The Starter Kit does not own release
+identity allocation and does not need a reverse cross-repository credential or
+callback loop.
 
 ## Starter Kit Workflow Design
 

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -197,10 +197,12 @@ The workflow:
 4. updates every example and lockfile to the exact coordinated versions;
 5. embeds the exact release identity and OTA pin where the example runtime
    needs observable release metadata;
-6. opens a version-synchronization pull request against the channel branch;
-7. explicitly dispatches the shared build workflow on the exact candidate SHA;
-8. merges the pull request only when the required checks belong to that same
-   head SHA and the target branch still contains the expected base;
+6. waits for MentraOS to open a version-synchronization pull request against the
+   channel branch;
+7. lets the repository's normal pull-request workflow validate the exact
+   candidate SHA;
+8. waits for MentraOS to merge the pull request only after the protected
+   required checks for that same head SHA pass;
 9. computes the filename, size, media type, and SHA-256 of every artifact;
 10. publishes an immutable Starter Kit source tag and uploads the artifacts to
     the base version's release container;
@@ -249,9 +251,11 @@ releases.
 MentraOS dispatches with a GitHub App installation token scoped to the two
 repositories. A personal access token is not part of the final release
 architecture. The App receives only the permissions needed to dispatch
-workflows and read run state in the Starter Kit. The Starter Kit's own
-`GITHUB_TOKEN` creates and merges its synchronization pull request and publishes
-its tag, release, and assets.
+workflows, read run state, create the synchronization pull request, and merge
+the exact validated head in the Starter Kit. This split is required because the
+organization does not permit a repository `GITHUB_TOKEN` to create or approve
+pull requests. The Starter Kit's own `GITHUB_TOKEN` creates the candidate
+commit and publishes its tag, release, and assets after MentraOS merges the PR.
 
 During bootstrap, the implementation may fall back to the existing scoped SDK
 push credential while `STARTER_KIT_COORDINATOR_TOKEN` is being provisioned. The

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -1,0 +1,619 @@
+# Coordinated Documentation and Example App Releases
+
+> Status: proposed; ready for review
+> Updated: 2026-08-27
+> Parent design: [Coordinated Release System](./coordinated-release-system-proposal.md)
+
+## Purpose
+
+This document defines how Mentra Live documentation and the Bluetooth SDK
+Starter Kit join the coordinated release pipeline.
+
+The parent design coordinates MentraOS, Mentra Engine, Bluetooth SDK packages,
+and the Mentra Live OTA bundle under one release identity such as
+`3.1.0-dev.42`, `3.1.0-beta.57`, or `3.1.0`. This companion design carries that
+same identity through the customer-facing documentation and example apps.
+
+The release is not complete merely because packages and mobile binaries were
+published. Customers must be able to:
+
+- read documentation that names the exact completed release;
+- clone a Starter Kit branch whose dependencies match its release channel;
+- download example binaries built from that exact dependency set; and
+- trace every link back to immutable source and artifact hashes.
+
+## Current State
+
+### Coordinated MentraOS releases
+
+The MentraOS coordinator currently:
+
+1. allocates a coordinated release identity;
+2. publishes the OTA bundle, packages, native SDKs, and MentraOS builds;
+3. runs the external Engine consumer gate;
+4. writes the finalized release manifest;
+5. renders and publishes release-matched dev or beta documentation; and
+6. posts the result to the channel's Slack build channel.
+
+The docs renderer updates `release-version` and `release-artifacts-url` in a
+temporary copy of `mintlify-docs/`. It deliberately does not edit the source
+checkout.
+
+### Documentation channels
+
+| Release channel | Source branch | Published site | Publisher |
+| --- | --- | --- | --- |
+| Development | `dev` | `https://docs-dev.mentraglass.com` | Coordinated CI to Cloudflare Pages |
+| Beta | `staging` | `https://docs-beta.mentraglass.com` | Coordinated CI to Cloudflare Pages |
+| Production | `main` | `https://docs.mentraglass.com` | Mintlify Git integration |
+
+Dev and beta sites are release outputs and carry `X-Robots-Tag: noindex`.
+Production uses the checked-in stable family base because Mintlify's Git
+integration does not run Mentra's release-time template renderer.
+
+### Starter Kit
+
+The Starter Kit currently has one `Example App Builds` workflow. A pull request
+or push to `main` builds four artifacts:
+
+- native Android APK;
+- native iOS unsigned IPA;
+- React Native Android APK; and
+- React Native ElevenLabs audio Android APK.
+
+On `main`, that workflow reads each example's dependency version and uploads
+the resulting file to a `sdk-<version>` GitHub release. It can currently update
+different releases when examples have drifted to different SDK versions. It
+also uses asset clobbering and force-moves release tags. Those behaviors do not
+provide immutable coordinated-release provenance.
+
+The checked-in examples are presently allowed to carry different SDK versions.
+The coordinated model instead requires every maintained example to consume the
+same exact release identity.
+
+### Known customer-facing gap
+
+The coordinated docs renderer currently leaves `example-app-version` and
+`example-app-url` at checked-in static values. The docs can therefore describe
+one coordinated release while linking to an older, independently published
+example app. Constructing a Starter Kit URL from the MentraOS release identity
+without first building the example would instead create a not-found link.
+
+## Goals
+
+1. Make the Starter Kit a verified consumer of each coordinated release.
+2. Keep Starter Kit source, builds, tags, releases, and future TestFlight upload
+   owned by the Starter Kit repository.
+3. Make MentraOS own release identity, ordering, finalization, docs, and the
+   channel Slack notification.
+4. Publish docs only after the matching example artifacts are publicly
+   readable.
+5. Put the exact example version and direct artifact links in docs, Slack, and
+   the finalized Mentra release manifest.
+6. Keep normal Starter Kit feature development possible without duplicating
+   release build implementations.
+7. Make retries idempotent and make published tags and bytes immutable.
+8. Later publish the React Native iOS example to the correct TestFlight group
+   from the same coordinated Starter Kit release.
+
+## Non-Goals
+
+- MentraOS will not vendor the Starter Kit as a Git submodule.
+- MentraOS will not build or host Starter Kit binaries.
+- The Starter Kit will not allocate Mentra release identities.
+- Pull requests will not publish packages, releases, docs, or TestFlight builds.
+- The first implementation will not publish the example app to TestFlight.
+- This design does not yet submit the example app to the public App Store.
+- The native iOS example remains an unsigned downloadable IPA; the future
+  TestFlight job applies to the React Native example app.
+
+## Ownership Boundary
+
+### MentraOS coordinator owns
+
+- family base, channel, sequence, and exact release identity;
+- package, Maven, and SwiftPM publication;
+- immutable OTA manifest and glasses artifact selection;
+- the release plan and finalized release manifest;
+- dispatching and waiting for the exact Starter Kit build;
+- release-matched docs rendering and publication; and
+- final Slack status and links.
+
+### Starter Kit owns
+
+- example source and lockfiles;
+- PR validation for example changes;
+- synchronized `dev`, `staging`, and `main` branches;
+- exact dependency updates requested by the coordinator;
+- all example builds and build validation;
+- immutable Starter Kit tags, releases, and artifact checksums;
+- the machine-readable result returned to MentraOS; and
+- the future React Native iOS TestFlight archive and upload.
+
+This boundary avoids both a Git submodule and copied build logic. MentraOS
+consumes a validated result from the repository that owns the source.
+
+## Branch and Channel Model
+
+The Starter Kit mirrors the coordinated product channels:
+
+| Starter Kit branch | Coordinated channel | Expected dependency identity |
+| --- | --- | --- |
+| `dev` | Development | Latest completed `X.Y.Z-dev.N` synchronized to that branch |
+| `staging` | Beta | Latest completed `X.Y.Z-beta.N` synchronized to that branch |
+| `main` | Production | Latest completed stable `X.Y.Z` |
+
+Human Starter Kit features land on `dev`. Stabilization fixes may land on
+`staging` first and must be merged back into `dev`. Production changes move
+through `staging`; automation must not treat `main` as an independent feature
+branch.
+
+A bot dependency-sync commit is release output, not a new release request. It
+must carry explicit machine-readable metadata so it cannot trigger a dispatch
+loop.
+
+If a human Starter Kit change reaches `dev` or `staging` without a concurrent
+MentraOS source change, the Starter Kit requests a coordinated release from
+MentraOS. MentraOS still allocates the identity and republishes the complete
+release family, subject to the channel's one-running/latest-pending coalescing
+policy. The callback to Starter Kit identifies the requesting head SHA, and the
+automation sync commit is excluded from generating another request.
+
+## Starter Kit Workflow Design
+
+The Starter Kit uses one reusable build implementation with two entrypoints.
+
+### Pull request validation
+
+`example-validation.yml` runs for pull requests targeting `dev`, `staging`, or
+`main`. It calls the reusable build workflow and publishes only ephemeral
+GitHub Actions artifacts.
+
+It verifies all maintained examples against their checked-in dependencies. It
+does not change versions, commit source, create tags, create releases, or upload
+to TestFlight.
+
+### Coordinated example release
+
+`coordinated-example-release.yml` is invoked by an authenticated dispatch from
+MentraOS. Required inputs are:
+
+- `releaseSetId`;
+- `releaseIdentity`;
+- `familyBaseVersion`;
+- `channel`;
+- exact package coordinates and expected registry hashes;
+- MentraOS source commit and coordinator run URL;
+- immutable OTA manifest URL and SHA-256;
+- expected Starter Kit channel-branch head SHA; and
+- a unique callback correlation identifier.
+
+The workflow:
+
+1. validates the caller, channel, identity, and expected branch head;
+2. waits for every required npm, Maven, and SwiftPM package to be publicly
+   readable and verifies its version and recorded integrity;
+3. creates an isolated candidate commit from the expected Starter Kit head;
+4. updates every example and lockfile to the exact coordinated versions;
+5. embeds the exact release identity and OTA pin where the example runtime
+   needs observable release metadata;
+6. calls the shared build workflow for the exact candidate commit;
+7. computes the filename, size, media type, and SHA-256 of every artifact;
+8. publishes an immutable Starter Kit source tag and uploads the artifacts to
+   the base version's release container;
+9. publishes `starter-kit-release-<identity>.json` alongside the binaries;
+10. advances the channel branch to the tested candidate only if its head still
+    equals the dispatch's expected head; and
+11. exposes a correlated success or failure result that MentraOS can poll.
+
+The branch compare-and-swap is required. A human commit that arrives during the
+build must not be overwritten. In that case, the coordinated example release
+fails clearly and the next coordinator run uses the new branch head.
+
+### Shared build workflow
+
+Both entrypoints call the same reusable workflow. The coordinated path must not
+reimplement the PR build commands in MentraOS or a second Starter Kit script.
+
+The initial artifact set is:
+
+```text
+mentra-example-android-<identity>.apk
+mentra-example-ios-<identity>-unsigned.ipa
+mentra-example-react-native-<identity>.apk
+mentra-example-rn-elevenlabs-audio-<identity>.apk
+starter-kit-release-<identity>.json
+```
+
+Artifact names include the full semantic release identity. Dates, workflow run
+IDs, and unexplained counters do not appear in primary filenames.
+
+### Immutable publication
+
+The current `--clobber` and force-tag behavior is removed for coordinated
+releases.
+
+- A tag always points to the exact tested candidate commit.
+- An existing asset is accepted on retry only when its bytes and recorded hash
+  are identical.
+- A differing existing asset, source commit, release plan, or result record
+  fails the run.
+- A retry reconciles missing outputs under the same release identity; it does
+  not allocate another identity.
+
+## Cross-Repository Protocol
+
+MentraOS dispatches with a GitHub App installation token scoped to the two
+repositories. A personal access token is not part of the release architecture.
+The App receives only the permissions needed to dispatch workflows, read run
+state and artifacts, and create the Starter Kit's release commit, tag, and
+release.
+
+GitHub workflow dispatch does not return synchronous outputs. The protocol is:
+
+1. MentraOS sends the exact release set and correlation identifier.
+2. Starter Kit starts the coordinated release and records that correlation in
+   its run and result JSON.
+3. MentraOS polls for the exact correlated result, with a bounded timeout.
+4. MentraOS validates repository, identity, source commits, package versions,
+   artifact URLs, and hashes before accepting it.
+5. A result from another release, branch, run, or Starter Kit head is rejected.
+
+The result record has at least this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "releaseSetId": "mentra-3.1.0-beta.57",
+  "releaseIdentity": "3.1.0-beta.57",
+  "channel": "beta",
+  "mentraos": {
+    "sourceCommit": "<sha>",
+    "coordinatorRunUrl": "<url>"
+  },
+  "starterKit": {
+    "baseCommit": "<sha>",
+    "releaseCommit": "<sha>",
+    "sourceTag": "sdk-3.1.0-beta.57",
+    "artifactContainerTag": "sdk-builds-v3.1.0",
+    "releaseUrl": "<url>"
+  },
+  "packages": {
+    "@mentra/bluetooth-sdk": "3.1.0-beta.57",
+    "@mentra/engine": "3.1.0-beta.57"
+  },
+  "artifacts": [
+    {
+      "name": "mentra-example-react-native-3.1.0-beta.57.apk",
+      "url": "<url>",
+      "size": 123,
+      "sha256": "<hex>",
+      "contentType": "application/vnd.android.package-archive"
+    }
+  ],
+  "testflight": null
+}
+```
+
+The exact schema is versioned and validated in both repositories. Unknown major
+schema versions fail closed.
+
+## GitHub Release Containers
+
+Coordinated prereleases do not create one visible GitHub release per commit.
+MentraOS keeps its existing base-version container:
+
+```text
+mentra-builds-v3.1.0
+```
+
+The Starter Kit uses the corresponding base-version container:
+
+```text
+sdk-builds-v3.1.0
+```
+
+Each asset filename contains the full coordinated identity, so dev and beta
+artifacts coexist without overwriting one another. Immutable source tags such
+as `sdk-3.1.0-dev.42` and `sdk-3.1.0-beta.57` identify the exact Starter Kit
+commit even though their downloadable assets share one visible release page.
+The grouped container tag is fixed when the container is created and is never
+used as source provenance or force-moved to the newest example commit.
+
+Stable publication uses the stable containers `mentra-v3.1.0` and
+`sdk-3.1.0`. It does not rename a prerelease artifact and pretend its embedded
+version changed.
+
+## Coordinated Release Ordering
+
+The Starter Kit becomes a required consumer gate before finalization:
+
+```text
+release plan and OTA selection
+  -> coordinated package and mobile publication
+  -> external Engine consumer verification
+  -> Starter Kit dispatch, build, and immutable publication
+  -> finalized Mentra release manifest
+  -> release-matched documentation
+  -> channel Slack notification
+```
+
+The Starter Kit gate runs only after its public dependencies exist. It may run
+in parallel with unrelated late gates when dependencies permit, but finalization
+waits for its validated result.
+
+If the Starter Kit fails, already published package artifacts remain recoverable
+under the in-progress release. There is no completed release manifest, docs do
+not advance, and Slack reports an incomplete release with links to both runs.
+A retry uses the same release identity.
+
+The finalized Mentra release manifest records the Starter Kit result URL,
+Starter Kit source commit, exact example artifact URLs, and hashes. Matching npm
+tags alone never prove that an example app belongs to the release.
+
+## Documentation Rendering
+
+### Variables
+
+The checked-in Mintlify config retains these structured variables:
+
+- `release-version`;
+- `release-artifacts-url`;
+- `example-app-version`; and
+- `example-app-url`.
+
+For dev and beta, the renderer receives both the immutable Mentra release plan
+and the validated Starter Kit result. It sets:
+
+- `release-version` to the exact coordinated identity;
+- `release-artifacts-url` to the coordinated Mentra release container;
+- `example-app-version` to that same exact identity; and
+- `example-app-url` to the published React Native APK URL from the Starter Kit
+  result, never to a constructed or guessed URL.
+
+The renderer does not mutate the source checkout. Before deployment it verifies
+that:
+
+- all required variables are resolved;
+- the example result matches the release set;
+- every linked required artifact is publicly readable;
+- the exported Mentra Live docs contain the exact release identity; and
+- no stale template token or older example version remains.
+
+The custom-domain verification checks the published software-update page and
+its example APK link. A docs deployment failure leaves the previous site online
+and makes the coordinated release incomplete in Slack, but does not rewrite an
+immutable release manifest.
+
+## Changelog Delivery
+
+The canonical customer changelog remains in the MentraOS repository at:
+
+```text
+changelogs/<family-base-version>.md
+```
+
+It describes the complete release family, including MentraOS, Engine,
+Bluetooth SDK, examples, and Mentra Live glasses software. It is not duplicated
+or independently edited in the Starter Kit.
+
+Coordinated Bluetooth SDK and Engine packages bundle the generated changelog
+catalog. Engine exposes the changelogs crossed between the starting and target
+coordinated versions, newest first, and retains them across multi-pass OTA
+restarts through the final `complete` or `up_to_date` screen. Legacy numeric ASG
+versions use the known target changelog when a valid coordinated starting
+version is unavailable.
+
+The React Native example consumes that public Engine OTA state and renders the
+provided changelogs on update completion. Its coordinated build verifies the
+exact Engine and Bluetooth SDK packages rather than copying markdown into the
+example source. Native examples may use the Bluetooth SDK changelog API when
+they add equivalent OTA completion presentation.
+
+The finalized release manifest records the changelog base version and content
+hash so docs, packages, OTA UI, and example artifacts can be audited as one
+release set.
+
+### Production docs
+
+Production remains a Mintlify Git deployment from `main`. The checked-in
+variables use the stable family base and stable URLs. The protected production
+flow must publish and verify the stable Starter Kit result before production
+documentation is declared complete. Moving Mintlify's configured source branch
+from `staging` to `main` is an operator action.
+
+The initial cross-repository implementation focuses on `dev` and `staging`,
+where CI controls rendering and ordering. Stable Starter Kit synchronization
+and the exact Mintlify publication check are added before the first production
+release under this model. A temporary not-found production link is not an
+accepted steady state.
+
+## Slack Notifications
+
+The existing channel mapping remains:
+
+- `dev` posts to `dev-builds` through `SLACK_WEBHOOK_DEV_BUILDS`;
+- `staging` posts to `staging-builds` through the existing staging webhook.
+
+One final coordinated message reports the full release, including:
+
+- release identity and source commit;
+- success or failure of OTA, npm, native SDK, MentraOS, Engine consumer,
+  Starter Kit, finalization, and docs;
+- MentraOS Android artifact;
+- React Native example APK direct download;
+- Starter Kit release page;
+- dev or beta docs URL;
+- TestFlight destination and processing state when that phase is enabled; and
+- links to the MentraOS and Starter Kit workflow runs on failure.
+
+Slack never guesses an artifact URL. It uses the validated release plan,
+MentraOS outputs, and Starter Kit result.
+
+## Concurrency and Retries
+
+MentraOS retains one running release plus the newest pending head per channel.
+`dev` and `staging` have distinct concurrency groups and cannot cancel or
+replace each other.
+
+Starter Kit coordinated releases also serialize by channel. They do not cancel
+an already running publication. Because MentraOS dispatches only an active
+coordinated run, superseded pending MentraOS heads do not create Starter Kit
+releases.
+
+Every boundary uses exact identities and compare-and-swap behavior:
+
+- expected Starter Kit branch head before candidate creation;
+- exact package versions and integrity before builds;
+- exact candidate source for every artifact;
+- immutable tags and asset hashes on retry; and
+- exact release-set correlation before MentraOS finalization.
+
+## TestFlight Phase
+
+TestFlight is added only after the cross-repository Android/unsigned-iOS
+artifact flow has completed successfully through several coordinated `dev`
+releases and at least one `staging` release.
+
+### Approved signing and App Store Connect decisions
+
+- Publish the React Native iOS example under App Store Connect app Apple ID
+  `6792839366`.
+- Reuse the Apple Distribution certificate and private key already installed on
+  the self-hosted Mac Mini runners for MentraOS CI.
+- Use the React Native example's own bundle identifier, App ID, entitlements,
+  and provisioning profile. The MentraOS provisioning profile is not reused.
+- Reuse the existing App Store Connect API key only after confirming it can
+  upload builds and manage TestFlight groups for app `6792839366`.
+- Send `dev` builds to the example app's `Mentra Dev` internal group.
+- Send `staging` builds to the example app's `Mentra Staging` internal group.
+
+The group IDs are resolved and pinned during implementation; automation does
+not depend only on mutable display names.
+
+### TestFlight job
+
+The Starter Kit adds a dedicated `react-native-ios-testflight` job to the
+coordinated release workflow. It runs on the self-hosted Mac Mini after the
+shared source and dependency checks. It is separate from the native iOS
+unsigned-IPA job.
+
+The job:
+
+1. generates the React Native iOS project from the tested candidate commit;
+2. archives with the example app's provisioning profile and the shared
+   distribution identity;
+3. exports and validates the signed IPA;
+4. uploads it to app `6792839366`;
+5. waits for App Store Connect processing;
+6. assigns the exact build to the channel's internal TestFlight group; and
+7. writes App Store app ID, bundle ID, marketing version, build number, upload
+   state, group ID, and processing result into the Starter Kit result.
+
+Apple requires a numeric native version representation. The intended mapping
+is:
+
+- `CFBundleShortVersionString`: plain family base such as `3.1.0`;
+- `CFBundleVersion`: one globally increasing numeric build number; and
+- in-app diagnostics and TestFlight release notes: full coordinated identity
+  such as `3.1.0-dev.42` or `3.1.0-beta.57`.
+
+The numeric build number must remain unique across both dev and staging uploads
+for this App Store app. Channel-local counters are not sufficient.
+
+The first TestFlight implementation is an additional required Starter Kit gate
+for dev and staging after it is enabled. Public App Store submission and stable
+example-app promotion require a separate explicit decision.
+
+## Security
+
+- Cross-repository automation uses a least-privilege GitHub App installation,
+  not a developer PAT.
+- Apple private keys, App Store Connect credentials, and provisioning material
+  remain only on the authorized Mac runners or in protected GitHub secrets.
+- No signing material is uploaded as a workflow artifact.
+- The shared Apple Distribution certificate does not imply shared bundle IDs or
+  provisioning profiles.
+- Release result JSON contains public identifiers and hashes, never credentials.
+
+## Implementation Plan
+
+### Phase 1: Starter Kit workflow cleanup
+
+1. Add `dev` and `staging` branches using the agreed branch protections.
+2. Extract the current build jobs into one reusable workflow.
+3. Add PR validation for all three target branches.
+4. Add the coordinated dispatch entrypoint and exact input validation.
+5. Replace force-moving tags and clobbered assets with immutable publication.
+6. Add candidate-commit dependency synchronization for every example and
+   lockfile.
+7. Publish and validate the versioned Starter Kit result JSON.
+
+### Phase 2: MentraOS integration
+
+1. Install GitHub App authentication for cross-repository dispatch.
+2. Add the Starter Kit gate after package and external Engine validation.
+3. Poll and validate the exact correlated Starter Kit result.
+4. Include that result in finalization and `release-manifest.json`.
+5. Render example variables from the result.
+6. Verify the public APK link before docs deployment.
+7. Add Starter Kit status and links to dev and staging Slack messages.
+8. Exercise fixes through follow-up PRs to `dev` until multiple coordinated
+   releases complete without manual repair.
+
+### Phase 3: Beta and production cutover
+
+1. Verify one complete `staging` release, including `docs-beta` and the
+   `staging-builds` Slack message.
+2. Add stable Starter Kit synchronization to the protected production flow.
+3. Verify stable example assets before considering Mintlify production docs
+   complete.
+4. Remove obsolete independent Starter Kit publication behavior after all
+   channels use the coordinated path.
+
+### Phase 4: React Native example TestFlight
+
+1. Verify the shared distribution identity on each eligible Mac Mini runner.
+2. Create or install the example app's provisioning profile with all required
+   entitlements.
+3. Verify App Store Connect API access to app `6792839366` and pin both internal
+   group IDs.
+4. Add archive, upload, processing wait, and group assignment.
+5. Add TestFlight results to the Starter Kit record, Mentra final manifest, and
+   Slack message.
+6. Prove one dev upload and one staging upload before making the job required.
+
+## Acceptance Criteria
+
+- Every completed dev or beta Mentra release has a matching immutable Starter
+  Kit result.
+- All maintained examples consume the exact coordinated package identity.
+- Starter Kit channel branches point to the latest successfully tested sync,
+  without overwriting human changes.
+- Pull requests validate examples but never publish.
+- Coordinated retries never force-move a tag or replace different bytes.
+- `release-manifest.json` records the Starter Kit source and artifact hashes.
+- Dev and beta software-update docs display the exact coordinated identity and
+  link to a publicly readable matching React Native APK.
+- Slack reports the same identity, docs URL, and example artifact URL.
+- A Starter Kit failure prevents finalization and docs advancement.
+- Dev and staging releases cannot cancel or replace one another.
+- After Phase 4, React Native iOS builds reach the correct example-app
+  TestFlight group using the shared distribution certificate and the example
+  app's own provisioning profile.
+
+## Remaining Implementation Checks
+
+The following values are intentionally verified during implementation rather
+than assumed in this design:
+
+- the GitHub App installation and exact repository permissions;
+- Starter Kit `dev` and `staging` branch protection rules;
+- the Maven and SwiftPM public-readiness probes used before example builds;
+- the example app's registered bundle ID matching
+  `com.mentra.bluetoothsdk.example.reactnative`;
+- the provisioning profile and entitlements available on the Mac runners;
+- App Store Connect API-key access to app `6792839366`;
+- the immutable IDs for the example app's `Mentra Dev` and `Mentra Staging`
+  groups; and
+- the globally monotonic TestFlight build-number source.

--- a/notes/coordinated-release-system-proposal.md
+++ b/notes/coordinated-release-system-proposal.md
@@ -79,6 +79,9 @@ make Engine installation and native resolution ambiguous to consumers.
 13. Dev and beta documentation is a post-finalization release output. The docs
     show the exact coordinated release identity and are never published ahead
     of the completed release manifest.
+14. Starter Kit examples are built and published by the Starter Kit repository,
+    but their validated result is a required consumer gate before coordinated
+    finalization. Documentation never guesses or constructs an example URL.
 
 ## Phase 0: Fix the Engine Boundary Now
 
@@ -505,12 +508,14 @@ After the OTA bundle and version map exist:
 3. After npm and native publication, a clean external OEM fixture installs only
    the exact public Engine package plus host-owned dependencies. It verifies the
    registry graph, TypeScript, Metro, Expo autolinking, Android, and iOS.
-4. Finalization writes the completed release manifest only after every product
-   lane and the external consumer gate succeeds.
-5. Dev and beta documentation publishes after finalization from the exact
-   source commit and release plan. Starter Kit artifacts remain a separate
-   downstream publication because their example binaries are not produced by
-   this repository.
+4. After its public dependencies are readable, the Starter Kit repository
+   synchronizes every maintained example to the exact release identity, builds
+   them from one tested commit, and publishes an immutable result with artifact
+   hashes.
+5. Finalization writes the completed release manifest only after every product
+   lane, the external consumer gate, and the Starter Kit gate succeed.
+6. Dev and beta documentation publishes after finalization from the exact
+   source commit, release plan, and validated Starter Kit result.
 
 Independent jobs may run in parallel when the dependency graph permits it. A
 consumer package cannot publish until its referenced versions are publicly
@@ -734,21 +739,29 @@ manifest, IPA, and Android store artifact are not rebuilt.
 
 ## Starter Kit and Documentation
 
+The detailed ownership, cross-repository protocol, artifact contract,
+documentation rendering, Slack integration, and deferred TestFlight design are
+specified in
+[Coordinated Documentation and Example App Releases](./coordinated-release-docs-and-example-apps-design.md).
+
 Starter Kit examples are downstream release consumers, not sources of package
 truth.
 
 1. Wait until npm, Maven, and SwiftPM all expose the coordinated SDK version and
    Engine's full dependency closure is readable.
-2. Update all three examples to the selected public versions.
-3. Build and publish example APK/IPA artifacts.
-4. Update the independently versioned example variables after its artifacts are
-   public. Coordinated dev and beta package/glasses versions are already
-   supplied by their release workflow.
+2. Dispatch the Starter Kit repository with the exact release identity and its
+   expected channel-branch head.
+3. Update every maintained example and lockfile to the selected public versions
+   in an isolated candidate commit.
+4. Build and publish immutable example APK/IPA artifacts and a machine-readable
+   result containing their source commit, URLs, and hashes.
+5. Validate that result before coordinated finalization, then render the exact
+   example version and URL into dev or beta documentation.
 
 The Starter Kit publication fails closed if a referenced package is
-unavailable. Documentation labels the separately published example version
-explicitly and never claims that its download matches a newer coordinated
-release.
+unavailable. Documentation never claims that an example matches a coordinated
+release unless its validated Starter Kit result is included in that release's
+final manifest.
 
 ## Verification Gates
 


### PR DESCRIPTION
## Summary

This joins release-matched Starter Kit artifacts to the coordinated Mentra release pipeline.

- dispatch and monitor an exact Starter Kit release after npm, Maven, SwiftPM, OTA, and Engine consumer validation
- verify the Starter Kit result and GitHub-hosted artifact digests before accepting it
- include all four example artifacts and provenance in the finalized release manifest
- render dev/beta docs with the matching React Native APK instead of stale checked-in example variables
- include Starter Kit status and links in dev/staging Slack notifications
- document repository ownership, branch synchronization, grouped releases, changelog delivery, retries, and the deferred React Native iOS TestFlight phase

The Starter Kit remains the owner of example source, validation, PR merging, tags, releases, and artifacts. MentraOS owns release identity, ordering, finalization, docs, and Slack.

## Ordering

`packages and native SDKs -> Engine consumer -> Starter Kit sync/build/release -> final manifest -> docs -> Slack`

The Starter Kit publishes its result JSON last. MentraOS rejects results with the wrong release identity, source commit, expected Starter Kit head, asset size, or GitHub-computed SHA-256 digest.

## Authentication

`STARTER_KIT_COORDINATOR_TOKEN` is the intended GitHub App installation token. During bootstrap the workflow can use the existing scoped SDK push credential; that fallback is documented migration debt and will be removed after the App token proves one dev and one beta dispatch.

## Validation

- coordinated workflow contract tests
- release result assembly/finalization tests
- coordinated docs rendering and fail-closed tests
- release-family tests
- `actionlint .github/workflows/coordinated-release.yml`
- Slack script syntax and dry-run payload validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical coordinated release path and cross-repo merge automation; a Starter Kit or validation failure blocks finalization and docs for every dev/beta run until fixed.
> 
> **Overview**
> Adds a **Starter Kit consumer gate** to dev/beta coordinated releases so example apps must match the release identity before the bill of materials, docs, or Slack notification complete.
> 
> The coordinator **dispatches** `Mentra-Bluetooth-SDK-Starter-Kit`, waits for builds, **opens/merges** the sync PR after required checks, and **accepts** `starter-kit-release-<identity>.json` only after identity, commits, tags, and GitHub asset **SHA-256 digests** line up. **Finalize** now depends on that job; assembly and manifest finalization **verify** four example artifacts and embed Starter Kit provenance.
> 
> **Dev/beta docs** require the Starter Kit result and set `example-app-version` / `example-app-url` from the published React Native APK (no stale Mintlify placeholders). **Slack** gains a Starter Kit section and release-check line. Contract, assembly, docs, and family tests cover the new ordering; design notes document cross-repo ownership and deferred TestFlight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ad5c2a0d1e2de129d5eee56264bd0b0638da1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->