### PR TITLE
ci: submit Maven publication asynchronously

### DIFF
--- a/.github/scripts/assemble-coordinated-release-results.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.mjs
@@ -65,8 +65,8 @@ function verifyStarterKitResult(plan, starterKit, resultUrl) {
   if (!/^https:\/\//.test(starterKit.starterKit?.validationRunUrl || "")) {
     throw new Error("Starter Kit validation run URL must be public HTTPS")
   }
-  if (!Array.isArray(starterKit.artifacts) || starterKit.artifacts.length !== 4) {
-    throw new Error("Starter Kit result must contain all four example artifacts")
+  if (!Array.isArray(starterKit.artifacts) || ![3, 4].includes(starterKit.artifacts.length)) {
+    throw new Error("Starter Kit result must contain the three required examples and optional native Android")
   }
   const keys = new Set()
   const artifacts = starterKit.artifacts.map((artifact) => {
@@ -92,7 +92,7 @@ function verifyStarterKitResult(plan, starterKit, resultUrl) {
       provenanceUrl: starterKit.starterKit.validationRunUrl,
     }
   })
-  for (const key of ["android", "ios", "reactNative", "reactNativeElevenLabsAudio"]) {
+  for (const key of ["ios", "reactNative", "reactNativeElevenLabsAudio"]) {
     if (!keys.has(key)) throw new Error(`Starter Kit result is missing ${key}`)
   }
   return {record: {...starterKit, resultUrl}, artifacts}

--- a/.github/scripts/assemble-coordinated-release-results.test.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.test.mjs
@@ -73,7 +73,10 @@ test("assembles every product target and finalizes one complete release manifest
     releaseSetId: plan.releaseSetId,
     publications: {
       "@mentra/bluetooth-sdk": {
-        "maven-central": publication(`com.mentraglass:bluetooth-sdk:${plan.releaseIdentity}`),
+        "maven-central": {
+          ...publication(`com.mentraglass:bluetooth-sdk:${plan.releaseIdentity}`),
+          status: "submitted",
+        },
         "swift-package-manager": publication(`Mentra-Community/mentra-bluetooth-sdk-ios@${plan.releaseIdentity}`),
       },
     },
@@ -157,7 +160,7 @@ test("assembles every product target and finalizes one complete release manifest
       "@mentra/bluetooth-sdk": plan.releaseIdentity,
       "@mentra/engine": plan.releaseIdentity,
     },
-    artifacts: ["android", "ios", "reactNative", "reactNativeElevenLabsAudio"].map((key, index) => ({
+    artifacts: ["ios", "reactNative", "reactNativeElevenLabsAudio"].map((key, index) => ({
       key,
       name: `mentra-example-${key}-${plan.releaseIdentity}.${key === "ios" ? "ipa" : "apk"}`,
       url: `https://example.com/mentra-example-${key}-${plan.releaseIdentity}`,
@@ -183,7 +186,7 @@ test("assembles every product target and finalizes one complete release manifest
   const manifest = finalizeReleaseManifest({plan, results, completedAt: "2026-08-25T02:00:00.000Z"})
 
   assert.equal(Object.keys(manifest.publications).length, 8)
-  assert.equal(manifest.publications["@mentra/bluetooth-sdk"]["maven-central"].status, "published")
+  assert.equal(manifest.publications["@mentra/bluetooth-sdk"]["maven-central"].status, "submitted")
   assert.equal(manifest.publications.mentraos["app-store-connect"].status, "published")
   assert.ok(manifest.artifacts.some((artifact) => artifact.coordinate === plan.artifactNames.asgSelection))
   assert.equal(manifest.starterKit.resultUrl, "https://example.com/starter-kit-result.json")

--- a/.github/scripts/coordinated-sdk-native-records.mjs
+++ b/.github/scripts/coordinated-sdk-native-records.mjs
@@ -8,7 +8,7 @@ import {serializeReleaseRecord} from "./release-family.mjs"
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/
 const COMMIT_PATTERN = /^[0-9a-f]{40}$/
-const STATUSES = new Set(["built", "published", "reused"])
+const STATUSES = new Set(["built", "published", "reused", "submitted"])
 
 function readJson(file) {
   return JSON.parse(readFileSync(file, "utf8"))

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -7,7 +7,7 @@ const COMMIT_PATTERN = /^[0-9a-f]{40}$/
 const CHANNELS = new Set(["dev", "beta", "production"])
 const KINDS = new Set(["package", "product"])
 const PUBLISH_TARGETS = new Set(["app-store-connect", "google-play", "maven-central", "npm", "swift-package-manager"])
-const PUBLICATION_STATUSES = new Set(["promoted", "published", "reused"])
+const PUBLICATION_STATUSES = new Set(["promoted", "published", "reused", "submitted"])
 const SHA256_PATTERN = /^[0-9a-f]{64}$/
 
 function fail(message) {
@@ -315,7 +315,7 @@ export function requirePublicHttpsUrl(value, label) {
 function validatePublication(publication, label) {
   if (!publication || typeof publication !== "object") throw new Error(`${label} is missing`)
   if (!PUBLICATION_STATUSES.has(publication.status)) {
-    throw new Error(`${label}.status must be promoted, published, or reused`)
+    throw new Error(`${label}.status must be promoted, published, reused, or submitted`)
   }
   requireString(publication.coordinate, `${label}.coordinate`)
   requirePublicHttpsUrl(publication.url, `${label}.url`)
@@ -369,7 +369,7 @@ function validateStarterKitEvidence(plan, starterKit, artifacts) {
     starterKit.channel !== plan.channel ||
     starterKit.mentraos?.sourceCommit !== plan.sourceCommit ||
     !Array.isArray(starterKit.artifacts) ||
-    starterKit.artifacts.length !== 4
+    ![3, 4].includes(starterKit.artifacts.length)
   ) {
     throw new Error("Starter Kit evidence does not match the release plan")
   }

--- a/.github/scripts/sonatype-central-deployment.mjs
+++ b/.github/scripts/sonatype-central-deployment.mjs
@@ -37,14 +37,14 @@ function requireDeploymentRecord(record) {
   return record
 }
 
-export async function uploadManagedDeployment({bundle, token, deploymentName, expectedPurls, fetchImpl = fetch}) {
+export async function uploadAutomaticDeployment({bundle, token, deploymentName, expectedPurls, fetchImpl = fetch}) {
   if (!bundle || !token || !deploymentName || expectedPurls.length === 0) {
     throw new Error("Bundle, token, deployment name, and expected PURLs are required")
   }
   const bytes = readFileSync(bundle)
   const url = new URL("/api/v1/publisher/upload", BASE_URL)
   url.searchParams.set("name", deploymentName)
-  url.searchParams.set("publishingType", "USER_MANAGED")
+  url.searchParams.set("publishingType", "AUTOMATIC")
   const form = new FormData()
   form.append("bundle", new Blob([bytes], {type: "application/octet-stream"}), path.basename(bundle))
   const response = await fetchImpl(url, {
@@ -169,7 +169,7 @@ async function main() {
   const args = parseArgs(process.argv.slice(3))
   let result
   if (command === "upload") {
-    result = await uploadManagedDeployment({
+    result = await uploadAutomaticDeployment({
       bundle: path.resolve(args.bundle),
       token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
       deploymentName: args.name,

--- a/.github/scripts/sonatype-central-deployment.test.mjs
+++ b/.github/scripts/sonatype-central-deployment.test.mjs
@@ -4,7 +4,7 @@ import {tmpdir} from "node:os"
 import path from "node:path"
 import test from "node:test"
 
-import {inspectDeployment, publishDeployment, uploadManagedDeployment} from "./sonatype-central-deployment.mjs"
+import {inspectDeployment, publishDeployment, uploadAutomaticDeployment} from "./sonatype-central-deployment.mjs"
 
 const deploymentId = "28570f16-da32-4c14-bd2e-c1acc0782365"
 const deploymentName = "mentra-3.1.0-beta.57-android-sdk"
@@ -33,9 +33,9 @@ function jsonResponse(value, status = 200) {
   return new Response(JSON.stringify(value), {status})
 }
 
-test("uploads a user-managed deployment and returns a durable recovery record", async () => {
+test("uploads an automatically published deployment and returns a durable recovery record", async () => {
   let request
-  const result = await uploadManagedDeployment({
+  const result = await uploadAutomaticDeployment({
     bundle: bundle(),
     token: "token",
     deploymentName,
@@ -46,7 +46,7 @@ test("uploads a user-managed deployment and returns a durable recovery record", 
     },
   })
 
-  assert.match(request.url, /publishingType=USER_MANAGED/)
+  assert.match(request.url, /publishingType=AUTOMATIC/)
   assert.match(request.url, /name=mentra-3.1.0-beta.57-android-sdk/)
   assert.equal(request.options.method, "POST")
   assert.equal(result.deploymentId, deploymentId)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -473,7 +473,7 @@ jobs:
           [[ "$(jq -r .baseRefName <<< "$pr_provenance")" == "$target_branch" ]]
           [[ "$(jq -r .mergeCommit.oid <<< "$pr_provenance")" == "$merge_commit" ]]
           [[ "$(gh api "repos/$STARTER_KIT_REPOSITORY/git/ref/tags/sdk-$identity" --jq .object.sha)" == "$release_commit" ]]
-          [[ "$(jq -er '.artifacts | length' "$result")" == "4" ]]
+          [[ "$(jq -er '.artifacts | length' "$result")" =~ ^(3|4)$ ]]
           if [[ -z "$run_url" ]]; then
             run_url=$(jq -er .starterKit.validationRunUrl "$result")
           fi

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -88,10 +88,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   maven:
-    name: Publish and verify Maven Central SDK
+    name: Build SDK and submit Maven Central publication
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -308,7 +308,7 @@ jobs:
             zip -q -r "$GITHUB_WORKSPACE/native-result/maven/central-bundle.zip" com
           )
 
-      - name: Upload and persist a user-managed Sonatype deployment
+      - name: Submit and persist an automatically published Sonatype deployment
         if: inputs.dry_run != true && steps.existing.outputs.exists != 'true' && steps.deployment.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -329,52 +329,7 @@ jobs:
             --input native-result/maven/sonatype-deployment.json \
             "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?name=$encoded_name" >/dev/null
 
-      - name: Publish or resume the persisted Sonatype deployment
-        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true'
-        env:
-          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
-        run: |
-          node .github/scripts/sonatype-central-deployment.mjs publish \
-            --record native-result/maven/sonatype-deployment.json \
-            --output native-result/maven/sonatype-result.json
-
-      - name: Wait for and download public Maven artifacts
-        id: public
-        if: inputs.dry_run != true
-        env:
-          LC3_URL: ${{ steps.release.outputs.lc3_url }}
-          SDK_URL: ${{ steps.release.outputs.sdk_url }}
-        run: |
-          set -euo pipefail
-          mkdir -p native-result/maven
-          for attempt in {1..180}; do
-            if curl --fail --silent --show-error --location "$SDK_URL" -o native-result/maven/bluetooth-sdk.aar \
-              && curl --fail --silent --show-error --location "$LC3_URL" -o native-result/maven/lc3Lib.aar; then
-              exit 0
-            fi
-            echo "Waiting for Maven Central propagation (attempt $attempt/180)"
-            sleep 10
-          done
-          echo "Maven Central did not expose the complete coordinated SDK within 30 minutes." >&2
-          exit 1
-
-      - name: Verify public Maven SDK metadata
-        if: inputs.dry_run != true
-        env:
-          OTA_MANIFEST_SHA256: ${{ inputs.ota_manifest_sha256 }}
-          OTA_MANIFEST_URL: ${{ inputs.ota_manifest_url }}
-          RELEASE_IDENTITY: ${{ steps.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          unzip -p native-result/maven/bluetooth-sdk.aar classes.jar > /tmp/mentra-public-sdk-classes.jar
-          javap -classpath /tmp/mentra-public-sdk-classes.jar -p -constants com.mentra.bluetoothsdk.GeneratedReleaseMetadata > /tmp/mentra-public-sdk-metadata.txt
-          javap -classpath /tmp/mentra-public-sdk-classes.jar -p -constants com.mentra.bluetoothsdk.BuildConfig >> /tmp/mentra-public-sdk-metadata.txt
-          grep -F "$RELEASE_IDENTITY" /tmp/mentra-public-sdk-metadata.txt
-          grep -F "$OTA_MANIFEST_URL" /tmp/mentra-public-sdk-metadata.txt
-          grep -F "$OTA_MANIFEST_SHA256" /tmp/mentra-public-sdk-metadata.txt
-
-      - name: Stage dry-run Maven artifacts
-        if: inputs.dry_run == true
+      - name: Stage locally verified Maven artifacts
         run: |
           mkdir -p native-result/maven
           cp "${{ steps.local.outputs.sdk }}" native-result/maven/bluetooth-sdk.aar
@@ -382,7 +337,7 @@ jobs:
 
       - name: Write Maven publication record
         env:
-          STATUS: ${{ inputs.dry_run && 'built' || ((steps.existing.outputs.exists == 'true' || steps.deployment.outputs.exists == 'true') && 'reused' || 'published') }}
+          STATUS: ${{ inputs.dry_run && 'built' || (steps.existing.outputs.exists == 'true' && 'reused' || 'submitted') }}
         run: >-
           node .github/scripts/coordinated-sdk-native-records.mjs create-maven
           --plan release-intent/release-plan.json

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -192,8 +192,8 @@ MentraOS. Required inputs are:
 The workflow:
 
 1. validates the caller, channel, identity, and expected branch head;
-2. waits for every required npm, Maven, and SwiftPM package to be publicly
-   readable and verifies its version and recorded integrity;
+2. waits for required npm and SwiftPM packages to be publicly readable without
+   waiting for the automatically submitted Sonatype deployment;
 3. creates an isolated candidate commit from the expected Starter Kit head;
 4. updates every example and lockfile to the exact coordinated versions;
 5. embeds the exact release identity and OTA pin where the example runtime
@@ -224,7 +224,7 @@ reimplement the PR build commands in MentraOS or a second Starter Kit script.
 The initial artifact set is:
 
 ```text
-mentra-example-android-<identity>.apk
+mentra-example-android-<identity>.apk  # optional until Maven Central exposes the identity
 mentra-example-ios-<identity>-unsigned.ipa
 mentra-example-react-native-<identity>.apk
 mentra-example-rn-elevenlabs-audio-<identity>.apk
@@ -353,9 +353,11 @@ release plan and OTA selection
   -> channel Slack notification
 ```
 
-The Starter Kit gate runs only after its public dependencies exist. It may run
-in parallel with unrelated late gates when dependencies permit, but finalization
-waits for its validated result.
+The Starter Kit gate runs after npm and SwiftPM exist. Native Android is built
+when Maven Central already exposes the exact SDK version; otherwise its APK is
+omitted from that release while the other examples remain required. The gate
+may run in parallel with unrelated late gates when dependencies permit, but
+finalization waits for its validated result.
 
 If the Starter Kit fails, already published package artifacts remain recoverable
 under the in-progress release. There is no completed release manifest, docs do

--- a/notes/coordinated-release-system-proposal.md
+++ b/notes/coordinated-release-system-proposal.md
@@ -508,10 +508,10 @@ After the OTA bundle and version map exist:
 3. After npm and native publication, a clean external OEM fixture installs only
    the exact public Engine package plus host-owned dependencies. It verifies the
    registry graph, TypeScript, Metro, Expo autolinking, Android, and iOS.
-4. After its public dependencies are readable, the Starter Kit repository
-   synchronizes every maintained example to the exact release identity, builds
-   them from one tested commit, and publishes an immutable result with artifact
-   hashes.
+4. After npm and SwiftPM are readable, the Starter Kit repository synchronizes
+   every maintained example to the exact release identity. Native Android is
+   built when Maven Central already exposes that identity; otherwise that
+   optional artifact is skipped without holding up the release.
 5. Finalization writes the completed release manifest only after every product
    lane, the external consumer gate, and the Starter Kit gate succeed.
 6. Dev and beta documentation publishes after finalization from the exact
@@ -747,8 +747,9 @@ specified in
 Starter Kit examples are downstream release consumers, not sources of package
 truth.
 
-1. Wait until npm, Maven, and SwiftPM all expose the coordinated SDK version and
-   Engine's full dependency closure is readable.
+1. Wait until npm and SwiftPM expose the coordinated SDK version and Engine's
+   full dependency closure is readable. Sonatype publication proceeds
+   automatically without blocking the Starter Kit gate.
 2. Dispatch the Starter Kit repository with the exact release identity and its
    expected channel-branch head.
 3. Update every maintained example and lockfile to the selected public versions
@@ -784,7 +785,9 @@ Each release set must prove:
 - mobile artifacts use the expected local workspace source hashes;
 - the OTA manifest's ASG, MTK, and BES URLs, hashes, and versions are valid;
 - an external Engine fixture app resolves, type-checks, autolinks, and builds;
-- Starter Kit examples build only after real registry publication.
+- Starter Kit npm and SwiftPM dependencies build only after real registry
+  publication; native Android is built only when Maven Central already exposes
+  the exact version and is otherwise an optional artifact.
 
 Any missing, malformed, mutable, unreachable, or mismatched release input blocks
 publication. There is no fallback to another channel.


### PR DESCRIPTION
## Problem

The coordinated release currently waits inside Sonatype for up to an hour and then waits up to another 30 minutes for Maven Central propagation. This has repeatedly exhausted the job timeout and blocks unrelated release outputs.

## Change

- upload the signed Maven bundle with Sonatype `publishingType=AUTOMATIC`
- persist the deployment ID as before, then continue without polling Sonatype or Maven Central
- record the Maven publication as `submitted` unless the exact coordinates were already public
- accept a Starter Kit result with the three required examples plus optional native Android
- reduce the Maven job timeout from 90 to 30 minutes

The Starter Kit companion PR probes both exact Maven coordinates once. It builds native Android when they are already public and otherwise proceeds with the three required examples.

## Validation

- 21 focused Node tests
- `actionlint .github/workflows/reusable-coordinated-sdk-native.yml .github/workflows/coordinated-release.yml`
- `git diff --check`

Sonatype documents that `AUTOMATIC` proceeds from validation to publication without a follow-up API request: https://central.sonatype.org/publish/publish-portal-api/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated release CI and manifest semantics for Maven (`submitted` vs `published`) and Starter Kit evidence; misalignment with the Starter Kit companion PR could allow releases without optional Android or with premature finalization assumptions.
> 
> **Overview**
> **Stops blocking coordinated releases on Maven Central propagation** by uploading Sonatype bundles with `publishingType=AUTOMATIC` instead of user-managed publish + poll. The native SDK Maven job now submits the deployment, persists the recovery record, and exits; it no longer runs the publish/resume step or the long Maven Central download/metadata verification loop.
> 
> **Records Maven as `submitted`** (new publication status) when coordinates are not already public, while **`reused`** still applies when both POMs exist. Release assembly, manifest validation, and tests accept this status for `maven-central`.
> 
> **Relaxes the Starter Kit gate** so finalization accepts **3 or 4** example artifacts: **iOS, React Native, and RN ElevenLabs** stay required; **native Android is optional** when Maven has not exposed the exact SDK version yet. Workflow checks and `assemble-coordinated-release-results` / `release-family` validation match that contract.
> 
> **Cuts the Maven job timeout** from 90 to 30 minutes and renames staging to “locally verified” artifacts. Design notes document that Starter Kit waits on npm/SwiftPM only, not Sonatype completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7ec0031260ee63d70a4d3665bb5516d6b1213d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->