### PR TITLE
Present chained OTA passes as one update

### DIFF
--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -176,6 +176,9 @@ export function CustomMentraLiveUpdate({onDone, onSetupWifi}: CustomMentraLiveUp
   if (state.screen === "checking" || state.screen === "initializing") {
     return <Text>Checking for updates…</Text>
   }
+  if (state.screen === "finishing") {
+    return <Text>Finishing your update…</Text>
+  }
   if (state.screen === "update_available") {
     return (
       <View>
@@ -220,6 +223,10 @@ fallback. When glasses report their coordinated release identity directly,
 Engine can replace this one source-version lookup without changing customer UI
 code. Engine captures the pair before installation and retains it through
 restarts and final verification.
+
+The `finishing` screen means the approved session is checking for additional
+required passes. Do not render terminal success or release notes until the
+controller reaches `up_to_date`.
 
 Start from the Starter Kit's
 [custom OTA presentation folder](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tree/main/examples/react-native/src/ota)

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -206,7 +206,7 @@ export function CustomMentraLiveUpdate({onDone, onSetupWifi}: CustomMentraLiveUp
     return (
       <View>
         {state.releaseTransition && <Text>Updated to {state.releaseTransition.toVersion}</Text>}
-        <Button title="Done" onPress={ota.finish} />
+        <Button title={state.completedUpdate || state.screen === "complete" ? "Done" : "Continue"} onPress={ota.finish} />
       </View>
     )
   }
@@ -227,6 +227,10 @@ restarts and final verification.
 The `finishing` screen means the approved session is checking for additional
 required passes. Do not render terminal success or release notes until the
 controller reaches `up_to_date`.
+
+Use `state.completedUpdate` to distinguish a terminal update session from a
+standalone check that was already up to date. Release metadata is optional, so
+do not infer completion from `state.releaseTransition`.
 
 Start from the Starter Kit's
 [custom OTA presentation folder](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tree/main/examples/react-native/src/ota)

--- a/mobile/modules/engine/README.md
+++ b/mobile/modules/engine/README.md
@@ -91,6 +91,10 @@ const ota = useMentraLiveOta({onFinished, onOpenWifiSetup})
 // Render ota.state.screen and invoke ota.install(), retryInstall(), finish(), etc.
 ```
 
+On `up_to_date`, use `ota.state.completedUpdate` to distinguish a completed
+update session from a standalone check. `releaseTransition` is optional release
+metadata and is not a completion marker.
+
 Customize presentation only. Engine must remain responsible for OTA ordering,
 hotspot staging, restart recovery, retries, and verification. The canonical
 stock and custom integration guide is

--- a/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
+++ b/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
@@ -67,7 +67,14 @@ export function CustomOtaConsumer({onDone, onSetupWifi}: {onDone: () => void; on
   const controller = useMentraLiveOta({onFinished: onDone, onOpenWifiSetup: onSetupWifi})
   const transition = controller.state.releaseTransition
   const releaseLabel = transition ? `${transition.fromVersion ?? "Unknown"} → ${transition.toVersion}` : ""
-  return React.createElement(React.Fragment, null, screenLabel(controller.state.screen), releaseLabel)
+  const completionLabel = controller.state.completedUpdate ? "Updated" : ""
+  return React.createElement(
+    React.Fragment,
+    null,
+    screenLabel(controller.state.screen),
+    releaseLabel,
+    completionLabel,
+  )
 }
 
 // Prove the curated low-level transport types resolve without a private import.

--- a/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
+++ b/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
@@ -17,6 +17,8 @@ function screenLabel(screen: MentraLiveOtaScreen): string {
     case "initializing":
     case "checking":
       return "Checking"
+    case "finishing":
+      return "Finishing update"
     case "update_available":
       return "Update available"
     case "wifi_required":

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -65,13 +65,19 @@ const DEFAULT_THEME: MentraLiveOtaFlowTheme = {
 
 const ENGLISH_COPY: Record<string, string> = {
   "common:continue": "Continue",
+  "common:done": "Done",
   "ota:checkingForUpdates": "Checking for updates",
   "ota:checkingForUpdatesMessage":
     "Connected devices will perform automatic updates. Automatic updates can be disabled in Device Settings",
+  "ota:finishingUpdate": "Finishing your update",
+  "ota:checkingAdditionalUpdates": "Checking whether your glasses need any additional updates.",
   "ota:updateAvailable": "{{deviceName}} Update Available",
   "ota:updateConnectWifi": "Connect your {{deviceName}} to WiFi to install the update.",
+  "ota:wifiRequiredTitle": "WiFi Needed for Update",
   "ota:updateDescription":
     "A new update is available for your glasses. We recommend updating now for the best experience.",
+  "ota:updateSequenceMessage":
+    "Your glasses may install more than one update and restart several times. Keep them nearby until finished.",
   "ota:releaseTransition": "{{fromVersion}} → {{toVersion}}",
   "ota:releaseTransitionUnknown": "Current version unknown → {{toVersion}}",
   "ota:updatedToVersion": "Updated to {{version}}",
@@ -81,6 +87,7 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:updateNow": "Update Now",
   "ota:setupWifi": "Setup WiFi",
   "ota:updateLater": "Later",
+  "ota:updateComplete": "Update complete",
   "ota:upToDate": "Up To Date",
   "ota:devBuild": "Development Build",
   "ota:devBuildNoOta":
@@ -185,12 +192,27 @@ function OtaFlowContent({
     )
   }
 
+  if (state.screen === "finishing") {
+    return (
+      <FlowPage colors={colors} icon="download" title={translate("ota:finishingUpdate")}>
+        <BodyText colors={colors}>{translate("ota:checkingAdditionalUpdates")}</BodyText>
+        <ActivityIndicator size="large" color={colors.foreground} />
+      </FlowPage>
+    )
+  }
+
   if (state.screen === "update_available" || state.screen === "wifi_required") {
+    const titleKey =
+      state.screen === "wifi_required"
+        ? "ota:wifiRequiredTitle"
+        : state.versionChange
+          ? "ota:downgradeAvailable"
+          : "ota:updateAvailable"
     return (
       <FlowPage
         colors={colors}
         icon="download"
-        title={translate(state.versionChange ? "ota:downgradeAvailable" : "ota:updateAvailable", {deviceName})}
+        title={translate(titleKey, {deviceName})}
         actions={
           <>
             <FlowButton
@@ -222,6 +244,7 @@ function OtaFlowContent({
             ? translate("ota:updateConnectWifi", {deviceName})
             : translate(state.versionChange ? "ota:downgradeDescription" : "ota:updateDescription")}
         </BodyText>
+        <BodyText colors={colors}>{translate("ota:updateSequenceMessage")}</BodyText>
       </FlowPage>
     )
   }
@@ -239,12 +262,19 @@ function OtaFlowContent({
   }
 
   if (state.screen === "up_to_date") {
+    const completedUpdate = state.releaseTransition !== null
     return (
       <FlowPage
-        actions={<FlowButton colors={colors} label={translate("common:continue")} onPress={controller.finish} />}
+        actions={
+          <FlowButton
+            colors={colors}
+            label={translate(completedUpdate ? "common:done" : "common:continue")}
+            onPress={controller.finish}
+          />
+        }
         colors={colors}
         icon="check"
-        title={translate("ota:upToDate")}>
+        title={translate(completedUpdate ? "ota:updateComplete" : "ota:upToDate")}>
         <BodyText colors={colors}>{translate("ota:noUpdatesAvailable")}</BodyText>
         {state.releaseTransition ? (
           <BodyText colors={colors}>
@@ -307,10 +337,10 @@ function OtaFlowContent({
       state.hotspotPhase === "downloading"
         ? "Downloading update to phone..."
         : state.hotspotPhase === "starting_hotspot"
-        ? "Starting glasses hotspot..."
-        : state.hotspotPhase === "joining_hotspot"
-        ? "Connecting phone to glasses..."
-        : "Starting update..."
+          ? "Starting glasses hotspot..."
+          : state.hotspotPhase === "joining_hotspot"
+            ? "Connecting phone to glasses..."
+            : "Starting update..."
     return (
       <FlowPage colors={colors} icon="download" title={title}>
         {state.hotspotPhase === "downloading" && state.hotspotArtifactPercent !== null ? (
@@ -362,13 +392,13 @@ function OtaFlowContent({
     const title = state.versionChangeConverged
       ? translate("ota:versionChangeComplete")
       : state.versionChange
-      ? translate("ota:versionChangeFirmwarePassComplete")
-      : "Update complete!"
+        ? translate("ota:versionChangeFirmwarePassComplete")
+        : "Update complete!"
     const message = state.versionChangeConverged
       ? translate("ota:versionChangeCompleteMessage")
       : state.versionChange
-      ? translate("ota:versionChangeFirmwarePassCompleteMessage")
-      : "Your glasses are up to date."
+        ? translate("ota:versionChangeFirmwarePassCompleteMessage")
+        : "Your glasses are up to date."
     return (
       <FlowPage
         actions={

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -262,19 +262,18 @@ function OtaFlowContent({
   }
 
   if (state.screen === "up_to_date") {
-    const completedUpdate = state.releaseTransition !== null
     return (
       <FlowPage
         actions={
           <FlowButton
             colors={colors}
-            label={translate(completedUpdate ? "common:done" : "common:continue")}
+            label={translate(state.completedUpdate ? "common:done" : "common:continue")}
             onPress={controller.finish}
           />
         }
         colors={colors}
         icon="check"
-        title={translate(completedUpdate ? "ota:updateComplete" : "ota:upToDate")}>
+        title={translate(state.completedUpdate ? "ota:updateComplete" : "ota:upToDate")}>
         <BodyText colors={colors}>{translate("ota:noUpdatesAvailable")}</BodyText>
         {state.releaseTransition ? (
           <BodyText colors={colors}>

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -149,9 +149,11 @@ mock.module("../../services/OtaErrorMapping", () => ({
 const {useMentraLiveOta} = require("../useMentraLiveOta") as typeof import("../useMentraLiveOta")
 
 let latestController: ReturnType<typeof useMentraLiveOta>
+let renderedScreens: string[] = []
 
 function Probe({initialPage = "progress"}: {initialPage?: "check" | "progress"}) {
   latestController = useMentraLiveOta({initialPage, initializeRuntime: false})
+  renderedScreens.push(latestController.state.screen)
   return null
 }
 
@@ -179,6 +181,7 @@ describe("useMentraLiveOta", () => {
     beginAutoChain.mockClear()
     stopAutoChain.mockClear()
     advanceAutoChain.mockClear()
+    renderedScreens = []
     autoChainActive = false
     autoChainRange = null
     currentCheckResult = checkResult
@@ -458,6 +461,7 @@ describe("useMentraLiveOta", () => {
     expect(finish).toHaveBeenCalledTimes(1)
     expect(fakeOta.checkForUpdates).not.toHaveBeenCalled()
     expect(latestController.state.screen).toBe("finishing")
+    const screenCountBeforeReturn = renderedScreens.length
 
     await act(async () => {
       resolveFinish()
@@ -466,6 +470,7 @@ describe("useMentraLiveOta", () => {
     })
 
     expect(fakeOta.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(renderedScreens.slice(screenCountBeforeReturn)).not.toContain("update_available")
     await act(async () => renderer.unmount())
   })
 })

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -408,17 +408,27 @@ describe("useMentraLiveOta", () => {
     await act(async () => renderer.unmount())
   })
 
-  test("resumes an approved session when an additional pass gets Wi-Fi", async () => {
+  test("keeps finishing visible until Wi-Fi status can resume an approved session", async () => {
     autoChainActive = true
     autoChainRange = {
       fromVersion: "3.0.0",
       toVersion: "3.1.0-dev.8",
       releaseVersion: "3.1.0-dev.8",
     }
-    otaSnapshot = {...otaSnapshot, hotspotOtaVersion: 0, wifiConnected: false}
+    otaSnapshot = {...otaSnapshot, hotspotOtaVersion: 0, wifiConnected: false, wifiStatusKnown: false}
     const renderer = await renderProbe("check")
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(latestController.state.screen).toBe("finishing")
+    expect(renderedScreens).not.toContain("update_available")
+    expect(stopAutoChain).not.toHaveBeenCalled()
+    expect(advanceAutoChain).not.toHaveBeenCalled()
+
+    otaSnapshot = {...otaSnapshot, wifiStatusKnown: true}
+    await act(async () => {
+      otaListeners.forEach((listener) => listener())
     })
 
     expect(latestController.state).toMatchObject({
@@ -426,7 +436,6 @@ describe("useMentraLiveOta", () => {
       canDismiss: false,
       releaseTransition: {fromVersion: "3.0.0", toVersion: "3.1.0-dev.8"},
     })
-    expect(stopAutoChain).not.toHaveBeenCalled()
 
     otaSnapshot = {...otaSnapshot, wifiConnected: true}
     await act(async () => {

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -258,7 +258,7 @@ describe("useMentraLiveOta", () => {
     await act(async () => renderer.unmount())
   })
 
-  test("exposes crossed release changelogs when an install completes", async () => {
+  test("treats an active pass completion as a continuation check", async () => {
     const renderer = await renderProbe("check")
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1_150))
@@ -277,12 +277,14 @@ describe("useMentraLiveOta", () => {
       installListeners.forEach((listener) => listener())
     })
 
-    expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.screen).toBe("finishing")
     expect(latestController.state.releaseTransition).toEqual({
       fromVersion: "3.0.0",
       toVersion: "3.1.0-dev.8",
     })
-    expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
+    expect(latestController.state.changelogs).toEqual([])
+    expect(latestController.state.canFinish).toBe(false)
+    expect(getReleaseChangelogs).not.toHaveBeenCalled()
     await act(async () => renderer.unmount())
   })
 
@@ -296,9 +298,9 @@ describe("useMentraLiveOta", () => {
 
     installSnapshot = {...installSnapshot, displayState: "complete"}
     const progressRenderer = await renderProbe("progress")
-    expect(getReleaseChangelogs).toHaveBeenCalledWith("3.0.0", "3.1.0-dev.8")
+    expect(latestController.state.screen).toBe("finishing")
     expect(latestController.state.releaseTransition?.toVersion).toBe("3.1.0-dev.8")
-    expect(latestController.state.changelogs).toEqual([{version: "3.1.0", markdown: "Release notes"}])
+    expect(latestController.state.changelogs).toEqual([])
     await act(async () => progressRenderer.unmount())
   })
 
@@ -375,7 +377,29 @@ describe("useMentraLiveOta", () => {
     await act(async () => renderer.unmount())
   })
 
-  test("keeps confirmed completion visible until hotspot teardown finishes", async () => {
+  test("keeps an approved session active when an additional pass needs Wi-Fi", async () => {
+    autoChainActive = true
+    autoChainRange = {
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.8",
+      releaseVersion: "3.1.0-dev.8",
+    }
+    otaSnapshot = {...otaSnapshot, hotspotOtaVersion: 0, wifiConnected: false}
+    const renderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(latestController.state).toMatchObject({
+      screen: "wifi_required",
+      canDismiss: false,
+      releaseTransition: {fromVersion: "3.0.0", toVersion: "3.1.0-dev.8"},
+    })
+    expect(stopAutoChain).not.toHaveBeenCalled()
+    await act(async () => renderer.unmount())
+  })
+
+  test("keeps continuation checking visible until hotspot teardown finishes", async () => {
     autoChainActive = true
     let resolveFinish!: () => void
     finishPromise = new Promise<void>((resolve) => {
@@ -387,14 +411,14 @@ describe("useMentraLiveOta", () => {
       installListeners.forEach((listener) => listener())
     })
 
-    expect(latestController.state.screen).toBe("complete")
+    expect(latestController.state.screen).toBe("finishing")
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 800))
     })
 
     expect(finish).toHaveBeenCalledTimes(1)
     expect(fakeOta.checkForUpdates).not.toHaveBeenCalled()
-    expect(latestController.state.screen).toBe("complete")
+    expect(latestController.state.screen).toBe("finishing")
 
     await act(async () => {
       resolveFinish()

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -323,6 +323,7 @@ describe("useMentraLiveOta", () => {
     })
 
     expect(latestController.state.screen).toBe("up_to_date")
+    expect(latestController.state.completedUpdate).toBe(true)
     expect(latestController.state.releaseTransition).toEqual({
       fromVersion: "3.0.0",
       toVersion: "3.1.0-dev.8",
@@ -340,6 +341,33 @@ describe("useMentraLiveOta", () => {
 
     expect(latestController.state).toMatchObject({
       screen: "update_available",
+      releaseTransition: null,
+    })
+    await act(async () => renderer.unmount())
+  })
+
+  test("reports completed session independently of an optional release label", async () => {
+    currentCheckResult = {...checkResult, releaseVersion: null}
+    const renderer = await renderProbe("check")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+    await act(async () => latestController.install())
+    currentCheckResult = {...checkResult, updateAvailable: false, updateInfo: null, updates: [], releaseVersion: null}
+    installSnapshot = {...installSnapshot, displayState: "complete"}
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 800))
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(latestController.state).toMatchObject({
+      screen: "up_to_date",
+      completedUpdate: true,
       releaseTransition: null,
     })
     await act(async () => renderer.unmount())
@@ -377,7 +405,7 @@ describe("useMentraLiveOta", () => {
     await act(async () => renderer.unmount())
   })
 
-  test("keeps an approved session active when an additional pass needs Wi-Fi", async () => {
+  test("resumes an approved session when an additional pass gets Wi-Fi", async () => {
     autoChainActive = true
     autoChainRange = {
       fromVersion: "3.0.0",
@@ -396,6 +424,17 @@ describe("useMentraLiveOta", () => {
       releaseTransition: {fromVersion: "3.0.0", toVersion: "3.1.0-dev.8"},
     })
     expect(stopAutoChain).not.toHaveBeenCalled()
+
+    otaSnapshot = {...otaSnapshot, wifiConnected: true}
+    await act(async () => {
+      otaListeners.forEach((listener) => listener())
+    })
+
+    expect(advanceAutoChain).toHaveBeenCalledTimes(1)
+    expect(beginAutoChain).not.toHaveBeenCalled()
+    expect(fakeOta.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(prepare).toHaveBeenCalledWith(currentCheckResult)
+    expect(latestController.state.screen).toBe("preparing_hotspot")
     await act(async () => renderer.unmount())
   })
 

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -391,6 +391,10 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
             const fromVersion = currentReleaseVersion(ota.snapshot().appVersion)
             setOfferedReleaseTransition(result.releaseVersion ? {fromVersion, toVersion: result.releaseVersion} : null)
           }
+          if (isOtaAutoChainActive() && !ota.snapshot().wifiStatusKnown) {
+            checkCompletedRef.current = true
+            return
+          }
           if (continueApprovedChain(result)) return
           checkCompletedRef.current = true
           setCheckState("update_available")
@@ -428,15 +432,19 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     if (
       !runtimeReady ||
       page !== "check" ||
-      checkState !== "update_available" ||
+      (checkState !== "checking" && checkState !== "update_available") ||
       !otaSnapshot.wifiStatusKnown ||
-      (!otaSnapshot.wifiConnected && otaSnapshot.hotspotOtaVersion !== 1) ||
       !isOtaAutoChainActive()
     ) {
       return
     }
     const result = selectedCheckResultRef.current
-    if (result?.updateAvailable && result.updateInfo) continueApprovedChain(result)
+    if (!result?.updateAvailable || !result.updateInfo) return
+    if (!otaSnapshot.wifiConnected && otaSnapshot.hotspotOtaVersion !== 1) {
+      setCheckState("update_available")
+      return
+    }
+    continueApprovedChain(result)
   }, [
     checkState,
     continueApprovedChain,

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -28,6 +28,7 @@ export type MentraLiveOtaFlowPage = "check" | "progress"
 export type MentraLiveOtaScreen =
   | "initializing"
   | "checking"
+  | "finishing"
   | "update_available"
   | "wifi_required"
   | "up_to_date"
@@ -163,10 +164,10 @@ function installProgress(snapshot: OtaInstallSnapshot): number | null {
   const isDownload = otaStatus?.phase === "download"
   const totalSteps = otaStatus?.totalSteps ?? 1
   const rawPercent = isDownload
-    ? otaStatus?.stepPercent ?? 0
+    ? (otaStatus?.stepPercent ?? 0)
     : totalSteps >= 2
-    ? otaStatus?.overallPercent ?? 0
-    : otaStatus?.stepPercent ?? 0
+      ? (otaStatus?.overallPercent ?? 0)
+      : (otaStatus?.stepPercent ?? 0)
   return Math.min(Math.max(rawPercent, snapshot.mtkInstallStallSimulatedPercent ?? 0, 0), 100)
 }
 
@@ -367,9 +368,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
           if (isOtaAutoChainActive()) {
             const snapshot = ota.snapshot()
             if (!snapshot.wifiStatusKnown) return
-            if (!snapshot.wifiConnected && snapshot.hotspotOtaVersion !== 1) {
-              stopOtaAutoChain()
-            } else {
+            if (snapshot.wifiConnected || snapshot.hotspotOtaVersion === 1) {
               const admission = tryAdvanceOtaAutoChain(
                 fingerprint,
                 result.updateInfo.isDowngrade === true,
@@ -534,6 +533,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const state = useMemo<MentraLiveOtaState>(() => {
     const hotspotSupported = otaSnapshot.hotspotOtaVersion === 1
     const canInstall = otaSnapshot.wifiStatusKnown && (otaSnapshot.wifiConnected || hotspotSupported)
+    const autoChainActive = isOtaAutoChainActive()
     if (!runtimeReady) {
       return {
         screen: "initializing",
@@ -570,26 +570,22 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
 
     if (page === "check") {
       const wifiRequired = otaSnapshot.wifiStatusKnown && !otaSnapshot.wifiConnected && !hotspotSupported
-      const screen: MentraLiveOtaScreen =
-        checkState === "checking"
-          ? "checking"
-          : checkState === "update_available"
-          ? wifiRequired
-            ? "wifi_required"
-            : "update_available"
-          : checkState === "no_update"
-          ? "up_to_date"
-          : checkState === "dev_build"
-          ? "dev_build"
-          : errorKind === "pin_unavailable"
-          ? "update_info_unavailable"
-          : "check_failed"
-      const error: MentraLiveOtaError | null =
-        screen === "check_failed"
-          ? {code: "check_failed", message: "Couldn't check for updates. Please check your connection and try again."}
-          : screen === "update_info_unavailable"
-          ? {code: "update_info_unavailable", message: "Update information for this app version is unavailable."}
-          : null
+      let screen: MentraLiveOtaScreen
+      if (checkState === "checking") screen = autoChainActive ? "finishing" : "checking"
+      else if (checkState === "update_available") screen = wifiRequired ? "wifi_required" : "update_available"
+      else if (checkState === "no_update") screen = "up_to_date"
+      else if (checkState === "dev_build") screen = "dev_build"
+      else screen = errorKind === "pin_unavailable" ? "update_info_unavailable" : "check_failed"
+
+      let error: MentraLiveOtaError | null = null
+      if (screen === "check_failed") {
+        error = {
+          code: "check_failed",
+          message: "Couldn't check for updates. Please check your connection and try again.",
+        }
+      } else if (screen === "update_info_unavailable") {
+        error = {code: "update_info_unavailable", message: "Update information for this app version is unavailable."}
+      }
       return {
         screen,
         connected: otaSnapshot.connected,
@@ -614,13 +610,16 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canInstall: screen === "update_available" && canInstall,
         canRetry: screen === "check_failed",
         canFinish: screen === "up_to_date" || screen === "dev_build" || screen === "update_info_unavailable",
-        canDismiss: (screen === "update_available" || screen === "wifi_required") && !isUpdateRequired,
+        canDismiss:
+          (screen === "update_available" || screen === "wifi_required") && !isUpdateRequired && !autoChainActive,
         canDiscard: false,
         canOpenWifiSetup: screen === "wifi_required",
         continueDisabled: false,
         releaseTransition:
           screen === "update_available" || screen === "wifi_required"
-            ? offeredReleaseTransition
+            ? autoChainActive
+              ? releaseTransitionFromRange(otaAutoChainReleaseRange())
+              : offeredReleaseTransition
             : screen === "up_to_date"
               ? completedReleaseTransition
               : null,
@@ -641,7 +640,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     const displayedError = requiresGlassesReboot
       ? BES_INSTALL_RESTART_MESSAGE
       : installSnapshot.errorMsg || getOtaErrorMessage(installSnapshot.otaStatus?.error)
-    const screen = progressScreen(installSnapshot)
+    const progressState = progressScreen(installSnapshot)
+    const screen = progressState === "complete" && autoChainActive ? "finishing" : progressState
     const error =
       screen === "failed"
         ? {

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -95,6 +95,8 @@ export type MentraLiveOtaState = {
   canDiscard: boolean
   canOpenWifiSetup: boolean
   continueDisabled: boolean
+  /** True only after an approved update session reaches a final no-update check. */
+  completedUpdate: boolean
   /** Release labels for the offered or just-completed coordinated update. */
   releaseTransition: MentraLiveOtaReleaseTransition | null
   /** Release notes crossed by this update, newest first. Populated on completion. */
@@ -216,6 +218,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const [completedReleaseTransition, setCompletedReleaseTransition] = useState<MentraLiveOtaReleaseTransition | null>(
     null,
   )
+  const [completedUpdate, setCompletedUpdate] = useState(false)
   const [completedChangelogs, setCompletedChangelogs] = useState<ReleaseChangelog[]>([])
   const [checkGeneration, setCheckGeneration] = useState(0)
   const performCheckGenerationRef = useRef(0)
@@ -259,6 +262,28 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     ota.clearProgress()
     setPage("progress")
   }, [])
+
+  const continueApprovedChain = useCallback(
+    (result: OtaCheckCurrentGlassesResult): boolean => {
+      if (installActionPendingRef.current || !isOtaAutoChainActive() || !result.updateInfo) return false
+      const snapshot = ota.snapshot()
+      if (!snapshot.wifiStatusKnown || (!snapshot.wifiConnected && snapshot.hotspotOtaVersion !== 1)) return false
+
+      const admission = tryAdvanceOtaAutoChain(
+        otaAutoChainFingerprint(result),
+        result.updateInfo.isDowngrade === true,
+        releaseRangeTargetVersion(result),
+        result.releaseVersion,
+      )
+      if (!admission.advance) return false
+
+      checkCompletedRef.current = true
+      ota.installSession.prepare(result)
+      navigateToProgress()
+      return true
+    },
+    [navigateToProgress],
+  )
 
   useEffect(() => {
     if (!runtimeReady || page !== "check") return
@@ -365,32 +390,17 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
             const fromVersion = currentReleaseVersion(ota.snapshot().appVersion)
             setOfferedReleaseTransition(result.releaseVersion ? {fromVersion, toVersion: result.releaseVersion} : null)
           }
-          if (isOtaAutoChainActive()) {
-            const snapshot = ota.snapshot()
-            if (!snapshot.wifiStatusKnown) return
-            if (snapshot.wifiConnected || snapshot.hotspotOtaVersion === 1) {
-              const admission = tryAdvanceOtaAutoChain(
-                fingerprint,
-                result.updateInfo.isDowngrade === true,
-                releaseRangeTargetVersion(result),
-                result.releaseVersion,
-              )
-              if (admission.advance) {
-                checkCompletedRef.current = true
-                ota.installSession.prepare(result)
-                navigateToProgress()
-                return
-              }
-            }
-          }
+          if (continueApprovedChain(result)) return
           checkCompletedRef.current = true
           setCheckState("update_available")
           return
         }
-        if (isOtaAutoChainActive()) {
+        const completedApprovedSession = isOtaAutoChainActive()
+        if (completedApprovedSession) {
           setCompletedChangelogs(releaseChangelogsForActiveChain())
           setCompletedReleaseTransition(releaseTransitionFromRange(otaAutoChainReleaseRange()))
         }
+        setCompletedUpdate(completedApprovedSession)
         stopOtaAutoChain()
         checkCompletedRef.current = true
         ota.clearUpdateAvailable()
@@ -411,7 +421,30 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       cancelled = true
       if (reconnectTimeout) clearTimeout(reconnectTimeout)
     }
-  }, [checkGeneration, navigateToProgress, otaSnapshot.connected, otaSnapshot.wifiStatusKnown, page, runtimeReady])
+  }, [checkGeneration, continueApprovedChain, otaSnapshot.connected, otaSnapshot.wifiStatusKnown, page, runtimeReady])
+
+  useEffect(() => {
+    if (
+      !runtimeReady ||
+      page !== "check" ||
+      checkState !== "update_available" ||
+      !otaSnapshot.wifiStatusKnown ||
+      (!otaSnapshot.wifiConnected && otaSnapshot.hotspotOtaVersion !== 1) ||
+      !isOtaAutoChainActive()
+    ) {
+      return
+    }
+    const result = selectedCheckResultRef.current
+    if (result?.updateAvailable && result.updateInfo) continueApprovedChain(result)
+  }, [
+    checkState,
+    continueApprovedChain,
+    otaSnapshot.hotspotOtaVersion,
+    otaSnapshot.wifiConnected,
+    otaSnapshot.wifiStatusKnown,
+    page,
+    runtimeReady,
+  ])
 
   useEffect(() => {
     if (!runtimeReady || page !== "progress") return
@@ -458,6 +491,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const check = useCallback(() => {
     setOfferedReleaseTransition(null)
     setCompletedReleaseTransition(null)
+    setCompletedUpdate(false)
     setCompletedChangelogs([])
     setPage("check")
     setCheckState("checking")
@@ -482,6 +516,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return
     }
     ota.installSession.prepare(result)
+    setCompletedUpdate(false)
     setCompletedChangelogs([])
     if (updateFingerprint) {
       const fromVersion = offeredReleaseTransition
@@ -563,6 +598,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: false,
         continueDisabled: false,
+        completedUpdate: false,
         releaseTransition: null,
         changelogs: [],
       }
@@ -615,6 +651,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canDiscard: false,
         canOpenWifiSetup: screen === "wifi_required",
         continueDisabled: false,
+        completedUpdate: screen === "up_to_date" && completedUpdate,
         releaseTransition:
           screen === "update_available" || screen === "wifi_required"
             ? autoChainActive
@@ -682,6 +719,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       canDiscard: screen === "disconnected",
       canOpenWifiSetup: screen === "failed" && showChangeWifi,
       continueDisabled: installSnapshot.continueButtonDisabled,
+      completedUpdate: false,
       releaseTransition: releaseTransitionFromRange(otaAutoChainReleaseRange()),
       changelogs,
     }
@@ -689,6 +727,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     checkState,
     completedChangelogs,
     completedReleaseTransition,
+    completedUpdate,
     errorKind,
     firmwareRestarting,
     installSnapshot,

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -253,6 +253,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   const returnToCheck = useCallback(() => {
     installActionPendingRef.current = false
     autoChainAdvancedRef.current = false
+    setCheckState("checking")
     setPage("check")
     setCheckGeneration((generation) => generation + 1)
   }, [])

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -200,7 +200,7 @@ describe("progress.tsx display states", () => {
     beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
     const replaceSpy = jest.spyOn(useNavigationStore.getState(), "replace")
     try {
-      const {getByText} = render(<OtaProgressScreen />)
+      const {getByText, queryByText} = render(<OtaProgressScreen />)
 
       act(() => {
         useGlassesStore.getState().setOtaStatus({
@@ -215,11 +215,13 @@ describe("progress.tsx display states", () => {
         })
       })
 
+      expect(getByText("ota:finishingUpdate")).toBeDefined()
+      expect(queryByText("Update complete!")).toBeNull()
       expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
       await act(async () => {
         await jest.advanceTimersByTimeAsync(750)
       })
-      expect(getByText("ota:checkingForUpdates")).toBeDefined()
+      expect(getByText("ota:finishingUpdate")).toBeDefined()
       expect(useConnectionOverlayConfig.getState().suppressOverlay).toBe(false)
       expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
     } finally {
@@ -255,7 +257,7 @@ describe("progress.tsx display states", () => {
       await act(async () => {
         await jest.advanceTimersByTimeAsync(750)
       })
-      expect(getByText("ota:checkingForUpdates")).toBeDefined()
+      expect(getByText("ota:finishingUpdate")).toBeDefined()
       expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
     } finally {
       replaceSpy.mockRestore()
@@ -298,7 +300,7 @@ describe("progress.tsx display states", () => {
       await act(async () => {
         await jest.advanceTimersByTimeAsync(750)
       })
-      expect(getByText("ota:checkingForUpdates")).toBeDefined()
+      expect(getByText("ota:finishingUpdate")).toBeDefined()
       expect(replaceSpy).not.toHaveBeenCalledWith("/ota/check-for-updates")
     } finally {
       replaceSpy.mockRestore()

--- a/mobile/src/app/ota/__tests__/shared-flow.test.tsx
+++ b/mobile/src/app/ota/__tests__/shared-flow.test.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import {act, fireEvent, render, waitFor} from "@testing-library/react-native"
 
 import {MentraLiveOtaFlow} from "@mentra/engine/ota"
+
+import {stopOtaAutoChain} from "@/services/otaAutoChain"
 import {ota} from "../../../../modules/engine/src/facades/ota"
 import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
 
@@ -11,6 +13,7 @@ describe("MentraLiveOtaFlow", () => {
   })
 
   afterEach(() => {
+    stopOtaAutoChain()
     jest.restoreAllMocks()
     jest.useRealTimers()
   })
@@ -66,6 +69,11 @@ describe("MentraLiveOtaFlow", () => {
     })
     expect(getByText("Mentra Live Update Available")).toBeDefined()
     expect(getByText("3.1.0-dev.7 → 3.1.0-dev.8")).toBeDefined()
+    expect(
+      getByText(
+        "Your glasses may install more than one update and restart several times. Keep them nearby until finished.",
+      ),
+    ).toBeDefined()
 
     fireEvent.press(getByTestId("button-Update Now"))
 

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -407,10 +407,15 @@ const en = {
     checkingForUpdates: "Checking for updates",
     checkingForUpdatesMessage:
       "Connected devices will perform automatic updates. Automatic updates can be disabled in Device Settings",
+    finishingUpdate: "Finishing your update",
+    checkingAdditionalUpdates: "Checking whether your glasses need any additional updates.",
     updateAvailable: "{{deviceName}} Update Available",
     updateReadyToInstall: "Version {{version}} for {{deviceName}} is ready to install.",
     updateConnectWifi: "Connect your {{deviceName}} to WiFi to install the update.",
+    wifiRequiredTitle: "WiFi Needed for Update",
     updateDescription: "A new update is available for your glasses. We recommend updating now for the best experience.",
+    updateSequenceMessage:
+      "Your glasses may install more than one update and restart several times. Keep them nearby until finished.",
     releaseTransition: "{{fromVersion}} → {{toVersion}}",
     releaseTransitionUnknown: "Current version unknown → {{toVersion}}",
     updatedToVersion: "Updated to {{version}}",

--- a/notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md
+++ b/notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md
@@ -1,0 +1,151 @@
+---
+status: active
+owner: Mentra
+---
+
+# Unified OTA update session design
+
+## Outcome
+
+After a user approves a Mentra Live update, every required APK, MTK, and BES
+install pass is presented as one update session. An individual pass completing
+must not claim that the whole update is complete. The flow reserves its success
+checkmark, final installed version, accumulated changelog, and **Done** action
+for the point where a fresh manifest check confirms that no additional update
+is available.
+
+## Current problem
+
+The OTA coordinator intentionally checks the manifest again after every install
+pass and automatically starts a newly offered pass. The UI currently exposes
+the boundaries of that implementation:
+
+1. An install pass renders **Update complete!**, **Your glasses are up to
+   date**, a success checkmark, and the accumulated changelog.
+2. After a short delay, the flow renders **Checking for updates**.
+3. A subsequent pass starts, or an update offer is shown if Wi-Fi setup is
+   required.
+
+This sequence contradicts itself. It tells the user the journey is finished,
+then resumes it. A multi-pass release can also expose the changelog before all
+of the release's components have converged.
+
+## UX principles
+
+1. One approval starts one user-visible update session.
+2. APK, MTK, BES, and manifest passes remain implementation details.
+3. An intermediate pass completion is progress, not success.
+4. The UI does not promise a step count because the number of passes is not
+   known before each refreshed manifest check.
+5. A percentage may reset for a new pass only after the copy establishes that
+   an additional update is being installed.
+6. The user is asked to approve the session once. The flow interrupts only
+   when it needs an action such as Wi-Fi setup or encounters an error.
+7. The changelog describes the complete starting-to-final release transition
+   and appears only on terminal success.
+
+## User flow
+
+### Initial offer
+
+The initial **Update Available** page keeps the existing release transition and
+approval controls. It adds this expectation:
+
+> Your glasses may install more than one update and restart several times. Keep
+> them nearby until finished.
+
+The existing downgrade explanation remains visible for required version
+changes.
+
+### Installation and continuation
+
+Downloading, installing, restarting, and verification keep their existing
+phase-specific pages and progress. When an install coordinator reports
+`complete` while the auto-chain session is active, the headless controller
+projects the semantic `finishing` screen instead of `complete`.
+
+The stock page renders:
+
+- Title: **Finishing your update**
+- Message: **Checking whether your glasses need any additional updates.**
+- Activity indicator; no success icon, changelog, or completion action
+
+This same presentation remains visible while hotspot resources are torn down
+and while the fresh manifest check runs, avoiding a flash between pages.
+
+If another install is admitted, the coordinator starts it automatically. The
+user may see its per-pass percentage, but it is introduced as a continuation of
+the same update session rather than a new update journey.
+
+### Wi-Fi intervention
+
+If an additional pass cannot begin because the glasses require Wi-Fi, the
+auto-chain session remains active while the existing Wi-Fi setup page is shown:
+
+- Title: **WiFi Needed for Update**
+- Message: **Connect your glasses to WiFi to install the update.**
+
+Returning with Wi-Fi available resumes the already approved session. This page
+does not offer **Later** because the user is already inside an update session.
+
+### Terminal success
+
+Only a successful refreshed manifest check with no remaining update ends the
+session. The final page renders:
+
+- Success checkmark
+- **Update complete** when the user just completed a release transition, or
+  **Up to Date** for a standalone manual check
+- Final coordinated release version when available
+- The accumulated changelog for the complete release range
+- **Done** after a completed session, or **Continue** after a standalone check
+
+The changelog is scrollable while the action remains outside its scrolling
+area. If no release notes exist, the changelog section is omitted.
+
+## Controller contract
+
+`MentraLiveOtaScreen` gains a `finishing` state. It represents both the brief
+install teardown after a pass completes and the refreshed manifest check that
+follows it.
+
+For an active session:
+
+- Intermediate install `complete` projects `screen: "finishing"`.
+- The auto-chain remains active through manifest checks and Wi-Fi intervention.
+- `canFinish` and `canDismiss` are `false` during continuation.
+- `changelogs` is empty until terminal `up_to_date`.
+- `releaseTransition` may remain available as session context, but the stock
+  continuation page does not render it.
+
+For terminal success:
+
+- The controller copies the active release range and changelogs into completed
+  state before stopping the auto-chain.
+- `screen` becomes `up_to_date` after the auto-chain ends.
+- `releaseTransition` and `changelogs` describe the full completed session.
+
+## Failure and recovery behavior
+
+Existing OTA safety behavior remains unchanged: duplicate offers, unapproved
+downgrades, maximum-pass admission, disconnect timeouts, install failures, and
+reboot-required failures still fail closed. An interrupted progress screen
+without an in-memory auto-chain session may still expose the existing recovery
+completion state because its prior approval and release range cannot be
+reconstructed safely.
+
+## Acceptance criteria
+
+- An active pass completion never renders **Update complete**, **Your glasses
+  are up to date**, a success checkmark, a changelog, or a completion button.
+- The continuation presentation remains stable across install teardown and the
+  refreshed update check.
+- A subsequent admissible offer begins automatically without showing a second
+  approval page.
+- A Wi-Fi-blocked continuation retains the session and does not offer **Later**.
+- Only the final no-update result renders the final version and accumulated
+  changelog.
+- A standalone no-update check still renders **Up to Date** without implying
+  that an installation occurred.
+- The public controller type, stock component, Mentra App translations,
+  integration documentation, and focused tests describe the same behavior.

--- a/notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md
+++ b/notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md
@@ -123,6 +123,8 @@ For terminal success:
 - The controller copies the active release range and changelogs into completed
   state before stopping the auto-chain.
 - `screen` becomes `up_to_date` after the auto-chain ends.
+- `completedUpdate` is `true` after an approved session reaches this terminal
+  check; it does not depend on optional release metadata.
 - `releaseTransition` and `changelogs` describe the full completed session.
 
 ## Failure and recovery behavior

--- a/notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md
+++ b/notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md
@@ -87,6 +87,8 @@ auto-chain session remains active while the existing Wi-Fi setup page is shown:
 
 Returning with Wi-Fi available resumes the already approved session. This page
 does not offer **Later** because the user is already inside an update session.
+While the glasses Wi-Fi status is still hydrating after a restart, the flow
+stays on **Finishing your update** instead of flashing a second approval page.
 
 ### Terminal success
 


### PR DESCRIPTION
## Summary

- model intermediate OTA pass completion and the following manifest check as a single `finishing` state
- reserve success, final release version, changelogs, and Done for the terminal `up_to_date` result
- retain an approved auto-chain through legacy Wi-Fi setup and set multi-pass expectations before installation
- document the UX contract and update the public custom-renderer example

## Validation

- `bun test ./src/react/__tests__/useMentraLiveOta.test.tsx` (9 passed)
- `bun run test --runInBand src/app/ota/__tests__/progress.test.tsx src/app/ota/__tests__/shared-flow.test.tsx` (34 passed)
- `bun run compile`
- `bun run test:public-ota-consumer`
- focused production-source ESLint
- repository-pinned Prettier 3.6.2 check
- `git diff --check`

## Design

- `notes/superpowers/specs/2026-08-27-unified-ota-update-session-design.md`

## Follow-up

- Starter Kit React Native custom UI: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible OTA flow and public controller semantics during multi-pass updates and Wi-Fi recovery; mistakes could strand users or show premature success, though behavior is heavily tested.
> 
> **Overview**
> Chained Mentra Live OTA installs are no longer shown as “done” after each APK/MTK/BES pass. The headless controller adds a **`finishing`** screen (and **`completedUpdate`** on terminal success) so intermediate **`complete`** states become “checking for more updates,” while success UI, changelogs, and **Done** appear only after a final manifest check reports no update.
> 
> **`useMentraLiveOta`** keeps the auto-chain alive through continuation checks and Wi-Fi gaps: **`canDismiss`** is off mid-session, Wi-Fi hydration stays on **`finishing`** instead of re-offering the update, and approved chains resume automatically when connectivity allows. **`MentraLiveOtaFlow`**, i18n, Mintlify/custom-UI docs, fixtures, and tests are aligned with that contract; a design spec documents the unified session UX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db42364f78ed23f409c1a64859ab43d932063f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->