### PR TITLE
fix(ci): dispatch Starter releases with contents permission

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -83,6 +83,9 @@ test("coordinated docs publish only after finalization to the matching channel",
 
   assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native, engine-consumer\]$/m)
   assert.match(starterKit, /coordinated-example-release\.yml/)
+  assert.match(starterKit, /event_type: "coordinated_example_release"/)
+  assert.match(starterKit, /--event repository_dispatch/)
+  assert.doesNotMatch(starterKit, /gh workflow run coordinated-example-release\.yml/)
   assert.match(starterKit, /starter-kit-release-\$identity\.json/)
   assert.match(starterKit, /select\(\.displayTitle == [^\n]+ and \.status != \\"completed\\"\)/)
   assert.match(starterKit, /encoded_candidate_branch=\$\(jq -rn[^\n]+'\$value \| @uri'\)/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -338,7 +338,7 @@ jobs:
             --output "starter-kit-result/$result_name" 2>/dev/null; then
             rm -f "starter-kit-result/$result_name"
             run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
-              --workflow coordinated-example-release.yml --event workflow_dispatch --limit 100 \
+              --workflow coordinated-example-release.yml --event repository_dispatch --limit 100 \
               --json databaseId,displayTitle,status,url \
               --jq ".[] | select(.displayTitle == \"$run_title\" and .status != \"completed\")" \
               | head -1)
@@ -349,11 +349,14 @@ jobs:
               echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
             else
               dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-              gh workflow run coordinated-example-release.yml \
-                --repo "$STARTER_KIT_REPOSITORY" \
-                --ref main \
-                -f "channel=$channel" \
-                -f "payload=$payload"
+              dispatch=$(jq -cn \
+                --arg channel "$channel" \
+                --arg payload "$payload" \
+                '{
+                  event_type: "coordinated_example_release",
+                  client_payload: {channel: $channel, payload: $payload}
+                }')
+              gh api --method POST "repos/$STARTER_KIT_REPOSITORY/dispatches" --input - <<< "$dispatch"
             fi
 
             candidate_branch="coordinated/$identity"
@@ -362,7 +365,7 @@ jobs:
             for _ in {1..180}; do
               if [[ -z "$run_id" ]]; then
                 run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
-                  --workflow coordinated-example-release.yml --event workflow_dispatch --limit 30 \
+                  --workflow coordinated-example-release.yml --event repository_dispatch --limit 30 \
                   --json databaseId,displayTitle,createdAt,url \
                   --jq ".[] | select(.displayTitle == \"$run_title\" and .createdAt >= \"$dispatched_at\")" \
                   | head -1)

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -177,7 +177,9 @@ to TestFlight.
 ### Coordinated example release
 
 `coordinated-example-release.yml` is invoked by an authenticated dispatch from
-MentraOS. Required inputs are:
+MentraOS. The coordinator uses GitHub's cross-repository `repository_dispatch`
+endpoint, which is covered by the GitHub App's existing Contents write grant;
+manual `workflow_dispatch` remains available for operators. Required inputs are:
 
 - `releaseSetId`;
 - `releaseIdentity`;


### PR DESCRIPTION
## Why

The first coordinated Starter Kit gate reached its cross-repository trigger but GitHub rejected `workflow_dispatch` with HTTP 403. That endpoint requires Actions write; the coordinator GitHub App intentionally has the narrower Contents write permission it already needs for Starter Kit release synchronization.

GitHub's `repository_dispatch` endpoint is designed for cross-repository events and requires Contents write, so it fits the existing least-privilege app grant.

## Changes

- post a typed `coordinated_example_release` repository event to the Starter Kit
- discover and correlate only `repository_dispatch` runs for that exact release identity
- preserve the existing payload, candidate PR, exact-head checks, validation, merge, artifact verification, and final release gate
- document and test the trigger contract

The Starter Kit receiver is Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit#54.

## Validation

- `node --test .github/scripts/coordinated-workflow-contract.test.mjs`
- `actionlint .github/workflows/coordinated-release.yml`
- `git diff --check`
- live repository dispatch accepted with HTTP 204 for `3.1.0-dev.44`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how coordinated releases start Starter Kit work; a receiver mismatch would block the gate, but scope is limited to CI dispatch and polling.
> 
> **Overview**
> Fixes **403 failures** when the coordinated release job triggers Starter Kit builds: cross-repo **`workflow_dispatch`** needs Actions write, but the coordinator GitHub App only has **Contents write**.
> 
> The **`starter-kit`** job now posts a typed **`coordinated_example_release`** event with **`gh api …/dispatches`** (channel + payload in `client_payload`) instead of **`gh workflow run`**. Run discovery and correlation use **`repository_dispatch`** only; PR merge, checks, artifact polling, and finalization are unchanged.
> 
> Contract tests lock in the new trigger, and the coordinated-release design note documents **`repository_dispatch`** vs operator **`workflow_dispatch`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3784f00b867d0552b96ac7b268fceaef2be19e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->