### PR TITLE
Respect theme in gallery video previews

### DIFF
--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx
@@ -6,6 +6,7 @@ import {AwesomeGalleryViewer, CustomOverlay} from "./AwesomeGalleryViewer"
 
 let mockGalleryProps: Record<string, unknown> = {}
 let mockImageProps: Record<string, unknown> = {}
+let mockVideoProps: Record<string, unknown> = {}
 
 jest.mock("@gorhom/bottom-sheet", () => ({
   __esModule: true,
@@ -15,6 +16,19 @@ jest.mock("@/components/ignite/Icon", () => {
   const React = require("react")
   const {Text} = require("react-native")
   return {Icon: ({name}: {name: string}) => React.createElement(Text, null, name)}
+})
+jest.mock("@/contexts/ThemeContext", () => {
+  const theme = {
+    colors: {background: "#f7f7f7", border: "#dddddd", foreground: "#111111"},
+    spacing: {s2: 8, s3: 12, s4: 16, s6: 24, s8: 32},
+  }
+
+  return {
+    useAppTheme: () => ({
+      theme,
+      themed: (style: unknown) => (typeof style === "function" ? style(theme) : style),
+    }),
+  }
 })
 jest.mock("expo-image", () => ({
   Image: (props: Record<string, unknown>) => {
@@ -50,7 +64,10 @@ jest.mock("react-native-vector-icons/MaterialCommunityIcons", () => {
     return React.createElement(Text, null, name)
   }
 })
-jest.mock("react-native-video", () => () => null)
+jest.mock("react-native-video", () => (props: Record<string, unknown>) => {
+  mockVideoProps = props
+  return null
+})
 
 describe("CustomOverlay", () => {
   it("exposes visible toolbar actions for closing, details, and sharing", () => {
@@ -119,5 +136,27 @@ describe("CustomOverlay", () => {
       source: {uri: "file:///gallery/photo.jpg"},
       transition: 0,
     })
+  })
+
+  it("uses the active theme background throughout video previews", () => {
+    const video = {
+      name: "video.mp4",
+      url: "file:///gallery/video.mp4",
+      thumbnailPath: "file:///gallery/video-thumbnail.jpg",
+      is_video: true,
+    } as PhotoInfo
+
+    render(<AwesomeGalleryViewer visible photos={[video]} initialIndex={0} onClose={jest.fn()} />)
+    const renderItem = mockGalleryProps.renderItem as (info: {
+      item: PhotoInfo
+      index: number
+      setImageDimensions: jest.Mock
+    }) => React.ReactElement
+
+    const videoView = render(renderItem({item: video, index: 0, setImageDimensions: jest.fn()}))
+
+    expect(videoView.getByTestId("video-player-container")).toHaveStyle({backgroundColor: "#f7f7f7"})
+    expect(videoView.getByTestId("video-thumbnail-overlay")).toHaveStyle({backgroundColor: "#f7f7f7"})
+    expect(mockVideoProps.style).toMatchObject({backgroundColor: "#f7f7f7"})
   })
 })

--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
@@ -56,7 +56,7 @@ const VideoPlayerItem = memo(function VideoPlayerItem({
   onSeekingChange,
   onDimensions,
 }: VideoPlayerItemProps) {
-  const {themed} = useAppTheme()
+  const {theme, themed} = useAppTheme()
   const {width: screenWidth, height: screenHeight} = useWindowDimensions()
   const videoRef = useRef<ElementRef<typeof Video>>(null)
   const [isPlaying, setIsPlaying] = useState(false)
@@ -135,11 +135,12 @@ const VideoPlayerItem = memo(function VideoPlayerItem({
 
   return (
     <View
+      testID="video-player-container"
       style={{
         flex: 1,
         width: screenWidth,
         height: screenHeight,
-        backgroundColor: "black",
+        backgroundColor: theme.colors.background,
         justifyContent: "center",
         alignItems: "center",
         paddingTop: screenHeight * 0.05,
@@ -149,7 +150,7 @@ const VideoPlayerItem = memo(function VideoPlayerItem({
         source={{uri: videoUrl}}
         poster={posterUrl}
         posterResizeMode="contain"
-        style={{width: "100%", aspectRatio: videoAspectRatio}}
+        style={{width: "100%", aspectRatio: videoAspectRatio, backgroundColor: theme.colors.background}}
         resizeMode="contain"
         paused={!isPlaying}
         controls={false}
@@ -228,7 +229,7 @@ const VideoPlayerItem = memo(function VideoPlayerItem({
 
       {/* Thumbnail placeholder while video loads - instant display */}
       {showThumbnail && posterUrl && !hasError && (
-        <View style={themed($thumbnailOverlay)} pointerEvents="none">
+        <View testID="video-thumbnail-overlay" style={themed($thumbnailOverlay)} pointerEvents="none">
           <Image
             source={{uri: posterUrl}}
             style={{width: "100%", aspectRatio: videoAspectRatio}}
@@ -707,13 +708,13 @@ const $timeText: ThemedStyle<any> = () => ({
 
 // Image item styles (dynamic dimensions now inlined via useWindowDimensions)
 
-const $thumbnailOverlay: ThemedStyle<any> = () => ({
+const $thumbnailOverlay: ThemedStyle<any> = ({colors}) => ({
   position: "absolute",
   top: 0,
   left: 0,
   bottom: 0,
   right: 0,
-  backgroundColor: "black",
+  backgroundColor: colors.background,
   justifyContent: "center",
   alignItems: "center",
   zIndex: 5,


### PR DESCRIPTION
## Summary
- use the active Mentra App theme for gallery video backgrounds
- apply the same background to the native video surface and loading thumbnail overlay
- add a light-mode regression test

Fixes report `rep_01M12NS4MEF1Z5G4YT5RPM44NH`.

## Testing
- `bun run test -- --runInBand src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx`
- `bun run compile`
- `bunx eslint src/components/glasses/Gallery/AwesomeGalleryViewer.tsx src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx` (no errors; existing inline-style warnings only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gallery video previews now use the active Mentra App theme background instead of hardcoded black, so light-mode users no longer see an all-black player area. Applies the theme to the video surface, the loading thumbnail overlay, and the container, with a regression test covering light-mode.

<sup>Written for commit 4011fd82d567e7b520bee9b21cd623a443ec4df1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/theming-only change in the gallery viewer with unit test coverage; no auth, data, or playback logic changes.
> 
> **Overview**
> **Gallery video previews** no longer force a black backdrop in light mode. `VideoPlayerItem` now applies `theme.colors.background` to the player container, the native `Video` surface, and the loading thumbnail overlay (via `$thumbnailOverlay`), matching the rest of the media viewer.
> 
> Tests mock `ThemeContext` and `react-native-video`, and add a regression case that asserts those surfaces use the mocked light background (`#f7f7f7`). `testID`s on the container and thumbnail overlay support that assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4011fd82d567e7b520bee9b21cd623a443ec4df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->