### PR TITLE
Gate OTA updates on glasses battery

### DIFF
--- a/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
+++ b/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
@@ -21,6 +21,8 @@ function screenLabel(screen: MentraLiveOtaScreen): string {
       return "Finishing update"
     case "update_available":
       return "Update available"
+    case "battery_required":
+      return "Charge required"
     case "wifi_required":
       return "Wi-Fi required"
     case "up_to_date":
@@ -68,13 +70,7 @@ export function CustomOtaConsumer({onDone, onSetupWifi}: {onDone: () => void; on
   const transition = controller.state.releaseTransition
   const releaseLabel = transition ? `${transition.fromVersion ?? "Unknown"} → ${transition.toVersion}` : ""
   const completionLabel = controller.state.completedUpdate ? "Updated" : ""
-  return React.createElement(
-    React.Fragment,
-    null,
-    screenLabel(controller.state.screen),
-    releaseLabel,
-    completionLabel,
-  )
+  return React.createElement(React.Fragment, null, screenLabel(controller.state.screen), releaseLabel, completionLabel)
 }
 
 // Prove the curated low-level transport types resolve without a private import.

--- a/mobile/modules/engine/src/facades/ota.ts
+++ b/mobile/modules/engine/src/facades/ota.ts
@@ -36,6 +36,7 @@ function projectSnapshot() {
     appVersion: s.appVersion || null,
     mtkFirmwareVersion: s.mtkFirmwareVersion || null,
     besFirmwareVersion: s.besFirmwareVersion || null,
+    batteryLevel: s.batteryLevel >= 0 ? s.batteryLevel : null,
     hotspotOtaVersion: s.hotspotOtaVersion ?? 0,
     wifiConnected: s.wifi.state === "connected",
     wifiStatusKnown: s.wifiStatusKnown,

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -13,7 +13,12 @@ import {
 import {SafeAreaView} from "react-native-safe-area-context"
 import Svg, {Path, Rect} from "react-native-svg"
 
-import {useMentraLiveOta, type MentraLiveOtaController, type MentraLiveOtaFlowPage} from "./useMentraLiveOta"
+import {
+  MINIMUM_OTA_BATTERY_LEVEL,
+  useMentraLiveOta,
+  type MentraLiveOtaController,
+  type MentraLiveOtaFlowPage,
+} from "./useMentraLiveOta"
 
 export type {MentraLiveOtaFlowPage} from "./useMentraLiveOta"
 
@@ -72,6 +77,10 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:finishingUpdate": "Finishing your update",
   "ota:checkingAdditionalUpdates": "Checking whether your glasses need any additional updates.",
   "ota:updateAvailable": "{{deviceName}} Update Available",
+  "ota:batteryRequiredTitle": "Charge {{deviceName}} to Update",
+  "ota:batteryRequiredMessage":
+    "{{deviceName}} is currently at {{batteryLevel}}%. Charge it to at least {{minimumBatteryLevel}}% before updating.",
+  "ota:batteryRequiredLiveUpdate": "This screen will update automatically as the battery charges.",
   "ota:updateConnectWifi": "Connect your {{deviceName}} to WiFi to install the update.",
   "ota:wifiRequiredTitle": "WiFi Needed for Update",
   "ota:updateDescription":
@@ -188,6 +197,32 @@ function OtaFlowContent({
       <FlowPage colors={colors} icon="download" title={translate("ota:checkingForUpdates")}>
         <BodyText colors={colors}>{translate("ota:checkingForUpdatesMessage")}</BodyText>
         <ActivityIndicator size="large" color={colors.foreground} />
+      </FlowPage>
+    )
+  }
+
+  if (state.screen === "battery_required") {
+    return (
+      <FlowPage
+        actions={
+          <>
+            <FlowButton colors={colors} disabled label={translate("ota:updateNow")} onPress={controller.install} />
+            {state.canDismiss ? (
+              <FlowButton colors={colors} label={translate("ota:updateLater")} onPress={controller.finish} secondary />
+            ) : null}
+          </>
+        }
+        colors={colors}
+        icon="alert"
+        title={translate("ota:batteryRequiredTitle", {deviceName})}>
+        <BodyText colors={colors}>
+          {translate("ota:batteryRequiredMessage", {
+            batteryLevel: String(state.batteryLevel),
+            deviceName,
+            minimumBatteryLevel: String(MINIMUM_OTA_BATTERY_LEVEL),
+          })}
+        </BodyText>
+        <BodyText colors={colors}>{translate("ota:batteryRequiredLiveUpdate")}</BodyText>
       </FlowPage>
     )
   }

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -30,6 +30,7 @@ export type MentraLiveOtaScreen =
   | "checking"
   | "finishing"
   | "update_available"
+  | "battery_required"
   | "wifi_required"
   | "up_to_date"
   | "dev_build"
@@ -70,6 +71,7 @@ export type MentraLiveOtaReleaseTransition = {
 export type MentraLiveOtaState = {
   screen: MentraLiveOtaScreen
   connected: boolean
+  batteryLevel: number | null
   transport: MentraLiveOtaTransport | null
   updateRequired: boolean
   versionChange: boolean
@@ -131,6 +133,7 @@ type CheckState = "checking" | "update_available" | "no_update" | "dev_build" | 
 
 const AUTO_CHAIN_NETWORK_RETRY_DELAY_MS = 5000
 const AUTO_CHAIN_COMPLETE_DELAY_MS = 750
+export const MINIMUM_OTA_BATTERY_LEVEL = 25
 
 function releaseRangeTargetVersion(result: OtaCheckCurrentGlassesResult): string | null {
   return result.releaseVersion ?? result.updateInfo?.versionName ?? result.latestVersionInfo?.versionName ?? null
@@ -220,6 +223,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   )
   const [completedUpdate, setCompletedUpdate] = useState(false)
   const [completedChangelogs, setCompletedChangelogs] = useState<ReleaseChangelog[]>([])
+  const [batteryBlocked, setBatteryBlocked] = useState(false)
   const [checkGeneration, setCheckGeneration] = useState(0)
   const performCheckGenerationRef = useRef(0)
   const activeCheckKeyRef = useRef<string | null>(null)
@@ -498,6 +502,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
   }, [installSnapshot.connected, installSnapshot.displayState, page, returnToCheck])
 
   const check = useCallback(() => {
+    setBatteryBlocked(false)
     setOfferedReleaseTransition(null)
     setCompletedReleaseTransition(null)
     setCompletedUpdate(false)
@@ -516,6 +521,10 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return
     }
     const snapshot = ota.snapshot()
+    if (snapshot.batteryLevel !== null && snapshot.batteryLevel < MINIMUM_OTA_BATTERY_LEVEL) {
+      setBatteryBlocked(true)
+      return
+    }
     if (!snapshot.wifiStatusKnown) {
       check()
       return
@@ -525,6 +534,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return
     }
     ota.installSession.prepare(result)
+    setBatteryBlocked(false)
     setCompletedUpdate(false)
     setCompletedChangelogs([])
     if (updateFingerprint) {
@@ -539,6 +549,15 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     }
     navigateToProgress()
   }, [check, isVersionChange, navigateToProgress, offeredReleaseTransition, page, updateFingerprint])
+
+  useEffect(() => {
+    if (
+      batteryBlocked &&
+      (otaSnapshot.batteryLevel === null || otaSnapshot.batteryLevel >= MINIMUM_OTA_BATTERY_LEVEL)
+    ) {
+      setBatteryBlocked(false)
+    }
+  }, [batteryBlocked, otaSnapshot.batteryLevel])
 
   const retryInstall = useCallback(() => {
     if (page !== "progress") return
@@ -582,6 +601,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return {
         screen: "initializing",
         connected: otaSnapshot.connected,
+        batteryLevel: otaSnapshot.batteryLevel,
         transport: null,
         updateRequired: isUpdateRequired,
         versionChange: isVersionChange,
@@ -617,8 +637,9 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       const wifiRequired = otaSnapshot.wifiStatusKnown && !otaSnapshot.wifiConnected && !hotspotSupported
       let screen: MentraLiveOtaScreen
       if (checkState === "checking") screen = autoChainActive ? "finishing" : "checking"
-      else if (checkState === "update_available") screen = wifiRequired ? "wifi_required" : "update_available"
-      else if (checkState === "no_update") screen = "up_to_date"
+      else if (checkState === "update_available") {
+        screen = wifiRequired ? "wifi_required" : batteryBlocked ? "battery_required" : "update_available"
+      } else if (checkState === "no_update") screen = "up_to_date"
       else if (checkState === "dev_build") screen = "dev_build"
       else screen = errorKind === "pin_unavailable" ? "update_info_unavailable" : "check_failed"
 
@@ -634,6 +655,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       return {
         screen,
         connected: otaSnapshot.connected,
+        batteryLevel: otaSnapshot.batteryLevel,
         transport: otaSnapshot.wifiConnected ? "wifi" : hotspotSupported ? "hotspot" : null,
         updateRequired: isUpdateRequired,
         versionChange: isVersionChange,
@@ -656,7 +678,9 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         canRetry: screen === "check_failed",
         canFinish: screen === "up_to_date" || screen === "dev_build" || screen === "update_info_unavailable",
         canDismiss:
-          (screen === "update_available" || screen === "wifi_required") && !isUpdateRequired && !autoChainActive,
+          (screen === "update_available" || screen === "wifi_required" || screen === "battery_required") &&
+          !isUpdateRequired &&
+          !autoChainActive,
         canDiscard: false,
         canOpenWifiSetup: screen === "wifi_required",
         continueDisabled: false,
@@ -700,6 +724,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     return {
       screen,
       connected: installSnapshot.connected,
+      batteryLevel: otaSnapshot.batteryLevel,
       transport: installSnapshot.transport,
       updateRequired: isUpdateRequired,
       versionChange: installSnapshot.isVersionChange,
@@ -734,6 +759,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     }
   }, [
     checkState,
+    batteryBlocked,
     completedChangelogs,
     completedReleaseTransition,
     completedUpdate,

--- a/mobile/src/app/ota/__tests__/shared-flow.test.tsx
+++ b/mobile/src/app/ota/__tests__/shared-flow.test.tsx
@@ -1,11 +1,10 @@
-import React from "react"
 import {act, fireEvent, render, waitFor} from "@testing-library/react-native"
 
 import {MentraLiveOtaFlow} from "@mentra/engine/ota"
 
 import {stopOtaAutoChain} from "@/services/otaAutoChain"
-import {ota} from "../../../../modules/engine/src/facades/ota"
-import {useGlassesStore} from "../../../../modules/engine/src/stores/glasses"
+import {ota} from "@/../modules/engine/src/facades/ota"
+import {useGlassesStore} from "@/../modules/engine/src/stores/glasses"
 
 describe("MentraLiveOtaFlow", () => {
   beforeEach(() => {
@@ -77,6 +76,58 @@ describe("MentraLiveOtaFlow", () => {
 
     fireEvent.press(getByTestId("button-Update Now"))
 
+    expect(prepare).toHaveBeenCalledWith(result)
+    expect(getByText("Starting update...")).toBeDefined()
+  })
+
+  it("blocks an update below 25% and reacts to live battery changes", async () => {
+    jest.useFakeTimers()
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      buildNumber: "37",
+      hotspotOtaVersion: 1,
+      wifi: {state: "disconnected"},
+    })
+    useGlassesStore.getState().setBatteryInfo(12, false, -1, false)
+    const result = {
+      hasCheckCompleted: true,
+      updateAvailable: true,
+      latestVersionInfo: null,
+      updates: ["apk"],
+      mtkPatch: null,
+      besVersion: null,
+      isApkDowngrade: false,
+      manifestBody: "{}",
+      releaseVersion: "3.1.0-dev.8",
+      updateInfo: {isDowngrade: false, updates: [{type: "apk"}], versionName: "38"},
+      isRequired: true,
+      manifestUrl: "https://example.com/version.json",
+      buildNumber: "37",
+    }
+    jest.spyOn(ota, "checkForUpdates").mockResolvedValue(result as never)
+    const prepare = jest.spyOn(ota.installSession, "prepare").mockImplementation(() => "hotspot")
+    const {getByTestId, getByText, queryByText} = render(
+      <MentraLiveOtaFlow initializeRuntime={false} onFinished={jest.fn()} onOpenWifiSetup={jest.fn()} />,
+    )
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1_100)
+    })
+    fireEvent.press(getByTestId("button-Update Now"))
+
+    expect(prepare).not.toHaveBeenCalled()
+    expect(getByText("Charge Mentra Live to Update")).toBeDefined()
+    expect(getByText("Mentra Live is currently at 12%. Charge it to at least 25% before updating.")).toBeDefined()
+    expect(getByText("This screen will update automatically as the battery charges.")).toBeDefined()
+
+    act(() => useGlassesStore.getState().setBatteryInfo(24, true, -1, false))
+    expect(getByText("Mentra Live is currently at 24%. Charge it to at least 25% before updating.")).toBeDefined()
+
+    act(() => useGlassesStore.getState().setBatteryInfo(25, true, -1, false))
+    await waitFor(() => expect(getByText("Mentra Live Update Available")).toBeDefined())
+    expect(queryByText("Charge Mentra Live to Update")).toBeNull()
+
+    fireEvent.press(getByTestId("button-Update Now"))
     expect(prepare).toHaveBeenCalledWith(result)
     expect(getByText("Starting update...")).toBeDefined()
   })

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -410,6 +410,10 @@ const en = {
     finishingUpdate: "Finishing your update",
     checkingAdditionalUpdates: "Checking whether your glasses need any additional updates.",
     updateAvailable: "{{deviceName}} Update Available",
+    batteryRequiredTitle: "Charge {{deviceName}} to Update",
+    batteryRequiredMessage:
+      "{{deviceName}} is currently at {{batteryLevel}}%. Charge it to at least {{minimumBatteryLevel}}% before updating.",
+    batteryRequiredLiveUpdate: "This screen will update automatically as the battery charges.",
     updateReadyToInstall: "Version {{version}} for {{deviceName}} is ready to install.",
     updateConnectWifi: "Connect your {{deviceName}} to WiFi to install the update.",
     wifiRequiredTitle: "WiFi Needed for Update",


### PR DESCRIPTION
## Summary

- block Mentra Live OTA installation when the latest known glasses battery level is below 25%
- show the current battery percentage and charging guidance on a dedicated screen
- react to battery updates live and automatically return to the update offer at 25%
- preserve the native fail-open behavior for an unknown battery reading

## Test evidence

- `bun run test --runInBand src/app/ota/__tests__/shared-flow.test.tsx`
- `bun run test --runInBand modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx src/app/ota/__tests__` (76 tests)
- `bun run compile`
- `node --test modules/engine/scripts/public-ota-boundary.test.mjs`
- targeted ESLint on changed files (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks Mentra Live OTA installation when the latest known glasses battery level drops below 25%, replacing the update offer with a charge screen that shows the current percentage and live charging guidance. The flow returns to the update offer automatically once battery reaches 25%; an unknown battery reading still allows the update as before.

<sup>Written for commit bfba481411af2db42f38de22916ab1c997da919e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when firmware OTA may start, but the gate is a simple threshold with fail-open on unknown battery and is covered by flow tests.
> 
> **Overview**
> Mentra Live OTA now **blocks starting an install** when the projected glasses battery is below **25%**, instead of proceeding straight into Wi‑Fi/hotspot prep.
> 
> The flow adds a **`battery_required`** screen that shows current %, the minimum threshold, and charging guidance; **Update Now** stays disabled until the level is high enough. Battery is included on the OTA snapshot/facade and in hook state, and the UI **updates live** as the store reports new levels—at **25%+** it returns to the normal update offer without a manual retry. **Unknown battery** (`null`) still **does not block** install.
> 
> Copy is wired through engine defaults, app `en.ts`, and a shared-flow test covers block → charge → install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfba481411af2db42f38de22916ab1c997da919e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->