### PR TITLE
ci: parallelize coordinated consumer gates

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -91,7 +91,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   const docs = jobBlock(coordinator, "docs")
   const notify = jobBlock(coordinator, "notify-slack")
 
-  assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native, engine-consumer\]$/m)
+  assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native\]$/m)
   assert.match(starterKit, /coordinated-example-release\.yml/)
   assert.match(starterKit, /event_type: "coordinated_example_release"/)
   assert.match(starterKit, /--event repository_dispatch/)
@@ -108,6 +108,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(exampleTestflight, /reusable-coordinated-example-testflight\.yml/)
   assert.match(jobBlock(coordinator, "finalize"), /needs\.starter-kit\.result == 'success'/)
   assert.match(jobBlock(coordinator, "finalize"), /needs\.example-testflight\.result == 'success'/)
+  assert.match(jobBlock(coordinator, "finalize"), /needs\.engine-consumer\.result == 'success'/)
   assert.match(docs, /^    needs: \[plan, starter-kit, finalize\]$/m)
   assert.match(docs, /needs\.starter-kit\.result == 'success'/)
   assert.match(docs, /needs\.finalize\.result == 'success'/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -250,7 +250,7 @@ jobs:
 
   starter-kit:
     name: Build coordinated Starter Kit examples
-    needs: [plan, ota, npm, sdk-native, engine-consumer]
+    needs: [plan, ota, npm, sdk-native]
     runs-on: ubuntu-latest
     timeout-minutes: 150
     outputs:

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -127,8 +127,10 @@ without first building the example would instead create a not-found link.
 - exact dependency updates requested by the coordinator;
 - all example builds and build validation;
 - immutable Starter Kit tags, releases, and artifact checksums;
-- the machine-readable result returned to MentraOS; and
-- the future React Native iOS TestFlight archive and upload.
+- the machine-readable result returned to MentraOS.
+
+MentraOS owns the signed React Native iOS archive and TestFlight upload after
+accepting that exact Starter Kit result.
 
 This boundary avoids both a Git submodule and copied build logic. MentraOS
 consumes a validated result from the repository that owns the source.
@@ -348,18 +350,18 @@ The Starter Kit becomes a required consumer gate before finalization:
 ```text
 release plan and OTA selection
   -> coordinated package and mobile publication
-  -> external Engine consumer verification
-  -> Starter Kit dispatch, build, and immutable publication
+       |-> external Engine consumer verification ----\
+       \-> Starter Kit build and publication --------+-> both required
   -> finalized Mentra release manifest
   -> release-matched documentation
   -> channel Slack notification
 ```
 
-The Starter Kit gate runs after npm and SwiftPM exist. Native Android is built
-when Maven Central already exposes the exact SDK version; otherwise its APK is
-omitted from that release while the other examples remain required. The gate
-may run in parallel with unrelated late gates when dependencies permit, but
-finalization waits for its validated result.
+The Starter Kit gate runs after npm and SwiftPM exist, in parallel with the
+external Engine consumer gate. Native Android is built when Maven Central
+already exposes the exact SDK version; otherwise its APK is omitted from that
+release while the other examples remain required. Finalization waits for both
+independent gates and the example TestFlight publication.
 
 If the Starter Kit fails, already published package artifacts remain recoverable
 under the in-progress release. There is no completed release manifest, docs do


### PR DESCRIPTION
## Summary

- start the Starter Kit coordinated release as soon as its own OTA, npm, and native SDK prerequisites are complete
- keep the external Engine consumer and Starter Kit as independent required gates at finalization
- correct the design documentation to reflect MentraOS ownership of the signed React Native example TestFlight upload

## Why

The first full `3.1.0-dev.49` verification showed the clean Android Engine host spending more than 20 minutes compiling the SDK native stack while the Starter Kit dispatch remained unnecessarily idle. The Starter Kit does not consume the Engine consumer result. Serializing those gates delays example artifacts and TestFlight without adding validation.

This changes only the DAG edge: finalization still fails unless the Engine consumer, Starter Kit, and example TestFlight jobs all succeed.

## Validation

- `node --test .github/scripts/coordinated-workflow-contract.test.mjs`
- `actionlint -ignore "label .* is unknown" .github/workflows/coordinated-release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DAG-only change with unchanged finalization gates; contract tests lock the behavior. Slightly higher coordination risk if parallel jobs contend for shared resources, but validation requirements are unchanged.
> 
> **Overview**
> **Removes the DAG edge** that forced the Starter Kit job to wait on `engine-consumer`, so example builds can start as soon as OTA, npm, and native SDK publication finish—while the clean Engine host verification runs on its own timeline.
> 
> The **workflow contract test** is updated to expect `starter-kit` `needs: [plan, ota, npm, sdk-native]` and to assert **finalize** still requires `engine-consumer`, Starter Kit, and example TestFlight success. **Design notes** now describe Engine consumer and Starter Kit as **parallel** required gates and clarify that **MentraOS** (not the Starter Kit) owns the signed React Native TestFlight upload after accepting the Starter Kit result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84b1aff8b9ec78f07494c0541cb063043e252b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->