### PR TITLE
ci: use a GitHub App for Starter Kit coordination

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -104,6 +104,19 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /gh pr view "\$pull_request_url"[^]*--json url,state,headRefOid,baseRefName,mergeCommit/)
   assert.match(starterKit, /git\/ref\/tags\/sdk-\$identity/)
   assert.match(starterKit, /\.digest <<< "\$asset"/)
+  assert.match(starterKit, /actions\/create-github-app-token@v3/)
+  assert.match(starterKit, /app-id: \$\{\{ vars\.STARTER_KIT_COORDINATOR_APP_ID \}\}/)
+  assert.match(starterKit, /private-key: \$\{\{ secrets\.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY \}\}/)
+  assert.match(starterKit, /continue-on-error: true/)
+  assert.doesNotMatch(starterKit, /STARTER_KIT_APP_PRIVATE_KEY:/)
+  assert.match(starterKit, /permission-actions: read/)
+  assert.match(starterKit, /permission-checks: read/)
+  assert.match(starterKit, /permission-contents: write/)
+  assert.match(starterKit, /permission-pull-requests: write/)
+  assert.match(
+    starterKit,
+    /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-app-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,
+  )
   assert.match(exampleTestflight, /^    needs: \[plan, starter-kit\]$/m)
   assert.match(exampleTestflight, /reusable-coordinated-example-testflight\.yml/)
   assert.match(jobBlock(coordinator, "finalize"), /needs\.starter-kit\.result == 'success'/)
@@ -129,6 +142,16 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(notify, /EXAMPLE_TESTFLIGHT_RESULT: \$\{\{ needs\.example-testflight\.result \}\}/)
   assert.match(notify, /STARTER_KIT_RUN_URL: \$\{\{ needs\.starter-kit\.outputs\.run_url \}\}/)
   assert.match(notify, /DOCS_RESULT: \$\{\{ needs\.docs\.result \}\}/)
+  const example = workflow("reusable-coordinated-example-testflight.yml")
+  assert.match(example, /actions\/create-github-app-token@v3/)
+  assert.match(example, /private-key: \$\{\{ secrets\.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY \}\}/)
+  assert.match(example, /continue-on-error: true/)
+  assert.doesNotMatch(example, /STARTER_KIT_APP_PRIVATE_KEY:/)
+  assert.match(example, /permission-contents: read/)
+  assert.match(
+    example,
+    /token: \$\{\{ steps\.starter-kit-app-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,
+  )
 })
 
 test("mobile release selects an existing Doppler token for its backend", () => {

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -270,11 +270,28 @@ jobs:
           name: ${{ needs.plan.outputs.plan_artifact }}
           path: release-input/plan
 
+      - name: Create Starter Kit coordinator token
+        id: starter-kit-app-token
+        if: vars.STARTER_KIT_COORDINATOR_APP_ID != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: |
+            MentraOS
+            Mentra-Bluetooth-SDK-Starter-Kit
+          permission-actions: read
+          permission-checks: read
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Dispatch and wait for the exact Starter Kit release
         id: coordinates
         if: needs.plan.outputs.dry_run != 'true'
         env:
-          STARTER_KIT_TOKEN: ${{ secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          STARTER_KIT_TOKEN: ${{ steps.starter-kit-app-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
           STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
           OTA_MANIFEST_URL: ${{ needs.ota.outputs.manifest_url }}
           OTA_MANIFEST_SHA256: ${{ needs.ota.outputs.manifest_sha256 }}

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -121,13 +121,27 @@ jobs:
           set -euo pipefail
           [[ "${{ steps.app-store.outputs.app_id }}" == "$EXAMPLE_APP_ID" ]]
 
+      - name: Create Starter Kit checkout token
+        id: starter-kit-app-token
+        if: steps.app-store.outputs.exists != 'true' && vars.STARTER_KIT_COORDINATOR_APP_ID != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: |
+            MentraOS
+            Mentra-Bluetooth-SDK-Starter-Kit
+          permission-contents: read
+
       - name: Checkout the exact validated Starter Kit source
         if: steps.app-store.outputs.exists != 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ env.STARTER_KIT_REPOSITORY }}
           ref: ${{ steps.coordinates.outputs.starter_release_commit }}
-          token: ${{ secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          token: ${{ steps.starter-kit-app-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
           path: starter-kit
 
       - name: Add runner-managed tools to PATH

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -262,6 +262,15 @@ organization does not permit a repository `GITHUB_TOKEN` to create or approve
 pull requests. The Starter Kit's own `GITHUB_TOKEN` creates the candidate
 commit and publishes its tag, release, and assets after MentraOS merges the PR.
 
+MentraOS stores the numeric App ID in the
+`STARTER_KIT_COORDINATOR_APP_ID` repository variable and its private key
+in the `STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY` repository secret. Release
+jobs mint short-lived installation tokens with
+`actions/create-github-app-token`; no generated token is persisted. The App is
+installed only on `MentraOS` and `Mentra-Bluetooth-SDK-Starter-Kit` with
+Actions read, Checks read, Contents read/write, and Pull requests read/write
+permissions. Each job requests only the subset it uses when minting its token.
+
 During bootstrap, the implementation may fall back to the existing scoped SDK
 push credential while `STARTER_KIT_COORDINATOR_TOKEN` is being provisioned. The
 fallback is explicit migration debt: it is not copied into another secret, and


### PR DESCRIPTION
## Why

The coordinated release can dispatch the Starter Kit workflow with the legacy SDK push token, but that token cannot create the required dependency synchronization pull request. The release therefore stops after the Starter Kit candidate branch is created.

## Changes

- Mint a short-lived GitHub App installation token in the Starter Kit coordinator job.
- Use the same App installation for the exact-source checkout used by the React Native example TestFlight job.
- Request only the per-job permissions each token uses.
- Prefer the App token while retaining the existing bootstrap fallback until dev and beta have both been proven.
- Document the App ID variable, private-key secret, repository scope, and required permissions.
- Extend the workflow contract test to prevent either cross-repository path from drifting back to the legacy token alone.

## Required repository configuration

- Variable: `STARTER_KIT_COORDINATOR_APP_ID`
- Secret: `STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY`
- Installed repositories: `MentraOS`, `Mentra-Bluetooth-SDK-Starter-Kit`
- App permissions: Actions read, Checks read, Contents read/write, Pull requests read/write

## Verification

- `actionlint .github/workflows/coordinated-release.yml .github/workflows/reusable-coordinated-example-testflight.yml`
- `node --test .github/scripts/coordinated-workflow-contract.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated-release authentication for cross-repo PR merge and private Starter Kit checkout; misconfigured App permissions or failed token mint could block releases until fallbacks work.
> 
> **Overview**
> Coordinated release can unblock Starter Kit dependency-sync PRs by authenticating cross-repo work with a **short-lived GitHub App installation token** instead of relying on the legacy SDK push credential alone.
> 
> The **starter-kit** job in `coordinated-release.yml` mints a token via `actions/create-github-app-token@v3` when `STARTER_KIT_COORDINATOR_APP_ID` is set (Actions/Checks read, Contents and PRs write), then uses it for dispatch, polling, PR creation, and merge. The **example TestFlight** reusable workflow gets a separate mint step with **Contents read** only for checking out the validated Starter Kit commit. Both paths prefer the App token and keep **`STARTER_KIT_COORDINATOR_TOKEN`** and **`MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN`** as explicit bootstrap fallbacks; App token steps use **`continue-on-error: true`** so migration does not hard-fail if the App is not configured yet.
> 
> Contract tests lock in the App wiring and token precedence, and the coordinated-release design note documents the **`STARTER_KIT_COORDINATOR_APP_ID`** variable, **`STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY`** secret, install scope, and per-job permission subset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67eae97c50f0299c276a3aae22625dc061a4f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->