### PR TITLE
ci: create coordinated Starter Kit PRs through REST

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -99,6 +99,8 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /starter-kit-release-\$identity\.json/)
   assert.match(starterKit, /select\(\.displayTitle == [^\n]+ and \.status != \\"completed\\"\)/)
   assert.match(starterKit, /encoded_candidate_branch=\$\(jq -rn[^\n]+'\$value \| @uri'\)/)
+  assert.match(starterKit, /gh api --method POST "repos\/\$STARTER_KIT_REPOSITORY\/pulls"/)
+  assert.doesNotMatch(starterKit, /gh pr create/)
   assert.match(starterKit, /gh pr checks "\$pr_url"[^]*--required --json name,bucket/)
   assert.match(starterKit, /gh pr merge "\$pr_url"[^]*--match-head-commit "\$candidate_sha"/)
   assert.match(starterKit, /gh pr view "\$pull_request_url"[^]*--json url,state,headRefOid,baseRefName,mergeCommit/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -418,11 +418,12 @@ jobs:
                 "Automated dependency synchronization for coordinated release \`$identity\`." \
                 "Coordinator: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
                 "Starter Kit workflow: $run_url")
-              pr_url=$(gh pr create --repo "$STARTER_KIT_REPOSITORY" \
-                --base "$target_branch" \
-                --head "$candidate_branch" \
-                --title "chore(release): synchronize examples to $identity" \
-                --body "$pr_body")
+              pr_url=$(gh api --method POST "repos/$STARTER_KIT_REPOSITORY/pulls" \
+                -f base="$target_branch" \
+                -f head="$candidate_branch" \
+                -f title="chore(release): synchronize examples to $identity" \
+                -f body="$pr_body" \
+                --jq .html_url)
             else
               pr_url=$(jq -r '.[0].url' <<< "$pr_json")
               merged_at=$(jq -r '.[0].mergedAt // empty' <<< "$pr_json")


### PR DESCRIPTION
## Problem

The first coordinated release using the new GitHub App token successfully dispatched the Starter Kit workflow and observed its exact candidate branch, but `gh pr create` failed under App authentication with GraphQL ref-resolution errors even though REST reported the candidate exactly one commit ahead of `dev`.

Observed in coordinated release `3.1.0-dev.52`:

- App installation token creation succeeded.
- Starter Kit dispatch run `33133772143` succeeded through candidate creation.
- Candidate `coordinated/3.1.0-dev.52` points to `741cf031cf1052606f09bc9c69bbcced2c81e7cc`.
- REST compare reports the candidate one commit ahead of Starter Kit `dev`.
- `gh pr create` failed with `Head sha can't be blank`, `Base sha can't be blank`, and `No commits between dev and coordinated/3.1.0-dev.52`.

## Change

Create the synchronization PR with `POST /repos/{owner}/{repo}/pulls`, passing the already validated `head` and `base` refs explicitly. All existing candidate polling, exact-head checks, required-check waiting, merge, and published-result verification remain unchanged.

The workflow contract now requires the REST endpoint and rejects reintroduction of `gh pr create` in this job.

## Validation

- `actionlint .github/workflows/coordinated-release.yml`
- `bun test coordinated-workflow-contract.test.mjs` from `.github/scripts`: 8 passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI change to PR creation only in the coordinated release workflow; downstream merge and verification behavior is unchanged.
> 
> **Overview**
> Fixes Starter Kit sync PR creation when the coordinator uses a **GitHub App installation token**: `gh pr create` is replaced with **`POST /repos/{owner}/{repo}/pulls`** via `gh api`, passing `base`, `head`, title, and body and reading `.html_url` for the PR link.
> 
> **Candidate polling, head SHA checks, required checks, merge with `--match-head-commit`, and result verification are unchanged.** The workflow contract test now **requires** the REST call and **forbids** `gh pr create` in the `starter-kit` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee503a868651386dc4d4d32e9bc06b35729da9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->