### PR TITLE
ci: tolerate transient Starter Kit poll failures

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -99,6 +99,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /starter-kit-release-\$identity\.json/)
   assert.match(starterKit, /select\(\.displayTitle == [^\n]+ and \.status != \\"completed\\"\)/)
   assert.match(starterKit, /encoded_candidate_branch=\$\(jq -rn[^\n]+'\$value \| @uri'\)/)
+  assert.match(starterKit, /--json status,conclusion 2>\/dev\/null \|\| true/)
   assert.match(starterKit, /gh api --method POST "repos\/\$STARTER_KIT_REPOSITORY\/pulls"/)
   assert.doesNotMatch(starterKit, /gh pr create/)
   assert.match(starterKit, /gh pr checks "\$pr_url"[^]*--required --json name,bucket/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -385,7 +385,7 @@ jobs:
                   --workflow coordinated-example-release.yml --event repository_dispatch --limit 30 \
                   --json databaseId,displayTitle,createdAt,url \
                   --jq ".[] | select(.displayTitle == \"$run_title\" and .createdAt >= \"$dispatched_at\")" \
-                  | head -1)
+                  2>/dev/null | head -1 || true)
                 if [[ -n "$run_json" ]]; then
                   run_id=$(jq -r .databaseId <<< "$run_json")
                   run_url=$(jq -r .url <<< "$run_json")
@@ -396,9 +396,11 @@ jobs:
                 --jq .commit.sha 2>/dev/null || true)
               [[ -n "$run_id" && -n "$candidate_sha" ]] && break
               if [[ -n "$run_id" ]]; then
-                status=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status --jq .status)
+                run_state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" \
+                  --json status,conclusion 2>/dev/null || true)
+                status=$(jq -r '.status // empty' <<< "${run_state:-{}}")
                 if [[ "$status" == "completed" ]]; then
-                  conclusion=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json conclusion --jq .conclusion)
+                  conclusion=$(jq -r '.conclusion // "unknown"' <<< "$run_state")
                   echo "Starter Kit run concluded $conclusion before creating $candidate_branch: $run_url" >&2
                   exit 1
                 fi
@@ -467,9 +469,11 @@ jobs:
                 --output "starter-kit-result/$result_name" 2>/dev/null; then
                 break
               fi
-              status=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status --jq .status)
+              run_state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" \
+                --json status,conclusion 2>/dev/null || true)
+              status=$(jq -r '.status // empty' <<< "${run_state:-{}}")
               if [[ "$status" == "completed" ]]; then
-                conclusion=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json conclusion --jq .conclusion)
+                conclusion=$(jq -r '.conclusion // "unknown"' <<< "$run_state")
                 echo "Starter Kit run concluded $conclusion before publishing $result_name: $run_url" >&2
                 exit 1
               fi


### PR DESCRIPTION
## Problem

The `3.1.0-dev.53` coordinated run successfully minted its GitHub App token and dispatched the exact Starter Kit workflow, but a transient `HTTP 422` from a read-only `gh run` polling command escaped the existing bounded loop. Because the shell uses `set -e`, one failed status probe terminated the coordinator instead of allowing the next poll to reconcile the pending run.

## Change

Treat only the read-only run-discovery and run-status probes inside the existing bounded polling loops as retryable:

- a failed post-dispatch discovery probe produces no result for that iteration;
- status and conclusion are fetched together;
- an unavailable status is retried by the existing loop;
- a confirmed completed run still fails immediately when no candidate/result was published;
- dispatch, PR creation, validation, publication verification, and overall timeout failures remain terminal.

No new retry abstraction or additional coordinator layer is introduced.

## Validation

- `actionlint .github/workflows/coordinated-release.yml`
- `.github/scripts`: `bun test coordinated-workflow-contract.test.mjs` (8 passed)
- shell fallback check with unset poll response
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only resilience in Starter Kit polling; terminal failure semantics for completed runs without artifacts are preserved.
> 
> **Overview**
> Fixes coordinated release aborts when read-only **Starter Kit** polling hits transient GitHub API errors (e.g. HTTP 422) under `set -e`.
> 
> In `coordinated-release.yml`, post-dispatch **run discovery** (`gh run list`) and both **status waits** (candidate branch and result artifact) now swallow probe failures (`2>/dev/null || true`) so the existing bounded loops retry instead of exiting. **Status and conclusion** come from a single `gh run view --json status,conclusion`, with empty responses treated as “still pending” rather than fatal.
> 
> The workflow contract test asserts the combined status/conclusion probe pattern. Dispatch, PR merge, validation failures, and overall timeouts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045a6fe076ffd530ac054631cb81a157e4d02e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->