### PR TITLE
ci: validate the created Starter PR response

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -101,6 +101,8 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /encoded_candidate_branch=\$\(jq -rn[^\n]+'\$value \| @uri'\)/)
   assert.match(starterKit, /--json status,conclusion 2>\/dev\/null \|\| true/)
   assert.match(starterKit, /gh api --method POST "repos\/\$STARTER_KIT_REPOSITORY\/pulls"/)
+  assert.match(starterKit, /pr_head=\$\(jq -r \.head\.sha <<< "\$pr_response"\)/)
+  assert.match(starterKit, /\[\[ "\$pr_head" == "\$candidate_sha" \]\]/)
   assert.doesNotMatch(starterKit, /gh pr create/)
   assert.match(starterKit, /gh pr checks "\$pr_url"[^]*--required --json name,bucket/)
   assert.match(starterKit, /gh pr merge "\$pr_url"[^]*--match-head-commit "\$candidate_sha"/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -420,14 +420,16 @@ jobs:
                 "Automated dependency synchronization for coordinated release \`$identity\`." \
                 "Coordinator: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
                 "Starter Kit workflow: $run_url")
-              pr_url=$(gh api --method POST "repos/$STARTER_KIT_REPOSITORY/pulls" \
+              pr_response=$(gh api --method POST "repos/$STARTER_KIT_REPOSITORY/pulls" \
                 -f base="$target_branch" \
                 -f head="$candidate_branch" \
                 -f title="chore(release): synchronize examples to $identity" \
-                -f body="$pr_body" \
-                --jq .html_url)
+                -f body="$pr_body")
+              pr_url=$(jq -r .html_url <<< "$pr_response")
+              pr_head=$(jq -r .head.sha <<< "$pr_response")
             else
               pr_url=$(jq -r '.[0].url' <<< "$pr_json")
+              pr_head=$(jq -r '.[0].headRefOid' <<< "$pr_json")
               merged_at=$(jq -r '.[0].mergedAt // empty' <<< "$pr_json")
               state=$(jq -r '.[0].state' <<< "$pr_json")
               if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
@@ -435,7 +437,7 @@ jobs:
                 exit 1
               fi
             fi
-            [[ "$(gh pr view "$pr_url" --repo "$STARTER_KIT_REPOSITORY" --json headRefOid --jq .headRefOid)" == "$candidate_sha" ]]
+            [[ "$pr_head" == "$candidate_sha" ]]
 
             if [[ -z "${merged_at:-}" ]]; then
               checks_ready=false


### PR DESCRIPTION
## Problem

The `3.1.0-dev.54` coordinator successfully created Starter Kit PR #62 through REST, then exited before entering required-check polling. The only command at that boundary was an immediate `gh pr view` exact-head reread. The PR and candidate are correct, and the REST creation response already contains the authoritative head SHA.

## Change

Validate exact-head provenance directly from the operation that established the PR:

- new PR: read `.html_url` and `.head.sha` from the REST creation response;
- existing PR: use the already-requested `headRefOid`;
- retain the strict equality check against the observed candidate SHA.

This removes a redundant eventually-consistent reread without weakening provenance.

## Validation

- `actionlint .github/workflows/coordinated-release.yml`
- `.github/scripts`: `bun test coordinated-workflow-contract.test.mjs` (8 passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Starter Kit PR head validation; provenance rules stay the same with one fewer GitHub API call at a flaky boundary.
> 
> **Overview**
> Fixes coordinated release **starter-kit** jobs that could die right after REST PR creation, before required-check polling, when an immediate `gh pr view` head reread failed.
> 
> **PR provenance** now comes from data already returned by the PR operation: for new PRs, `html_url` and `head.sha` are parsed from the full `gh api` POST response; for an existing PR, `headRefOid` from the prior `gh pr list` JSON. The same strict `pr_head == candidate_sha` gate remains, without a redundant view call at that step.
> 
> Contract tests in `coordinated-workflow-contract.test.mjs` assert the new `pr_response` / `pr_head` parsing and equality check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4fbc1c034278ff779f7c2bfd87ea23ca5e85c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->