### PR TITLE
ci: bound Starter Kit coordinator token lifetimes

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -104,8 +104,11 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /pr_head=\$\(jq -r \.head\.sha <<< "\$pr_response"\)/)
   assert.match(starterKit, /\[\[ "\$pr_head" == "\$candidate_sha" \]\]/)
   assert.doesNotMatch(starterKit, /gh pr create/)
-  assert.match(starterKit, /gh pr checks "\$pr_url"[^]*--required --json name,bucket/)
-  assert.match(starterKit, /gh pr merge "\$pr_url"[^]*--match-head-commit "\$candidate_sha"/)
+  assert.doesNotMatch(starterKit, /gh pr checks/)
+  assert.doesNotMatch(starterKit, /gh pr merge/)
+  assert.match(starterKit, /Create Starter Kit request token/)
+  assert.match(starterKit, /Wait for the immutable Starter Kit result/)
+  assert.match(starterKit, /Create Starter Kit verification token/)
   assert.match(starterKit, /gh pr view "\$pull_request_url"[^]*--json url,state,headRefOid,baseRefName,mergeCommit/)
   assert.match(starterKit, /git\/ref\/tags\/sdk-\$identity/)
   assert.match(starterKit, /\.digest <<< "\$asset"/)
@@ -115,12 +118,17 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /continue-on-error: true/)
   assert.doesNotMatch(starterKit, /STARTER_KIT_APP_PRIVATE_KEY:/)
   assert.match(starterKit, /permission-actions: read/)
-  assert.match(starterKit, /permission-checks: read/)
   assert.match(starterKit, /permission-contents: write/)
   assert.match(starterKit, /permission-pull-requests: write/)
+  assert.match(starterKit, /permission-contents: read/)
+  assert.match(starterKit, /permission-pull-requests: read/)
   assert.match(
     starterKit,
-    /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-app-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,
+    /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-request-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,
+  )
+  assert.match(
+    starterKit,
+    /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-verification-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,
   )
   assert.match(exampleTestflight, /^    needs: \[plan, starter-kit\]$/m)
   assert.match(exampleTestflight, /reusable-coordinated-example-testflight\.yml/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -270,8 +270,8 @@ jobs:
           name: ${{ needs.plan.outputs.plan_artifact }}
           path: release-input/plan
 
-      - name: Create Starter Kit coordinator token
-        id: starter-kit-app-token
+      - name: Create Starter Kit request token
+        id: starter-kit-request-token
         if: vars.STARTER_KIT_COORDINATOR_APP_ID != ''
         continue-on-error: true
         uses: actions/create-github-app-token@v3
@@ -283,15 +283,14 @@ jobs:
             MentraOS
             Mentra-Bluetooth-SDK-Starter-Kit
           permission-actions: read
-          permission-checks: read
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Dispatch and wait for the exact Starter Kit release
-        id: coordinates
+      - name: Request the exact Starter Kit release
+        id: request
         if: needs.plan.outputs.dry_run != 'true'
         env:
-          STARTER_KIT_TOKEN: ${{ steps.starter-kit-app-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          STARTER_KIT_TOKEN: ${{ steps.starter-kit-request-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
           STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
           OTA_MANIFEST_URL: ${{ needs.ota.outputs.manifest_url }}
           OTA_MANIFEST_SHA256: ${{ needs.ota.outputs.manifest_sha256 }}
@@ -349,11 +348,8 @@ jobs:
           result_name="starter-kit-release-$identity.json"
           container_tag="sdk-builds-v$family_base"
           result_url="https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$container_tag/$result_name"
-          mkdir -p starter-kit-result
 
-          if ! curl --fail --silent --show-error --location "$result_url" \
-            --output "starter-kit-result/$result_name" 2>/dev/null; then
-            rm -f "starter-kit-result/$result_name"
+          if ! curl --fail --silent --show-error --location --head "$result_url" >/dev/null 2>&1; then
             run_json=$(gh run list --repo "$STARTER_KIT_REPOSITORY" \
               --workflow coordinated-example-release.yml --event repository_dispatch --limit 100 \
               --json databaseId,displayTitle,status,url \
@@ -420,11 +416,21 @@ jobs:
                 "Automated dependency synchronization for coordinated release \`$identity\`." \
                 "Coordinator: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
                 "Starter Kit workflow: $run_url")
-              pr_response=$(gh api --method POST "repos/$STARTER_KIT_REPOSITORY/pulls" \
-                -f base="$target_branch" \
-                -f head="$candidate_branch" \
-                -f title="chore(release): synchronize examples to $identity" \
-                -f body="$pr_body")
+              pr_response=""
+              for attempt in {1..6}; do
+                if pr_response=$(gh api --method POST "repos/$STARTER_KIT_REPOSITORY/pulls" \
+                  -f base="$target_branch" \
+                  -f head="$candidate_branch" \
+                  -f title="chore(release): synchronize examples to $identity" \
+                  -f body="$pr_body" 2>pr-create-error.log); then
+                  break
+                fi
+                if (( attempt == 6 )); then
+                  cat pr-create-error.log >&2
+                  exit 1
+                fi
+                sleep 5
+              done
               pr_url=$(jq -r .html_url <<< "$pr_response")
               pr_head=$(jq -r .head.sha <<< "$pr_response")
             else
@@ -438,50 +444,82 @@ jobs:
               fi
             fi
             [[ "$pr_head" == "$candidate_sha" ]]
-
-            if [[ -z "${merged_at:-}" ]]; then
-              checks_ready=false
-              for _ in {1..540}; do
-                checks=$(gh pr checks "$pr_url" --repo "$STARTER_KIT_REPOSITORY" \
-                  --required --json name,bucket 2>/dev/null || true)
-                if [[ -n "$checks" && "$(jq 'length' <<< "$checks")" != "0" ]]; then
-                  if jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<< "$checks" >/dev/null; then
-                    jq -r '.[] | "\(.bucket)\t\(.name)"' <<< "$checks" >&2
-                    echo "Required Starter Kit validation failed for $pr_url." >&2
-                    exit 1
-                  fi
-                  if jq -e 'all(.[]; .bucket == "pass" or .bucket == "skipping")' <<< "$checks" >/dev/null; then
-                    checks_ready=true
-                    break
-                  fi
-                fi
-                sleep 10
-              done
-              if [[ "$checks_ready" != "true" ]]; then
-                echo "Required Starter Kit validation did not finish within 90 minutes: $pr_url" >&2
-                exit 1
-              fi
-
-              gh pr merge "$pr_url" --repo "$STARTER_KIT_REPOSITORY" \
-                --merge --match-head-commit "$candidate_sha"
-            fi
-
-            for _ in {1..90}; do
-              if curl --fail --silent --show-error --location "$result_url" \
-                --output "starter-kit-result/$result_name" 2>/dev/null; then
-                break
-              fi
-              run_state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" \
-                --json status,conclusion 2>/dev/null || true)
-              status=$(jq -r '.status // empty' <<< "${run_state:-{}}")
-              if [[ "$status" == "completed" ]]; then
-                conclusion=$(jq -r '.conclusion // "unknown"' <<< "$run_state")
-                echo "Starter Kit run concluded $conclusion before publishing $result_name: $run_url" >&2
-                exit 1
-              fi
-              sleep 10
-            done
           fi
+
+          {
+            echo "identity=$identity"
+            echo "release_set_id=$release_set_id"
+            echo "source_commit=$source_commit"
+            echo "target_branch=$target_branch"
+            echo "result_name=$result_name"
+            echo "container_tag=$container_tag"
+            echo "result_url=$result_url"
+            echo "run_url=$run_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the immutable Starter Kit result
+        if: needs.plan.outputs.dry_run != 'true'
+        env:
+          RESULT_NAME: ${{ steps.request.outputs.result_name }}
+          RESULT_URL: ${{ steps.request.outputs.result_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p starter-kit-result
+          for _ in {1..540}; do
+            if curl --fail --silent --show-error --location "$RESULT_URL" \
+              --output "starter-kit-result/$RESULT_NAME" 2>/dev/null; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Starter Kit did not publish $RESULT_NAME within 90 minutes." >&2
+          exit 1
+
+      - name: Create Starter Kit verification token
+        id: starter-kit-verification-token
+        if: needs.plan.outputs.dry_run != 'true' && vars.STARTER_KIT_COORDINATOR_APP_ID != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: |
+            MentraOS
+            Mentra-Bluetooth-SDK-Starter-Kit
+          permission-contents: read
+          permission-pull-requests: read
+
+      - name: Verify the exact Starter Kit release
+        id: coordinates
+        if: needs.plan.outputs.dry_run != 'true'
+        env:
+          STARTER_KIT_TOKEN: ${{ steps.starter-kit-verification-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
+          IDENTITY: ${{ steps.request.outputs.identity }}
+          RELEASE_SET_ID: ${{ steps.request.outputs.release_set_id }}
+          SOURCE_COMMIT: ${{ steps.request.outputs.source_commit }}
+          TARGET_BRANCH: ${{ steps.request.outputs.target_branch }}
+          RESULT_NAME: ${{ steps.request.outputs.result_name }}
+          CONTAINER_TAG: ${{ steps.request.outputs.container_tag }}
+          RESULT_URL: ${{ steps.request.outputs.result_url }}
+          RUN_URL: ${{ steps.request.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$STARTER_KIT_TOKEN" ]]; then
+            echo "A Starter Kit GitHub App token is required in STARTER_KIT_COORDINATOR_TOKEN." >&2
+            exit 1
+          fi
+          export GH_TOKEN="$STARTER_KIT_TOKEN"
+
+          identity="$IDENTITY"
+          release_set_id="$RELEASE_SET_ID"
+          source_commit="$SOURCE_COMMIT"
+          target_branch="$TARGET_BRANCH"
+          result_name="$RESULT_NAME"
+          container_tag="$CONTAINER_TAG"
+          result_url="$RESULT_URL"
+          run_url="$RUN_URL"
           result="starter-kit-result/$result_name"
           test -s "$result"
           [[ "$(jq -er .releaseSetId "$result")" == "$release_set_id" ]]

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -126,6 +126,7 @@ without first building the example would instead create a not-found link.
 - synchronized `dev`, `staging`, and `main` branches;
 - exact dependency updates requested by the coordinator;
 - all example builds and build validation;
+- merging the exact validated synchronization pull request;
 - immutable Starter Kit tags, releases, and artifact checksums;
 - the machine-readable result returned to MentraOS.
 
@@ -206,8 +207,8 @@ The workflow:
    channel branch;
 7. lets the repository's normal pull-request workflow validate the exact
    candidate SHA;
-8. waits for MentraOS to merge the pull request only after the protected
-   required checks for that same head SHA pass;
+8. merges the pull request itself only after the protected required checks for
+   that same head SHA pass;
 9. computes the filename, size, media type, and SHA-256 of every artifact;
 10. publishes an immutable Starter Kit source tag and uploads the artifacts to
     the base version's release container;
@@ -256,17 +257,19 @@ releases.
 MentraOS dispatches with a GitHub App installation token scoped to the two
 repositories. A personal access token is not part of the final release
 architecture. The App receives only the permissions needed to dispatch
-workflows, read run state, create the synchronization pull request, and merge
-the exact validated head in the Starter Kit. This split is required because the
-organization does not permit a repository `GITHUB_TOKEN` to create or approve
-pull requests. The Starter Kit's own `GITHUB_TOKEN` creates the candidate
-commit and publishes its tag, release, and assets after MentraOS merges the PR.
+workflows, read run state, and create the synchronization pull request. The
+Starter Kit's own `GITHUB_TOKEN` creates the candidate commit, observes its
+normal pull-request validation, merges the exact validated head, and publishes
+the tag, release, and assets.
 
 MentraOS stores the numeric App ID in the
 `STARTER_KIT_COORDINATOR_APP_ID` repository variable and its private key
 in the `STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY` repository secret. Release
 jobs mint short-lived installation tokens with
-`actions/create-github-app-token`; no generated token is persisted. The App is
+`actions/create-github-app-token`; no generated token is persisted. MentraOS
+uses one token for the bounded request phase, waits for the immutable public
+result without credentials, and mints a fresh read-only token for final
+provenance verification. The App is
 installed only on `MentraOS` and `Mentra-Bluetooth-SDK-Starter-Kit` with
 Actions read, Checks read, Contents read/write, and Pull requests read/write
 permissions. Each job requests only the subset it uses when minting its token.


### PR DESCRIPTION
## Why

The Starter Kit coordination job allowed one GitHub App installation token to span a 30-minute candidate wait, a 90-minute validation wait, merge, and final provenance checks. Installation tokens expire after one hour, so a healthy but queued build could lose authentication before merge or verification. This addresses the unresolved high-severity review on #3830.

The dev.55 run also observed a transient HTTP 422 while creating a valid one-commit-ahead Starter Kit PR. Creating the same PR seconds later succeeded.

## Change

- use the App token only for the bounded dispatch/candidate/PR-request phase;
- retry REST PR creation briefly to tolerate GitHub branch/compare propagation;
- remove duplicate cross-repository check polling and merge ownership;
- wait for the immutable Starter Kit result through its public URL without credentials;
- mint a fresh, read-only App token for final PR/tag/release provenance;
- update the contract test and coordinated release design document.

This pairs with Starter Kit #64, where the repository merges its own exact validated synchronization PR before publishing the result.

## Verification

- actionlint .github/workflows/coordinated-release.yml
- bun test .github/scripts/coordinated-workflow-contract.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-repo release orchestration and token scoping; mis-timed waits or permission gaps could block coordinated dev/staging releases without affecting production app runtime.
> 
> **Overview**
> Splits the coordinated **starter-kit** job so GitHub App installation tokens no longer span long waits that can exceed the one-hour token lifetime.
> 
> **Request phase** uses a write-scoped **request token** only for dispatch, candidate polling, and opening the sync PR (with up to six retries on REST PR creation for transient 422s). MentraOS **stops** polling required checks and **merging** the Starter Kit PR; that ownership moves to the Starter Kit repo (paired change).
> 
> **Wait phase** polls the public `starter-kit-release-<identity>.json` URL with **no credentials** until the artifact appears (up to ~90 minutes).
> 
> **Verification phase** mints a separate **read-only** App token to validate the downloaded result JSON, merged PR provenance, tags, and release asset digests.
> 
> Contract tests and the coordinated-release design doc are updated to match the new token steps, permissions, and responsibility split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 583103c6149f12eb1c2807db55fd491d42be9677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->