### PR TITLE
ci: retry Sonatype receipt persistence

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -41,7 +41,8 @@ test("release finalization reads the preserved OTA artifact layout", () => {
 
 test("production validates before approval and proves packages before mobile promotion", () => {
   const production = workflow("coordinated-production-promotion.yml")
-  const sdkNative = jobBlock(workflow("reusable-coordinated-sdk-native.yml"), "prepare")
+  const sdkNativeWorkflow = workflow("reusable-coordinated-sdk-native.yml")
+  const sdkNative = jobBlock(sdkNativeWorkflow, "prepare")
 
   assert.doesNotMatch(jobBlock(production, "plan"), /^    needs:/m)
   assert.match(jobBlock(production, "approve"), /^    needs: plan$/m)
@@ -63,6 +64,8 @@ test("production validates before approval and proves packages before mobile pro
     sdkNative,
     /else\s+\[\[ "\$\(jq -r \.draft <<< "\$release"\)" == "false" \]\]\s+\[\[ "\$\(jq -r \.prerelease <<< "\$release"\)" == "true" \]\]/,
   )
+  assert.match(sdkNativeWorkflow, /for attempt in \{1\.\.6\}/)
+  assert.match(sdkNativeWorkflow, /cmp --silent native-result\/maven\/sonatype-deployment\.json persisted-deployment\.json/)
 })
 
 test("mobile destinations use real TestFlight groups without changing the release channel", () => {

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -323,11 +323,30 @@ jobs:
             --expected-purls "${{ steps.release.outputs.sdk_purl }},${{ steps.release.outputs.lc3_purl }}" \
             --output native-result/maven/sonatype-deployment.json
           encoded_name=$(jq -rn --arg value "$ASSET_NAME" '$value | @uri')
-          gh api \
-            --method POST \
-            -H "Content-Type: application/octet-stream" \
-            --input native-result/maven/sonatype-deployment.json \
-            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?name=$encoded_name" >/dev/null
+          persisted=false
+          for attempt in {1..6}; do
+            if gh api \
+              --method POST \
+              -H "Content-Type: application/octet-stream" \
+              --input native-result/maven/sonatype-deployment.json \
+              "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?name=$encoded_name" \
+              >/dev/null 2>deployment-upload-error.log; then
+              persisted=true
+              break
+            fi
+            (( attempt < 6 )) && sleep 5
+          done
+          if [[ "$persisted" != "true" ]]; then
+            asset_id=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?per_page=100" \
+              --jq ".[] | select(.name == \"$ASSET_NAME\") | .id" 2>/dev/null | head -1 || true)
+            if [[ -z "$asset_id" ]]; then
+              cat deployment-upload-error.log >&2
+              exit 1
+            fi
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > persisted-deployment.json
+            cmp --silent native-result/maven/sonatype-deployment.json persisted-deployment.json
+          fi
 
       - name: Stage locally verified Maven artifacts
         run: |


### PR DESCRIPTION
dev.56 successfully built and submitted its Maven Central bundle, then GitHub's release-asset upload returned HTTP 502 while persisting the Sonatype deployment receipt.

This change:
- retries only the GitHub receipt upload, not the Sonatype deployment;
- after exhausted retries, accepts an already-created asset only when its bytes exactly match the local receipt;
- preserves the existing asynchronous Maven publication contract.

Verification:
- actionlint .github/workflows/reusable-coordinated-sdk-native.yml
- bun test .github/scripts/coordinated-workflow-contract.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only resilience around GitHub asset upload; Sonatype deploy is untouched and recovery requires an exact receipt match.
> 
> **Overview**
> Hardens the coordinated SDK native workflow when **GitHub’s release-asset API flakes** (e.g. HTTP 502) after Sonatype Central has already accepted the Maven bundle.
> 
> The **Submit and persist** step still uploads `sonatype-deployment.json` via `gh api`, but now **retries up to six times** with a five-second pause, logging failures to `deployment-upload-error.log`. If uploads keep failing, it **looks for an existing asset** with the expected name; missing assets still fail with the logged error, while an existing asset is **downloaded and byte-compared** (`cmp`) to the local receipt so a partial or wrong upload cannot pass.
> 
> Contract tests in `coordinated-workflow-contract.test.mjs` assert the full `reusable-coordinated-sdk-native.yml` contains the retry loop and comparison—**Sonatype submission and the earlier “recover persisted deployment” path are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a9137ff9d6845226c1790ed2fad44b53f9ca5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->