### PR TITLE
ci: reconcile ambiguous Starter PR creation

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -105,6 +105,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /--json status,conclusion 2>\/dev\/null \|\| true/)
   assert.match(starterKit, /gh api --method POST "repos\/\$STARTER_KIT_REPOSITORY\/pulls"/)
   assert.match(starterKit, /pr_head=\$\(jq -r \.head\.sha <<< "\$pr_response"\)/)
+  assert.match(starterKit, /reconciled_pr=\$\(gh pr list[^]*--json url,state,mergedAt,headRefOid/)
   assert.match(starterKit, /\[\[ "\$pr_head" == "\$candidate_sha" \]\]/)
   assert.doesNotMatch(starterKit, /gh pr create/)
   assert.doesNotMatch(starterKit, /gh pr checks/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -425,14 +425,30 @@ jobs:
                   -f body="$pr_body" 2>pr-create-error.log); then
                   break
                 fi
+                reconciled_pr=$(gh pr list --repo "$STARTER_KIT_REPOSITORY" --state all \
+                  --base "$target_branch" --head "$candidate_branch" --limit 1 \
+                  --json url,state,mergedAt,headRefOid 2>/dev/null || true)
+                if [[ "$(jq 'length' <<< "${reconciled_pr:-[]}")" != "0" ]]; then
+                  pr_url=$(jq -r '.[0].url' <<< "$reconciled_pr")
+                  pr_head=$(jq -r '.[0].headRefOid' <<< "$reconciled_pr")
+                  state=$(jq -r '.[0].state' <<< "$reconciled_pr")
+                  merged_at=$(jq -r '.[0].mergedAt // empty' <<< "$reconciled_pr")
+                  if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
+                    echo "Reconciled coordinator PR $pr_url was closed without merging." >&2
+                    exit 1
+                  fi
+                  break
+                fi
                 if (( attempt == 6 )); then
                   cat pr-create-error.log >&2
                   exit 1
                 fi
                 sleep 5
               done
-              pr_url=$(jq -r .html_url <<< "$pr_response")
-              pr_head=$(jq -r .head.sha <<< "$pr_response")
+              if [[ -n "$pr_response" ]]; then
+                pr_url=$(jq -r .html_url <<< "$pr_response")
+                pr_head=$(jq -r .head.sha <<< "$pr_response")
+              fi
             else
               pr_url=$(jq -r '.[0].url' <<< "$pr_json")
               pr_head=$(jq -r '.[0].headRefOid' <<< "$pr_json")


### PR DESCRIPTION
dev.58 created Starter Kit PR #66 at the exact candidate SHA, but the create request returned nonzero and the coordinator failed after retrying.

This change makes PR creation idempotent:
- after a failed POST, query the exact base/head PR;
- accept it only through the existing exact candidate-SHA assertion;
- reject a reconciled PR closed without merge;
- retain bounded retries when neither a successful response nor a matching PR is visible.

Verification:
- actionlint .github/workflows/coordinated-release.yml
- bun test .github/scripts/coordinated-workflow-contract.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated release automation for Starter Kit PR creation; mistakes could block releases or accept the wrong PR, though candidate-SHA verification and closed-without-merge checks limit exposure.
> 
> **Overview**
> Makes Starter Kit coordinator PR creation **idempotent** when `gh api` POST to open a PR fails but GitHub already created the pull request.
> 
> In **`coordinated-release.yml`**, each failed create attempt now **lists** an existing PR for the same `base`/`head`, adopts its URL and `headRefOid`, and **fails** if that PR was closed without merge. **`pr_url` / `pr_head` from the POST response** are only applied when the create call succeeded; otherwise reconciliation supplies them. The existing **`pr_head == candidate_sha`** check still gates acceptance.
> 
> The **workflow contract test** asserts the starter-kit job embeds this `reconciled_pr` / `gh pr list` path so the behavior stays pinned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47265d874e0b98e78feea832fb47a1c3db9061bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->