### PR TITLE
ci: preserve reconciled Starter PR state

### DIFF
--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -423,6 +423,8 @@ jobs:
                   -f head="$candidate_branch" \
                   -f title="chore(release): synchronize examples to $identity" \
                   -f body="$pr_body" 2>pr-create-error.log); then
+                  pr_url=$(jq -r .html_url <<< "$pr_response")
+                  pr_head=$(jq -r .head.sha <<< "$pr_response")
                   break
                 fi
                 reconciled_pr=$(gh pr list --repo "$STARTER_KIT_REPOSITORY" --state all \
@@ -445,10 +447,6 @@ jobs:
                 fi
                 sleep 5
               done
-              if [[ -n "$pr_response" ]]; then
-                pr_url=$(jq -r .html_url <<< "$pr_response")
-                pr_head=$(jq -r .head.sha <<< "$pr_response")
-              fi
             else
               pr_url=$(jq -r '.[0].url' <<< "$pr_json")
               pr_head=$(jq -r '.[0].headRefOid' <<< "$pr_json")


### PR DESCRIPTION
A failed GitHub PR-create call can emit a JSON error body on stdout. The coordinator correctly reconciled the exact newly-created PR, then treated that nonempty error JSON as a successful create response and overwrote the reconciled head with null.

Parse successful create responses inside the success branch only. Failed responses now flow exclusively through the exact base/head PR reconciliation path.

Verification:
- actionlint .github/workflows/coordinated-release.yml
- bun test .github/scripts/coordinated-workflow-contract.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI shell fix in coordinated-release PR creation; reduces false failures without changing release artifacts or auth.
> 
> **Overview**
> Fixes a bug in the **Starter Kit** coordinator step where a failed `gh api` PR create could still leave a non-empty `pr_response` (error JSON on stdout). The workflow would then parse that body as a successful create and **overwrite** `pr_url` / `pr_head` that had already been set by the base/head **reconciliation** path—often with nulls and breaking the later `pr_head == candidate_sha` check.
> 
> **`pr_url` and `pr_head` are now set only inside the successful POST branch**; failed attempts rely solely on listing the existing PR by `base`/`head`. The post-loop block that parsed any nonempty `pr_response` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff58b2d50c0f64995f0f70265d73ba23c8534f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->