### PR TITLE
ci: reject invalid Starter branch responses

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -130,6 +130,8 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /permission-pull-requests: write/)
   assert.match(starterKit, /permission-contents: read/)
   assert.match(starterKit, /permission-pull-requests: read/)
+  assert.match(starterKit, /\[\[ "\$branch_sha" =~ \^\[0-9a-f\]\{40\}\$ \]\]/)
+  assert.doesNotMatch(starterKit, /candidate_sha=\$\([^\n]+\n\s+--jq \.commit\.sha 2>\/dev\/null \|\| true\)/)
   assert.match(
     starterKit,
     /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-request-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -388,8 +388,11 @@ jobs:
                   echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
                 fi
               fi
-              candidate_sha=$(gh api "repos/$STARTER_KIT_REPOSITORY/branches/$encoded_candidate_branch" \
-                --jq .commit.sha 2>/dev/null || true)
+              candidate_sha=""
+              if branch_sha=$(gh api "repos/$STARTER_KIT_REPOSITORY/branches/$encoded_candidate_branch" \
+                --jq .commit.sha 2>/dev/null) && [[ "$branch_sha" =~ ^[0-9a-f]{40}$ ]]; then
+                candidate_sha="$branch_sha"
+              fi
               [[ -n "$run_id" && -n "$candidate_sha" ]] && break
               if [[ -n "$run_id" ]]; then
                 run_state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" \


### PR DESCRIPTION
## What changed

- keep the coordinated Starter candidate SHA empty when GitHub still returns `404 Branch not found`
- accept only a real 40-character commit SHA before creating or validating the exact Starter Kit PR
- add a workflow contract assertion for the boundary

## Why

The `3.1.0-dev.61` coordinator run queried the new Starter branch before GitHub's branch endpoint had converged. `gh api` wrote the 404 JSON body to stdout before returning failure; command substitution followed by `|| true` preserved that body, so the workflow compared the PR head against an error object and failed. The polling loop should keep waiting in that state.

## Validation

- `actionlint .github/workflows/coordinated-release.yml`
- `bun test --cwd .github/scripts coordinated-workflow-contract.test.mjs` (8 pass)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI shell change in Starter Kit polling with contract tests; no runtime app or auth paths touched.
> 
> **Overview**
> Fixes a race in the **starter-kit** polling loop where a premature GitHub branch lookup could treat a **404 JSON body** as `candidate_sha` and fail PR head validation instead of waiting.
> 
> The workflow now clears `candidate_sha` each iteration and only accepts a **40-character hex** commit SHA from the branch API before creating or checking the Starter Kit PR. Contract tests lock in the SHA guard and forbid the old `gh api … || true` substitution pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc035393954a77ed12d396aabef4be79437bbe32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->