### PR TITLE
ci: retry Starter PR reads

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -133,6 +133,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /permission-pull-requests: read/)
   assert.match(starterKit, /\[\[ "\$branch_sha" =~ \^\[0-9a-f\]\{40\}\$ \]\]/)
   assert.doesNotMatch(starterKit, /candidate_sha=\$\([^\n]+\n\s+--jq \.commit\.sha 2>\/dev\/null \|\| true\)/)
+  assert.match(starterKit, /lookup_starter_pr\(\)[^]*for attempt in \{1\.\.6\}[^]*jq -e 'type == "array"'/)
   assert.match(
     starterKit,
     /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-request-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -412,17 +412,29 @@ jobs:
             fi
 
             lookup_starter_pr() {
-              gh api --method GET "repos/$STARTER_KIT_REPOSITORY/pulls" \
-                -f state=all \
-                -f base="$target_branch" \
-                -f head="Mentra-Community:$candidate_branch" \
-                -f per_page=1 \
-                --jq '[.[] | {
-                  url: .html_url,
-                  state: (.state | ascii_upcase),
-                  mergedAt: .merged_at,
-                  headRefOid: .head.sha
-                }]'
+              local response
+              for attempt in {1..6}; do
+                if response=$(gh api --method GET "repos/$STARTER_KIT_REPOSITORY/pulls" \
+                  -f state=all \
+                  -f base="$target_branch" \
+                  -f head="Mentra-Community:$candidate_branch" \
+                  -f per_page=1 2>pr-lookup-error.log) && \
+                  jq -e 'type == "array"' <<< "$response" >/dev/null 2>&1; then
+                  jq '[.[] | {
+                    url: .html_url,
+                    state: (.state | ascii_upcase),
+                    mergedAt: .merged_at,
+                    headRefOid: .head.sha
+                  }]' <<< "$response"
+                  return 0
+                fi
+                if (( attempt == 6 )); then
+                  echo "Could not read a valid Starter Kit PR list after $attempt attempts." >&2
+                  cat pr-lookup-error.log >&2
+                  return 1
+                fi
+                sleep 2
+              done
             }
             pr_json=$(lookup_starter_pr)
             if [[ "$(jq 'length' <<< "$pr_json")" == "0" ]]; then


### PR DESCRIPTION
## What changed

- read the Starter PR list as raw API JSON
- require the expected array shape before transforming it into coordinator state
- retry transient or malformed responses six times with a short bounded delay

## Why

The `3.1.0-dev.63` proof run reached the newly created Starter candidate branch, then GitHub returned malformed JSON during the first PR-list read. The unguarded `gh api --jq` output reached a later `jq` call and terminated the request step. External response bytes now remain outside coordinator state until they parse and match the expected shape.

Failed proof run: https://github.com/Mentra-Community/MentraOS/actions/runs/33144891336/job/98765508841

## Validation

- `actionlint .github/workflows/coordinated-release.yml`
- `bun test --cwd .github/scripts coordinated-workflow-contract.test.mjs` (8 pass)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Starter Kit PR lookup resilience; no runtime product or auth paths affected.
> 
> **Overview**
> Hardens **Starter Kit PR discovery** in the coordinated release `starter-kit` job so transient or malformed GitHub API responses no longer abort the step.
> 
> `lookup_starter_pr()` now fetches the pulls list as **raw JSON** (no `gh api --jq`), validates that the body is an **array** before mapping it to coordinator fields, and **retries up to six times** with a short delay. Failures log `pr-lookup-error.log` and exit with a clear error instead of passing bad bytes into later `jq` calls.
> 
> A **workflow contract test** asserts the starter-kit job keeps this retry loop and array-shape check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807185ddb9ce6d69f5e1535ddb3b6b084139ab87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->