### PR TITLE
ci: localize Starter PR ownership

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -104,11 +104,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(starterKit, /select\(\.displayTitle == [^\n]+ and \.status != \\"completed\\"\)/)
   assert.match(starterKit, /encoded_candidate_branch=\$\(jq -rn[^\n]+'\$value \| @uri'\)/)
   assert.match(starterKit, /--json status,conclusion 2>\/dev\/null \|\| true/)
-  assert.match(starterKit, /gh api --method POST "repos\/\$STARTER_KIT_REPOSITORY\/pulls"/)
-  assert.match(starterKit, /pr_head=\$\(jq -r \.head\.sha <<< "\$pr_response"\)/)
-  assert.match(starterKit, /lookup_starter_pr\(\)[^]*repos\/\$STARTER_KIT_REPOSITORY\/pulls/)
-  assert.match(starterKit, /reconciled_pr=\$\(lookup_starter_pr/)
-  assert.match(starterKit, /Starter Kit PR head \$pr_head does not match candidate \$candidate_sha/)
+  assert.doesNotMatch(starterKit, /repos\/\$STARTER_KIT_REPOSITORY\/pulls/)
   assert.doesNotMatch(starterKit, /gh pr create/)
   assert.doesNotMatch(starterKit, /gh pr checks/)
   assert.doesNotMatch(starterKit, /gh pr merge/)
@@ -128,12 +124,12 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.doesNotMatch(starterKit, /STARTER_KIT_APP_PRIVATE_KEY:/)
   assert.match(starterKit, /permission-actions: read/)
   assert.match(starterKit, /permission-contents: write/)
-  assert.match(starterKit, /permission-pull-requests: write/)
+  assert.doesNotMatch(starterKit, /permission-pull-requests: write/)
   assert.match(starterKit, /permission-contents: read/)
   assert.match(starterKit, /permission-pull-requests: read/)
   assert.match(starterKit, /\[\[ "\$branch_sha" =~ \^\[0-9a-f\]\{40\}\$ \]\]/)
   assert.doesNotMatch(starterKit, /candidate_sha=\$\([^\n]+\n\s+--jq \.commit\.sha 2>\/dev\/null \|\| true\)/)
-  assert.match(starterKit, /lookup_starter_pr\(\)[^]*for attempt in \{1\.\.6\}[^]*jq -e 'type == "array"'/)
+  assert.doesNotMatch(starterKit, /lookup_starter_pr|repos\/\$STARTER_KIT_REPOSITORY\/pulls/)
   assert.match(
     starterKit,
     /STARTER_KIT_TOKEN: \$\{\{ steps\.starter-kit-request-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -284,7 +284,6 @@ jobs:
             Mentra-Bluetooth-SDK-Starter-Kit
           permission-actions: read
           permission-contents: write
-          permission-pull-requests: write
 
       - name: Request the exact Starter Kit release
         id: request
@@ -408,82 +407,6 @@ jobs:
             done
             if [[ -z "$run_id" || -z "$candidate_sha" ]]; then
               echo "Starter Kit did not create $candidate_branch for $identity within 30 minutes." >&2
-              exit 1
-            fi
-
-            lookup_starter_pr() {
-              local response
-              for attempt in {1..6}; do
-                if response=$(gh api --method GET "repos/$STARTER_KIT_REPOSITORY/pulls" \
-                  -f state=all \
-                  -f base="$target_branch" \
-                  -f head="Mentra-Community:$candidate_branch" \
-                  -f per_page=1 2>pr-lookup-error.log) && \
-                  jq -e 'type == "array"' <<< "$response" >/dev/null 2>&1; then
-                  jq '[.[] | {
-                    url: .html_url,
-                    state: (.state | ascii_upcase),
-                    mergedAt: .merged_at,
-                    headRefOid: .head.sha
-                  }]' <<< "$response"
-                  return 0
-                fi
-                if (( attempt == 6 )); then
-                  echo "Could not read a valid Starter Kit PR list after $attempt attempts." >&2
-                  cat pr-lookup-error.log >&2
-                  return 1
-                fi
-                sleep 2
-              done
-            }
-            pr_json=$(lookup_starter_pr)
-            if [[ "$(jq 'length' <<< "$pr_json")" == "0" ]]; then
-              pr_body=$(printf '%s\n\n%s\n%s\n' \
-                "Automated dependency synchronization for coordinated release \`$identity\`." \
-                "Coordinator: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-                "Starter Kit workflow: $run_url")
-              pr_response=""
-              for attempt in {1..6}; do
-                if pr_response=$(gh api --method POST "repos/$STARTER_KIT_REPOSITORY/pulls" \
-                  -f base="$target_branch" \
-                  -f head="$candidate_branch" \
-                  -f title="chore(release): synchronize examples to $identity" \
-                  -f body="$pr_body" 2>pr-create-error.log); then
-                  pr_url=$(jq -r .html_url <<< "$pr_response")
-                  pr_head=$(jq -r .head.sha <<< "$pr_response")
-                  break
-                fi
-                reconciled_pr=$(lookup_starter_pr 2>/dev/null || true)
-                if [[ "$(jq 'length' <<< "${reconciled_pr:-[]}")" != "0" ]]; then
-                  pr_url=$(jq -r '.[0].url' <<< "$reconciled_pr")
-                  pr_head=$(jq -r '.[0].headRefOid' <<< "$reconciled_pr")
-                  state=$(jq -r '.[0].state' <<< "$reconciled_pr")
-                  merged_at=$(jq -r '.[0].mergedAt // empty' <<< "$reconciled_pr")
-                  if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
-                    echo "Reconciled coordinator PR $pr_url was closed without merging." >&2
-                    exit 1
-                  fi
-                  break
-                fi
-                if (( attempt == 6 )); then
-                  cat pr-create-error.log >&2
-                  [[ -n "$pr_response" ]] && printf '%s\n' "$pr_response" >&2
-                  exit 1
-                fi
-                sleep 5
-              done
-            else
-              pr_url=$(jq -r '.[0].url' <<< "$pr_json")
-              pr_head=$(jq -r '.[0].headRefOid' <<< "$pr_json")
-              merged_at=$(jq -r '.[0].mergedAt // empty' <<< "$pr_json")
-              state=$(jq -r '.[0].state' <<< "$pr_json")
-              if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
-                echo "Existing coordinator PR $pr_url was closed without merging." >&2
-                exit 1
-              fi
-            fi
-            if [[ "$pr_head" != "$candidate_sha" ]]; then
-              echo "Starter Kit PR head $pr_head does not match candidate $candidate_sha." >&2
               exit 1
             fi
           fi

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -203,8 +203,8 @@ The workflow:
 4. updates every example and lockfile to the exact coordinated versions;
 5. embeds the exact release identity and OTA pin where the example runtime
    needs observable release metadata;
-6. waits for MentraOS to open a version-synchronization pull request against the
-   channel branch;
+6. opens or reuses a version-synchronization pull request against the channel
+   branch with the repository-local workflow token;
 7. lets the repository's normal pull-request workflow validate the exact
    candidate SHA;
 8. merges the pull request itself only after the protected required checks for
@@ -256,11 +256,11 @@ releases.
 
 MentraOS dispatches with a GitHub App installation token scoped to the two
 repositories. A personal access token is not part of the final release
-architecture. The App receives only the permissions needed to dispatch
-workflows, read run state, and create the synchronization pull request. The
-Starter Kit's own `GITHUB_TOKEN` creates the candidate commit, observes its
-normal pull-request validation, merges the exact validated head, and publishes
-the tag, release, and assets.
+architecture. The App receives only the permissions needed to dispatch the
+workflow and read run state. The Starter Kit's own `GITHUB_TOKEN` creates the
+candidate commit and synchronization pull request, observes its normal
+pull-request validation, merges the exact validated head, and publishes the
+tag, release, and assets.
 
 MentraOS stores the numeric App ID in the
 `STARTER_KIT_COORDINATOR_APP_ID` repository variable and its private key


### PR DESCRIPTION
## What changed

- remove cross-repository Starter PR creation and all of its reconciliation logic from MentraOS
- stop requesting GitHub App pull-request write permission during dispatch
- end the bounded request phase once the exact Starter run and candidate SHA are visible
- document that the Starter repository owns its complete PR lifecycle

Paired Starter Kit changes:
- main controller: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/72
- dev channel source: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/73

## Why

The Starter Kit already owns candidate creation, normal PR checks, exact-head merge, tagging, and artifact publication. Cross-repository PR creation inserted one foreign write in the middle and produced repeated API response/reconciliation failures in dev.63 and dev.64. With this change, MentraOS dispatches and verifies the immutable result; Starter owns everything between those boundaries.

This is a net simplification: 77 workflow lines are removed from MentraOS and pull-request write permission is no longer minted there.

## Validation

- `actionlint .github/workflows/coordinated-release.yml`
- `bun test --cwd .github/scripts coordinated-workflow-contract.test.mjs` (8 pass)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the cross-repository coordinated release boundary; a mismatch with paired Starter Kit workflow changes could block dev/staging releases until both sides align.
> 
> **Overview**
> **MentraOS no longer creates or reconciles version-sync pull requests in the Starter Kit repo.** The coordinated `starter-kit` job drops cross-repo `gh api` calls to `repos/.../pulls`, `lookup_starter_pr`, PR head vs candidate SHA checks, and related retry logic (~77 lines). The bounded request phase now stops once the Starter Kit workflow run and `coordinated/<identity>` candidate branch SHA are visible, then continues polling the immutable `starter-kit-release-<identity>.json` result and read-only provenance checks (`gh pr view` on URLs from that result).
> 
> The GitHub App token for the **request** phase no longer requests **`permission-pull-requests: write`** (verification still uses read-only PR access where needed). Contract tests in `coordinated-workflow-contract.test.mjs` were flipped to **forbid** pulls API usage and PR-write permission in MentraOS while keeping dispatch, polling, and verification expectations.
> 
> Design notes in `coordinated-release-docs-and-example-apps-design.md` now state that the **Starter Kit** opens/reuses the sync PR with its own `GITHUB_TOKEN`, and that the coordinator App only needs dispatch and run-state read—not cross-repo PR creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d7037e9e93bbc8c556028c92340716c3699c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->