### PR TITLE
ci: handle missing Starter Kit run state

### DIFF
--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -396,7 +396,7 @@ jobs:
               if [[ -n "$run_id" ]]; then
                 run_state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" \
                   --json status,conclusion 2>/dev/null || true)
-                status=$(jq -r '.status // empty' <<< "${run_state:-{}}")
+                status=$(jq -r '.status // empty' <<< "${run_state:-null}")
                 if [[ "$status" == "completed" ]]; then
                   conclusion=$(jq -r '.conclusion // "unknown"' <<< "$run_state")
                   echo "Starter Kit run concluded $conclusion before creating $candidate_branch: $run_url" >&2


### PR DESCRIPTION
Keep the Starter Kit request waiter parsing valid JSON when a transient `gh run view` returns no state. This lets the coordinator report the downstream workflow failure instead of exiting early on a malformed jq fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI shell/jq fallback change in the Starter Kit waiter with no runtime or security impact.
> 
> **Overview**
> Fixes the coordinated release **Starter Kit** wait loop so a failed or empty `gh run view` does not break `jq` parsing.
> 
> When polling for the downstream run, the fallback input for `status` changes from `${run_state:-{}}` to **`null`**, so `jq` always sees valid JSON and the coordinator can keep waiting or surface the intended “run concluded before branch” error instead of dying on a parse failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1bd3b60fff0420d1877e0a7aadec0cb4fa4b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->