### PR TITLE
ci: fail fast when example iOS prebuild is incomplete

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -80,6 +80,7 @@ test("mobile destinations use real TestFlight groups without changing the releas
   assert.match(example, /EXAMPLE_APP_ID: "6792839366"/)
   assert.match(example, /EXAMPLE_BUNDLE_ID: com\.mentra\.bluetoothsdkexample/)
   assert.match(example, /config\.expo\.ios\.bundleIdentifier = process\.env\.EXAMPLE_BUNDLE_ID/)
+  assert.match(example, /find ios -maxdepth 1 -name '\*\.xcworkspace'/)
   assert.equal([...example.matchAll(/--app-id "\$EXAMPLE_APP_ID"/g)].length, 3)
   assert.match(example, /starterKit\.releaseCommit/)
   assert.match(example, /runs-on: \[self-hosted, macOS, ARM64\]/)

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -188,6 +188,7 @@ jobs:
           writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`)
           NODE
           bunx expo prebuild --platform ios --clean
+          test -n "$(find ios -maxdepth 1 -name '*.xcworkspace' -print -quit)"
 
       - name: Install the shared Apple distribution identity
         if: steps.app-store.outputs.exists != 'true'


### PR DESCRIPTION
Expo prebuild can report a CocoaPods failure without a nonzero process exit. Require the generated xcworkspace immediately after prebuild so coordinated example TestFlight runs stop before certificate setup and report the failure at its source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guardrail in the example TestFlight workflow and its contract test; no runtime or production behavior changes.
> 
> **Overview**
> Coordinated example TestFlight builds now **fail immediately after Expo iOS prebuild** if no `*.xcworkspace` exists under `ios/`, instead of continuing into Match signing and Xcode archive.
> 
> This guards against cases where CocoaPods can fail while `expo prebuild` still exits successfully. A workflow contract test asserts the reusable example TestFlight workflow keeps that `find ios … xcworkspace` check in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a83ce59bd23821cec84a99336446635aec7904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->