### PR TITLE
ci: archive the React Native example app scheme

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -81,6 +81,7 @@ test("mobile destinations use real TestFlight groups without changing the releas
   assert.match(example, /EXAMPLE_BUNDLE_ID: com\.mentra\.bluetoothsdkexample/)
   assert.match(example, /config\.expo\.ios\.bundleIdentifier = process\.env\.EXAMPLE_BUNDLE_ID/)
   assert.match(example, /find ios -maxdepth 1 -name '\*\.xcworkspace'/)
+  assert.match(example, /select\(\. == "MentraSDKRN"\)/)
   assert.equal([...example.matchAll(/--app-id "\$EXAMPLE_APP_ID"/g)].length, 3)
   assert.match(example, /starterKit\.releaseCommit/)
   assert.match(example, /runs-on: \[self-hosted, macOS, ARM64\]/)

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -251,7 +251,8 @@ jobs:
           security unlock-keychain -p "$MENTRA_CI_KEYCHAIN_PASSWORD" "$MENTRA_CI_KEYCHAIN"
           workspace=$(find ios -maxdepth 1 -name '*.xcworkspace' -print -quit)
           test -n "$workspace"
-          scheme=$(xcodebuild -workspace "$workspace" -list -json | jq -er '.workspace.schemes[0]')
+          scheme=$(xcodebuild -workspace "$workspace" -list -json \
+            | jq -er '.workspace.schemes[] | select(. == "MentraSDKRN")')
           archive="$RUNNER_TEMP/mentra-example-react-native.xcarchive"
           output="$RUNNER_TEMP/mentra-example-react-native-export"
           rm -rf "$archive" "$output"


### PR DESCRIPTION
Select the generated `MentraSDKRN` application scheme explicitly for the coordinated example TestFlight archive. Workspace scheme index zero is a dependency scheme (`BitByteData`) and produces a non-distributable pod archive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Xcode scheme selection for the example TestFlight archive; no runtime app or auth logic changes.
> 
> **Overview**
> The coordinated React Native example TestFlight workflow no longer uses the **first** Xcode workspace scheme when archiving. It now **pins** the archive/export step to the **`MentraSDKRN`** app scheme via `jq`, so CI does not accidentally build **`BitByteData`** (a CocoaPods dependency scheme) and produce a non-distributable pod archive.
> 
> A workflow contract test was updated to assert the workflow contains this explicit scheme selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e235e2cc4d21447b8feb8585ab31d7617337a3b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->