### PR TITLE
Allow App Store processing latency

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -93,6 +93,7 @@ test("mobile destinations use real TestFlight groups without changing the releas
   assert.match(example, /PROVISIONING_PROFILE_SPECIFIER="\$MENTRA_CI_PROVISIONING_PROFILE_NAME"/)
   assert.match(example, /OTHER_CODE_SIGN_FLAGS="--keychain \$MENTRA_CI_KEYCHAIN"/)
   assert.match(example, /provisioningProfiles: \{\(\$bundle_id\): \$profile\}/)
+  assert.match(example, /PlistBuddy -c 'Print :com\.apple\.developer\.networking\.HotspotConfiguration'/)
   assert.equal([...example.matchAll(/--app-id "\$EXAMPLE_APP_ID"/g)].length, 3)
   assert.match(example, /starterKit\.releaseCommit/)
   assert.match(example, /runs-on: \[self-hosted, macOS, ARM64\]/)

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -361,7 +361,7 @@ jobs:
           [[ "$(plutil -extract CFBundleShortVersionString raw "$app/Info.plist")" == "$EXPECTED_VERSION" ]]
           [[ "$(plutil -extract CFBundleVersion raw "$app/Info.plist")" == "$EXPECTED_BUILD" ]]
           codesign -d --entitlements :- "$app" > "$RUNNER_TEMP/mentra-example-entitlements.plist"
-          [[ "$(plutil -extract com.apple.developer.networking.HotspotConfiguration raw "$RUNNER_TEMP/mentra-example-entitlements.plist")" == "true" ]]
+          [[ "$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.networking.HotspotConfiguration' "$RUNNER_TEMP/mentra-example-entitlements.plist")" == "true" ]]
           application_identifier=$(plutil -extract application-identifier raw "$RUNNER_TEMP/mentra-example-entitlements.plist")
           [[ "$application_identifier" == "$APPLE_TEAM_ID.$EXAMPLE_BUNDLE_ID" ]]
 

--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -110,7 +110,7 @@ export async function findProcessedBuild(client, {appId, buildNumber, marketingV
 
 export async function waitForProcessedBuild(
   client,
-  {appId, buildNumber, marketingVersion, attempts = 120, delay = 10_000},
+  {appId, buildNumber, marketingVersion, attempts = 360, delay = 10_000},
 ) {
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const build = await findProcessedBuild(client, {appId, buildNumber, marketingVersion})


### PR DESCRIPTION
## Summary
- allow App Store Connect up to 60 minutes to finish processing an accepted upload
- verify the literal Hotspot Configuration entitlement with PlistBuddy instead of treating its dots as a nested `plutil` key path

The first coordinated example upload succeeded without validation errors, then remained in App Store processing beyond the previous 20-minute bound.

## Verification
- `node --test mobile/scripts/app-store-connect-build.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs`
- `actionlint -ignore SC2129 .github/workflows/reusable-coordinated-example-testflight.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI timing and entitlement assertion changes only; no production app runtime or auth logic is modified.
> 
> **Overview**
> Extends how long coordinated release flows wait for App Store Connect to finish processing an uploaded build, and fixes IPA entitlement verification for the networking Hotspot Configuration capability.
> 
> **`waitForProcessedBuild`** in `app-store-connect-build.mjs` now defaults to **360** poll attempts (still 10s apart), raising the ceiling from ~20 minutes to **~60 minutes** before `assign` and related commands fail. This addresses uploads that validate but stay in processing longer than the old limit.
> 
> The example TestFlight workflow checks the **`com.apple.developer.networking.HotspotConfiguration`** entitlement with **`PlistBuddy`** (`Print :com.apple.developer.networking.HotspotConfiguration`) instead of **`plutil -extract`**, so the dotted key is read as a single entitlement name rather than a nested path. The coordinated workflow contract test asserts that pattern is present in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d781a4cadbd6f1d11a4f1264c79c70db81f6c07a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->