### PR TITLE
Track App Store build uploads

### DIFF
--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -100,6 +100,32 @@ export async function findBuild(client, {appId, buildNumber, marketingVersion}) 
   return exactlyOne(response, `build ${buildNumber}`)
 }
 
+export async function findBuildUpload(client, {appId, buildNumber, marketingVersion}) {
+  const filters = {"filter[cfBundleVersion]": String(buildNumber), "sort": "-uploadedDate", "limit": "2"}
+  if (marketingVersion) filters["filter[cfBundleShortVersionString]"] = marketingVersion
+  const response = await client.request(query(`/v1/apps/${encodeURIComponent(appId)}/buildUploads`, filters))
+  if (!Array.isArray(response?.data) || response.data.length === 0) return null
+  return response.data[0]
+}
+
+function buildUploadState(upload) {
+  return upload?.attributes?.state?.state || null
+}
+
+function buildUploadDetails(upload) {
+  const state = upload?.attributes?.state
+  return [...(state?.errors || []), ...(state?.warnings || []), ...(state?.infos || [])]
+    .map((detail) => [detail.code, detail.description].filter(Boolean).join(": "))
+    .filter(Boolean)
+    .join("; ")
+}
+
+function assertBuildUploadDidNotFail(upload, buildNumber) {
+  if (buildUploadState(upload) !== "FAILED") return
+  const details = buildUploadDetails(upload)
+  throw new Error(`App Store Connect build upload ${buildNumber} failed${details ? `: ${details}` : ""}`)
+}
+
 export async function findProcessedBuild(client, {appId, buildNumber, marketingVersion}) {
   const build = await findBuild(client, {appId, buildNumber, marketingVersion})
   if (!build) return null
@@ -112,12 +138,22 @@ export async function waitForProcessedBuild(
   client,
   {appId, buildNumber, marketingVersion, attempts = 360, delay = 10_000},
 ) {
+  let lastUploadState = null
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const build = await findProcessedBuild(client, {appId, buildNumber, marketingVersion})
     if (build) return build
+    const upload = await findBuildUpload(client, {appId, buildNumber, marketingVersion})
+    assertBuildUploadDidNotFail(upload, buildNumber)
+    const state = buildUploadState(upload)
+    if (state && state !== lastUploadState) console.log(`App Store Connect build upload ${buildNumber} is ${state}`)
+    lastUploadState = state || lastUploadState
     if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, delay))
   }
-  throw new Error(`App Store Connect build ${buildNumber} did not finish processing`)
+  throw new Error(
+    `App Store Connect build ${buildNumber} did not finish processing${
+      lastUploadState ? `; upload state is ${lastUploadState}` : ""
+    }`,
+  )
 }
 
 function uploadWithAltool({ipaPath, issuerId, keyId, keyPath}) {
@@ -149,6 +185,9 @@ export async function uploadExactBuild(
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const existing = await findBuild(client, {appId, buildNumber, marketingVersion})
     if (existing) return {build: existing, reused: true}
+    const existingUpload = await findBuildUpload(client, {appId, buildNumber, marketingVersion})
+    assertBuildUploadDidNotFail(existingUpload, buildNumber)
+    if (existingUpload) return {build: null, upload: existingUpload, reused: true}
     try {
       await upload()
       return {build: null, reused: false}
@@ -159,6 +198,9 @@ export async function uploadExactBuild(
   }
   const existing = await findBuild(client, {appId, buildNumber, marketingVersion})
   if (existing) return {build: existing, reused: true}
+  const existingUpload = await findBuildUpload(client, {appId, buildNumber, marketingVersion})
+  assertBuildUploadDidNotFail(existingUpload, buildNumber)
+  if (existingUpload) return {build: null, upload: existingUpload, reused: true}
   throw lastError
 }
 
@@ -286,14 +328,32 @@ async function main() {
       buildNumber: args["build-number"],
       marketingVersion: args["marketing-version"],
     })
+    const upload = build
+      ? null
+      : await findBuildUpload(client, {
+          appId: app.id,
+          buildNumber: args["build-number"],
+          marketingVersion: args["marketing-version"],
+        })
+    assertBuildUploadDidNotFail(upload, args["build-number"])
+    const exists = Boolean(build || upload)
+    const uploadState = buildUploadState(upload)
     if (process.env.GITHUB_OUTPUT) {
       const {appendFileSync} = await import("node:fs")
       appendFileSync(
         process.env.GITHUB_OUTPUT,
-        `exists=${Boolean(build)}\nprocessed=${build?.attributes?.processingState === "VALID"}\napp_id=${app.id}\nbuild_id=${build?.id || ""}\n`,
+        `exists=${exists}\nprocessed=${build?.attributes?.processingState === "VALID"}\napp_id=${app.id}\nbuild_id=${
+          build?.id || ""
+        }\nupload_id=${upload?.id || ""}\nupload_state=${uploadState || ""}\n`,
       )
     }
-    console.log(build ? `Found App Store Connect build ${args["build-number"]}` : "Build is absent")
+    console.log(
+      build
+        ? `Found App Store Connect build ${args["build-number"]}`
+        : upload
+        ? `Found App Store Connect build upload ${args["build-number"]} in ${uploadState}`
+        : "Build and build upload are absent",
+    )
     return
   }
   if (command === "upload") {
@@ -312,7 +372,7 @@ async function main() {
     })
     console.log(
       result.reused
-        ? `Verified App Store Connect already has build ${args["build-number"]}`
+        ? `Verified App Store Connect already has build or upload ${args["build-number"]}`
         : `Uploaded App Store Connect build ${args["build-number"]}`,
     )
     return

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -44,10 +44,14 @@ test("rejects an App Store app whose numeric ID belongs to another bundle", asyn
 test("waits for an uploaded build to finish processing", async () => {
   const api = client([
     {data: []},
+    {data: [{id: "upload-1", attributes: {state: {state: "PROCESSING"}}}]},
     {data: [{id: "build-1", attributes: {processingState: "PROCESSING"}}]},
+    {data: [{id: "upload-1", attributes: {state: {state: "COMPLETE"}}}]},
+    {data: [{id: "build-1", attributes: {processingState: "PROCESSING"}}]},
+    {data: [{id: "upload-1", attributes: {state: {state: "COMPLETE"}}}]},
     {data: [{id: "build-1", attributes: {processingState: "VALID"}}]},
   ])
-  const build = await waitForProcessedBuild(api, {appId: "app-1", buildNumber: 310000057, attempts: 3, delay: 0})
+  const build = await waitForProcessedBuild(api, {appId: "app-1", buildNumber: 310000057, attempts: 4, delay: 0})
   assert.equal(build.id, "build-1")
   assert.match(api.calls[0].resource, /filter%5Bversion%5D=310000057/)
 })
@@ -69,7 +73,12 @@ test("fails when App Store Connect marks a build invalid", async () => {
 })
 
 test("reconciles an upload accepted before a transient transport failure", async () => {
-  const api = client([{data: []}, {data: [{id: "build-1", attributes: {processingState: "PROCESSING"}}]}])
+  const api = client([
+    {data: []},
+    {data: []},
+    {data: []},
+    {data: [{id: "upload-1", attributes: {state: {state: "PROCESSING"}}}]},
+  ])
   let uploads = 0
   const result = await uploadExactBuild(api, {
     appId: "app-1",
@@ -84,12 +93,12 @@ test("reconciles an upload accepted before a transient transport failure", async
     },
   })
   assert.equal(result.reused, true)
-  assert.equal(result.build.id, "build-1")
+  assert.equal(result.upload.id, "upload-1")
   assert.equal(uploads, 1)
 })
 
 test("retries a failed upload only while the exact build remains absent", async () => {
-  const api = client([{data: []}, {data: []}])
+  const api = client([{data: []}, {data: []}, {data: []}, {data: []}])
   let uploads = 0
   const result = await uploadExactBuild(api, {
     appId: "app-1",
@@ -104,6 +113,67 @@ test("retries a failed upload only while the exact build remains absent", async 
   })
   assert.equal(result.reused, false)
   assert.equal(uploads, 2)
+})
+
+test("does not upload over an exact build upload that is still processing", async () => {
+  const api = client([{data: []}, {data: [{id: "upload-1", attributes: {state: {state: "PROCESSING"}}}]}])
+  let uploads = 0
+  const result = await uploadExactBuild(api, {
+    appId: "app-1",
+    buildNumber: 310000047,
+    marketingVersion: "3.1.0",
+    upload: async () => {
+      uploads += 1
+    },
+  })
+  assert.equal(result.reused, true)
+  assert.equal(result.upload.id, "upload-1")
+  assert.equal(uploads, 0)
+  assert.match(api.calls[1].resource, /filter%5BcfBundleShortVersionString%5D=3.1.0/)
+  assert.match(api.calls[1].resource, /sort=-uploadedDate/)
+})
+
+test("uses the newest upload when Apple retains an older failed attempt", async () => {
+  const api = client([
+    {data: []},
+    {
+      data: [
+        {id: "upload-new", attributes: {state: {state: "PROCESSING"}}},
+        {id: "upload-old", attributes: {state: {state: "FAILED"}}},
+      ],
+    },
+  ])
+  const result = await uploadExactBuild(api, {
+    appId: "app-1",
+    buildNumber: 310000047,
+    upload: async () => {},
+  })
+  assert.equal(result.upload.id, "upload-new")
+})
+
+test("surfaces exact build upload validation failures", async () => {
+  const api = client([
+    {data: []},
+    {
+      data: [
+        {
+          id: "upload-1",
+          attributes: {
+            state: {state: "FAILED", errors: [{code: "STATE_ERROR", description: "Invalid entitlement"}]},
+          },
+        },
+      ],
+    },
+  ])
+  await assert.rejects(
+    () =>
+      uploadExactBuild(api, {
+        appId: "app-1",
+        buildNumber: 310000047,
+        upload: async () => {},
+      }),
+    /STATE_ERROR: Invalid entitlement/,
+  )
 })
 
 test("idempotently adds a build to exactly one TestFlight group", async () => {


### PR DESCRIPTION
## Summary
- track exact App Store Connect `buildUploads` alongside processed `builds`
- treat an accepted `PROCESSING` or `COMPLETE` upload as present so retries never submit the same build again
- surface structured Apple validation failures and upload state transitions while waiting

The first three coordinated example IPAs were accepted by `altool`, but no corresponding processed build appeared within 20, 20, and 60 minutes. This closes the idempotency and observability gap exposed by that delay.

## Verification
- `node --test mobile/scripts/app-store-connect-build.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the mobile release script and its tests; behavior is additive for CI observability and safer upload idempotency with no production runtime impact.
> 
> **Overview**
> Extends the App Store Connect CLI script so CI can see **build uploads** (`buildUploads`) before Apple finishes creating a processed **build**, fixing cases where `altool` accepted an IPA but no build showed up for a long time.
> 
> Adds `findBuildUpload` (newest by `uploadedDate`, scoped by bundle version/marketing version), helpers to read upload state and throw on `FAILED` with Apple error codes, and wires them into **`uploadExactBuild`** (treat an in-flight upload as “already present” so retries don’t re-upload), **`waitForProcessedBuild`** (log upload state transitions; include last upload state in timeout errors), and **`lookup`** (GitHub Actions outputs now include `upload_id` / `upload_state`; `exists` is true when either a build or upload is present).
> 
> Tests are updated and expanded for upload polling, idempotent reuse after transport failures, skipping upload when processing, preferring the newest upload over an older failed one, and surfacing validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15548801779266b6b60b3ee2a57a99c6006ed665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->