### PR TITLE
Retry App Store polling network failures

### DIFF
--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -136,7 +136,16 @@ function buildUploadDisposition(upload, buildNumber) {
 }
 
 function isTransientAppStoreConnectError(error) {
-  return error?.status === 429 || (error?.status >= 500 && error.status <= 599)
+  return (
+    error?.status === 429 ||
+    (error?.status >= 500 && error.status <= 599) ||
+    (error instanceof TypeError && error.message === "fetch failed")
+  )
+}
+
+function transientAppStoreConnectErrorLabel(error) {
+  if (error?.status) return `HTTP ${error.status}`
+  return error?.cause?.code || error?.message || "network failure"
 }
 
 export async function findProcessedBuild(client, {appId, buildNumber, marketingVersion}) {
@@ -164,7 +173,7 @@ export async function waitForProcessedBuild(
     } catch (error) {
       if (!isTransientAppStoreConnectError(error) || attempt === attempts) throw error
       console.warn(
-        `App Store Connect temporarily failed while checking build ${buildNumber} (HTTP ${error.status}); retrying`,
+        `App Store Connect temporarily failed while checking build ${buildNumber} (${transientAppStoreConnectErrorLabel(error)}); retrying`,
       )
     }
     if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, delay))

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -184,6 +184,19 @@ test("retries transient App Store Connect failures while polling", async () => {
   assert.equal(build.id, "build-1")
 })
 
+test("retries transient fetch timeouts while polling", async () => {
+  const transient = new TypeError("fetch failed")
+  transient.cause = {code: "UND_ERR_HEADERS_TIMEOUT"}
+  const api = client([{data: []}, transient, {data: [{id: "build-1", attributes: {processingState: "VALID"}}]}])
+  const build = await waitForProcessedBuild(api, {
+    appId: "app-1",
+    buildNumber: 310000047,
+    attempts: 2,
+    delay: 0,
+  })
+  assert.equal(build.id, "build-1")
+})
+
 test("uses the newest upload when Apple retains an older failed attempt", async () => {
   const api = client([
     {data: []},


### PR DESCRIPTION
## Summary

- retry transient `fetch failed` transport errors while polling App Store Connect build processing
- include the underlying Undici error code in retry logs
- preserve immediate failures for application errors and for the final exhausted attempt

## Evidence

The dev.74 React Native example upload poll failed after 14 minutes with `TypeError: fetch failed`, caused by `UND_ERR_HEADERS_TIMEOUT`. HTTP 429 and 5xx responses were already retried, but an equivalent network timeout was not.

## Validation

- `node --test mobile/scripts/app-store-connect-build.test.mjs` (21 passed)
- Prettier check
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/mobile script-only change to retry logic and logging; no auth, data, or production runtime impact beyond more resilient upload polls.
> 
> **Overview**
> **App Store Connect build polling** (`waitForProcessedBuild`) now treats transport-level `TypeError: fetch failed` the same as HTTP 429/5xx: it retries until attempts are exhausted instead of failing immediately.
> 
> Retry warnings no longer assume an HTTP status. A new `transientAppStoreConnectErrorLabel` helper logs `HTTP …` when present, otherwise the Undici `cause.code` (e.g. `UND_ERR_HEADERS_TIMEOUT`) or a generic network label.
> 
> A unit test covers recovery after a headers-timeout style fetch failure during polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3d2869d08d335256033ee916aa46010f322eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->