### PR TITLE
Retry transient Android NDK downloads in coordinated SDK release

### DIFF
--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -164,6 +164,20 @@ jobs:
           cp .env.example .env
           bun expo prebuild --platform android
 
+      - name: Install Android NDK with transient-download retries
+        run: |
+          set -euo pipefail
+          for attempt in {1..3}; do
+            if sdkmanager "ndk;27.1.12297006"; then
+              exit 0
+            fi
+            if (( attempt == 3 )); then
+              exit 1
+            fi
+            echo "::warning::Android NDK download failed; retrying ($attempt/3)."
+            sleep 10
+          done
+
       - name: Inspect public Maven state
         id: existing
         env:


### PR DESCRIPTION
## Summary
- install the exact generated-project NDK before the Maven build
- retry the install up to three times when the Android repository returns a corrupt transient download

## Why
The `3.1.0-dev.78` native SDK lane failed before publication because Gradle's one-shot automatic NDK install received `Error on ZipFile unknown archive`. The release still runs native publication independently; this only makes its local prerequisite resilient.

## Validation
- `actionlint .github/workflows/reusable-coordinated-sdk-native.yml`
- `node --test .github/scripts/coordinated-workflow-contract.test.mjs .github/scripts/coordinated-sdk-native-records.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only prerequisite install with retries; no application, auth, or publication logic changes.
> 
> **Overview**
> Adds an explicit **Install Android NDK with transient-download retries** step to the reusable coordinated native SDK Maven job, placed after `expo prebuild` and before Maven inspection/build.
> 
> The step runs `sdkmanager "ndk;27.1.12297006"` with up to **three attempts**, a **10s** backoff, and a `::warning::` on failure so flaky/corrupt NDK zip downloads from Google’s repo don’t fail the whole release before Gradle runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0e44ca51e6213512e4e156666fa2cedfb598a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->