### PR TITLE
Derive coordinated Android NDK from the release source

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -278,6 +278,9 @@ test("Maven generation builds every local config plugin before Expo prebuild", (
   assert.notEqual(prebuild, -1)
   assert.ok(crustPluginBuild < prebuild)
   assert.ok(bluetoothPluginBuild < prebuild)
+  assert.match(sdkNative, /react-native\/gradle\/libs\.versions\.toml/)
+  assert.match(sdkNative, /sdkmanager "ndk;\$ndk_version"/)
+  assert.doesNotMatch(sdkNative, /sdkmanager "ndk;[0-9]/)
 })
 
 test("Android release preserves the Expo-configured marketing version", () => {

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -167,8 +167,11 @@ jobs:
       - name: Install Android NDK with transient-download retries
         run: |
           set -euo pipefail
+          ndk_version=$(awk -F'"' '/^ndkVersion = "/ { print $2; exit }' \
+            mobile/node_modules/react-native/gradle/libs.versions.toml)
+          [[ "$ndk_version" =~ ^[0-9]+(\.[0-9]+)+$ ]]
           for attempt in {1..3}; do
-            if sdkmanager "ndk;27.1.12297006"; then
+            if sdkmanager "ndk;$ndk_version"; then
               exit 0
             fi
             if (( attempt == 3 )); then


### PR DESCRIPTION
## Summary
- read the required NDK from the checked-out React Native version catalog
- retain transient download retries without pinning the coordinator workflow to today's NDK
- add a workflow contract assertion against future hardcoding

## Why
This addresses the valid post-merge review on #3860. A production promotion can release an older beta source commit, so its generated project must choose its own NDK.

## Validation
- `actionlint .github/workflows/reusable-coordinated-sdk-native.yml`
- `node --test .github/scripts/coordinated-workflow-contract.test.mjs .github/scripts/coordinated-sdk-native-records.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to NDK install sourcing; no app runtime, auth, or data-path impact.
> 
> **Overview**
> Coordinated **SDK native** Android CI no longer pins a fixed NDK (e.g. `27.1.12297006`). The **Install Android NDK** step reads `ndkVersion` from `react-native/gradle/libs.versions.toml` in the checked-out mobile deps, validates the string, then runs `sdkmanager` with that version. **Transient download retries** are unchanged.
> 
> **Workflow contract tests** now require that catalog lookup and variable-based `sdkmanager` call, and forbid literal `ndk;<digits>` in the maven job so future hardcoding fails in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73479bd5715b48dcccbb2003565982a17bc7fd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->