### PR TITLE
Retry transient App Store Connect reads

### DIFF
--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -25,25 +25,48 @@ export function createAppStoreConnectToken({issuerId, keyId, privateKey, now = D
   return `${input}.${signature}`
 }
 
-export function createAppStoreConnectClient({issuerId, keyId, privateKey, fetchImpl = fetch}) {
+export function createAppStoreConnectClient({
+  issuerId,
+  keyId,
+  privateKey,
+  fetchImpl = fetch,
+  attempts = 3,
+  delay = 2_000,
+  sleep = (duration) => new Promise((resolve) => setTimeout(resolve, duration)),
+}) {
   async function request(resource, options = {}) {
-    const response = await fetchImpl(new URL(resource, API_ROOT), {
-      ...options,
-      headers: {
-        "Authorization": `Bearer ${createAppStoreConnectToken({issuerId, keyId, privateKey})}`,
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-    })
-    const body = await response.text()
-    if (!response.ok) {
-      const error = new Error(
-        `App Store Connect ${options.method || "GET"} ${resource} failed with HTTP ${response.status}: ${body}`,
-      )
-      error.status = response.status
-      throw error
+    let lastError
+    const method = (options.method || "GET").toUpperCase()
+    const canRetry = method === "GET" || method === "HEAD"
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const response = await fetchImpl(new URL(resource, API_ROOT), {
+          ...options,
+          headers: {
+            "Authorization": `Bearer ${createAppStoreConnectToken({issuerId, keyId, privateKey})}`,
+            "Content-Type": "application/json",
+            ...options.headers,
+          },
+        })
+        const body = await response.text()
+        if (!response.ok) {
+          const error = new Error(
+            `App Store Connect ${options.method || "GET"} ${resource} failed with HTTP ${response.status}: ${body}`,
+          )
+          error.status = response.status
+          throw error
+        }
+        return body ? JSON.parse(body) : null
+      } catch (error) {
+        lastError = error
+        if (!canRetry || !isTransientAppStoreConnectError(error) || attempt === attempts) throw error
+        console.warn(
+          `App Store Connect temporarily failed ${method} ${resource} (${transientAppStoreConnectErrorLabel(error)}); retrying`,
+        )
+        await sleep(delay)
+      }
     }
-    return body ? JSON.parse(body) : null
+    throw lastError
   }
   return {request}
 }

--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -158,11 +158,22 @@ function buildUploadDisposition(upload, buildNumber) {
   throw new Error(`App Store Connect build upload ${buildNumber} has unknown state ${state || "<missing>"}`)
 }
 
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+])
+
 function isTransientAppStoreConnectError(error) {
   return (
     error?.status === 429 ||
     (error?.status >= 500 && error.status <= 599) ||
-    (error instanceof TypeError && error.message === "fetch failed")
+    (error instanceof TypeError && (error.message === "fetch failed" || error.message === "terminated")) ||
+    TRANSIENT_NETWORK_ERROR_CODES.has(error?.code) ||
+    TRANSIENT_NETWORK_ERROR_CODES.has(error?.cause?.code)
   )
 }
 

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict"
+import {generateKeyPairSync} from "node:crypto"
 import test from "node:test"
 
 import {
   assignBuildToGroup,
   collectPaginatedData,
+  createAppStoreConnectClient,
   findApp,
   findProcessedBuild,
   productionSubmissionStatus,
@@ -12,6 +14,21 @@ import {
   waitForProductionSubmission,
   waitForProcessedBuild,
 } from "./app-store-connect-build.mjs"
+
+const TEST_PRIVATE_KEY = generateKeyPairSync("ec", {namedCurve: "P-256"}).privateKey.export({
+  format: "pem",
+  type: "pkcs8",
+})
+
+function response(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return body === undefined ? "" : JSON.stringify(body)
+    },
+  }
+}
 
 function client(responses) {
   const calls = []
@@ -25,6 +42,65 @@ function client(responses) {
     },
   }
 }
+
+test("retries transient failures for App Store Connect read requests", async () => {
+  const timeout = new TypeError("fetch failed")
+  timeout.cause = {code: "UND_ERR_CONNECT_TIMEOUT"}
+  const responses = [timeout, response(200, {data: {id: "app-1", attributes: {bundleId: "com.mentra.example"}}})]
+  const delays = []
+  const api = createAppStoreConnectClient({
+    issuerId: "issuer",
+    keyId: "key",
+    privateKey: TEST_PRIVATE_KEY,
+    delay: 25,
+    sleep: async (duration) => delays.push(duration),
+    fetchImpl: async () => {
+      const next = responses.shift()
+      if (next instanceof Error) throw next
+      return next
+    },
+  })
+
+  const app = await findApp(api, "com.mentra.example", "app-1")
+  assert.equal(app.id, "app-1")
+  assert.deepEqual(delays, [25])
+})
+
+test("does not retry permanent App Store Connect request failures", async () => {
+  let requests = 0
+  const api = createAppStoreConnectClient({
+    issuerId: "issuer",
+    keyId: "key",
+    privateKey: TEST_PRIVATE_KEY,
+    delay: 0,
+    sleep: async () => {},
+    fetchImpl: async () => {
+      requests += 1
+      return response(400, {errors: [{detail: "bad request"}]})
+    },
+  })
+
+  await assert.rejects(() => findApp(api, "com.mentra.example", "app-1"), /failed with HTTP 400/)
+  assert.equal(requests, 1)
+})
+
+test("does not replay a mutating request after a transient failure", async () => {
+  let requests = 0
+  const api = createAppStoreConnectClient({
+    issuerId: "issuer",
+    keyId: "key",
+    privateKey: TEST_PRIVATE_KEY,
+    delay: 0,
+    sleep: async () => {},
+    fetchImpl: async () => {
+      requests += 1
+      throw new TypeError("fetch failed")
+    },
+  })
+
+  await assert.rejects(() => api.request("/v1/betaGroups", {method: "POST"}), /fetch failed/)
+  assert.equal(requests, 1)
+})
 
 test("resolves an App Store app by its authoritative numeric ID", async () => {
   const api = client([{data: {id: "6792839366", attributes: {bundleId: "com.mentra.example"}}}])

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -66,6 +66,34 @@ test("retries transient failures for App Store Connect read requests", async () 
   assert.deepEqual(delays, [25])
 })
 
+test("retries App Store Connect reads terminated while consuming the response body", async () => {
+  const terminated = new TypeError("terminated")
+  terminated.cause = {code: "UND_ERR_SOCKET"}
+  const responses = [
+    {
+      ok: true,
+      status: 200,
+      async text() {
+        throw terminated
+      },
+    },
+    response(200, {data: {id: "app-1", attributes: {bundleId: "com.mentra.example"}}}),
+  ]
+  let requests = 0
+  const api = createAppStoreConnectClient({
+    issuerId: "issuer",
+    keyId: "key",
+    privateKey: TEST_PRIVATE_KEY,
+    delay: 0,
+    sleep: async () => {},
+    fetchImpl: async () => responses[requests++],
+  })
+
+  const app = await findApp(api, "com.mentra.example", "app-1")
+  assert.equal(app.id, "app-1")
+  assert.equal(requests, 2)
+})
+
 test("does not retry permanent App Store Connect request failures", async () => {
   let requests = 0
   const api = createAppStoreConnectClient({


### PR DESCRIPTION
## Summary
- retry transient App Store Connect read failures in the shared API client
- limit automatic replay to safe GET/HEAD requests
- keep permanent API errors and mutating requests fail-fast
- cover connection timeouts, permanent 4xx responses, and mutation non-replay

## Why
The coordinated `3.1.0-dev.81` release built and published the MentraOS IPA, but its first App Store Connect lookup failed on a single `UND_ERR_CONNECT_TIMEOUT`. Retry handling existed only in the later processing poll, so this transient read failure made the mobile lane fail and prevented finalization/docs publication even though the rest of the release, including the example app TestFlight upload, succeeded.

Centralizing bounded retries in the read side of `createAppStoreConnectClient` covers lookup, polling, and relationship reads consistently. POST/PATCH requests are intentionally not replayed because a timed-out mutation may have succeeded server-side.

## Verification
- `node --test mobile/scripts/*.test.mjs` (35 passing)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the mobile release script’s HTTP client and only add retries for safe read operations; mutating requests stay single-shot.
> 
> **Overview**
> Adds **bounded automatic retries** to `createAppStoreConnectClient` so release scripts survive flaky App Store Connect reads (e.g. connect timeouts) that previously failed the whole mobile lane on a single lookup.
> 
> **GET/HEAD** requests retry up to **3** times with a **2s** delay (configurable via `attempts`, `delay`, and injectable `sleep`). Retries apply to **429**, **5xx**, generic `fetch failed` / **`terminated`** errors, and common **undici/socket timeout codes** on the error or `error.cause`. Each retry logs a warning with a short failure label.
> 
> **POST/PATCH** and other mutating calls **do not** replay after transient failures, avoiding duplicate side effects when a mutation may have succeeded before the client timed out. **4xx** and other permanent API errors still **fail fast** on the first attempt.
> 
> New unit tests cover successful retry after timeout, retry when the body read fails mid-response, no retry on HTTP 400, and no replay on POST after `fetch failed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce92da0b29bdfb7d0b31649359ac3c9642ffa5c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->