### PR TITLE
fix(release): clear stale beta review notes

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -166,6 +166,7 @@ test("mobile destinations use real TestFlight groups without changing the releas
   assert.doesNotMatch(exampleIos, /app-store-connect-build\.mjs assign/)
   assert.match(exampleStore, /^    runs-on: ubuntu-latest$/m)
   assert.match(exampleStore, /app-store-connect-build\.mjs assign/)
+  assert.match(exampleStore, /--review-notes ""/)
 })
 
 test("coordinated docs publish only after finalization to the matching channel", () => {

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -605,6 +605,7 @@ jobs:
           --audience "${{ inputs.testflight_audience }}"
           --install-url "${{ needs.preflight.outputs.install_url }}"
           --allow-rejected-override false
+          --review-notes ""
           --whats-new "Coordinated example release ${{ steps.coordinates.outputs.release_identity }}."
 
       - name: Write example TestFlight publication result

--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -702,7 +702,9 @@ async function main() {
         )
       }
       installUrl = readiness.installUrl
-      if (args["review-notes"]) await updateBetaAppReviewNotes(client, {appId: app.id, notes: args["review-notes"]})
+      if (Object.hasOwn(args, "review-notes")) {
+        await updateBetaAppReviewNotes(client, {appId: app.id, notes: args["review-notes"]})
+      }
     }
     const result = await assignBuildToGroup(client, {
       appId: app.id,

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -14,6 +14,7 @@ import {
   productionSubmissionStatus,
   setBetaBuildWhatsNew,
   submitBuildForBetaReview,
+  updateBetaAppReviewNotes,
   uploadExactBuild,
   waitForProductionSubmission,
   waitForProcessedBuild,
@@ -589,6 +590,17 @@ test("refuses to resubmit an existing rejected beta build", async () => {
     submitBuildForBetaReview(api, {buildId: "build-rejected"}),
     /build build-rejected was rejected; submit a later replacement build/,
   )
+})
+
+test("clears stale beta review notes when given an empty value", async () => {
+  const api = client([
+    {data: {type: "betaAppReviewDetails", id: "detail-1", attributes: {notes: "Previous fix details"}}},
+    {data: {type: "betaAppReviewDetails", id: "detail-1", attributes: {notes: ""}}},
+  ])
+  const result = await updateBetaAppReviewNotes(api, {appId: "app-1", notes: ""})
+  assert.equal(result.reused, false)
+  assert.equal(api.calls[1].options.method, "PATCH")
+  assert.equal(JSON.parse(api.calls[1].options.body).data.attributes.notes, "")
 })
 
 test("promotes only an approved build to a public production group", async () => {


### PR DESCRIPTION
## Summary

- clear app-level TestFlight beta review notes before each automatic external example submission
- let the manual exact-build workflow replace those notes with its optional review explanation, including an explicitly empty value
- add focused API and workflow-contract coverage

## Why

App Store Connect stores beta review notes on the app review detail rather than on one build. Leaving the flag absent after a manual replacement would carry its old change explanation into later automatic beta reviews.

## Verification

- `node --test .github/scripts/coordinated-workflow-contract.test.mjs mobile/scripts/app-store-connect-build.test.mjs`
- `actionlint .github/workflows/reusable-coordinated-example-testflight.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted release/TestFlight automation change with tests; no auth or production data-path changes beyond clearing optional ASC metadata before submit.
> 
> **Overview**
> Prevents **stale app-level beta review notes** from being sent with automated coordinated example TestFlight submissions. App Store Connect keeps those notes on the app review detail, so a prior manual explanation could otherwise ride along on later external beta reviews.
> 
> The reusable example TestFlight workflow now passes **`--review-notes ""`** on `assign`, and **`app-store-connect-build.mjs`** updates notes whenever the flag is **present** (`Object.hasOwn`), including when the value is empty—so clearing is intentional and optional manual workflows can still set or replace text. Contract and unit tests lock in the empty-flag behavior and the PATCH that wipes previous notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790246edd1e884c30a4dfd469626ed397f771a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->