### PR TITLE
fix(docs): render coordinated release links

### DIFF
--- a/.github/scripts/render-coordinated-docs.mjs
+++ b/.github/scripts/render-coordinated-docs.mjs
@@ -1,9 +1,29 @@
 #!/usr/bin/env node
-import {cpSync, readFileSync, realpathSync, rmSync, writeFileSync} from "node:fs"
+import {cpSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync} from "node:fs"
 import path from "node:path"
 import {pathToFileURL} from "node:url"
 
 const RELEASE_IDENTITY_PATTERN = /^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/
+
+function renderUrlVariables(directory, variables) {
+  for (const entry of readdirSync(directory, {withFileTypes: true})) {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      renderUrlVariables(entryPath, variables)
+      continue
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".mdx")) continue
+
+    const source = readFileSync(entryPath, "utf8")
+    const rendered = Object.entries(variables)
+      .filter(([name]) => name.endsWith("-url"))
+      .reduce((content, [name, value]) => content.replaceAll(`{{${name}}}`, value), source)
+    if (/\{\{[A-Za-z0-9_-]+-url\}\}/.test(rendered)) {
+      throw new Error(`Unresolved URL variable in ${entryPath}`)
+    }
+    if (rendered !== source) writeFileSync(entryPath, rendered)
+  }
+}
 
 function parseArgs(args) {
   const values = {}
@@ -118,6 +138,7 @@ export function renderCoordinatedDocs({
     )
   }
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
+  renderUrlVariables(output, config.variables)
 
   return {releaseIdentity: releasePlan.releaseIdentity, outputDir: output}
 }

--- a/.github/scripts/render-coordinated-docs.test.mjs
+++ b/.github/scripts/render-coordinated-docs.test.mjs
@@ -24,7 +24,15 @@ function fixture() {
       },
     }),
   )
-  writeFileSync(path.join(source, "page.mdx"), "Release {{release-version}}")
+  writeFileSync(
+    path.join(source, "page.mdx"),
+    [
+      "Release {{release-version}}",
+      "[Android]({{example-app-url}})",
+      "[iPhone]({{example-app-ios-url}})",
+      "[Artifacts]({{release-artifacts-url}})",
+    ].join("\n"),
+  )
   return {root, source, output: path.join(root, "output")}
 }
 
@@ -88,7 +96,37 @@ test("renders exact coordinated release variables without changing source", (con
   assert.equal(rendered.variables["example-app-url"], starterKitResult.artifacts[0].url)
   assert.equal(rendered.variables["example-app-ios-url"], exampleTestflightResult.distribution.installUrl)
   assert.equal(original.variables["release-version"], "3.1.0")
-  assert.equal(readFileSync(path.join(output, "page.mdx"), "utf8"), "Release {{release-version}}")
+  assert.equal(
+    readFileSync(path.join(output, "page.mdx"), "utf8"),
+    [
+      "Release {{release-version}}",
+      `[Android](${starterKitResult.artifacts[0].url})`,
+      `[iPhone](${exampleTestflightResult.distribution.installUrl})`,
+      "[Artifacts](https://github.com/Mentra/MentraOS/releases/tag/mentra-builds-v3.1.0)",
+    ].join("\n"),
+  )
+  assert.match(readFileSync(path.join(source, "page.mdx"), "utf8"), /\{\{example-app-url\}\}/)
+})
+
+test("rejects unresolved URL variables", (context) => {
+  const {root, source, output} = fixture()
+  context.after(() => rmSync(root, {recursive: true, force: true}))
+  writeFileSync(path.join(source, "page.mdx"), "[Unknown]({{unknown-url}})")
+
+  assert.throws(
+    () =>
+      renderCoordinatedDocs({
+        sourceDir: source,
+        outputDir: output,
+        releasePlan: {
+          releaseIdentity: "3.1.0",
+          releaseSetId: "mentra-3.1.0",
+          artifactContainerTag: "mentra-builds-v3.1.0",
+        },
+        repository: "Mentra/MentraOS",
+      }),
+    /Unresolved URL variable/,
+  )
 })
 
 test("rejects an inconsistent release plan", (context) => {

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -885,8 +885,8 @@ jobs:
             X-Robots-Tag: noindex
           HEADERS
           grep -R --fixed-strings --quiet "$RELEASE_IDENTITY" "$export_dir/mentra-live"
-          if grep -R --fixed-strings --quiet '{{release-version}}' "$export_dir/mentra-live"; then
-            echo "Mintlify export contains an unresolved release-version variable." >&2
+          if grep -R --extended-regexp --ignore-case --quiet '\{\{[a-z0-9_-]+\}\}|%7b%7b[a-z0-9_-]+%7d%7d' "$export_dir/mentra-live"; then
+            echo "Mintlify export contains an unresolved documentation variable." >&2
             exit 1
           fi
           grep -R --fixed-strings --quiet "${{ needs.starter-kit.outputs.react_native_apk_url }}" "$export_dir/mentra-live"


### PR DESCRIPTION
## Problem

The coordinated docs renderer updated Mintlify `docs.json` variables, but Mintlify does not interpolate variables inside Markdown link destinations. The dev.82 site therefore published literal URL-encoded placeholders such as `%7B%7Bexample-app-url%7D%7D`, while CI still passed because the expected concrete URL appeared elsewhere in the exported metadata.

This affected the React Native APK link, the iPhone TestFlight link, and the coordinated release-artifacts link.

## Change

- Replace URL-valued variables directly in the copied MDX tree before Mintlify export.
- Keep normal text variables such as `release-version` and `example-app-version` under Mintlify control.
- Fail rendering if any `*-url` placeholder remains unresolved.
- Fail the exported-site gate for either raw or URL-encoded documentation placeholders.
- Add focused coverage for all three coordinated links and preservation of the templated source tree.

## Verification

- `node --test .github/scripts/render-coordinated-docs.test.mjs`
- `actionlint .github/workflows/coordinated-release.yml`
- `git diff --check`

The live dev.82 page demonstrates the escaped-placeholder failure this PR prevents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the coordinated docs render script, its tests, and a stricter CI export check; no runtime product or auth/data paths are affected.
> 
> **Overview**
> Coordinated release docs were shipping **broken download links** because Mintlify does not substitute `*-url` variables inside Markdown link targets, so pages could show literal `{{…}}` placeholders (including URL-encoded forms) even when `docs.json` had the right values.
> 
> The renderer now **walks the copied MDX tree** and replaces only variables whose names end in `-url` with concrete URLs (Android APK, TestFlight, release artifacts), while leaving text variables like `{{release-version}}` for Mintlify. Rendering **fails** if any `*-url` placeholder remains. The coordinated release workflow’s export gate now rejects **any** unresolved `{{…}}` or encoded placeholder in the published site, not just `release-version`.
> 
> Tests cover the three coordinated links, unchanged source templates, and the unresolved-URL error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3a3c620933bb710ac30c119ca1490ec6c30f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->