### PR TITLE
ci(docs): verify published release anchors

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -239,7 +239,9 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(docs, /--example-testflight/)
   assert.match(docs, /X-Robots-Tag: noindex/)
   assert.match(docs, /grep --fixed-strings --quiet "\$RELEASE_IDENTITY" "\$body"/)
-  assert.match(docs, /grep --fixed-strings --quiet "\$EXAMPLE_IOS_URL" "\$body"/)
+  assert.match(docs, /grep --fixed-strings --quiet "href=\\"\$EXAMPLE_APK_URL\\"" "\$body"/)
+  assert.match(docs, /grep --fixed-strings --quiet "href=\\"\$EXAMPLE_IOS_URL\\"" "\$body"/)
+  assert.match(docs, /%7b%7b\[a-z0-9_-\]\+%7d%7d/)
   assert.match(
     notify,
     /^    needs:\n      \[plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, example-testflight, finalize, docs\]$/m,

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -923,10 +923,11 @@ jobs:
             if curl --fail --silent --show-error --location \
               --dump-header "$headers" --output "$body" "$page" && \
               grep --fixed-strings --quiet "$RELEASE_IDENTITY" "$body" && \
-              grep --fixed-strings --quiet "$EXAMPLE_APK_URL" "$body" && \
-              grep --fixed-strings --quiet "$EXAMPLE_IOS_URL" "$body" && \
+              grep --fixed-strings --quiet "href=\"$EXAMPLE_APK_URL\"" "$body" && \
+              grep --fixed-strings --quiet "href=\"$EXAMPLE_IOS_URL\"" "$body" && \
               grep --ignore-case --quiet '^x-robots-tag:.*noindex' "$headers" && \
-              ! grep --fixed-strings --quiet '{{release-version}}' "$body"; then
+              ! grep --extended-regexp --ignore-case --quiet \
+                '\{\{[a-z0-9_-]+\}\}|%7b%7b[a-z0-9_-]+%7d%7d' "$body"; then
               echo "Verified $page for $RELEASE_IDENTITY"
               exit 0
             fi


### PR DESCRIPTION
## Problem

The custom-domain verification searched for expected URLs anywhere in Mintlify HTML. Embedded `docs.json` metadata could therefore satisfy the check even when the actual link destination remained a URL-encoded template placeholder.

## Change

- Require the published Android and TestFlight URLs as exact anchor `href` values.
- Reject any raw or URL-encoded documentation placeholder on the published software-update page.
- Extend the coordinated workflow contract test to preserve both guarantees.

## Verification

- `node --test .github/scripts/coordinated-workflow-contract.test.mjs .github/scripts/render-coordinated-docs.test.mjs`
- `actionlint .github/workflows/coordinated-release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to docs verification logic; no runtime product or auth paths affected.
> 
> **Overview**
> Tightens the coordinated release **post-publish docs check** on the software-update page so release URLs must appear as real download links, not just anywhere in the HTML.
> 
> The custom-domain poll now requires **`href="$EXAMPLE_APK_URL"`** and **`href="$EXAMPLE_IOS_URL"`** instead of substring matches, so embedded Mintlify metadata (e.g. in `docs.json`) cannot pass while user-facing anchors still point at templates. Placeholder detection is broadened from a single `{{release-version}}` string to **any raw or URL-encoded `{{…}}` token** via extended regexp, matching the export-time guard.
> 
> **`coordinated-workflow-contract.test.mjs`** is updated so the workflow contract continues to assert these href and placeholder rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2df082484457b4e96b9bb007c221907db0b337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->