### PR TITLE
Keep OTA chaining active through glasses restarts

### DIFF
--- a/mobile/modules/engine/src/facades/ota.ts
+++ b/mobile/modules/engine/src/facades/ota.ts
@@ -17,7 +17,7 @@ import type {
   OtaUpdateInfo,
   ReleaseChangelog,
 } from "@mentra/bluetooth-sdk"
-import {isGlassesConnected, useGlassesStore} from "../stores/glasses"
+import {isGlassesConnected, isGlassesReady, useGlassesStore} from "../stores/glasses"
 import {resolveOtaManifestUrl} from "../services/otaManifestUrl"
 import {otaInstallCoordinator, type OtaInstallSnapshot} from "../services/OtaInstallCoordinator"
 import {startGlassesStatusProjection} from "../services/GlassesStatusProjection"
@@ -32,6 +32,7 @@ function projectSnapshot() {
   const s = useGlassesStore.getState()
   return {
     connected: isGlassesConnected(s.connection),
+    ready: isGlassesReady(s.connection),
     buildNumber: s.buildNumber || null,
     appVersion: s.appVersion || null,
     mtkFirmwareVersion: s.mtkFirmwareVersion || null,

--- a/mobile/modules/engine/src/index.ts
+++ b/mobile/modules/engine/src/index.ts
@@ -89,6 +89,7 @@ export {
   GLOBAL_OTA_TIMEOUT_MS,
   PING_INTERVAL_MS,
   QUERY_REPLY_TIMEOUT_MS,
+  BES_RESTART_TIMEOUT_MS,
   OtaProgressMessages,
 } from "./services/otaInstallPolicy"
 export {deriveDisplayState} from "./services/otaDisplayState"

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -113,6 +113,10 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:versionChangeRestarting": "Installing a different version…",
   "ota:versionChangeVerifying": "Verifying your glasses…",
   "ota:versionChangeKeepNearby": "Keep your glasses nearby and connected. They will restart on their own.",
+  "ota:restartingGlasses": "Restarting {{deviceName}}…",
+  "ota:restartingGlassesMessage":
+    "The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.",
+  "ota:restartingGlassesAutomatic": "We'll continue automatically when they're ready.",
   "ota:versionChangeComplete": "Version Change Complete",
   "ota:versionChangeCompleteMessage":
     "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
@@ -414,14 +418,11 @@ function OtaFlowContent({
 
   if (state.screen === "restarting") {
     return (
-      <FlowPage
-        actions={
-          <FlowButton colors={colors} disabled={state.continueDisabled} label="Continue" onPress={controller.finish} />
-        }
-        colors={colors}
-        icon="check"
-        title="Update Installed"
-      />
+      <FlowPage colors={colors} icon="download" title={translate("ota:restartingGlasses", {deviceName})}>
+        <ActivityIndicator size="large" color={colors.foreground} />
+        <BodyText colors={colors}>{translate("ota:restartingGlassesMessage")}</BodyText>
+        <BodyText colors={colors}>{translate("ota:restartingGlassesAutomatic")}</BodyText>
+      </FlowPage>
     )
   }
 

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -32,6 +32,7 @@ let currentCheckResult = checkResult
 
 let otaSnapshot = {
   connected: true,
+  ready: true,
   buildNumber: "39",
   appVersion: "3.0.0",
   mtkFirmwareVersion: "0801",
@@ -185,7 +186,7 @@ describe("useMentraLiveOta", () => {
     autoChainActive = false
     autoChainRange = null
     currentCheckResult = checkResult
-    otaSnapshot = {...otaSnapshot, appVersion: "3.0.0"}
+    otaSnapshot = {...otaSnapshot, appVersion: "3.0.0", connected: true, ready: true}
     finishPromise = Promise.resolve()
     installSnapshot = {
       displayState: "starting",
@@ -258,6 +259,27 @@ describe("useMentraLiveOta", () => {
     })
     latestController.retryInstall()
     expect(retry).toHaveBeenCalledTimes(1)
+    await act(async () => renderer.unmount())
+  })
+
+  test("does not let a host finish while glasses are still restarting", async () => {
+    autoChainActive = true
+    autoChainRange = {
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.8",
+      releaseVersion: "3.1.0-dev.8",
+    }
+    installSnapshot = {...installSnapshot, connected: false, displayState: "restarting"}
+    const renderer = await renderProbe()
+
+    expect(latestController.state).toMatchObject({screen: "restarting", canFinish: false})
+    await act(async () => {
+      await latestController.finish()
+    })
+
+    expect(finish).not.toHaveBeenCalled()
+    expect(stopAutoChain).not.toHaveBeenCalled()
+    expect(latestController.state.screen).toBe("restarting")
     await act(async () => renderer.unmount())
   })
 
@@ -447,6 +469,29 @@ describe("useMentraLiveOta", () => {
     expect(fakeOta.checkForUpdates).toHaveBeenCalledTimes(1)
     expect(prepare).toHaveBeenCalledWith(currentCheckResult)
     expect(latestController.state.screen).toBe("preparing_hotspot")
+    await act(async () => renderer.unmount())
+  })
+
+  test("waits for the restarted ASG client to be fully ready before checking the next pass", async () => {
+    autoChainActive = true
+    autoChainRange = {
+      fromVersion: "3.0.0",
+      toVersion: "3.1.0-dev.8",
+      releaseVersion: "3.1.0-dev.8",
+    }
+    otaSnapshot = {...otaSnapshot, connected: true, ready: false}
+    const renderer = await renderProbe("check")
+
+    expect(latestController.state.screen).toBe("finishing")
+    expect(fakeOta.checkForUpdates).not.toHaveBeenCalled()
+
+    otaSnapshot = {...otaSnapshot, ready: true}
+    await act(async () => {
+      otaListeners.forEach((listener) => listener())
+      await new Promise((resolve) => setTimeout(resolve, 1_150))
+    })
+
+    expect(fakeOta.checkForUpdates).toHaveBeenCalledTimes(1)
     await act(async () => renderer.unmount())
   })
 

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -310,18 +310,18 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
 
     const performCheck = async () => {
       if (checkCompletedRef.current) return
+      if (isOtaAutoChainActive() && !otaSnapshot.ready) {
+        const remainingMs = otaAutoChainReconnectWaitRemaining()
+        if (remainingMs === null) return
+        reconnectTimeout = setTimeout(() => {
+          if (cancelled || myGeneration !== performCheckGenerationRef.current || ota.snapshot().ready) return
+          stopOtaAutoChain()
+          checkCompletedRef.current = true
+          setCheckState("error")
+        }, remainingMs)
+        return
+      }
       if (!otaSnapshot.connected) {
-        if (isOtaAutoChainActive()) {
-          const remainingMs = otaAutoChainReconnectWaitRemaining()
-          if (remainingMs === null) return
-          reconnectTimeout = setTimeout(() => {
-            if (cancelled || myGeneration !== performCheckGenerationRef.current || ota.snapshot().connected) return
-            stopOtaAutoChain()
-            checkCompletedRef.current = true
-            setCheckState("error")
-          }, remainingMs)
-          return
-        }
         if (checkStartedRef.current) {
           stopOtaAutoChain()
           checkCompletedRef.current = true
@@ -430,7 +430,15 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       cancelled = true
       if (reconnectTimeout) clearTimeout(reconnectTimeout)
     }
-  }, [checkGeneration, continueApprovedChain, otaSnapshot.connected, otaSnapshot.wifiStatusKnown, page, runtimeReady])
+  }, [
+    checkGeneration,
+    continueApprovedChain,
+    otaSnapshot.connected,
+    otaSnapshot.ready,
+    otaSnapshot.wifiStatusKnown,
+    page,
+    runtimeReady,
+  ])
 
   useEffect(() => {
     if (
@@ -570,7 +578,11 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       onFinishedRef.current?.()
       return
     }
-    if (installSnapshot.displayState === "restarting") stopOtaAutoChain()
+    const restartStillInProgress =
+      installSnapshot.displayState === "restarting" ||
+      installSnapshot.versionChangePhase === "restarting" ||
+      installSnapshot.versionChangePhase === "verifying"
+    if (restartStillInProgress) return
     const requiresGlassesReboot = shouldRequireGlassesRebootForBesFailure(
       installSnapshot.otaStatus,
       installSnapshot.otaProgress,
@@ -748,7 +760,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       error,
       canInstall: false,
       canRetry: screen === "failed" && !requiresGlassesReboot,
-      canFinish: screen === "complete" || screen === "restarting" || (screen === "failed" && requiresGlassesReboot),
+      canFinish: screen === "complete" || (screen === "failed" && requiresGlassesReboot),
       canDismiss: false,
       canDiscard: screen === "disconnected",
       canOpenWifiSetup: screen === "failed" && showChangeWifi,

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -26,10 +26,12 @@ import type {OtaCheckCurrentGlassesResult} from "./OtaUpdateCheckService"
 import {deriveDisplayState, type DisplayState} from "./otaDisplayState"
 import {
   BES_CONTINUE_LOCKOUT_MS,
+  BES_RESTART_TIMEOUT_MS,
   DOWNLOAD_STUCK_TIMEOUT_MS,
   GLOBAL_OTA_TIMEOUT_MS,
   LEGACY_APK_COMPLETION_SETTLE_MS,
   LEGACY_BES_CONTINUE_LOCKOUT_MS,
+  LEGACY_BES_RESTART_TIMEOUT_MS,
   LEGACY_DOWNLOAD_STUCK_TIMEOUT_MS,
   LEGACY_GLOBAL_OTA_TIMEOUT_MS,
   LEGACY_MTK_INSTALL_TIMEOUT_MS,
@@ -245,6 +247,7 @@ class OtaInstallCoordinator {
   private pingInterval: ReturnType<typeof setInterval> | null = null
   private queryReplyTimeout: ReturnType<typeof setTimeout> | null = null
   private continueLockoutTimer: ReturnType<typeof setTimeout> | null = null
+  private restartRecoveryTimeout: ReturnType<typeof setTimeout> | null = null
   private legacyApkSettleTimer: ReturnType<typeof setTimeout> | null = null
   private mtkStallDetectTimer: ReturnType<typeof setTimeout> | null = null
   private mtkSimTickTimer: ReturnType<typeof setInterval> | null = null
@@ -1000,12 +1003,22 @@ class OtaInstallCoordinator {
     // (15s unified, 35s for legacy-shaped sessions — WP 8C-f).
     if (displayStateChanged && displayState === "restarting") {
       this.clearContinueLockoutTimer()
+      this.clearRestartRecoveryTimeout()
       const lockoutMs = legacySession ? LEGACY_BES_CONTINUE_LOCKOUT_MS : BES_CONTINUE_LOCKOUT_MS
+      const restartTimeoutMs = legacySession ? LEGACY_BES_RESTART_TIMEOUT_MS : BES_RESTART_TIMEOUT_MS
       this.setContinueButtonDisabled(true)
       this.continueLockoutTimer = setTimeout(() => {
         this.continueLockoutTimer = null
         this.setContinueButtonDisabled(false)
       }, lockoutMs)
+      this.restartRecoveryTimeout = setTimeout(() => {
+        this.restartRecoveryTimeout = null
+        if (this.computeDisplayStateNow() !== "restarting") return
+        console.log(`[OTA_PROGRESS] watchdog: glasses did not finish restarting in ${restartTimeoutMs}ms`)
+        this.setErrorMsg(OtaProgressMessages.restartTimeout)
+      }, restartTimeoutMs)
+    } else if (displayStateChanged) {
+      this.clearRestartRecoveryTimeout()
     }
 
     // Legacy MTK install stall simulation (WP 8C-e): display-only. The simulation
@@ -1668,6 +1681,13 @@ class OtaInstallCoordinator {
     }
   }
 
+  private clearRestartRecoveryTimeout(): void {
+    if (this.restartRecoveryTimeout) {
+      clearTimeout(this.restartRecoveryTimeout)
+      this.restartRecoveryTimeout = null
+    }
+  }
+
   private clearLegacyApkSettleTimer(): void {
     if (this.legacyApkSettleTimer) {
       clearTimeout(this.legacyApkSettleTimer)
@@ -1706,6 +1726,7 @@ class OtaInstallCoordinator {
     this.clearPingInterval()
     this.clearLegacyApkSettleTimer()
     this.clearMtkSimulationTimers()
+    this.clearRestartRecoveryTimeout()
   }
 }
 

--- a/mobile/modules/engine/src/services/otaInstallPolicy.ts
+++ b/mobile/modules/engine/src/services/otaInstallPolicy.ts
@@ -32,6 +32,8 @@ export const PING_INTERVAL_MS = 10_000
 export const QUERY_REPLY_TIMEOUT_MS = 6000
 /** 15s lockout on the Continue button after a BES restart, to prevent an accidental tap. */
 export const BES_CONTINUE_LOCKOUT_MS = 15_000
+/** Fail closed if a BES reboot never reconnects; normal restarts complete in a fraction of this window. */
+export const BES_RESTART_TIMEOUT_MS = 120_000
 
 // --- Legacy old-build (< MINIMUM_OTA_STATUS_BUILD) OTA policy (WP 8C) ---
 //
@@ -51,6 +53,7 @@ export const LEGACY_MTK_INSTALL_TIMEOUT_MS = MTK_INSTALL_TIMEOUT_MS + LEGACY_EXT
 export const LEGACY_GLOBAL_OTA_TIMEOUT_MS = GLOBAL_OTA_TIMEOUT_MS + LEGACY_EXTRA_TIMEOUT_MS
 export const LEGACY_PING_INTERVAL_MS = PING_INTERVAL_MS + LEGACY_EXTRA_TIMEOUT_MS
 export const LEGACY_BES_CONTINUE_LOCKOUT_MS = BES_CONTINUE_LOCKOUT_MS + LEGACY_EXTRA_TIMEOUT_MS
+export const LEGACY_BES_RESTART_TIMEOUT_MS = BES_RESTART_TIMEOUT_MS + LEGACY_EXTRA_TIMEOUT_MS
 /**
  * After a legacy apk `install FINISHED` observed in-flight, the legacy screen held the
  * completed state for 12s (+20s pad) so the ASG process restart settles (and fresh
@@ -122,6 +125,7 @@ export function selectOtaProtocolProfile(
 export const OtaProgressMessages = {
   stalledOrStuck: "Update may have failed. Ensure glasses have internet access and try again.",
   globalTimeout: "Update took too long. Please try again.",
+  restartTimeout: "Glasses did not finish restarting. Restart them before trying the update again.",
   sendOtaStartFailed: "Failed to communicate with glasses.",
   hotspotArtifactDownloadFailed: "Could not download the update to your phone. Check phone internet and try again.",
   hotspotArtifactVerifyFailed: "The update package could not be verified. Please try again later.",

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -8,7 +8,7 @@ import {useConnectionOverlayConfig} from "@/contexts/ConnectionOverlayContext"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 
 import OtaProgressScreen from "@/app/ota/progress"
-import {MINIMUM_OTA_STATUS_BUILD, OtaProgressMessages} from "@mentra/engine"
+import {BES_RESTART_TIMEOUT_MS, MINIMUM_OTA_STATUS_BUILD, OtaProgressMessages} from "@mentra/engine"
 import {BES_INSTALL_RESTART_MESSAGE} from "@/utils/otaErrorMapping"
 import {beginOtaAutoChain, isOtaAutoChainActive, stopOtaAutoChain} from "@/services/otaAutoChain"
 
@@ -307,10 +307,10 @@ describe("progress.tsx display states", () => {
     }
   })
 
-  it("stops automatic chaining when Continue bypasses BES reboot verification", async () => {
+  it("keeps a chained BES reboot non-actionable until the glasses reconnect", async () => {
     setGlassesConnected()
     beginOtaAutoChain("initial-offer", false, AUTO_CHAIN_RELEASE_RANGE)
-    const {getByTestId} = render(<OtaProgressScreen />)
+    const {getByText, queryByTestId} = render(<OtaProgressScreen />)
 
     act(() => {
       useGlassesStore.getState().setOtaStatus({
@@ -325,11 +325,22 @@ describe("progress.tsx display states", () => {
       })
     })
 
+    expect(getByText("ota:restartingGlasses")).toBeDefined()
+    expect(getByText("ota:restartingGlassesMessage")).toBeDefined()
+    expect(getByText("ota:restartingGlassesAutomatic")).toBeDefined()
+    expect(queryByTestId("button-Continue")).toBeNull()
+
     await act(async () => {
-      await jest.advanceTimersByTimeAsync(15_000)
+      await jest.advanceTimersByTimeAsync(35_000)
     })
-    fireEvent.press(getByTestId("button-Continue"))
-    expect(isOtaAutoChainActive()).toBe(false)
+    expect(queryByTestId("button-Continue")).toBeNull()
+    expect(isOtaAutoChainActive()).toBe(true)
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(BES_RESTART_TIMEOUT_MS - 35_000)
+    })
+    expect(getByText("Update Failed")).toBeDefined()
+    expect(getByText(BES_INSTALL_RESTART_MESSAGE)).toBeDefined()
   })
 
   it("transitions to failed on failed ota_status with error", () => {

--- a/mobile/src/app/ota/__tests__/shared-flow.test.tsx
+++ b/mobile/src/app/ota/__tests__/shared-flow.test.tsx
@@ -238,4 +238,40 @@ describe("MentraLiveOtaFlow", () => {
     unmount()
     expect(onFirmwareRestartingChange).toHaveBeenLastCalledWith(false, false)
   })
+
+  it("presents a firmware reboot as active work with no completion action", () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+    })
+    const {getByText, queryByTestId} = render(
+      <MentraLiveOtaFlow
+        initialPage="progress"
+        initializeRuntime={false}
+        onFinished={jest.fn()}
+        onOpenWifiSetup={jest.fn()}
+      />,
+    )
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "session",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "bes",
+        phase: "install",
+        stepPercent: 100,
+        overallPercent: 100,
+        status: "step_complete",
+      })
+    })
+
+    expect(getByText("Restarting Mentra Live…")).toBeDefined()
+    expect(
+      getByText(
+        "The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.",
+      ),
+    ).toBeDefined()
+    expect(getByText("We'll continue automatically when they're ready.")).toBeDefined()
+    expect(queryByTestId("button-Continue")).toBeNull()
+  })
 })

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -452,6 +452,10 @@ const en = {
     versionChangeRestarting: "Installing a different version\u2026",
     versionChangeVerifying: "Verifying your glasses\u2026",
     versionChangeKeepNearby: "Keep your glasses nearby and connected. They will restart on their own.",
+    restartingGlasses: "Restarting {{deviceName}}…",
+    restartingGlassesMessage:
+      "The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.",
+    restartingGlassesAutomatic: "We'll continue automatically when they're ready.",
     versionChangeComplete: "Version Change Complete",
     versionChangeCompleteMessage:
       "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",


### PR DESCRIPTION
## Summary
- present MTK/BES reboot as active work with no premature Continue action
- keep approved chains active until glasses are fully booted before rechecking
- bound restart recovery and fail safely if glasses never return

## Root cause
The shared restarting state became finishable after a 15s/35s lockout. Finishing stopped the auto-chain; if glasses were still disconnected, the flow returned Home and the background checker later prompted for the remaining update. Link-level connected also did not guarantee the restarted ASG client could answer `version_info`.

## Tests
- `bun run test --runInBand src/__tests__/otaInstallCoordinator.test.ts src/app/ota/__tests__/progress.test.tsx src/app/ota/__tests__/shared-flow.test.tsx src/__tests__/otaAutoChain.test.ts` (128 passed)
- `bun test modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx` (12 passed)
- `bun run compile`
- `git diff --check`

## Follow-up validation
- connected Mentra Live run from January/day-one software through the current coordinated release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OTA install state machine, auto-chain timing, and finish paths; wrong readiness gating could delay or fail multi-step updates, but behavior is bounded by restart timeouts and covered by tests.
> 
> **Overview**
> Fixes OTA **multi-pass chaining** breaking when users could **Continue** after a BES/MTK reboot while glasses were still booting, which stopped the auto-chain and left later updates to a background prompt.
> 
> The OTA snapshot now exposes **`ready`** (fully booted ASG), and continuation checks during an active chain **wait for `ready`**, not only BLE **connected**, before running the next manifest check. The **restarting** progress screen is **non-actionable**: spinner plus new copy, no Continue; **`canFinish`** / **`finish()`** are blocked through restart and version-change verify phases.
> 
> **`OtaInstallCoordinator`** arms **`BES_RESTART_TIMEOUT_MS`** (120s, legacy +20s) while display state is **restarting** and surfaces **`restartTimeout`** if the device never recovers. Tests cover blocked finish, ready-gated recheck, and chained BES reboot UX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc04fd805c04d195e6c609312c3cc1d453b9dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->