### PR TITLE
Split Android release ABIs by artifact

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -352,6 +352,12 @@ test("Android release keeps the GitHub APK arm64-only and the Play AAB multi-ABI
     2,
   )
   assert.doesNotMatch(mobileAndroid, /ORG_GRADLE_PROJECT_reactNativeArchitectures:/)
+  assert.match(mobileAndroid, /- name: Verify Android native version and production signature/)
+  assert.match(mobileAndroid, /- name: Verify newly built Android ABI contract\n/)
+  assert.match(
+    mobileAndroid,
+    /if: inputs\.dry_run == true \|\| needs\.prepare\.outputs\.android_assets_exist != 'true'/,
+  )
   assert.match(mobileAndroid, /GitHub APK ABIs '\$\{apk_abis:-<none>\}' do not match required arm64-v8a/)
   assert.match(
     mobileAndroid,

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -6,6 +6,10 @@ function workflow(name) {
   return readFileSync(new URL(`../workflows/${name}`, import.meta.url), "utf8")
 }
 
+function mobileScript(name) {
+  return readFileSync(new URL(`../../mobile/scripts/${name}`, import.meta.url), "utf8")
+}
+
 function jobBlock(source, name) {
   const start = source.indexOf(`\n  ${name}:\n`)
   assert.notEqual(start, -1, `Missing workflow job ${name}`)
@@ -327,4 +331,30 @@ test("Android release preserves the Expo-configured marketing version", () => {
   assert.doesNotMatch(androidPlugin, /replace\([^\n]*versionName/)
   assert.match(mobile, /version_name=\$\(sed -n "s\/\.\*versionName=/)
   assert.match(mobile, /Android versionName \$\{version_name:-<missing>\} does not match \$EXPECTED_VERSION/)
+})
+
+test("Android release keeps the GitHub APK arm64-only and the Play AAB multi-ABI", () => {
+  const releaseAndroid = mobileScript("release-android.mjs")
+  const mobileAndroid = jobBlock(workflow("reusable-coordinated-mobile.yml"), "android")
+
+  assert.match(releaseAndroid, /const APK_ARCHITECTURES = 'arm64-v8a'/)
+  assert.match(releaseAndroid, /const AAB_ARCHITECTURES = 'armeabi-v7a,arm64-v8a,x86,x86_64'/)
+  assert.match(
+    releaseAndroid,
+    /gradlew assembleRelease -PreactNativeArchitectures=\$\{APK_ARCHITECTURES\}/,
+  )
+  assert.equal(
+    [
+      ...releaseAndroid.matchAll(
+        /gradlew bundleRelease -PreactNativeArchitectures=\$\{AAB_ARCHITECTURES\}/g,
+      ),
+    ].length,
+    2,
+  )
+  assert.doesNotMatch(mobileAndroid, /ORG_GRADLE_PROJECT_reactNativeArchitectures:/)
+  assert.match(mobileAndroid, /GitHub APK ABIs '\$\{apk_abis:-<none>\}' do not match required arm64-v8a/)
+  assert.match(
+    mobileAndroid,
+    /Google Play AAB ABIs '\$\{aab_abis:-<none>\}' do not match required \$expected_aab_abis/,
+  )
 })

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -326,14 +326,13 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/releases/assets/${{ needs.prepare.outputs.aab_asset_id }}" \
             > "mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
 
-      - name: Verify Android version, signature, and ABI contract
+      - name: Verify Android native version and production signature
         env:
           EXPECTED_BUILD: ${{ needs.prepare.outputs.build_number }}
           EXPECTED_VERSION: ${{ needs.prepare.outputs.marketing_version }}
         run: |
           set -euo pipefail
           apk="mobile-release/android/${{ needs.prepare.outputs.apk_name }}"
-          aab="mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
           apksigner=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -perm -111 | sort | tail -1)
           aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm -111 | sort | tail -1)
           "$apksigner" verify --print-certs "$apk" > /tmp/mentra-mobile-certs.txt
@@ -354,6 +353,17 @@ jobs:
             exit 1
           fi
 
+      # ABI shape is a creation-time contract. A complete pair found here is
+      # immutable and may have been published under an earlier contract, so a
+      # retry verifies its permanent identity above without retroactively
+      # rejecting it. Every newly built pair must satisfy the current contract
+      # before its first publication below.
+      - name: Verify newly built Android ABI contract
+        if: inputs.dry_run == true || needs.prepare.outputs.android_assets_exist != 'true'
+        run: |
+          set -euo pipefail
+          apk="mobile-release/android/${{ needs.prepare.outputs.apk_name }}"
+          aab="mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
           apk_abis=$(unzip -Z1 "$apk" \
             | sed -n 's#^lib/\([^/]*\)/.*\.so$#\1#p' \
             | LC_ALL=C sort -u \

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -212,7 +212,6 @@ jobs:
     env:
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
-      ORG_GRADLE_PROJECT_reactNativeArchitectures: armeabi-v7a,arm64-v8a,x86,x86_64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -327,13 +326,14 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/releases/assets/${{ needs.prepare.outputs.aab_asset_id }}" \
             > "mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
 
-      - name: Verify Android native version and production signature
+      - name: Verify Android version, signature, and ABI contract
         env:
           EXPECTED_BUILD: ${{ needs.prepare.outputs.build_number }}
           EXPECTED_VERSION: ${{ needs.prepare.outputs.marketing_version }}
         run: |
           set -euo pipefail
           apk="mobile-release/android/${{ needs.prepare.outputs.apk_name }}"
+          aab="mobile-release/android/${{ needs.prepare.outputs.aab_name }}"
           apksigner=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -perm -111 | sort | tail -1)
           aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm -111 | sort | tail -1)
           "$apksigner" verify --print-certs "$apk" > /tmp/mentra-mobile-certs.txt
@@ -351,6 +351,25 @@ jobs:
           fi
           if [[ "$version_name" != "$EXPECTED_VERSION" ]]; then
             echo "Android versionName ${version_name:-<missing>} does not match $EXPECTED_VERSION." >&2
+            exit 1
+          fi
+
+          apk_abis=$(unzip -Z1 "$apk" \
+            | sed -n 's#^lib/\([^/]*\)/.*\.so$#\1#p' \
+            | LC_ALL=C sort -u \
+            | paste -sd, -)
+          if [[ "$apk_abis" != "arm64-v8a" ]]; then
+            echo "GitHub APK ABIs '${apk_abis:-<none>}' do not match required arm64-v8a." >&2
+            exit 1
+          fi
+
+          aab_abis=$(unzip -Z1 "$aab" \
+            | sed -n 's#^[^/]*/lib/\([^/]*\)/.*\.so$#\1#p' \
+            | LC_ALL=C sort -u \
+            | paste -sd, -)
+          expected_aab_abis="arm64-v8a,armeabi-v7a,x86,x86_64"
+          if [[ "$aab_abis" != "$expected_aab_abis" ]]; then
+            echo "Google Play AAB ABIs '${aab_abis:-<none>}' do not match required $expected_aab_abis." >&2
             exit 1
           fi
 

--- a/mobile/scripts/release-android.mjs
+++ b/mobile/scripts/release-android.mjs
@@ -9,6 +9,9 @@ import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
 
+const APK_ARCHITECTURES = 'arm64-v8a';
+const AAB_ARCHITECTURES = 'armeabi-v7a,arm64-v8a,x86,x86_64';
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function parseVersion(version) {
@@ -54,13 +57,11 @@ console.log(`versionCode: ${versionCode}`);
 // ── Step 3: Prebuild + bundle ────────────────────────────────────────────────
 
 console.log('\n━━━ Step 3: Prebuild + bundle ━━━');
-// Default phone-only (arm64). Staging production sets
-// ORG_GRADLE_PROJECT_reactNativeArchitectures to all four ABIs; do not
-// clobber a caller-provided value.
-if (!process.env.ORG_GRADLE_PROJECT_reactNativeArchitectures) {
-  process.env.ORG_GRADLE_PROJECT_reactNativeArchitectures = 'arm64-v8a';
-}
-console.log(`reactNativeArchitectures: ${process.env.ORG_GRADLE_PROJECT_reactNativeArchitectures}`);
+// GitHub APKs are sideloaded onto physical phones, so keep the prebuild and
+// APK arm64-only. The Play AAB is built separately with every supported ABI;
+// Google Play then serves only the matching split to each device.
+process.env.ORG_GRADLE_PROJECT_reactNativeArchitectures = APK_ARCHITECTURES;
+console.log(`APK architectures: ${APK_ARCHITECTURES}`);
 
 // Clean android/ to avoid cached version number issues
 await $({ stdio: 'inherit' })`rm -rf android`;
@@ -94,7 +95,7 @@ console.log('\n━━━ Step 5: Building APK ━━━');
 await withRetry(
   'gradlew assembleRelease',
   () => {
-    const p = $({ cwd: 'android' })`./gradlew assembleRelease`;
+    const p = $({ cwd: 'android' })`./gradlew assembleRelease -PreactNativeArchitectures=${APK_ARCHITECTURES}`;
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
     return p;
@@ -125,10 +126,11 @@ if (coordinatedOutputDir) {
     throw new Error('MENTRA_COORDINATED_RELEASE_IDENTITY is required with MENTRA_COORDINATED_OUTPUT_DIR');
   }
   console.log('\n━━━ Coordinated release: building AAB ━━━');
+  console.log(`AAB architectures: ${AAB_ARCHITECTURES}`);
   await withRetry(
     'gradlew bundleRelease',
     () => {
-      const p = $({ cwd: 'android' })`./gradlew bundleRelease`;
+      const p = $({ cwd: 'android' })`./gradlew bundleRelease -PreactNativeArchitectures=${AAB_ARCHITECTURES}`;
       p.stdout.pipe(process.stdout);
       p.stderr.pipe(process.stderr);
       return p;
@@ -207,10 +209,11 @@ console.log(`Uploaded ${apkName} to release ${tag}`);
 // ── Step 8: Build AAB ─────────────────────────────────────────────────────────
 
 console.log('\n━━━ Step 8: Building AAB ━━━');
+console.log(`AAB architectures: ${AAB_ARCHITECTURES}`);
 await withRetry(
   'gradlew bundleRelease',
   () => {
-    const p = $({ cwd: 'android' })`./gradlew bundleRelease`;
+    const p = $({ cwd: 'android' })`./gradlew bundleRelease -PreactNativeArchitectures=${AAB_ARCHITECTURES}`;
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
     return p;


### PR DESCRIPTION
## Summary

- build the GitHub sideload APK for `arm64-v8a` only
- keep the Google Play AAB on all supported ABIs so Play can serve device-specific splits
- verify both published archives satisfy that ABI contract and add regression coverage

This returns the GitHub APK from roughly 694 MB to the prior arm64-only size while preserving the full-ABI Play bundle.

## Validation

- `node --test` across all coordinated-release test files: 124 passed
- `node .github/scripts/release-family-cli.mjs validate --require-version-mirrors`
- `git diff --check origin/dev...HEAD`
- artifact parser verified against the published 3.0 arm64 APK and 3.1 multi-ABI APK/AAB layouts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated Android release artifacts and CI gates; wrong ABI wiring could break sideload installs or Play uploads, though contract tests and unzip verification reduce that risk.
> 
> **Overview**
> **GitHub sideload APKs are arm64-only again; Google Play AABs stay multi-ABI** so Play can serve per-device splits while shrinking the GitHub download.
> 
> `release-android.mjs` now defines `APK_ARCHITECTURES` (`arm64-v8a`) and `AAB_ARCHITECTURES` (all four ABIs), pins prebuild to the APK set, and passes `-PreactNativeArchitectures` on `assembleRelease` vs both `bundleRelease` paths. The coordinated mobile workflow **drops** the job-level `ORG_GRADLE_PROJECT_reactNativeArchitectures` override that forced every ABI into one build.
> 
> CI adds **Verify newly built Android ABI contract** (only when building a new pair, not when reusing immutable release assets): it inspects `.so` ABIs inside the APK and AAB and fails publication if they do not match the contract.
> 
> Regression coverage in `coordinated-workflow-contract.test.mjs` locks the script constants, Gradle flags, workflow step, and absence of the old Gradle env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de110b5f859ec457b4118044208140bea74c8b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->