### PR TITLE
fix(ci): preserve internal TestFlight link

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -161,6 +161,11 @@ test("mobile destinations use real TestFlight groups without changing the releas
   assert.match(example, /app-store-connect-build\.mjs assign/)
   assert.match(example, /app-store-connect-build\.mjs testflight-preflight/)
   assert.match(example, /app-store-connect-build\.mjs wait/)
+  assert.match(
+    example,
+    /INTERNAL_INSTALL_URL: https:\/\/appstoreconnect\.apple\.com\/apps\/6792839366\/testflight\/groups\/\{groupId\}/,
+  )
+  assert.doesNotMatch(example, /appstoreconnect\.apple\.com\/teams\//)
   assert.match(example, /Mentra Staging Public/)
   assert.match(example, /testflight_audience/)
   assert.match(example, /destination="\$GITHUB_WORKSPACE\/release-output\/mentra-example-react-native-/)

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Check for an unresolved external review
         id: preflight
         env:
-          INTERNAL_INSTALL_URL: https://appstoreconnect.apple.com/teams/52733bd2-726b-4742-b1e2-1cfc0174c696/apps/6792839366/testflight/groups/{groupId}
+          INTERNAL_INSTALL_URL: https://appstoreconnect.apple.com/apps/6792839366/testflight/groups/{groupId}
         run: >-
           node mobile/scripts/app-store-connect-build.mjs testflight-preflight
           --issuer-id "${{ secrets.ASC_API_ISSUER_ID }}"


### PR DESCRIPTION
## Failure

Dev.84 successfully uploaded and assigned build `310000084` to the `Mentra Dev` internal group, but GitHub refused to propagate the group URL from the preflight job:

```text
Skip output `install_url` since it may contain secret.
```

The URL embedded the App Store Connect team UUID, which matches a repository secret. Record creation therefore received an empty URL and failed closed after the successful assignment.

## Change

Use App Store Connect's accepted team-independent app/group route:

```text
https://appstoreconnect.apple.com/apps/6792839366/testflight/groups/{groupId}
```

The resolved group ID is already a permitted job output. External beta still uses Apple's public `testflight.apple.com/join/...` link.

## Verification

- Confirmed the team-independent route preserves its complete target through App Store Connect login.
- `node --test .github/scripts/coordinated-workflow-contract.test.mjs mobile/scripts/app-store-connect-build.test.mjs .github/scripts/coordinated-example-testflight-record.test.mjs` (50 passed)
- `actionlint .github/workflows/reusable-coordinated-example-testflight.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI URL template change with contract-test guardrails; no runtime app or auth logic changes.
> 
> **Overview**
> Fixes coordinated example TestFlight preflight so GitHub Actions can expose the internal install link as a job output instead of redacting it as a secret.
> 
> **`INTERNAL_INSTALL_URL`** in the example TestFlight reusable workflow now uses App Store Connect’s app/group path (`/apps/6792839366/testflight/groups/{groupId}`) instead of a `/teams/<uuid>/...` URL. The team UUID in the old link matched a repo secret, which triggered `Skip output install_url since it may contain secret` and left downstream record creation without a URL after a successful assign.
> 
> Contract tests were updated to require the new URL shape and forbid `/teams/` in the example workflow definition. External beta links are unchanged (`testflight.apple.com/join/...`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1af9ccc3549dd41a84ca91cad4b8f1fa7e5ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->