### PR TITLE
Record coordinated changelog provenance

### DIFF
--- a/.github/scripts/prepare-production-release.test.mjs
+++ b/.github/scripts/prepare-production-release.test.mjs
@@ -6,6 +6,7 @@ import {prepareProductionRelease} from "./prepare-production-release.mjs"
 
 const family = {
   familyBaseVersion: "3.1.0",
+  changelog: {version: "3.1.0", path: "changelogs/3.1.0.md", sha256: "f".repeat(64)},
   products: ["mentraos"],
   publicationOrder: ["mentraos"],
   members: [

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -40,6 +40,30 @@ function requireUniqueStrings(values, label) {
   return seen
 }
 
+function changelogForVersion(rootDir, version) {
+  const relativePath = `changelogs/${version}.md`
+  const file = path.join(rootDir, relativePath)
+  if (!existsSync(file)) fail(`missing ${relativePath} for the current family base version`)
+  const content = readFileSync(file)
+  if (content.length === 0) fail(`${relativePath} must not be empty`)
+  return {
+    version,
+    path: relativePath,
+    sha256: createHash("sha256").update(content).digest("hex"),
+  }
+}
+
+function validateChangelog(changelog, familyBaseVersion) {
+  if (
+    changelog?.version !== familyBaseVersion ||
+    changelog?.path !== `changelogs/${familyBaseVersion}.md` ||
+    !SHA256_PATTERN.test(changelog?.sha256 || "")
+  ) {
+    throw new Error("Release plan has invalid changelog provenance")
+  }
+  return changelog
+}
+
 export function validateFamilyBaseVersion(version) {
   if (typeof version !== "string" || !STABLE_VERSION_PATTERN.test(version)) {
     fail(`family base version ${JSON.stringify(version)} must be a plain X.Y.Z version`)
@@ -104,9 +128,7 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
   requireString(definition.family, "family")
   const versionSource = requireString(definition.versionSource, "versionSource")
   const familyBaseVersion = validateFamilyBaseVersion(readJson(path.join(rootDir, versionSource)).version)
-  if (!existsSync(path.join(rootDir, "changelogs", `${familyBaseVersion}.md`))) {
-    fail(`missing changelogs/${familyBaseVersion}.md for the current family base version`)
-  }
+  const changelog = changelogForVersion(rootDir, familyBaseVersion)
 
   if (!Array.isArray(definition.members) || definition.members.length === 0) fail("members must not be empty")
   const members = []
@@ -214,6 +236,7 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
     family: definition.family,
     familyBaseVersion,
     versionSource,
+    changelog,
     products,
     members,
     publicationOrder,
@@ -222,6 +245,7 @@ export function loadReleaseFamily({rootDir = process.cwd(), requireVersionMirror
 
 export function createReleasePlan({family, channel, sequence, sourceCommit, nativeBuildNumber, otaInputs = {}}) {
   if (!family?.members || !family?.familyBaseVersion) throw new Error("A validated release family is required")
+  const changelog = validateChangelog(family.changelog, family.familyBaseVersion)
   if (!CHANNELS.has(channel)) throw new Error(`Unknown release channel ${JSON.stringify(channel)}`)
   if (typeof sourceCommit !== "string" || !COMMIT_PATTERN.test(sourceCommit)) {
     throw new Error("sourceCommit must be a full lowercase Git commit SHA")
@@ -249,6 +273,7 @@ export function createReleasePlan({family, channel, sequence, sourceCommit, nati
     schemaVersion: 1,
     releaseSetId: releaseSetId(releaseIdentity),
     familyBaseVersion: family.familyBaseVersion,
+    changelog: {...changelog},
     releaseIdentity,
     artifactContainerTag:
       channel === "production" ? `mentra-v${releaseIdentity}` : `mentra-builds-v${family.familyBaseVersion}`,
@@ -491,6 +516,7 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
   ) {
     throw new Error("Release plan has invalid native build identity")
   }
+  const changelog = validateChangelog(plan.changelog, plan.familyBaseVersion)
 
   const publications = {}
   for (const [memberName, member] of Object.entries(plan.members)) {
@@ -555,6 +581,7 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
     schemaVersion: 1,
     releaseSetId: plan.releaseSetId,
     familyBaseVersion: plan.familyBaseVersion,
+    changelog,
     releaseIdentity: plan.releaseIdentity,
     channel: plan.channel,
     sourceCommit: plan.sourceCommit,

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -45,6 +45,9 @@ test("loads the repository release family and derives dependency-first publicati
   const family = loadReleaseFamily({rootDir: repositoryRoot})
 
   assert.equal(family.familyBaseVersion, "3.1.0")
+  assert.equal(family.changelog.version, "3.1.0")
+  assert.equal(family.changelog.path, "changelogs/3.1.0.md")
+  assert.match(family.changelog.sha256, /^[0-9a-f]{64}$/)
   assert.deepEqual(family.products, ["mentraos", "@mentra/engine", "@mentra/bluetooth-sdk"])
   assert.equal(family.members.length, 8)
   assert.ok(family.publicationOrder.indexOf("@mentra/jspolyfill") < family.publicationOrder.indexOf("@mentra/crust"))
@@ -112,6 +115,7 @@ test("creates a deterministic release plan with exact dependency versions", () =
   assert.equal(plan.artifactContainerName, "Mentra 3.1.0 development builds")
   assert.equal(plan.native.marketingVersion, "3.1.0")
   assert.equal(plan.native.buildNumber, 3100057)
+  assert.deepEqual(plan.changelog, family.changelog)
   assert.equal(plan.products["@mentra/engine"], "3.1.0-beta.57")
   assert.equal(plan.members["@mentra/engine"].dependencies["@mentra/bluetooth-sdk"], "3.1.0-beta.57")
   assert.equal(plan.members["@mentra/bluetooth-sdk"].publishTargets.length, 3)
@@ -183,6 +187,7 @@ test("serializes records canonically and finalizes only complete release results
   assert.equal(manifest.releasePlanSha256, releaseRecordSha256(plan))
   assert.equal(manifest.publications["@mentra/engine"].npm.coordinate, "@mentra/engine@3.1.0-beta.57")
   assert.deepEqual(manifest.native, plan.native)
+  assert.deepEqual(manifest.changelog, plan.changelog)
   assert.equal(manifest.cloud.environment, "staging")
   assert.equal(serializeReleaseRecord({z: 1, a: 2}), '{\n  "a": 2,\n  "z": 1\n}\n')
 

--- a/.github/scripts/stage-release-family.mjs
+++ b/.github/scripts/stage-release-family.mjs
@@ -16,6 +16,9 @@ export function stageReleaseFamily({rootDir = process.cwd(), plan}) {
       `Release plan base ${JSON.stringify(plan.familyBaseVersion)} does not match source ${family.familyBaseVersion}`,
     )
   }
+  if (JSON.stringify(plan.changelog) !== JSON.stringify(family.changelog)) {
+    throw new Error("Release plan changelog does not match the source changelog")
+  }
   if (!plan.releaseIdentity || plan.releaseSetId !== `mentra-${plan.releaseIdentity}`) {
     throw new Error("Release plan has an invalid release identity")
   }

--- a/.github/scripts/stage-release-family.test.mjs
+++ b/.github/scripts/stage-release-family.test.mjs
@@ -62,3 +62,17 @@ test("rejects a plan from another family base", () => {
 
   assert.throws(() => stageReleaseFamily({rootDir: root, plan}), /does not match source/)
 })
+
+test("rejects a plan whose changelog does not match the source", () => {
+  const {root, family} = fixture()
+  const plan = createReleasePlan({
+    family,
+    channel: "dev",
+    sequence: 4,
+    sourceCommit: "b".repeat(40),
+    nativeBuildNumber: 310000004,
+  })
+  plan.changelog.sha256 = "0".repeat(64)
+
+  assert.throws(() => stageReleaseFamily({rootDir: root, plan}), /changelog does not match/)
+})


### PR DESCRIPTION
## Summary

- hash the canonical `changelogs/<family-base-version>.md` source into every coordinated release plan
- preserve the changelog version, path, and SHA-256 in the finalized release manifest
- reject staging when a release plan no longer matches the source changelog

This closes the final provenance requirement in the coordinated docs and example-app design without changing the release workflow graph.

## Verification

- `node --test .github/scripts/*.test.mjs` (111 passed)
- generated a dev release plan and independently matched its changelog digest with `shasum -a 256 changelogs/3.1.0.md`
- `npx --no-install prettier --check` on all changed files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to GitHub release scripting and validation; they add provenance fields and checks without altering auth, data stores, or the release workflow graph, though release plan digests will change for plans that now include changelog.
> 
> **Overview**
> Coordinated releases now **pin the canonical release notes file** (`changelogs/<family-base-version>.md`) with version, path, and a SHA-256 of its contents.
> 
> `loadReleaseFamily` computes that provenance (and still fails if the file is missing or empty). **`createReleasePlan` copies it into every release plan**, `finalizeReleaseManifest` **carries the same record into the finalized manifest**, and **`stageReleaseFamily` aborts** if a plan’s changelog no longer matches what’s on disk—so staging can’t proceed with stale or tampered release notes metadata.
> 
> Tests and fixtures were updated to include the new `changelog` field on family/plan objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b515ab71743618d64ea3e36eab1997fcad695483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->