### PR TITLE
Compare release changelog fields explicitly

### DIFF
--- a/.github/scripts/stage-release-family.mjs
+++ b/.github/scripts/stage-release-family.mjs
@@ -16,7 +16,11 @@ export function stageReleaseFamily({rootDir = process.cwd(), plan}) {
       `Release plan base ${JSON.stringify(plan.familyBaseVersion)} does not match source ${family.familyBaseVersion}`,
     )
   }
-  if (JSON.stringify(plan.changelog) !== JSON.stringify(family.changelog)) {
+  if (
+    plan.changelog?.version !== family.changelog.version ||
+    plan.changelog?.path !== family.changelog.path ||
+    plan.changelog?.sha256 !== family.changelog.sha256
+  ) {
     throw new Error("Release plan changelog does not match the source changelog")
   }
   if (!plan.releaseIdentity || plan.releaseSetId !== `mentra-${plan.releaseIdentity}`) {

--- a/.github/scripts/stage-release-family.test.mjs
+++ b/.github/scripts/stage-release-family.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path"
 import test from "node:test"
 import {fileURLToPath} from "node:url"
 
-import {createReleasePlan, loadReleaseFamily} from "./release-family.mjs"
+import {createReleasePlan, loadReleaseFamily, serializeReleaseRecord} from "./release-family.mjs"
 import {stageReleaseFamily} from "./stage-release-family.mjs"
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
@@ -38,7 +38,8 @@ test("stages one exact prerelease identity without changing MentraOS workspace e
     nativeBuildNumber: 310000057,
   })
 
-  stageReleaseFamily({rootDir: root, plan})
+  const downloadedPlan = JSON.parse(serializeReleaseRecord(plan))
+  stageReleaseFamily({rootDir: root, plan: downloadedPlan})
 
   for (const member of family.members) {
     const manifest = JSON.parse(readFileSync(path.join(root, member.manifest), "utf8"))


### PR DESCRIPTION
## Summary

- compare changelog provenance fields explicitly when staging a coordinated release
- exercise the staging path with a canonically serialized and parsed release plan, matching the artifact downloaded by CI

This fixes the dev.90 failure caused by object key order differing after canonical serialization.

## Verification

- `node --test .github/scripts/stage-release-family.test.mjs .github/scripts/release-family.test.mjs` (13 passed)
- `npx --no-install prettier --check .github/scripts/stage-release-family.mjs .github/scripts/stage-release-family.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change in release scripting with a targeted test update; no runtime product or auth/data paths affected.
> 
> **Overview**
> **Release staging** no longer treats the release plan changelog as equal only when `JSON.stringify` matches the source object. It now checks **`version`**, **`path`**, and **`sha256`** only, so canonical serialization/re-parse in CI (different key order) does not falsely fail staging—addressing the **dev.90** failure.
> 
> The **staging test** round-trips the plan through `serializeReleaseRecord` and `JSON.parse` before calling `stageReleaseFamily`, matching how CI loads the downloaded release plan artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b955cb7ed61d1220d0367536656b8e4750036655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->