### PR TITLE
Add Cloud V2 pull request validation

### DIFF
--- a/.github/CI_GATE.md
+++ b/.github/CI_GATE.md
@@ -3,8 +3,8 @@
 ## Problem this solves
 
 Branch protection requires a **fixed list of check names**. Our area builders are
-**path-filtered** (iOS/Android only run when `mobile/**` changes, cloud only when
-`cloud/**` changes, etc.). A path-filtered workflow that doesn't match **never
+**path-filtered** (iOS/Android only run when `mobile/**` changes, Cloud V2 only
+when `cloud-v2/**` changes, etc.). A path-filtered workflow that doesn't match **never
 reports a status**, so requiring it directly leaves the PR stuck forever in
 _"Expected — waiting for status to be reported."_ That is exactly what blocked
 every `dev` PR (#3204, #3205, #3206, …): the required contexts
@@ -26,26 +26,16 @@ posts a single `ci-gate-dev` commit status:
 | A gated workflow that ran is still in progress / queued                  | ⏳ pending          |
 | A gated workflow **did not run** (path filter didn't match this PR)      | not gated — ignored |
 
-Two kinds of gated workflow, with different "runs when" behavior:
-
-- **Path-filtered builders** — iOS/Android/ASG/jest, `Bun Lockfile Checks`, and
-  `Run Cloud Tests ☁️` only run when their area changes (`mobile/**`,
-  `asg_client/**`, lockfile/workspace package manifests, `cloud/**`). On a PR
-  that doesn't touch their area they **don't run at all**, so the gate never
-  waits on them. This is the heavy work (Mac builds, device tests) plus the
-  targeted dependency-integrity work we want scoped — a cloud-only PR never runs
-  iOS/Android, and vice-versa.
-- **Always-on cloud builds** — the four `🧪 Test * build` workflows have an
-  **unfiltered** `pull_request` trigger, so they run on **every** `dev` PR. They
-  self-skip internally (via `dorny/paths-filter`) when their package didn't
-  change, reporting `success` quickly. So the gate technically always includes
-  them, but on an unrelated PR they finish near-instantly and don't meaningfully
-  block.
-
-Net effect: each PR is gated on the **heavy** builders only for the areas it
-touches (the requirement — your cloud engineer never runs iOS/Android), plus the
-four lightweight cloud build checks that run-and-pass on everything. Nothing that
-doesn't run is ever waited on.
+All aggregated workflows are path-filtered. iOS/Android/ASG/jest,
+`Bun Lockfile Checks`, coordinated release-family checks, and
+`Cloud V2 Validation` run only when their area changes. A workflow that does not
+match the PR does not run, so the gate never waits on it. A Cloud V2-only PR does
+not run iOS/Android, and a mobile-only PR does not run Cloud V2 validation.
+If no gated workflow registers at all, the gate succeeds after the same
+90-second registration grace window instead of polling until its timeout. That
+empty-area success does not suppress the grace window if a gated workflow
+registers later, so one late completion cannot hide sibling builders that have
+not appeared yet.
 
 ### Why match by workflow name, not job/check-run name
 
@@ -58,19 +48,15 @@ below. `Recovery Worker Build` is deliberately excluded.
 
 ### Workflows aggregated (the allowlist)
 
-| Area        | Workflow name               | Runs when                                                 |
-| ----------- | --------------------------- | --------------------------------------------------------- |
-| iOS         | `Mobile App iOS Build`      | `mobile/**`                                               |
-| Android     | `Mobile App Android Build`  | `mobile/**`                                               |
-| ASG         | `MentraOS ASG Client Build` | `asg_client/**`                                           |
-| Mobile jest | `Mobile App Quality Checks` | `mobile/**`                                               |
-| Release     | `Coordinated Release Family Checks` | coordinated release definitions and workflows      |
-| Lockfiles   | `Bun Lockfile Checks`       | root/mobile/sdk lockfiles and workspace package manifests |
-| Cloud       | `🧪 Test Cloud build`       | all dev PRs (self-skips internally)                       |
-| SDK         | `🧪 Test SDK build`         | all dev PRs (self-skips internally)                       |
-| Console     | `🧪 Test Console build`     | all dev PRs (self-skips internally)                       |
-| Store       | `🧪 Test Store build`       | all dev PRs (self-skips internally)                       |
-| Cloud tests | `Run Cloud Tests ☁️`        | `cloud/**` (PR trigger added in this PR)                  |
+| Area        | Workflow name                       | Runs when                                                 |
+| ----------- | ----------------------------------- | --------------------------------------------------------- |
+| iOS         | `Mobile App iOS Build`              | `mobile/**`                                               |
+| Android     | `Mobile App Android Build`          | `mobile/**`                                               |
+| ASG         | `MentraOS ASG Client Build`         | `asg_client/**`                                           |
+| Mobile jest | `Mobile App Quality Checks`         | `mobile/**`                                               |
+| Release     | `Coordinated Release Family Checks` | coordinated release definitions and workflows             |
+| Lockfiles   | `Bun Lockfile Checks`               | root/mobile/sdk lockfiles and workspace package manifests |
+| Cloud V2    | `Cloud V2 Validation`               | `cloud-v2/**`, `sdk/miniapp-cli/**`, or its workflow      |
 
 If you add or remove a builder, update the `GATED` set **and** the `workflow_run`
 `workflows:` list in `ci-gate.yml` — both must list the same workflow names.
@@ -89,8 +75,8 @@ Then:
 
 1. Open a throwaway PR to `dev` touching `mobile/**`; confirm `ci-gate-dev` goes
    pending → success and that iOS/Android/jest are the builders it waited on.
-2. Open one touching only `cloud/**`; confirm `ci-gate-dev` waits on the cloud
-   builds + `Run Cloud Tests ☁️` and **not** on mobile.
+2. Open one touching only `cloud-v2/**`; confirm `ci-gate-dev` waits on
+   `Cloud V2 Validation` and **not** on mobile.
 3. Set branch protection on `dev` to require the single context **`ci-gate-dev`**
    (Settings → Branches → `dev`, or the API call below). Remove the old
    `Build Mobile App (*)`, `Build ASG Client`, `Upload to staging-builds release`,

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -47,15 +47,11 @@ externalReviewers:
 # Path-scoped required CI check names (must match workflow `name:` fields)
 ciGates:
   - paths:
-      - "cloud/**"
+      - "cloud-v2/**"
+      - "sdk/miniapp-cli/**"
+      - ".github/workflows/cloud-v2-validation.yml"
     workflows:
-      - "🧪 Test Cloud build"
-  - paths:
-      - "cloud/packages/**"
-      - "cloud/bun.lock"
-      - "cloud/package.json"
-    workflows:
-      - "Run Cloud Tests ☁️"
+      - "Cloud V2 Validation"
   - paths:
       - "mobile/**"
     workflows:
@@ -65,7 +61,3 @@ ciGates:
       - "asg_client/**"
     workflows:
       - "MentraOS ASG Client Build"
-  - paths:
-      - "cloud/packages/sdk/**"
-    workflows:
-      - "🧪 Test SDK build"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -65,11 +65,7 @@ on:
       - "OEM Host Boundary Gate"
       - "Coordinated Release Family Checks"
       - "Bun Lockfile Checks"
-      - "🧪 Test Cloud build"
-      - "🧪 Test SDK build"
-      - "🧪 Test Console build"
-      - "🧪 Test Store build"
-      - "Run Cloud Tests ☁️"
+      - "Cloud V2 Validation"
     types: [completed]
 
 concurrency:
@@ -107,6 +103,7 @@ jobs:
         with:
           script: |
             const STATUS_CONTEXT = "ci-gate-dev";
+            const EMPTY_AREA_DESCRIPTION = "No required area builds for this change";
 
             // Workflows this gate aggregates, matched by exact workflow name.
             // A workflow absent from a commit's runs didn't run for this PR
@@ -121,11 +118,7 @@ jobs:
               "OEM Host Boundary Gate",
               "Coordinated Release Family Checks",
               "Bun Lockfile Checks",
-              "🧪 Test Cloud build",
-              "🧪 Test SDK build",
-              "🧪 Test Console build",
-              "🧪 Test Store build",
-              "Run Cloud Tests ☁️",
+              "Cloud V2 Validation",
             ]);
 
             // Resolve the head SHA for whichever event triggered us.
@@ -139,8 +132,9 @@ jobs:
             const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"]);
             const OK = new Set(["success", "skipped", "neutral"]);
 
-            // Did an earlier ci-gate run already SETTLE this commit (post success
-            // or failure)? If so, every builder the PR triggers had already
+            // Did an earlier ci-gate run already SETTLE a non-empty builder set
+            // for this commit (post success or failure)? If so, every builder
+            // the PR triggers had already
             // registered by then, so the grace window — whose only job is to wait
             // for path-filtered builders to first appear — is no longer needed.
             // Skipping grace when already settled does two things:
@@ -162,7 +156,11 @@ jobs:
               // listCommitStatusesForRef returns newest first; find the latest
               // status for our context.
               const latest = existing.find(s => s.context === STATUS_CONTEXT);
-              alreadySettled = latest?.state === "success" || latest?.state === "failure";
+              const hasSettledState = latest?.state === "success" || latest?.state === "failure";
+              // Empty-area success only proves that nothing registered during
+              // that evaluation's grace window. A genuinely late gated run must
+              // receive a fresh grace window so sibling builders can register.
+              alreadySettled = hasSettledState && latest?.description !== EMPTY_AREA_DESCRIPTION;
             } catch (e) {
               core.info(`could not read existing ci-gate-dev status: ${e.message}`);
             }
@@ -170,8 +168,8 @@ jobs:
 
             // The commit-status `description` field rejects 4-byte Unicode
             // (422 "Description doesn't accept 4-byte Unicode"). Some gated
-            // workflow names contain emoji (e.g. "🧪 Test Cloud build"), so strip
-            // any astral-plane code points and clamp to the 140-char limit.
+            // Workflow names can contain emoji, so strip any astral-plane code
+            // points and clamp to the 140-char limit.
             const sanitize = (s) =>
               s.replace(/[\u{10000}-\u{10FFFF}]/gu, "").replace(/\s+/g, " ").trim().slice(0, 140);
 
@@ -230,9 +228,16 @@ jobs:
                 // registered its run yet. Hold pending until the window elapses.
                 state = "pending"; settled = false;
                 description = "Confirming all area builds have registered…";
+              } else if (elapsedMs >= GRACE_MS || alreadySettled) {
+                // No gated workflow registered during the same grace window.
+                // This PR did not touch a gated area, so there is nothing to
+                // wait for. The always-on Cloud V1 builders used to mask this
+                // case by ensuring at least one gated run existed on every PR.
+                state = "success"; settled = true;
+                description = EMPTY_AREA_DESCRIPTION;
               } else {
                 // No gated workflow has appeared for this commit yet — builders are
-                // still spinning up. Not settled; keep polling.
+                // still within their registration grace period. Keep polling.
                 state = "pending"; settled = false;
                 description = "Waiting for area builds to report";
               }

--- a/.github/workflows/cloud-v2-validation.yml
+++ b/.github/workflows/cloud-v2-validation.yml
@@ -1,0 +1,84 @@
+name: Cloud V2 Validation
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+    paths:
+      - "cloud-v2/**"
+      - "sdk/miniapp-cli/**"
+      - ".github/workflows/cloud-v2-validation.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: cloud-v2-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Typecheck, test, and build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          # Match the Cloud V2 deployment image.
+          bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-cloud-v2-${{ hashFiles('cloud-v2/bun.lock', 'sdk/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-cloud-v2-
+
+      - name: Install dependencies
+        working-directory: cloud-v2
+        run: bun install --frozen-lockfile
+
+      - name: Install Miniapp CLI dependencies
+        working-directory: sdk
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Test Miniapp CLI
+        working-directory: sdk
+        run: bun test miniapp-cli/src
+
+      - name: Typecheck Miniapp CLI
+        working-directory: sdk/miniapp-cli
+        run: bun run tsc --noEmit -p tsconfig.json
+
+      - name: Run package tests
+        working-directory: cloud-v2
+        # Keep CI deterministic and local: integration, soak, and external-service
+        # tests under cloud-v2/tests require a separately designed environment.
+        # Run before typecheck creates dist output, which would duplicate tests.
+        run: bun test packages
+
+      - name: Typecheck backend packages
+        working-directory: cloud-v2
+        run: bun run typecheck
+
+      - name: Typecheck websites
+        working-directory: cloud-v2
+        run: |
+          bun run typecheck:console
+          bun run typecheck:admin
+          bun run typecheck:portal
+
+      - name: Build websites
+        working-directory: cloud-v2
+        run: |
+          bun run build:console
+          bun run build:admin
+          bun run build:portal

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -5,9 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_run:
     workflows:
-      - "🧪 Test Cloud build"
-      - "Run Cloud Tests ☁️"
-      - "🧪 Test SDK build"
+      - "Cloud V2 Validation"
       - "Mobile App Quality Checks"
       - "Bun Lockfile Checks"
       - "MentraOS ASG Client Build"

--- a/notes/superpowers/plans/2026-08-28-cloud-workflow-transition.md
+++ b/notes/superpowers/plans/2026-08-28-cloud-workflow-transition.md
@@ -1,0 +1,105 @@
+---
+status: active
+owner: Mentra
+---
+
+# Cloud workflow transition implementation plan
+
+**Goal:** Deliver three focused PRs that add Cloud V2 PR validation, delete
+Cloud V1 workflow ownership, and point staging-triggered beta Mentra App builds
+at Cloud V2 staging.
+
+**Spec source of truth:**
+`notes/superpowers/specs/2026-08-28-cloud-workflow-transition.md`
+
+## Research and design
+
+- [x] Inventory workflow triggers from the `origin/dev` workflow tree.
+- [x] Compare Cloud V1 capabilities with coordinated Cloud V2 deployment.
+- [x] Confirm `cloud-test` was a shared real deployment, not a test suite or
+      isolated PR preview.
+- [x] Identify deterministic Cloud V2 package, backend, and website checks.
+- [x] Find every CI Gate, PR-agent, and documentation reference to deleted
+      Cloud V1 workflow names.
+- [x] Trace `backend_environment` through the coordinator, reusable Android and
+      iOS jobs, environment generator, contract tests, and production promotion.
+- [x] Record the exact-byte production-promotion incompatibility as a required
+      later design.
+
+## PR 1: Cloud V2 validation
+
+### Files
+
+- `.github/workflows/cloud-v2-validation.yml`
+- `.github/workflows/ci-gate.yml`
+- `.github/workflows/pr-agent-orchestrator.yml`
+- `.github/pr-agent.yml`
+- this spec and plan
+
+### Tasks
+
+- [x] Add path-filtered PR validation for `cloud-v2/**`,
+      `sdk/miniapp-cli/**`, and its workflow definition.
+- [x] Pin Bun to the Cloud V2 deployment image version and use the frozen
+      lockfile.
+- [x] Run package tests before generated TypeScript output exists.
+- [x] Typecheck backend packages.
+- [x] Typecheck and build Console, Admin, and Portal.
+- [x] Exclude runtime smoke tests, infrastructure-backed integration tests, and
+      every deployment side effect.
+- [x] Register the workflow with CI Gate and PR-agent orchestration.
+- [x] Remove the replaced Cloud V1 workflow names and path gates from CI Gate,
+      PR Agent Orchestrator, `.github/pr-agent.yml`, and `.github/CI_GATE.md`.
+- [x] Run local validation.
+- [x] Commit, push, and open PR 1 against `dev` as PR #3876.
+
+## PR 2: Cloud V1 workflow cleanup
+
+### Workflow deletions
+
+- [ ] Delete the six Cloud V1 validation/functional workflows listed in the
+      spec.
+- [ ] Delete the two Cloud V1 China workflows.
+- [ ] Delete the eleven Cloud V1 Porter workflows.
+- [ ] Assert that exactly those 19 workflow files were removed.
+
+### End-state verification
+
+- [ ] Confirm PR 1 removed Cloud V1 workflow names from CI Gate, PR Agent
+      Orchestrator, `.github/pr-agent.yml`, and `.github/CI_GATE.md`.
+- [ ] Confirm Cloud V2 Pages, coordinated release/promotion, debug/Isaiah,
+      Local Merge, and release-family checks remain.
+- [ ] Validate the combined post-PR-1 tree, commit, push, and open PR 2.
+
+## PR 3: Staging-backed beta mobile builds
+
+### Coordinator and environment generator
+
+- [ ] Change the `staging` branch channel output from
+      `backend_environment=prod` to `backend_environment=staging`.
+- [ ] Change beta environment validation from `beta -> prod` to
+      `beta -> staging`.
+- [ ] Assert staging Core/Runtime URLs and `EXPO_PUBLIC_BUILD_ENV=staging`.
+
+### Android and iOS reusable jobs
+
+- [ ] Accept `staging` in both backend-token selection blocks.
+- [ ] Reuse `DOPPLER_TOKEN_MOBILE_PRD` only for the public Sentry DSN.
+- [ ] Keep dev and production behavior unchanged.
+
+### Tests and documentation
+
+- [ ] Update environment-generator unit tests.
+- [ ] Update coordinated workflow contract tests.
+- [ ] Add a superseding policy note to the prior coordinated Cloud V2 design.
+- [ ] Run the complete coordinated script test suite.
+- [ ] Run workflow/static validation, commit, push, and open PR 3.
+
+## Final audit
+
+- [ ] Verify all three PRs target `dev` and describe their required merge order.
+- [ ] Verify a resulting push to `staging` has one Cloud V2 backend deployment
+      owner and produces staging-backed beta Android and iOS builds.
+- [ ] Verify no Cloud V1 workflow remains in the combined tree.
+- [ ] Report the production-promotion incompatibility without expanding this
+      goal into its redesign.

--- a/notes/superpowers/specs/2026-08-28-cloud-workflow-transition.md
+++ b/notes/superpowers/specs/2026-08-28-cloud-workflow-transition.md
@@ -1,0 +1,232 @@
+---
+status: active
+owner: Mentra
+---
+
+# Cloud workflow transition and staging beta backend design
+
+## Outcome
+
+Replace the useful pre-merge validation previously supplied by Cloud V1
+workflows, delete Cloud V1 workflow ownership without redirecting it to Cloud
+V2, and make coordinated beta Mentra App builds from `staging` connect to the
+staging Cloud V2 backend.
+
+The work is split into three focused pull requests against `dev`:
+
+1. Add deterministic Cloud V2 pull-request validation.
+2. Delete Cloud V1 workflows and their orchestration references.
+3. Change staging-triggered beta mobile builds from the production backend to
+   the staging backend.
+
+The pull requests must merge in that order. The design is based on the workflow
+tree at `origin/dev` commit `80585dd0dec3b5b77c13be19fddeccd20e288144`.
+
+## Decisions
+
+### Validate Cloud V2 before merge without deploying it
+
+One path-filtered `Cloud V2 Validation` workflow will run for pull requests into
+`dev`, `staging`, and `main` when `cloud-v2/**`, `sdk/miniapp-cli/**`, or the
+validation workflow changes. It will:
+
+- install `cloud-v2` dependencies with the frozen lockfile and Bun `1.3.14`,
+  matching the Cloud V2 deployment image;
+- run the package tests under `cloud-v2/packages`;
+- typecheck the Cloud V2 backend project references;
+- typecheck and build Console, Admin, and Enterprise Portal;
+- participate in `ci-gate-dev` and the PR-agent CI configuration.
+
+Package tests run before TypeScript build output is generated so Bun does not
+discover duplicate tests under ignored `dist/` directories. The workflow does
+not start MongoDB or Redis and does not run `cloud-v2/tests`, whose integration,
+soak, and external-service requirements need a separate design.
+
+### Do not port `cloud-test`
+
+The Cloud V1 `porter-cloud-test.yml` workflow deployed every qualifying PR merge
+commit into one shared Porter application named `cloud-test`. It did not run
+tests, check readiness, publish a preview URL, isolate PRs, or clean up. Its only
+useful signal was that the Cloud V1 image could build and Porter could apply it.
+
+Cloud V2 will not receive a `cloud-test` deployment or PR-preview replacement.
+Pre-merge validation is local and deterministic. Post-merge coordinated Cloud V2
+deployment already builds the image, waits for Porter, checks DNS, and requires
+`/healthz` and `/ready` before mobile publication.
+
+### Leave runtime smoke-test design alone
+
+The old dev-to-main Cloud V1 workflow tested Live Captions, Mira, and
+translation. Mira is obsolete, and Live Captions now runs locally on the phone.
+Cloud Runtime transcription remains important, but an end-to-end transcription
+smoke test would require product-level decisions about credentials, audio input,
+provider cost, cleanup, failure policy, and the environment in which it runs.
+
+No runtime smoke test is added by these pull requests. It is not a prerequisite
+for merging `dev` into `staging`.
+
+### Delete Cloud V1 workflows rather than redirecting them
+
+The cleanup pull request deletes these 19 workflow files:
+
+- validation and functional tests:
+  - `augmentos_cloud_pr_dev_main.yml`
+  - `cloud-build.yml`
+  - `cloud-console-build.yml`
+  - `cloud-sdk-build.yml`
+  - `cloud-store-build.yml`
+  - `cloud-tests.yml`
+- China Cloud V1 deployment:
+  - `china-deploy-static-websites-prod.yaml`
+  - `china-deployment-prod.yml`
+- Porter Cloud V1 deployment and test targets:
+  - `porter-cloud-isaiah.yml`
+  - `porter-cloud-test.yml`
+  - `porter-debug.yml`
+  - `porter-dev.yml`
+  - `porter-prod.yml`
+  - `porter-staging.yml`
+  - `porter-stress.yml`
+  - `porter-us-west.yml`
+  - `porter-us.yml`
+  - `porter_app_end-to-end-tests-prod_4689.yml`
+  - `porter_app_live-captions-testing-monitor_4689.yml`
+
+The validation pull request atomically replaces their names and path gates in
+`ci-gate.yml`, `pr-agent-orchestrator.yml`, `.github/pr-agent.yml`, and
+`.github/CI_GATE.md`. The cleanup pull request then deletes the 19 workflow
+files only. It does not delete `cloud/` source code; that remains a later
+repository cleanup.
+
+The following are deliberately retained:
+
+- coordinated Cloud V2 release and production-promotion workflows;
+- `cloud-v2-pages.yml` for Console, Admin, and Portal deployment;
+- Cloud V2 debug and Isaiah sandbox workflows;
+- Local Merge dev/prod workflows;
+- coordinated release-family checks;
+- unrelated reusable or manual workflows, even if a later inventory may find
+  additional cleanup candidates.
+
+China is not mechanically ported. Cloud V2 documentation describes Alibaba OSS
+as planned and China streaming as undecided, so a future China surface requires
+its own regional design if the product still supports it.
+
+### Staging beta mobile uses staging Cloud V2
+
+`Coordinated Mentra Release` runs on every push to `dev` or `staging`. The
+environment matrix becomes:
+
+| Source branch                  | Cloud deployed   | Mobile backend embedded                | Mobile distribution            |
+| ------------------------------ | ---------------- | -------------------------------------- | ------------------------------ |
+| `dev`                          | Cloud V2 dev     | dev                                    | existing dev/internal channels |
+| `staging`                      | Cloud V2 staging | **staging**                            | existing beta channels         |
+| protected production promotion | Cloud V2 prod    | currently promotes selected beta bytes | production stores              |
+
+For staging, both `EXPO_PUBLIC_CLOUD_CORE_URL` and
+`EXPO_PUBLIC_CLOUD_RUNTIME_URL` are stamped to the staging regional endpoints,
+and `EXPO_PUBLIC_BUILD_ENV` is `staging`. Android and iOS use the same mapping.
+
+The reusable mobile workflow currently has only development and production
+Doppler tokens. It uses the selected token only to fetch the public Sentry DSN;
+the backend endpoints come from the checked-in environment generator. The
+staging case will reuse `DOPPLER_TOKEN_MOBILE_PRD`, matching the existing
+standalone mobile build behavior for distributable builds, without adding a new
+secret or using Doppler to select the backend.
+
+## Production-promotion incompatibility
+
+The current production workflow promotes the exact Android and iOS beta bytes.
+After the third pull request, those bytes contain staging endpoints. Promoting
+them unchanged would publish a production app that still connects to staging.
+
+Redesigning production promotion is explicitly outside these three pull
+requests. Until that follow-up lands, operators must not promote a
+staging-backed beta with the current exact-byte production workflow. The future
+design must choose between rebuilding production-configured signed binaries or
+making backend selection environment-neutral at runtime; merely changing the
+promotion workflow cannot rewrite endpoints inside an already signed binary.
+
+The current release record does not persist the embedded mobile backend, so a
+future promotion design should also add verifiable backend identity to mobile
+publication evidence and fail closed on an incompatible candidate.
+
+## Trigger behavior after all three pull requests
+
+### Pull requests
+
+- Cloud V2 changes run `Cloud V2 Validation` for PRs into `dev`, `staging`, or
+  `main`.
+- `ci-gate-dev` aggregates that workflow for PRs into `dev`.
+- No Cloud V1 build, test, shared test deployment, regional deployment, or China
+  deployment workflow remains.
+
+### Push to `staging`
+
+- `Coordinated Mentra Release` runs unconditionally.
+- It deploys the exact source to Cloud V2 staging and requires readiness.
+- Its beta Android and iOS builds connect to Cloud V2 staging.
+- Cloud V2 Pages deploy only when their existing website paths change.
+- No Cloud V1 workflow runs because the files no longer exist in the resulting
+  branch tree.
+
+### Push to `main`
+
+- No coordinated Cloud V2 backend production deployment runs automatically.
+- Cloud V2 Pages retain their existing path-filtered production deployment.
+- Production Cloud V2 remains owned by the protected manual production
+  promotion workflow.
+- External Mintlify and repository Pages settings remain outside this YAML
+  design.
+
+## Pull-request boundaries and merge order
+
+| PR  | Scope                                                                       | Must not include                                                         |
+| --- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| 1   | Cloud V2 validation, atomic CI Gate/PR-agent replacement, design and plan   | deployments, Cloud V1 workflow-file deletion, mobile mapping             |
+| 2   | Exactly 19 Cloud V1 workflow deletions                                      | `cloud/` source deletion, Cloud V2 sandbox deletion, runtime smoke tests |
+| 3   | staging beta backend mapping plus contract/unit tests and policy-doc update | production-promotion redesign, new deployment owner, runtime smoke tests |
+
+PR 2 depends on PR 1 providing the replacement Cloud V2 validation. PR 3 is
+code-independent but merges third so the final branch state and operational
+warning are reviewed after the workflow cleanup.
+
+## Verification
+
+PR 1:
+
+- frozen Cloud V2 install;
+- package tests only, excluding generated `dist` duplication and
+  `cloud-v2/tests`;
+- backend typecheck;
+- all three website typechecks and builds;
+- actionlint, pinned Prettier, and `git diff --check`.
+
+PR 2:
+
+- exact 19-file deletion assertion;
+- repository search proving PR 1 removed every deleted workflow name from CI
+  Gate and PR-agent configuration;
+- actionlint on all surviving workflows;
+- pinned Prettier and `git diff --check`;
+- combined-tree audit proving Cloud V2 validation remains registered.
+
+PR 3:
+
+- environment-generator unit tests for beta-to-staging URLs and rejection of
+  beta-to-prod mismatches;
+- coordinated workflow contract tests for `staging -> staging` mobile mapping;
+- both Android and iOS reusable jobs accept staging and select the intended
+  Sentry-token source;
+- the complete `.github/scripts/*.test.mjs` suite;
+- actionlint, pinned Prettier, and `git diff --check`.
+
+## Rollback
+
+- PR 1 can be reverted without affecting any deployment.
+- PR 2 can restore individual deleted workflow files from its parent commit,
+  but Cloud V1 targets must not be re-enabled accidentally after `cloud/`
+  deletion.
+- PR 3 can restore `staging -> prod` mobile mapping if beta distribution must
+  return to production services before the promotion redesign is ready. Cloud
+  V2 staging deployment ownership remains unchanged either way.

--- a/scripts/pr-agent/tests/workflow-guards.test.ts
+++ b/scripts/pr-agent/tests/workflow-guards.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { requiredWorkflowsForPaths } from '../src/ci-gates.js';
 import { shouldBlankPrForWorkflowRunHandoff } from '../src/handoff-gate.js';
 import { repoRoot } from './helpers.js';
 
@@ -8,6 +9,7 @@ const workflowPath = join(
   repoRoot,
   '.github/workflows/pr-agent-orchestrator.yml',
 );
+const ciGateWorkflowPath = join(repoRoot, '.github/workflows/ci-gate.yml');
 
 /** Slice from `  jobId:` through the line before the next 2-space job key. */
 function jobBlock(workflow: string, jobId: string): string {
@@ -83,6 +85,34 @@ describe('shouldBlankPrForWorkflowRunHandoff', () => {
     expect(
       shouldBlankPrForWorkflowRunHandoff('workflow_run', ['agent-in-progress']),
     ).toBe(false);
+  });
+});
+
+describe('CI Gate empty-area handling', () => {
+  const workflow = readFileSync(ciGateWorkflowPath, 'utf8');
+
+  test('settles successfully after grace when no gated workflow registers', () => {
+    expect(workflow).toContain(
+      'else if (elapsedMs >= GRACE_MS || alreadySettled)',
+    );
+    expect(workflow).toContain(
+      'const EMPTY_AREA_DESCRIPTION = "No required area builds for this change"',
+    );
+    expect(workflow).toContain(
+      'latest?.description !== EMPTY_AREA_DESCRIPTION',
+    );
+    expect(workflow).toContain('description = EMPTY_AREA_DESCRIPTION');
+  });
+});
+
+describe('Cloud V2 validation gate paths', () => {
+  test('requires validation when its workflow definition changes', () => {
+    expect(
+      requiredWorkflowsForPaths(
+        ['.github/workflows/cloud-v2-validation.yml'],
+        repoRoot,
+      ),
+    ).toContain('Cloud V2 Validation');
   });
 });
 


### PR DESCRIPTION
## Summary

- add one path-filtered Cloud V2 validation workflow for PRs into `dev`, `staging`, and `main`
- run Cloud V2 package tests, backend typechecking, and build/typecheck all three Cloud V2 websites without deploying anything
- explicitly test and typecheck `sdk/miniapp-cli` whenever this gate runs
- atomically replace Cloud V1 registrations in CI Gate and PR-agent orchestration with `Cloud V2 Validation`
- let CI Gate settle successfully after its registration grace period when a PR matches no gated area
- document the three-PR Cloud workflow transition and staging-beta backend plan

## Boundaries

This PR does not deploy Cloud V2, add a runtime/transcription smoke test, delete Cloud V1 workflow files, or change the mobile backend mapping. The 19 obsolete workflow files are deleted in the cleanup PR.

## Validation

- Miniapp CLI: 92 tests passed and strict TypeScript project passed
- exact Bun 1.3.14 clean checkout: 204 Cloud V2 package tests passed
- Cloud V2 backend `tsc -b` passed
- Console, Admin, and Portal typechecks and builds passed
- PR-agent typecheck passed
- PR-agent tests: 68 passed, including empty-area CI Gate and workflow-definition path regressions
- actionlint passed, ignoring only the repository custom Blacksmith runner label
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes required CI aggregation and branch-protection semantics for `dev` PRs; misconfiguration could block merges or skip intended checks until rollout is verified.
> 
> **Overview**
> Introduces path-filtered **`Cloud V2 Validation`** for PRs into `dev`, `staging`, and `main` when `cloud-v2/**`, `sdk/miniapp-cli/**`, or the workflow file changes. The job runs frozen Bun installs, miniapp-cli tests/typecheck, `cloud-v2` package tests (before builds), backend typecheck, and website typecheck/builds—**no deploys** or `cloud-v2/tests` integration runs.
> 
> **CI orchestration** swaps out Cloud V1 gate names (`🧪 Test * build`, `Run Cloud Tests ☁️`) for **`Cloud V2 Validation`** in `ci-gate.yml`, PR-agent `ciGates`, and the orchestrator `workflow_run` list. Docs now describe an all path-filtered gate model.
> 
> **`ci-gate-dev`** can succeed after the 90s grace window when no gated workflow registers (`EMPTY_AREA_DESCRIPTION`), and empty-area success no longer counts as “already settled” so late sibling builders still get a grace period.
> 
> Adds transition **spec/plan** notes and PR-agent **regression tests** for empty-area handling and workflow-definition path gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d246972701c7b1d8ddb7276ec30217dd33c5277d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->