### PR TITLE
Make production finalization irreversible

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -355,9 +355,12 @@ phased-release state, record monotonically increasing observations:
 
 `--complete` first records 100 percent and enters the durable `finalizing`
 checkpoint. It then stages `mentra-release-plan-X.Y.Z.json` and
-`mentra-release-X.Y.Z.json` in the draft `mentra-vX.Y.Z` release and only then
-closes the immutable promotion chain. If finalization is interrupted, rerun the
-same `--complete` command; it verifies identical existing assets and resumes.
+`mentra-release-X.Y.Z.json`, plus the exact finalizing checkpoint record, in the
+draft `mentra-vX.Y.Z` release and only then closes the immutable promotion
+chain. If finalization is interrupted, rerun the same `--complete` command; it
+verifies identical existing assets and resumes. Do not abort or start a
+replacement attempt after `finalizing`: the 100 percent rollout is already
+public, so the only valid recovery is to finish reconciling this attempt.
 Do not complete until both store pages are publicly reachable in intended
 territories, install/update returns the exact coordinates, production Cloud is
 healthy, and the release owner has recorded the final observation window.
@@ -377,7 +380,12 @@ Abort an attempt with:
 Abort is terminal and does not itself roll Cloud back or remove store builds.
 Follow the incident commander's explicit mitigation. A new attempt allocates
 new store build numbers and references the failed attempt. Never delete failed
-evidence.
+evidence. The workflow refuses to allocate another attempt until every prior
+attempt for that release identity is aborted, and it never permits abort after
+the 100 percent `finalizing` checkpoint. Preparation runs are serialized while
+they allocate attempts, so starting two beta selections does not create two
+active promotions. A retry resumes a zero-state container only when its selected
+beta and source commit match exactly.
 
 Common stop conditions include source/lock mismatch, missing store provenance,
 unclassified Cloud config, non-backward-compatible migration, Mobile N failure,

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -58,6 +58,9 @@ test("production promotion is resumable and keeps irreversible actions behind se
     assert.doesNotMatch(source, /pull_request:/)
     assert.match(source, /ref: main/)
   }
+  assert.match(prepare, /group: production-release-prepare\n/)
+  assert.doesNotMatch(prepare, /group: production-release-prepare-\$\{\{/)
+  assert.match(prepare, /--beta "\$\{\{ inputs\.beta_identity \}\}"/)
   assert.match(compatibilityLab, /name: production-compatibility-lab/)
   assert.match(compatibilityLab, /backend_environment: staging/)
   assert.match(compatibilityLab, /compatibility_lab: true/)
@@ -97,6 +100,8 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(rollout, /finalize-production-promotion\.mjs/)
   assert.match(rollout, /\.artifactNames\.releasePlan/)
   assert.match(rollout, /\.artifactNames\.releaseManifest/)
+  assert.match(rollout, /checkpoint_name=.*promotionAssetName/)
+  assert.match(rollout, /releases\/download\/\$tag\/\$checkpoint_name/)
   assert.match(rollout, /--to completed/)
   assert.doesNotMatch(rollout, /releases\/\$\{\{ steps\.promotion\.outputs\.release_id \}\}\/assets/)
   for (const source of [compatibilityLab, cloud, mobile, submit, release, rollout]) {
@@ -111,7 +116,10 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(starterAndroid, /Persist and verify the exact App Bundle before Play upload/)
   assert.match(starterAndroid, /publish-immutable-release-asset\.mjs/)
   assert.match(starterAndroid, /GOOGLE_PLAY_AAB: \$\{\{ steps\.staged\.outputs\.aab \}\}/)
-  assert.match(starterAndroid, /Google Play contains this version code without this attempt's previously persisted App Bundle/)
+  assert.match(
+    starterAndroid,
+    /Google Play contains this version code without this attempt's previously persisted App Bundle/,
+  )
   assert.equal(existsSync(new URL("../workflows/coordinated-production-promotion.yml", import.meta.url)), false)
   assert.equal(existsSync(new URL("../workflows/reusable-coordinated-mobile-promotion.yml", import.meta.url)), false)
 })

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -9,6 +9,7 @@ import {requirePublicHttpsUrl} from "./release-family.mjs"
 import {promotionAssetName, validatePromotionChain, validatePromotionRecord} from "./production-promotion-state.mjs"
 
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+const BETA_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.([1-9]\d*)$/
 const EVIDENCE_KIND_PATTERN = /^[a-z][a-z0-9-]{0,79}$/
 const ASSET_PREFIX_PATTERN = /^[a-z0-9][a-z0-9.-]{0,119}$/
 
@@ -47,6 +48,14 @@ export function promotionContainerTag(releaseIdentity, attempt) {
 export function promotionContainerName(releaseIdentity, attempt) {
   promotionContainerTag(releaseIdentity, attempt)
   return `Mentra ${releaseIdentity} production promotion attempt ${attempt}`
+}
+
+export function promotionContainerBody(releaseIdentity, selectedBeta) {
+  const match = BETA_PATTERN.exec(selectedBeta || "")
+  if (!match || `${match[1]}.${match[2]}.${match[3]}` !== releaseIdentity) {
+    throw new Error(`selected beta must be a ${releaseIdentity}-beta.N identity`)
+  }
+  return `Append-only evidence for an in-progress Mentra production promotion. This draft is not a customer release. Selected beta: ${selectedBeta}.`
 }
 
 export function prepareEvidenceAsset({file, kind, url, outputDirectory, assetPrefix}) {
@@ -115,6 +124,41 @@ export function requirePromotionContainer(releases, releaseIdentity, attempt) {
   return release
 }
 
+export function requireNewPromotionAttemptAllowed(records, releaseIdentity) {
+  for (const record of records) {
+    validatePromotionRecord(record)
+    if (record.releaseIdentity !== releaseIdentity) {
+      throw new Error(`Prior promotion record belongs to ${record.releaseIdentity}, expected ${releaseIdentity}`)
+    }
+    if (record.state !== "aborted") {
+      throw new Error(
+        `Cannot start another ${releaseIdentity} promotion while attempt ${record.attempt} is ${record.state}`,
+      )
+    }
+  }
+}
+
+export function planPromotionContainerAllocation(containers, {releaseIdentity, targetCommit, selectedBeta}) {
+  requireNewPromotionAttemptAllowed(
+    containers.flatMap(({record}) => (record ? [record] : [])),
+    releaseIdentity,
+  )
+  const empty = containers.filter(({record}) => !record)
+  if (empty.length > 1) throw new Error(`Multiple empty ${releaseIdentity} promotion containers require reconciliation`)
+  if (empty.length === 1) {
+    const candidate = empty[0]
+    if (candidate !== containers.at(-1)) {
+      throw new Error(`Only the latest empty ${releaseIdentity} promotion container can be resumed`)
+    }
+    const expectedBody = promotionContainerBody(releaseIdentity, selectedBeta)
+    if (candidate.release.target_commitish !== targetCommit || candidate.release.body !== expectedBody) {
+      throw new Error(`Empty promotion attempt ${candidate.attempt} belongs to another frozen selection`)
+    }
+    return {action: "reuse", attempt: candidate.attempt, release: candidate.release}
+  }
+  return {action: "create", attempt: containers.length === 0 ? 1 : containers.at(-1).attempt + 1}
+}
+
 export function stateAssets(assets, releaseIdentity, attempt) {
   const pattern = new RegExp(
     `^production-promotion-${releaseIdentity.replaceAll(".", "\\.")}-attempt-${attempt}-(\\d{2,})-([a-z-]+)\\.json$`,
@@ -166,16 +210,27 @@ function resolveContainer(repository, releaseIdentity, attempt) {
   return requirePromotionContainer(listReleases(repository), releaseIdentity, attempt)
 }
 
-function createContainer({repository, releaseIdentity, targetCommit}) {
+function createContainer({repository, releaseIdentity, targetCommit, selectedBeta}) {
   const releases = listReleases(repository)
-  const attempt = nextPromotionAttempt(releases, releaseIdentity)
+  const containers = matchingPromotionContainers(releases, releaseIdentity).map(({attempt, release, ...entry}) => {
+    requirePromotionContainer(releases, releaseIdentity, attempt)
+    return {
+      ...entry,
+      attempt,
+      release,
+      record: loadPromotionState({repository, releaseIdentity, attempt, release})?.record || null,
+    }
+  })
+  const allocation = planPromotionContainerAllocation(containers, {releaseIdentity, targetCommit, selectedBeta})
+  if (allocation.action === "reuse") return {release: allocation.release, attempt: allocation.attempt}
+  const attempt = allocation.attempt
   const tag = promotionContainerTag(releaseIdentity, attempt)
   const name = promotionContainerName(releaseIdentity, attempt)
   const payload = JSON.stringify({
     tag_name: tag,
     target_commitish: targetCommit,
     name,
-    body: "Append-only evidence for an in-progress Mentra production promotion. This draft is not a customer release.",
+    body: promotionContainerBody(releaseIdentity, selectedBeta),
     draft: true,
     prerelease: false,
   })
@@ -186,10 +241,9 @@ function createContainer({repository, releaseIdentity, targetCommit}) {
   return {release, attempt}
 }
 
-function downloadLatest({repository, releaseIdentity, attempt, outputFile}) {
-  const release = resolveContainer(repository, releaseIdentity, attempt)
+function loadPromotionState({repository, releaseIdentity, attempt, release}) {
   const states = stateAssets(listAssets(repository, release.id), releaseIdentity, attempt)
-  if (states.length === 0) throw new Error(`Promotion ${releaseIdentity} attempt ${attempt} has no state record`)
+  if (states.length === 0) return null
   const entries = states.map((state) => {
     const bytes = gh(
       ["api", "-H", "Accept: application/octet-stream", `repos/${repository}/releases/assets/${state.asset.id}`],
@@ -199,6 +253,14 @@ function downloadLatest({repository, releaseIdentity, attempt, outputFile}) {
   })
   const record = validateStateRecordChain(entries, releaseIdentity, attempt)
   const latest = entries.at(-1)
+  return {release, latest, record}
+}
+
+function downloadLatest({repository, releaseIdentity, attempt, outputFile}) {
+  const release = resolveContainer(repository, releaseIdentity, attempt)
+  const loaded = loadPromotionState({repository, releaseIdentity, attempt, release})
+  if (!loaded) throw new Error(`Promotion ${releaseIdentity} attempt ${attempt} has no state record`)
+  const {latest, record} = loaded
   mkdirSync(path.dirname(outputFile), {recursive: true})
   writeFileSync(outputFile, latest.bytes)
   return {release, latest, record}
@@ -212,6 +274,7 @@ function main() {
       repository: args.repository,
       releaseIdentity: args.release,
       targetCommit: args["target-commit"],
+      selectedBeta: args.beta,
     })
     output(
       {

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -7,14 +7,18 @@ import test from "node:test"
 import {
   matchingPromotionContainers,
   nextPromotionAttempt,
+  planPromotionContainerAllocation,
   prepareEvidenceAsset,
+  promotionContainerBody,
   promotionContainerName,
   promotionContainerTag,
+  requireNewPromotionAttemptAllowed,
   requirePromotionContainer,
   stateAssets,
   validateStateRecordChain,
 } from "./production-promotion-assets.mjs"
 import {
+  abortPromotionRecord,
   createInitialPromotionRecord,
   promotionAssetName,
   transitionPromotionRecord,
@@ -131,6 +135,75 @@ function initialRecord() {
     provenanceUrl: "https://example.com/actions/1",
   })
 }
+
+test("allows a replacement only after every prior attempt is aborted", () => {
+  const active = initialRecord()
+  assert.throws(() => requireNewPromotionAttemptAllowed([active], "3.1.0"), /attempt 1 is selected/)
+  const aborted = abortPromotionRecord({
+    record: active,
+    actor: "owner",
+    createdAt: "2026-08-28T20:02:00.000Z",
+    provenanceUrl: "https://example.com/actions/3",
+    reason: "candidate rejected before public release",
+  })
+  assert.doesNotThrow(() => requireNewPromotionAttemptAllowed([aborted], "3.1.0"))
+  assert.throws(() => requireNewPromotionAttemptAllowed([aborted], "3.2.0"), /belongs to 3.1.0/)
+})
+
+test("resumes the latest empty container only for the same frozen beta and source", () => {
+  const targetCommit = "a".repeat(40)
+  const selectedBeta = "3.1.0-beta.57"
+  const draft = release(2, {
+    body: promotionContainerBody("3.1.0", selectedBeta),
+    target_commitish: targetCommit,
+  })
+  const aborted = abortPromotionRecord({
+    record: initialRecord(),
+    actor: "owner",
+    createdAt: "2026-08-28T20:02:00.000Z",
+    provenanceUrl: "https://example.com/actions/3",
+    reason: "candidate rejected before public release",
+  })
+  const containers = [
+    {releaseIdentity: "3.1.0", attempt: 1, release: release(1), record: aborted},
+    {releaseIdentity: "3.1.0", attempt: 2, release: draft, record: null},
+  ]
+  const allocation = planPromotionContainerAllocation(containers, {
+    releaseIdentity: "3.1.0",
+    targetCommit,
+    selectedBeta,
+  })
+  assert.equal(allocation.action, "reuse")
+  assert.equal(allocation.attempt, 2)
+  assert.equal(allocation.release, draft)
+  assert.throws(
+    () =>
+      planPromotionContainerAllocation(containers, {
+        releaseIdentity: "3.1.0",
+        targetCommit: "b".repeat(40),
+        selectedBeta,
+      }),
+    /another frozen selection/,
+  )
+  assert.throws(
+    () =>
+      planPromotionContainerAllocation(containers, {
+        releaseIdentity: "3.1.0",
+        targetCommit,
+        selectedBeta: "3.1.0-beta.58",
+      }),
+    /another frozen selection/,
+  )
+  assert.throws(
+    () =>
+      planPromotionContainerAllocation([...containers, {...containers[1], attempt: 3, release: release(3)}], {
+        releaseIdentity: "3.1.0",
+        targetCommit,
+        selectedBeta,
+      }),
+    /Multiple empty/,
+  )
+})
 
 test("validates every immutable state and digest before returning latest", () => {
   const initial = initialRecord()

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -316,6 +316,9 @@ export function transitionPromotionRecord({record, to, actor, createdAt, provena
 
 export function abortPromotionRecord({record, actor, createdAt, provenanceUrl, reason, evidence}) {
   validatePromotionRecord(record)
+  if (record.state === "finalizing") {
+    fail("cannot abort after the 100 percent rollout checkpoint; resume finalization")
+  }
   const next = {
     ...record,
     state: "aborted",

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -365,6 +365,17 @@ test("allows append-only rollout observations before completion", () => {
     provenanceUrl: "https://github.com/Mentra-Community/MentraOS/actions/runs/4",
     evidence: evidence("production-rollout-observation"),
   })
+  assert.throws(
+    () =>
+      abortPromotionRecord({
+        record: finalizing,
+        actor: "release-owner",
+        createdAt: "2026-08-28T15:30:00.000Z",
+        provenanceUrl: "https://github.com/Mentra-Community/MentraOS/actions/runs/4",
+        reason: "too late to replace a fully public rollout",
+      }),
+    /cannot abort after the 100 percent rollout checkpoint/,
+  )
   const completed = transitionPromotionRecord({
     record: finalizing,
     to: "completed",

--- a/.github/workflows/production-release-prepare.yml
+++ b/.github/workflows/production-release-prepare.yml
@@ -13,7 +13,10 @@ permissions:
   contents: write
 
 concurrency:
-  group: production-release-prepare-${{ inputs.beta_identity }}
+  # Preparation allocates the authoritative attempt number. Serialize all
+  # production allocations so two beta selections cannot race before either
+  # attempt has published its initial state record.
+  group: production-release-prepare
   cancel-in-progress: false
 
 jobs:
@@ -186,6 +189,7 @@ jobs:
           node .github/scripts/production-promotion-assets.mjs create-container
           --repository "$GITHUB_REPOSITORY"
           --release "${{ steps.identity.outputs.release_identity }}"
+          --beta "${{ inputs.beta_identity }}"
           --target-commit "${{ steps.beta.outputs.source_commit }}"
           --github-output "$GITHUB_OUTPUT"
 

--- a/.github/workflows/production-release-rollout.yml
+++ b/.github/workflows/production-release-rollout.yml
@@ -166,18 +166,22 @@ jobs:
 
           plan_name=$(jq -er .artifactNames.releasePlan "$plan")
           manifest_name=$(jq -er .artifactNames.releaseManifest "$plan")
-          cp "$plan" "production-finalization/$plan_name"
           checkpoint_name=$(node --input-type=module -e 'import {readFileSync} from "node:fs"; import {promotionAssetName} from "./.github/scripts/production-promotion-state.mjs"; process.stdout.write(promotionAssetName(JSON.parse(readFileSync(process.argv[1], "utf8"))))' "$record")
-          checkpoint_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ steps.finalizing.outputs.tag }}/$checkpoint_name"
+          cp "$plan" "production-finalization/$plan_name"
+          cp "$record" "production-finalization/$checkpoint_name"
+          stable_release_id=$(jq -er .id <<< "$stable_release")
+          checkpoint_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/$checkpoint_name"
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --file "production-finalization/$plan_name" --name "$plan_name" \
+            --release-id "$stable_release_id" --repository "$GITHUB_REPOSITORY"
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --file "production-finalization/$checkpoint_name" --name "$checkpoint_name" \
+            --release-id "$stable_release_id" --repository "$GITHUB_REPOSITORY"
           node .github/scripts/finalize-production-promotion.mjs \
             --plan "$plan" \
             --record "$record" \
             --checkpoint-url "$checkpoint_url" \
             --output "production-finalization/$manifest_name"
-          stable_release_id=$(jq -er .id <<< "$stable_release")
-          node .github/scripts/publish-immutable-release-asset.mjs \
-            --file "production-finalization/$plan_name" --name "$plan_name" \
-            --release-id "$stable_release_id" --repository "$GITHUB_REPOSITORY"
           node .github/scripts/publish-immutable-release-asset.mjs \
             --file "production-finalization/$manifest_name" --name "$manifest_name" \
             --release-id "$stable_release_id" --repository "$GITHUB_REPOSITORY"
@@ -222,6 +226,6 @@ jobs:
           {
             echo "## Production promotion completed"
             echo
-            echo "The immutable promotion chain is complete and the canonical plan and manifest are staged in draft release \`${{ steps.stable.outputs.tag }}\`."
+            echo "The immutable promotion chain is complete and the canonical plan, finalizing checkpoint, and manifest are staged in draft release \`${{ steps.stable.outputs.tag }}\`."
             echo "Publish that stable GitHub release only after the README final public-availability checks have also passed."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/notes/superpowers/specs/2026-08-28-production-promotion-system-design.md
+++ b/notes/superpowers/specs/2026-08-28-production-promotion-system-design.md
@@ -248,7 +248,13 @@ selected
 
 `aborted` is terminal for one promotion attempt. A new attempt can reuse the
 same source only when it allocates new unique store build numbers and clearly
-references the aborted attempt.
+references the aborted attempt. The allocator permits at most one non-aborted
+attempt for a release identity, so a second operator or direct workflow dispatch
+cannot bypass the point-of-no-return rule. Production preparation is serialized
+across release identities while it allocates the attempt, avoiding a second
+beta selection racing the initial state publication. If allocation succeeds but
+initial state publication does not, retry resumes that same empty container only
+when its draft metadata matches the exact selected beta and source commit.
 
 Each transition consumes the immutable records from earlier phases and emits a
 new append-only record. It never edits an earlier successful record to make a
@@ -259,7 +265,10 @@ observation. From there the workflow creates or verifies the canonical stable
 plan and manifest in the draft `mentra-vX.Y.Z` release before it may append
 `completed`. Candidate archives remain in the private, attempt-scoped promotion
 container so an aborted attempt cannot be mistaken for a later attempt or for
-the public release.
+the public release. The exact finalizing checkpoint is copied into the stable
+draft as a public-verifiable canonical asset. Because 100 percent rollout is
+already a customer-visible point of no return, `finalizing` cannot be aborted;
+an interrupted attempt must resume finalization.
 
 Workflow-produced evidence assets use content-addressed names. Evidence is
 published before the state that references it; if state publication fails, a

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -226,6 +226,9 @@ export function requireCommandState(command, record, options = {}) {
   if (command === "advance" && !new Set(["rolling-out", "finalizing"]).has(record.state)) {
     throw new Error(`Rollout advancement requires rolling-out or finalizing, not ${record.state}`)
   }
+  if (command === "abort" && record.state === "finalizing") {
+    throw new Error("Cannot abort after the 100 percent rollout checkpoint; resume finalization")
+  }
   if (command === "abort" && new Set(["aborted", "completed"]).has(record.state)) {
     throw new Error(`Cannot abort terminal promotion state ${record.state}`)
   }
@@ -245,6 +248,12 @@ export function validateAdvanceOptions(record, options) {
     throw commandError("a finalizing promotion can only be resumed with --complete")
   }
   return {action: options.complete ? "complete" : "advance", androidPercent: percent || "100"}
+}
+
+export function advanceConfirmationMessage(request) {
+  return request.action === "complete"
+    ? "This requests final verification and completion of the public release."
+    : `This requests increasing the Android production rollout to ${request.androidPercent}%.`
 }
 
 async function main(argv = process.argv.slice(2)) {
@@ -350,12 +359,7 @@ async function main(argv = process.argv.slice(2)) {
 
   if (command === "advance") {
     const request = validateAdvanceOptions(loaded.record, options)
-    await confirmEffect(
-      options.complete
-        ? "This requests final verification and completion of the public release."
-        : `This requests increasing the Android production rollout to ${percent}%.`,
-      {...options, release: releaseIdentity},
-    )
+    await confirmEffect(advanceConfirmationMessage(request), {...options, release: releaseIdentity})
     dispatch("production-release-rollout.yml", {
       release_identity: releaseIdentity,
       attempt: loaded.record.attempt,

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import {parseCliArgs, requireCommandState, statusSummary, validateAdvanceOptions} from "./production-release.mjs"
+import {
+  advanceConfirmationMessage,
+  parseCliArgs,
+  requireCommandState,
+  statusSummary,
+  validateAdvanceOptions,
+} from "./production-release.mjs"
 
 const baseRecord = {
   schemaVersion: 1,
@@ -65,11 +71,21 @@ test("reserves 100 percent for the completion command", () => {
     action: "complete",
     androidPercent: "100",
   })
+  assert.match(
+    advanceConfirmationMessage({action: "advance", androidPercent: "25"}),
+    /increasing the Android production rollout to 25%/,
+  )
+  assert.match(advanceConfirmationMessage({action: "complete", androidPercent: "100"}), /completion/)
   assert.throws(() => validateAdvanceOptions(rolling, {"android-percent": "100"}), /use --complete/)
   assert.throws(
     () => validateAdvanceOptions({...rolling, state: "finalizing"}, {"android-percent": "99"}),
     /only be resumed with --complete/,
   )
+})
+
+test("treats the 100 percent finalizing checkpoint as a point of no return", () => {
+  assert.throws(() => requireCommandState("abort", {...baseRecord, state: "finalizing"}), /Cannot abort/)
+  assert.equal(validateAdvanceOptions({...baseRecord, state: "finalizing"}, {complete: true}).action, "complete")
 })
 
 const labReadyRecord = {


### PR DESCRIPTION
## Summary

- define the observed 100 percent rollout as the irreversible finalization boundary
- require interrupted finalization to resume the same attempt and reject replacement attempts until all earlier attempts are aborted
- serialize production attempt allocation so concurrent beta selections cannot race
- resume an interrupted zero-state allocation only when a canonical digest over every plan-affecting frozen input matches exactly
- copy the exact immutable finalizing checkpoint into the stable draft and point the canonical manifest at that future-public asset
- derive rollout confirmation text from the validated request, fixing the undefined percentage failure

## Design rationale

Before 100 percent, an operator may abort an attempt and start a replacement with fresh store coordinates. Once 100 percent has been observed, customers are already on that release; allowing an abort would create conflicting canonical assets and misrepresent reality. The only safe recovery is to reconcile and finish the same attempt.

This is the focused follow-up to the valid finalization findings on #3880, which merged before the correction reached its branch.

## Validation

- node --test .github/scripts/*.test.mjs mobile/scripts/app-store-connect-build.test.mjs scripts/production-release.test.mjs (180 passing)
- parsed all 42 workflow YAML files
- actionlint on the changed workflows
- git diff --check

No production workflow was dispatched and no release action was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production promotion abort rules, attempt allocation, and finalization asset staging—security- and customer-visible release infrastructure where mistakes could block or misrepresent a live rollout.
> 
> **Overview**
> Treats the observed **100% Android rollout** as a **point of no return**: promotions in `finalizing` can no longer be aborted via the state machine, operator CLI, or runbook—only `--complete` can resume the same attempt.
> 
> **Attempt allocation** is tightened so only one non-aborted promotion can exist per release identity, `production-release-prepare` runs under a **global concurrency group** (no racing beta selections), and `create-container` **reuses** the latest empty draft only when the selected beta and source commit match; otherwise it blocks or allocates the next attempt.
> 
> On completion, the rollout workflow now publishes the **immutable finalizing checkpoint record** into the draft `mentra-vX.Y.Z` release (with plan and manifest) and wires the canonical manifest to that public asset URL. Docs/spec and workflow-contract tests reflect these rules.
> 
> Separately, rollout confirmation text is derived from the validated advance/complete request (`advanceConfirmationMessage`), fixing a bug where completion confirmation could reference an undefined percentage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46c3112e47c62e699f59e63654b5ffcefa8410e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->