### PR TITLE
Bind empty promotion retries to frozen inputs

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -385,7 +385,8 @@ attempt for that release identity is aborted, and it never permits abort after
 the 100 percent `finalizing` checkpoint. Preparation runs are serialized while
 they allocate attempts, so starting two beta selections does not create two
 active promotions. A retry resumes a zero-state container only when its selected
-beta and source commit match exactly.
+beta, source commit, prior-production provenance, store inventories, release
+family, and Starter Kit commit match exactly through one deterministic digest.
 
 Common stop conditions include source/lock mismatch, missing store provenance,
 unclassified Cloud config, non-backward-compatible migration, Mobile N failure,

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -61,6 +61,8 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(prepare, /group: production-release-prepare\n/)
   assert.doesNotMatch(prepare, /group: production-release-prepare-\$\{\{/)
   assert.match(prepare, /--beta "\$\{\{ inputs\.beta_identity \}\}"/)
+  assert.match(prepare, /production-promotion-assets\.mjs selection-digest/)
+  assert.match(prepare, /--selection-digest "\$\{\{ steps\.selection\.outputs\.selection_digest \}\}"/)
   assert.match(compatibilityLab, /name: production-compatibility-lab/)
   assert.match(compatibilityLab, /backend_environment: staging/)
   assert.match(compatibilityLab, /compatibility_lab: true/)

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -5,13 +5,14 @@ import {appendFileSync, copyFileSync, mkdirSync, readFileSync, writeFileSync} fr
 import path from "node:path"
 import {fileURLToPath} from "node:url"
 
-import {requirePublicHttpsUrl} from "./release-family.mjs"
+import {loadReleaseFamily, releaseRecordSha256, requirePublicHttpsUrl} from "./release-family.mjs"
 import {promotionAssetName, validatePromotionChain, validatePromotionRecord} from "./production-promotion-state.mjs"
 
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 const BETA_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.([1-9]\d*)$/
 const EVIDENCE_KIND_PATTERN = /^[a-z][a-z0-9-]{0,79}$/
 const ASSET_PREFIX_PATTERN = /^[a-z0-9][a-z0-9.-]{0,119}$/
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
 
 function gh(args, options = {}) {
   const stdin = options.input === undefined ? "ignore" : "pipe"
@@ -50,12 +51,17 @@ export function promotionContainerName(releaseIdentity, attempt) {
   return `Mentra ${releaseIdentity} production promotion attempt ${attempt}`
 }
 
-export function promotionContainerBody(releaseIdentity, selectedBeta) {
+export function promotionContainerBody(releaseIdentity, selectedBeta, selectionDigest) {
   const match = BETA_PATTERN.exec(selectedBeta || "")
   if (!match || `${match[1]}.${match[2]}.${match[3]}` !== releaseIdentity) {
     throw new Error(`selected beta must be a ${releaseIdentity}-beta.N identity`)
   }
-  return `Append-only evidence for an in-progress Mentra production promotion. This draft is not a customer release. Selected beta: ${selectedBeta}.`
+  if (!SHA256_PATTERN.test(selectionDigest || "")) throw new Error("selection digest must be a lowercase SHA-256")
+  return `Append-only evidence for an in-progress Mentra production promotion. This draft is not a customer release. Selected beta: ${selectedBeta}. Selection digest: ${selectionDigest}.`
+}
+
+export function productionPromotionSelectionDigest(selection) {
+  return releaseRecordSha256({schemaVersion: 1, kind: "mentra-production-promotion-selection", inputs: selection})
 }
 
 export function prepareEvidenceAsset({file, kind, url, outputDirectory, assetPrefix}) {
@@ -138,7 +144,10 @@ export function requireNewPromotionAttemptAllowed(records, releaseIdentity) {
   }
 }
 
-export function planPromotionContainerAllocation(containers, {releaseIdentity, targetCommit, selectedBeta}) {
+export function planPromotionContainerAllocation(
+  containers,
+  {releaseIdentity, targetCommit, selectedBeta, selectionDigest},
+) {
   requireNewPromotionAttemptAllowed(
     containers.flatMap(({record}) => (record ? [record] : [])),
     releaseIdentity,
@@ -150,7 +159,7 @@ export function planPromotionContainerAllocation(containers, {releaseIdentity, t
     if (candidate !== containers.at(-1)) {
       throw new Error(`Only the latest empty ${releaseIdentity} promotion container can be resumed`)
     }
-    const expectedBody = promotionContainerBody(releaseIdentity, selectedBeta)
+    const expectedBody = promotionContainerBody(releaseIdentity, selectedBeta, selectionDigest)
     if (candidate.release.target_commitish !== targetCommit || candidate.release.body !== expectedBody) {
       throw new Error(`Empty promotion attempt ${candidate.attempt} belongs to another frozen selection`)
     }
@@ -210,7 +219,7 @@ function resolveContainer(repository, releaseIdentity, attempt) {
   return requirePromotionContainer(listReleases(repository), releaseIdentity, attempt)
 }
 
-function createContainer({repository, releaseIdentity, targetCommit, selectedBeta}) {
+function createContainer({repository, releaseIdentity, targetCommit, selectedBeta, selectionDigest}) {
   const releases = listReleases(repository)
   const containers = matchingPromotionContainers(releases, releaseIdentity).map(({attempt, release, ...entry}) => {
     requirePromotionContainer(releases, releaseIdentity, attempt)
@@ -221,7 +230,12 @@ function createContainer({repository, releaseIdentity, targetCommit, selectedBet
       record: loadPromotionState({repository, releaseIdentity, attempt, release})?.record || null,
     }
   })
-  const allocation = planPromotionContainerAllocation(containers, {releaseIdentity, targetCommit, selectedBeta})
+  const allocation = planPromotionContainerAllocation(containers, {
+    releaseIdentity,
+    targetCommit,
+    selectedBeta,
+    selectionDigest,
+  })
   if (allocation.action === "reuse") return {release: allocation.release, attempt: allocation.attempt}
   const attempt = allocation.attempt
   const tag = promotionContainerTag(releaseIdentity, attempt)
@@ -230,7 +244,7 @@ function createContainer({repository, releaseIdentity, targetCommit, selectedBet
     tag_name: tag,
     target_commitish: targetCommit,
     name,
-    body: promotionContainerBody(releaseIdentity, selectedBeta),
+    body: promotionContainerBody(releaseIdentity, selectedBeta, selectionDigest),
     draft: true,
     prerelease: false,
   })
@@ -269,12 +283,35 @@ function downloadLatest({repository, releaseIdentity, attempt, outputFile}) {
 function main() {
   const command = process.argv[2]
   const args = parseArgs(process.argv.slice(3))
+  if (command === "selection-digest") {
+    const readJson = (name) => JSON.parse(readFileSync(path.resolve(args[name]), "utf8"))
+    const fileSha256 = (name) =>
+      createHash("sha256")
+        .update(readFileSync(path.resolve(args[name])))
+        .digest("hex")
+    const digest = productionPromotionSelectionDigest({
+      family: loadReleaseFamily({requireVersionMirrors: true}),
+      betaPlan: readJson("beta-plan"),
+      betaManifest: readJson("beta-manifest"),
+      betaManifestSha256: fileSha256("beta-manifest"),
+      betaManifestUrl: args["beta-manifest-url"],
+      previousPlanSha256: fileSha256("previous-plan"),
+      previousManifestSha256: fileSha256("previous-manifest"),
+      previousManifestUrl: args["previous-manifest-url"],
+      mentraInventory: readJson("mentra-inventory"),
+      starterKitInventory: readJson("starter-kit-inventory"),
+      starterKitCommit: args["starter-kit-commit"],
+    })
+    output({selection_digest: digest}, args["github-output"])
+    return
+  }
   if (command === "create-container") {
     const result = createContainer({
       repository: args.repository,
       releaseIdentity: args.release,
       targetCommit: args["target-commit"],
       selectedBeta: args.beta,
+      selectionDigest: args["selection-digest"],
     })
     output(
       {

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -9,6 +9,7 @@ import {
   nextPromotionAttempt,
   planPromotionContainerAllocation,
   prepareEvidenceAsset,
+  productionPromotionSelectionDigest,
   promotionContainerBody,
   promotionContainerName,
   promotionContainerTag,
@@ -150,11 +151,12 @@ test("allows a replacement only after every prior attempt is aborted", () => {
   assert.throws(() => requireNewPromotionAttemptAllowed([aborted], "3.2.0"), /belongs to 3.1.0/)
 })
 
-test("resumes the latest empty container only for the same frozen beta and source", () => {
+test("resumes the latest empty container only for the complete frozen selection", () => {
   const targetCommit = "a".repeat(40)
   const selectedBeta = "3.1.0-beta.57"
+  const selectionDigest = productionPromotionSelectionDigest({beta: selectedBeta, storeMax: 57})
   const draft = release(2, {
-    body: promotionContainerBody("3.1.0", selectedBeta),
+    body: promotionContainerBody("3.1.0", selectedBeta, selectionDigest),
     target_commitish: targetCommit,
   })
   const aborted = abortPromotionRecord({
@@ -172,6 +174,7 @@ test("resumes the latest empty container only for the same frozen beta and sourc
     releaseIdentity: "3.1.0",
     targetCommit,
     selectedBeta,
+    selectionDigest,
   })
   assert.equal(allocation.action, "reuse")
   assert.equal(allocation.attempt, 2)
@@ -182,6 +185,7 @@ test("resumes the latest empty container only for the same frozen beta and sourc
         releaseIdentity: "3.1.0",
         targetCommit: "b".repeat(40),
         selectedBeta,
+        selectionDigest,
       }),
     /another frozen selection/,
   )
@@ -191,6 +195,17 @@ test("resumes the latest empty container only for the same frozen beta and sourc
         releaseIdentity: "3.1.0",
         targetCommit,
         selectedBeta: "3.1.0-beta.58",
+        selectionDigest,
+      }),
+    /another frozen selection/,
+  )
+  assert.throws(
+    () =>
+      planPromotionContainerAllocation(containers, {
+        releaseIdentity: "3.1.0",
+        targetCommit,
+        selectedBeta,
+        selectionDigest: productionPromotionSelectionDigest({beta: selectedBeta, storeMax: 58}),
       }),
     /another frozen selection/,
   )
@@ -200,8 +215,35 @@ test("resumes the latest empty container only for the same frozen beta and sourc
         releaseIdentity: "3.1.0",
         targetCommit,
         selectedBeta,
+        selectionDigest,
       }),
     /Multiple empty/,
+  )
+})
+
+test("selection digests are canonical and cover every frozen input", () => {
+  const selection = {
+    betaPlan: {sourceCommit: "a".repeat(40), native: {buildNumber: 57}},
+    previousManifestSha256: "b".repeat(64),
+    starterKitCommit: "c".repeat(40),
+    mentraInventory: {apple: {maxBuildNumber: 57}},
+  }
+  assert.equal(
+    productionPromotionSelectionDigest(selection),
+    productionPromotionSelectionDigest({
+      mentraInventory: selection.mentraInventory,
+      starterKitCommit: selection.starterKitCommit,
+      previousManifestSha256: selection.previousManifestSha256,
+      betaPlan: selection.betaPlan,
+    }),
+  )
+  assert.notEqual(
+    productionPromotionSelectionDigest(selection),
+    productionPromotionSelectionDigest({...selection, starterKitCommit: "d".repeat(40)}),
+  )
+  assert.notEqual(
+    productionPromotionSelectionDigest(selection),
+    productionPromotionSelectionDigest({...selection, mentraInventory: {apple: {maxBuildNumber: 58}}}),
   )
 })
 

--- a/.github/workflows/production-release-prepare.yml
+++ b/.github/workflows/production-release-prepare.yml
@@ -181,6 +181,25 @@ jobs:
             ../stores/starter-apple.json ../stores/starter-google.json \
             > ../stores/starter-inventory.json
 
+      - name: Fingerprint every frozen preparation input
+        id: selection
+        env:
+          BETA_IDENTITY: ${{ inputs.beta_identity }}
+          BETA_TAG: ${{ steps.identity.outputs.beta_tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node .github/scripts/production-promotion-assets.mjs selection-digest
+          --beta-plan promotion-input/beta/release-plan.json
+          --beta-manifest promotion-input/beta/release-manifest.json
+          --beta-manifest-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$BETA_TAG/mentra-release-$BETA_IDENTITY.json"
+          --previous-plan promotion-input/current/release-plan.json
+          --previous-manifest promotion-input/current/release-manifest.json
+          --previous-manifest-url "${{ steps.previous.outputs.manifest_url }}"
+          --mentra-inventory promotion-input/stores/mentra-inventory.json
+          --starter-kit-inventory promotion-input/stores/starter-inventory.json
+          --starter-kit-commit "${{ steps.starter-kit.outputs.commit }}"
+          --github-output "$GITHUB_OUTPUT"
+
       - name: Allocate append-only promotion container
         id: container
         env:
@@ -190,6 +209,7 @@ jobs:
           --repository "$GITHUB_REPOSITORY"
           --release "${{ steps.identity.outputs.release_identity }}"
           --beta "${{ inputs.beta_identity }}"
+          --selection-digest "${{ steps.selection.outputs.selection_digest }}"
           --target-commit "${{ steps.beta.outputs.source_commit }}"
           --github-output "$GITHUB_OUTPUT"
 

--- a/notes/superpowers/specs/2026-08-28-production-promotion-system-design.md
+++ b/notes/superpowers/specs/2026-08-28-production-promotion-system-design.md
@@ -254,7 +254,9 @@ cannot bypass the point-of-no-return rule. Production preparation is serialized
 across release identities while it allocates the attempt, avoiding a second
 beta selection racing the initial state publication. If allocation succeeds but
 initial state publication does not, retry resumes that same empty container only
-when its draft metadata matches the exact selected beta and source commit.
+when its draft metadata matches a deterministic digest over every input that can
+affect the frozen plan, including prior-production provenance, both store
+inventories, the release family, and the Starter Kit commit.
 
 Each transition consumes the immutable records from earlier phases and emits a
 new append-only record. It never edits an earlier successful record to make a


### PR DESCRIPTION
## Summary

- compute one canonical digest over every input that can affect the frozen production plan
- record that digest in a newly allocated zero-state promotion container
- resume that empty container only when the complete selection, selected beta, and source target all match
- fail explicitly for mismatched or multiple empty allocations instead of silently allocating another attempt

This is the final focused correction from the latest review of #3881, which merged before that review completed. It contains only the complete-selection binding delta; the finalization lifecycle changes from #3881 are already on dev.

## Validation

- node --test .github/scripts/*.test.mjs mobile/scripts/app-store-connect-build.test.mjs scripts/production-release.test.mjs (180 passing)
- parsed all 42 workflow YAML files
- actionlint on the changed production workflows
- git diff --check

No production workflow was dispatched and no release action was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production promotion container allocation and retry semantics for interrupted prepare runs; mistakes could block legitimate retries or allow mismatched inputs if the digest inputs are wrong, but scope is limited to preparation—not deploy or store release.
> 
> **Overview**
> Production prepare now **fingerprints every input that can change the frozen plan** (beta plan/manifest and hashes, prior-production artifacts, Mentra and Starter Kit store inventories, release family, Starter Kit commit) into one canonical SHA-256 via `productionPromotionSelectionDigest` and a new `selection-digest` workflow step.
> 
> That digest is **stored on the draft promotion container** (release body) and required when **reusing an empty attempt** after a failed bootstrap. Resume succeeds only when beta, source commit, and the full selection digest match; any drift (e.g. different store max build or Starter Kit commit) fails with an explicit “another frozen selection” error instead of silently creating another attempt.
> 
> Docs, the promotion system design spec, workflow contract tests, and unit tests are updated to match this stricter binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c53c08085f8bed007d94263122c1e9b03536858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->