### PR TITLE
Keep generated iOS pod caches runner-local

### DIFF
--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -83,22 +83,31 @@ jobs:
 
       - name: Get cache week number
         id: cache-week
-        run: echo "week=$(date +%Y-%U)" >> $GITHUB_OUTPUT
+        run: echo "week=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache CocoaPods
-        id: pods-cache
+      - name: Cache CocoaPods downloads
         uses: actions/cache@v4
         with:
           path: |
-            mobile/ios/Pods
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
-          key: pods-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/ios/Podfile.lock', 'mobile/package.json') }}
+          # Downloaded pod archives and specs are portable between runners.
+          key: cocoapods-downloads-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/package.json', 'mobile/bun.lock') }}
           restore-keys: |
-            pods-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
-            pods-${{ runner.os }}-
+            cocoapods-downloads-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+            cocoapods-downloads-${{ runner.os }}-
+
+      - name: Cache installed CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: mobile/ios/Pods
+          # Generated pod support files can embed absolute node_modules and
+          # workspace paths. Keep them runner-local and exact so a runner never
+          # inherits another runner's Hermes or React Native build-script paths.
+          key: pods-installed-${{ runner.name }}-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/ios/Podfile.lock', 'mobile/package.json', 'mobile/bun.lock') }}
 
       - name: Cache Xcode DerivedData (device build)
+        id: xcode-derived-cache
         uses: actions/cache@v4
         with:
           path: mobile/ios/build-device
@@ -371,6 +380,15 @@ jobs:
           SENTRY_DISABLE_AUTO_UPLOAD: "true"
         continue-on-error: true
         run: |
+          started_at="$(date +%s)"
+          record_duration() {
+            status=$?
+            echo "duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+            trap - EXIT
+            exit "$status"
+          }
+          trap record_duration EXIT
+
           xcodebuild -workspace Mentra.xcworkspace \
                      -scheme Mentra \
                      -configuration Release \
@@ -381,11 +399,21 @@ jobs:
                      CODE_SIGNING_ALLOWED=NO
 
       - name: Retry build with clean caches (if first attempt failed)
+        id: xcode-build-clean
         if: steps.xcode-build.outcome == 'failure'
         working-directory: ./mobile/ios
         env:
           SENTRY_DISABLE_AUTO_UPLOAD: "true"
         run: |
+          started_at="$(date +%s)"
+          record_duration() {
+            status=$?
+            echo "duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+            trap - EXIT
+            exit "$status"
+          }
+          trap record_duration EXIT
+
           echo "First build failed, nuking caches and retrying from scratch..."
 
           # Kill any hung xcodebuild from THIS job's failed attempt only — scoped to our
@@ -430,6 +458,45 @@ jobs:
                      CODE_SIGN_IDENTITY="" \
                      CODE_SIGNING_REQUIRED=NO \
                      CODE_SIGNING_ALLOWED=NO
+
+      - name: Summarize iOS build attempts
+        if: always()
+        env:
+          DERIVED_CACHE_HIT: ${{ steps.xcode-derived-cache.outputs.cache-hit }}
+          CACHED_OUTCOME: ${{ steps.xcode-build.outcome }}
+          CACHED_DURATION_SECONDS: ${{ steps.xcode-build.outputs.duration_seconds }}
+          RETRY_OUTCOME: ${{ steps.xcode-build-clean.outcome }}
+          RETRY_DURATION_SECONDS: ${{ steps.xcode-build-clean.outputs.duration_seconds }}
+        run: |
+          format_duration() {
+            seconds="$1"
+            if ! [[ "$seconds" =~ ^[0-9]+$ ]]; then
+              echo "not recorded"
+              return
+            fi
+            printf '%dm %02ds\n' "$((seconds / 60))" "$((seconds % 60))"
+          }
+
+          cache_hit="${DERIVED_CACHE_HIT:-false}"
+          cached_outcome="${CACHED_OUTCOME:-not run}"
+          retry_outcome="${RETRY_OUTCOME:-not run}"
+          cached_duration="$(format_duration "$CACHED_DURATION_SECONDS")"
+          retry_duration="$(format_duration "$RETRY_DURATION_SECONDS")"
+
+          {
+            echo "## iOS device build attempts"
+            echo ""
+            echo "- DerivedData exact-key hit: $cache_hit"
+            echo ""
+            echo "| Attempt | Outcome | Duration |"
+            echo "| --- | --- | ---: |"
+            echo "| Cache-enabled build | $cached_outcome | $cached_duration |"
+            echo "| Clean-cache retry | $retry_outcome | $retry_duration |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$cached_outcome" = "failure" ]; then
+            echo "::warning::Cache-enabled iOS build failed after $cached_duration; clean-cache retry outcome: $retry_outcome ($retry_duration)."
+          fi
 
       - name: Fail if both builds failed
         if: steps.xcode-build.outcome == 'failure'


### PR DESCRIPTION
## Summary

- split portable CocoaPods download/spec caches from the generated `mobile/ios/Pods` tree
- key installed Pods by runner identity and exact dependency inputs so generated Hermes and React Native scripts cannot cross runner workspace paths
- report the DerivedData exact-hit state plus the real outcome and duration of both Xcode attempts in the job summary
- emit a visible warning whenever the cache-enabled attempt falls back to a clean build

## Root cause

In [Actions run 33203360475](https://github.com/Mentra-Community/MentraOS/actions/runs/33203360475), the job ran on `big-bob-3` and correctly used its runner-specific DerivedData key, but a restored generated Pods script still referenced `actions-runner-2/.../hermesc`. The cache-enabled build failed and the clean retry rescued it. The remaining cross-runner surface was the combined CocoaPods cache, which mixed portable downloads with generated, absolute-path-bearing Pod support files.

## Validation

- `actionlint .github/workflows/mentra-app-ios-build.yml`
- `git diff --check`
- exercised the timing trap locally and confirmed it preserves a failing command exit status while recording `duration_seconds`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the self-hosted iOS GitHub Actions workflow (caching keys and CI reporting); no app runtime, auth, or data-handling code is affected.
> 
> **Overview**
> Fixes cross-runner iOS CI failures where a restored **generated** `mobile/ios/Pods` tree still pointed at another runner’s Hermes/React Native paths (e.g. wrong `hermesc` under a different `actions-runner-*` workspace).
> 
> The workflow **splits CocoaPods caching**: portable download/spec caches (`~/Library/Caches/CocoaPods`, `~/.cocoapods`) stay shareable with keys based on `mobile/package.json` and `mobile/bun.lock`, while **`mobile/ios/Pods` is cached separately** with a **runner-specific, exact** key (`runner.name` + lockfiles) so generated pod scripts are never restored from another machine.
> 
> **Build observability** improves: the DerivedData cache step is named (`xcode-derived-cache`), both device `xcodebuild` attempts record **duration** via an `EXIT` trap (without masking failure exit codes), and a new **job summary** reports DerivedData exact-cache hit, outcomes, and durations for the cache-enabled vs clean-cache retry, plus a **workflow warning** when the first attempt fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966e321701ee0759a1487d7c30f348a92d2f0a7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->