### PR TITLE
dev -> staging

### DIFF
--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -83,22 +83,31 @@ jobs:
 
       - name: Get cache week number
         id: cache-week
-        run: echo "week=$(date +%Y-%U)" >> $GITHUB_OUTPUT
+        run: echo "week=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache CocoaPods
-        id: pods-cache
+      - name: Cache CocoaPods downloads
         uses: actions/cache@v4
         with:
           path: |
-            mobile/ios/Pods
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
-          key: pods-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/ios/Podfile.lock', 'mobile/package.json') }}
+          # Downloaded pod archives and specs are portable between runners.
+          key: cocoapods-downloads-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/package.json', 'mobile/bun.lock') }}
           restore-keys: |
-            pods-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
-            pods-${{ runner.os }}-
+            cocoapods-downloads-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+            cocoapods-downloads-${{ runner.os }}-
+
+      - name: Cache installed CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: mobile/ios/Pods
+          # Generated pod support files can embed absolute node_modules and
+          # workspace paths. Keep them runner-local and exact so a runner never
+          # inherits another runner's Hermes or React Native build-script paths.
+          key: pods-installed-${{ runner.name }}-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/ios/Podfile.lock', 'mobile/package.json', 'mobile/bun.lock') }}
 
       - name: Cache Xcode DerivedData (device build)
+        id: xcode-derived-cache
         uses: actions/cache@v4
         with:
           path: mobile/ios/build-device
@@ -371,6 +380,15 @@ jobs:
           SENTRY_DISABLE_AUTO_UPLOAD: "true"
         continue-on-error: true
         run: |
+          started_at="$(date +%s)"
+          record_duration() {
+            status=$?
+            echo "duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+            trap - EXIT
+            exit "$status"
+          }
+          trap record_duration EXIT
+
           xcodebuild -workspace Mentra.xcworkspace \
                      -scheme Mentra \
                      -configuration Release \
@@ -381,11 +399,21 @@ jobs:
                      CODE_SIGNING_ALLOWED=NO
 
       - name: Retry build with clean caches (if first attempt failed)
+        id: xcode-build-clean
         if: steps.xcode-build.outcome == 'failure'
         working-directory: ./mobile/ios
         env:
           SENTRY_DISABLE_AUTO_UPLOAD: "true"
         run: |
+          started_at="$(date +%s)"
+          record_duration() {
+            status=$?
+            echo "duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+            trap - EXIT
+            exit "$status"
+          }
+          trap record_duration EXIT
+
           echo "First build failed, nuking caches and retrying from scratch..."
 
           # Kill any hung xcodebuild from THIS job's failed attempt only — scoped to our
@@ -430,6 +458,45 @@ jobs:
                      CODE_SIGN_IDENTITY="" \
                      CODE_SIGNING_REQUIRED=NO \
                      CODE_SIGNING_ALLOWED=NO
+
+      - name: Summarize iOS build attempts
+        if: always()
+        env:
+          DERIVED_CACHE_HIT: ${{ steps.xcode-derived-cache.outputs.cache-hit }}
+          CACHED_OUTCOME: ${{ steps.xcode-build.outcome }}
+          CACHED_DURATION_SECONDS: ${{ steps.xcode-build.outputs.duration_seconds }}
+          RETRY_OUTCOME: ${{ steps.xcode-build-clean.outcome }}
+          RETRY_DURATION_SECONDS: ${{ steps.xcode-build-clean.outputs.duration_seconds }}
+        run: |
+          format_duration() {
+            seconds="$1"
+            if ! [[ "$seconds" =~ ^[0-9]+$ ]]; then
+              echo "not recorded"
+              return
+            fi
+            printf '%dm %02ds\n' "$((seconds / 60))" "$((seconds % 60))"
+          }
+
+          cache_hit="${DERIVED_CACHE_HIT:-false}"
+          cached_outcome="${CACHED_OUTCOME:-not run}"
+          retry_outcome="${RETRY_OUTCOME:-not run}"
+          cached_duration="$(format_duration "$CACHED_DURATION_SECONDS")"
+          retry_duration="$(format_duration "$RETRY_DURATION_SECONDS")"
+
+          {
+            echo "## iOS device build attempts"
+            echo ""
+            echo "- DerivedData exact-key hit: $cache_hit"
+            echo ""
+            echo "| Attempt | Outcome | Duration |"
+            echo "| --- | --- | ---: |"
+            echo "| Cache-enabled build | $cached_outcome | $cached_duration |"
+            echo "| Clean-cache retry | $retry_outcome | $retry_duration |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$cached_outcome" = "failure" ]; then
+            echo "::warning::Cache-enabled iOS build failed after $cached_duration; clean-cache retry outcome: $retry_outcome ($retry_duration)."
+          fi
 
       - name: Fail if both builds failed
         if: steps.xcode-build.outcome == 'failure'

--- a/cloud-v2/packages/runtime/src/services/camera/camera.service.ts
+++ b/cloud-v2/packages/runtime/src/services/camera/camera.service.ts
@@ -25,7 +25,11 @@ import { ulid } from "ulid";
 import { createLogger } from "@mentra/cloud-shared";
 import { getRedis } from "../../clients/redis.client";
 import { getStorageProvider } from "../storage/storage.service";
-import { getStreamProvider } from "../stream/stream.service";
+import {
+  provisionStream,
+  stopStream as stopManagedStream,
+  streamStatus as getManagedStreamStatus,
+} from "../stream/stream.service";
 import { forwardToUserSessions } from "../../net/ws";
 import { PROTOCOL_MAJOR } from "@mentra/cloud-protocol/envelope";
 import type {
@@ -155,7 +159,7 @@ export async function startStream(
   mentraUserId: string,
   opts: StreamOptions,
 ): Promise<ManagedStream> {
-  const stream = await getStreamProvider().provision(mentraUserId, opts);
+  const stream = await provisionStream(mentraUserId, opts);
   logger.info({ mentraUserId, streamId: stream.streamId }, "managed stream provisioned");
   return stream;
 }
@@ -166,11 +170,11 @@ export async function streamStatus(
   streamId: string,
 ): Promise<StreamStatusResult> {
   void mentraUserId;
-  return await getStreamProvider().status(streamId);
+  return await getManagedStreamStatus(streamId);
 }
 
 /** Stop a managed stream. */
 export async function stopStream(mentraUserId: string, streamId: string): Promise<void> {
-  await getStreamProvider().stop(streamId);
+  await stopManagedStream(streamId);
   logger.info({ mentraUserId, streamId }, "managed stream stopped");
 }

--- a/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/providers/cloudflare-stream.provider.ts
@@ -29,24 +29,36 @@
  * storage quota. Recording cannot simply be turned off -- HLS playback requires
  * `mode: automatic` -- so `stop()` deletes the recordings before the input, and
  * `deleteRecordingAfterDays` is set as a floor for anything that slips past.
+ * Inputs are disabled before cleanup and retained whenever a recording is still
+ * finalizing, so no billable recording becomes unreachable through its input.
  */
 
 import type { ManagedStream, StreamOptions, StreamStatusResult } from "@mentra/cloud-protocol/camera";
-import type { StreamProvider } from "../stream.service";
+import type {
+  StreamCleanupResult,
+  StreamDiscoveryResult,
+  StreamProvider,
+} from "../stream.service";
 
 const CF_API = "https://api.cloudflare.com/client/v4";
 
 /** Cloudflare's minimum for `deleteRecordingAfterDays`. A floor, not the policy. */
 const RECORDING_RETENTION_DAYS = 30;
 
+interface LiveInputSummary {
+  uid?: string;
+  created?: string;
+  modified?: string;
+  meta?: unknown;
+}
+
 /** `GET /live_inputs` -- every input on the account. */
 interface LiveInputListResult {
-  result?: Array<{
-    uid: string;
-    created?: string;
-    modified?: string;
-    status?: { current?: { state?: string | null } | null } | null;
-  }>;
+  result?: {
+    liveInputs?: LiveInputSummary[];
+    range?: number;
+    total?: number;
+  };
   success: boolean;
 }
 
@@ -62,19 +74,24 @@ interface VideoListResult {
 interface LiveInputResult {
   result?: {
     uid: string;
+    enabled?: boolean;
+    meta?: unknown;
     rtmps?: { url: string; streamKey: string };
     rtmpsPlayback?: { url: string; streamKey: string };
     srt?: { url: string; streamId: string; passphrase: string };
     webRTC?: { url: string };
     webRTCPlayback?: { url: string };
-    status?: {
-      current?: {
-        state?: string | null;
-        statusEnteredAt?: string;
-        statusLastSeen?: string;
-        reason?: string;
-      } | null;
-    } | null;
+    status?:
+      | string
+      | {
+          current?: {
+            state?: string | null;
+            statusEnteredAt?: string;
+            statusLastSeen?: string;
+            reason?: string;
+          } | null;
+        }
+      | null;
   };
   success: boolean;
   errors?: Array<{ code: number; message: string }>;
@@ -116,74 +133,184 @@ export function createCloudflareStreamProvider(): StreamProvider {
     };
   }
 
+  function currentStatus(input: NonNullable<LiveInputResult["result"]>): {
+    state: string | null;
+    statusEnteredAt?: string;
+    statusLastSeen?: string;
+    reason?: string;
+  } {
+    if (typeof input.status === "string") return { state: input.status };
+    return {
+      state: input.status?.current?.state ?? null,
+      statusEnteredAt: input.status?.current?.statusEnteredAt,
+      statusLastSeen: input.status?.current?.statusLastSeen,
+      reason: input.status?.current?.reason,
+    };
+  }
+
+  function isReclaimProtectedState(state: string | null): boolean {
+    return (
+      state === "connected" ||
+      state === "reconnected" ||
+      state === "reconnecting" ||
+      state === "live"
+    );
+  }
+
+  function isConnectedState(state: string | null): boolean {
+    return state === "connected" || state === "reconnected" || state === "live";
+  }
+
+  function isMentraInput(input: LiveInputSummary): boolean {
+    if (!input.meta || typeof input.meta !== "object") return false;
+    const name = (input.meta as Record<string, unknown>).name;
+    return typeof name === "string" && name.startsWith("mentra-");
+  }
+
+  async function getLiveInput(inputUid: string): Promise<NonNullable<LiveInputResult["result"]> | null> {
+    const res = await fetch(`${base}/${inputUid}`, { headers: authHeaders });
+    if (res.status === 404) return null;
+
+    const body = (await res.json()) as LiveInputResult;
+    if (!res.ok || !body.success || !body.result) {
+      const detail = body.errors?.map((e) => e.message).join("; ") ?? res.statusText;
+      throw new Error(`cloudflare live input get failed: ${detail}`);
+    }
+    return body.result;
+  }
+
+  async function disableInput(inputUid: string): Promise<boolean> {
+    const res = await fetch(`${base}/${inputUid}`, {
+      method: "PUT",
+      headers: { ...authHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    if (res.status === 404) return false;
+    if (!res.ok) throw new Error(`cloudflare live input disable failed: ${res.status}`);
+    return true;
+  }
+
+  async function deleteInput(inputUid: string): Promise<void> {
+    const res = await fetch(`${base}/${inputUid}`, {
+      method: "DELETE",
+      headers: authHeaders,
+    });
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`cloudflare live input delete failed: ${res.status}`);
+    }
+  }
+
+  interface RecordingCleanupResult {
+    deleted: number;
+    failed: number;
+    pending: number;
+    seen: number;
+  }
+
   /**
    * Delete every finished recording belonging to a live input.
    *
-   * Best-effort by design: a stream that has just ended may not have a
-   * recording yet (Cloudflare takes up to ~60s to make one available), and a
-   * failure here must not stop the caller from tearing the input down. What
-   * this misses, the sweeper and `deleteRecordingAfterDays` catch.
+   * A stream that has just ended may not have a recording yet (Cloudflare can
+   * take time to make one available). Callers use the returned pending/failure
+   * counts to retain the input for a later sweep instead of orphaning video.
    *
-   * Returns the number deleted, so callers can log it.
+   * Returns a lifecycle summary so callers can distinguish complete cleanup
+   * from a safe deferral.
    */
-  async function deleteRecordings(inputUid: string): Promise<number> {
+  async function cleanupRecordings(inputUid: string): Promise<RecordingCleanupResult> {
     const listed = await fetch(`${base}/${inputUid}/videos`, { headers: authHeaders });
-    if (!listed.ok) return 0;
+    if (!listed.ok) {
+      throw new Error(`cloudflare recording list failed: ${listed.status}`);
+    }
 
     const body = (await listed.json()) as VideoListResult;
+    if (!body.success || !Array.isArray(body.result)) {
+      throw new Error("cloudflare recording list returned an invalid response");
+    }
     const videos = body.result ?? [];
     let deleted = 0;
+    let failed = 0;
+    let pending = 0;
 
     for (const video of videos) {
-      // An in-progress broadcast is not a recording yet. Deleting it would
-      // kill a live stream.
-      if (video.status?.state === "live-inprogress") continue;
+      const state = video.status?.state;
+      if (state !== "ready" && state !== "error") {
+        // Unknown and processing states are deliberately retained. Deleting
+        // the input now would orphan a recording that Cloudflare has not
+        // finished materializing yet.
+        pending += 1;
+        continue;
+      }
 
       const res = await fetch(`${CF_API}/accounts/${accountId}/stream/${video.uid}`, {
         method: "DELETE",
         headers: authHeaders,
       });
       if (res.ok || res.status === 404) deleted += 1;
+      else failed += 1;
     }
-    return deleted;
+    return { deleted, failed, pending, seen: videos.length };
+  }
+
+  async function listLiveInputs(): Promise<{
+    inputs: LiveInputSummary[];
+    total: number;
+  }> {
+    const listed = await fetch(base, { headers: authHeaders });
+    if (!listed.ok) throw new Error(`cloudflare live input list failed: ${listed.status}`);
+
+    const body = (await listed.json()) as LiveInputListResult;
+    const inputs = body.result?.liveInputs;
+    if (!body.success || !Array.isArray(inputs)) {
+      throw new Error("cloudflare live input list returned an invalid response");
+    }
+    return { inputs, total: body.result?.total ?? inputs.length };
   }
 
   /**
-   * Reclaim what `stop()` never got to.
-   *
-   * `stop()` only runs when a client explicitly ends a stream. A stream that
-   * ends because the device dropped, the app closed, or the pod restarted
-   * leaves its input and recordings behind forever. That is the leak that
-   * filled the account: thousands of abandoned inputs, each with recordings
-   * still billed against the storage quota.
-   *
-   * Deletes inputs (and their recordings) last modified before the cutoff,
-   * skipping anything currently connected. Idempotent: a 404 counts as done,
-   * so concurrent pods sweeping at once is harmless.
+   * Disable an input, delete terminal recordings, then delete the input only
+   * when no recording can be orphaned. Explicit stops defer an empty recording
+   * list because Cloudflare may still be materializing it; queue recovery can
+   * accept an empty list after its grace period.
    */
-  async function sweep(olderThanMs: number): Promise<{ recordings: number; inputs: number }> {
-    const cutoff = Date.now() - olderThanMs;
-    let recordings = 0;
-    let inputs = 0;
+  async function cleanupInput(
+    inputUid: string,
+    allowEmpty: boolean,
+  ): Promise<StreamCleanupResult> {
+    if (!(await disableInput(inputUid))) return { recordings: 0, input: "missing" };
 
-    const listed = await fetch(base, { headers: authHeaders });
-    if (!listed.ok) return { recordings, inputs };
-
-    const body = (await listed.json()) as LiveInputListResult;
-    for (const input of body.result ?? []) {
-      const modified = Date.parse(input.modified ?? input.created ?? "");
-      if (!Number.isFinite(modified) || modified >= cutoff) continue;
-
-      // Never touch an input a device is publishing to right now.
-      const state = input.status?.current?.state ?? null;
-      if (state === "connected" || state === "live") continue;
-
-      recordings += await deleteRecordings(input.uid);
-
-      const res = await fetch(`${base}/${input.uid}`, { method: "DELETE", headers: authHeaders });
-      if (res.ok || res.status === 404) inputs += 1;
+    const cleanup = await cleanupRecordings(inputUid);
+    if (cleanup.failed > 0) {
+      throw new Error(`cloudflare recording cleanup failed for ${cleanup.failed} recording(s)`);
     }
-    return { recordings, inputs };
+    if (cleanup.pending > 0 || (!allowEmpty && cleanup.seen === 0)) {
+      return { recordings: cleanup.deleted, input: "retained" };
+    }
+
+    await deleteInput(inputUid);
+    return { recordings: cleanup.deleted, input: "deleted" };
+  }
+
+  async function reclaim(inputUid: string): Promise<StreamCleanupResult> {
+    // A registry entry may refer to a live stream lasting longer than the
+    // abandonment grace period. Verify provider state before disabling it.
+    const current = await getLiveInput(inputUid);
+    if (!current) return { recordings: 0, input: "missing" };
+    if (isReclaimProtectedState(currentStatus(current).state)) {
+      return { recordings: 0, input: "retained" };
+    }
+    return await cleanupInput(inputUid, true);
+  }
+
+  async function discover(): Promise<StreamDiscoveryResult> {
+    const listed = await listLiveInputs();
+    const inputs = listed.inputs.flatMap((input) => {
+      if (!input.uid || !isMentraInput(input)) return [];
+      const createdAt = Date.parse(input.created ?? input.modified ?? "");
+      if (!Number.isFinite(createdAt)) return [];
+      return [{ streamId: input.uid, createdAt }];
+    });
+    return { inputs, truncated: listed.total > listed.inputs.length };
   }
 
   return {
@@ -256,43 +383,25 @@ export function createCloudflareStreamProvider(): StreamProvider {
     },
 
     async status(streamId: string): Promise<StreamStatusResult> {
-      const res = await fetch(`${base}/${streamId}`, { headers: authHeaders });
-      const body = (await res.json()) as LiveInputResult;
-      if (!res.ok || !body.success || !body.result) {
-        const detail = body.errors?.map((e) => e.message).join("; ") ?? res.statusText;
-        throw new Error(`cloudflare live input status failed: ${detail}`);
-      }
-      const current = body.result.status?.current ?? null;
-      const state = current?.state ?? null;
+      const input = await getLiveInput(streamId);
+      if (!input) throw new Error("cloudflare live input status failed: input not found");
+      const current = currentStatus(input);
+      const state = current.state;
       return {
         streamId,
-        isConnected: state === "connected",
+        isConnected: isConnectedState(state),
         state,
-        connectedAt: current?.statusEnteredAt,
-        lastSeenAt: current?.statusLastSeen,
-        reason: current?.reason,
+        connectedAt: current.statusEnteredAt,
+        lastSeenAt: current.statusLastSeen,
+        reason: current.reason,
       };
     },
 
-    async stop(streamId: string): Promise<void> {
-      // Recordings first, then the input. Deleting the input orphans its
-      // recordings -- they survive, keep counting against the storage quota,
-      // and are no longer reachable through the input's /videos listing -- so
-      // the order matters. Once the account is over quota Cloudflare still
-      // creates live inputs but rejects the broadcast at publish, which
-      // surfaces to the user as a network failure.
-      await deleteRecordings(streamId);
-
-      const res = await fetch(`${base}/${streamId}`, {
-        method: "DELETE",
-        headers: authHeaders,
-      });
-      if (!res.ok && res.status !== 404) {
-        throw new Error(`cloudflare live input delete failed: ${res.status}`);
-      }
+    async stop(streamId: string): Promise<StreamCleanupResult> {
+      return await cleanupInput(streamId, false);
     },
 
-    deleteRecordings,
-    sweep,
+    reclaim,
+    discover,
   };
 }

--- a/cloud-v2/packages/runtime/src/services/stream/stream.service.ts
+++ b/cloud-v2/packages/runtime/src/services/stream/stream.service.ts
@@ -15,6 +15,7 @@
 
 import type { ManagedStream, StreamOptions, StreamStatusResult } from "@mentra/cloud-protocol/camera";
 import { createLogger } from "@mentra/cloud-shared";
+import { getRedis } from "../../clients/redis.client";
 import { createCloudflareStreamProvider } from "./providers/cloudflare-stream.provider";
 
 const logger = createLogger("audio").child({ service: "stream.service" });
@@ -23,20 +24,24 @@ export interface StreamProvider {
   readonly name: string;
   provision(mentraUserId: string, opts: StreamOptions): Promise<ManagedStream>;
   status(streamId: string): Promise<StreamStatusResult>;
-  stop(streamId: string): Promise<void>;
+  stop(streamId: string): Promise<StreamCleanupResult>;
   /**
-   * Delete the finished recordings belonging to a stream, returning how many
-   * went. `stop()` already does this; it is exposed so the sweeper can reclaim
-   * recordings whose stream ended without anyone calling `stop()`.
-   *
-   * Optional: a provider that does not record has nothing to delete.
+   * Reclaim a known abandoned input. Unlike an explicit stop, an empty
+   * recording list is terminal because the queue's grace period has elapsed.
    */
-  deleteRecordings?(streamId: string): Promise<number>;
-  /**
-   * Delete recordings and inputs abandoned before `olderThanMs`, returning what
-   * was reclaimed. Optional for the same reason.
-   */
-  sweep?(olderThanMs: number): Promise<{ recordings: number; inputs: number }>;
+  reclaim?(streamId: string): Promise<StreamCleanupResult>;
+  /** Seed the durable queue with inputs created before the queue existed. */
+  discover?(): Promise<StreamDiscoveryResult>;
+}
+
+export interface StreamCleanupResult {
+  recordings: number;
+  input: "deleted" | "retained" | "missing";
+}
+
+export interface StreamDiscoveryResult {
+  inputs: Array<{ streamId: string; createdAt: number }>;
+  truncated: boolean;
 }
 
 let provider: StreamProvider | null = null;
@@ -57,18 +62,181 @@ export function resetStreamProvider(): void {
   provider = null;
 }
 
+// === Managed stream lifecycle ===
+
+const CLEANUP_QUEUE_KEY = "managed-stream:cleanup";
+const ABANDONED_STREAM_GRACE_MS = 6 * 60 * 60 * 1000;
+const STOP_CLEANUP_RETRY_MS = 60 * 1000;
+const SWEEP_RETRY_MS = 15 * 60 * 1000;
+const LEGACY_DISCOVERY_INTERVAL_MS = 60 * 60 * 1000;
+const SWEEP_BATCH_SIZE = 100;
+
+type CleanupAction = "reclaim" | "stop";
+
+function cleanupQueueMember(action: CleanupAction, streamId: string): string {
+  return `${action}:${streamId}`;
+}
+
+function parseCleanupQueueMember(member: string): {
+  action: CleanupAction;
+  streamId: string;
+} {
+  if (member.startsWith("stop:")) {
+    return { action: "stop", streamId: member.slice("stop:".length) };
+  }
+  if (member.startsWith("reclaim:")) {
+    return { action: "reclaim", streamId: member.slice("reclaim:".length) };
+  }
+  // Entries written by earlier builds used the bare stream id.
+  return { action: "reclaim", streamId: member };
+}
+
+function cleanupQueueMembers(streamId: string): [string, string] {
+  return [cleanupQueueMember("reclaim", streamId), cleanupQueueMember("stop", streamId)];
+}
+
+export async function provisionStream(
+  mentraUserId: string,
+  opts: StreamOptions,
+): Promise<ManagedStream> {
+  const p = getStreamProvider();
+  const stream = await p.provision(mentraUserId, opts);
+  try {
+    await getRedis().zadd(
+      CLEANUP_QUEUE_KEY,
+      Date.now() + ABANDONED_STREAM_GRACE_MS,
+      cleanupQueueMember("reclaim", stream.streamId),
+    );
+  } catch (err) {
+    // Do not hand out an input that recovery cannot find. This input has never
+    // been published to, so reclaiming an empty input is safe.
+    await p.reclaim?.(stream.streamId).catch(() => undefined);
+    throw err;
+  }
+  return stream;
+}
+
+export async function streamStatus(streamId: string): Promise<StreamStatusResult> {
+  const status = await getStreamProvider().status(streamId);
+  // Status is polled throughout an active managed stream. Treat each successful
+  // observation as activity so a long-running stream never becomes sweepable
+  // merely because its original provision time is old. XX prevents a status
+  // response that finishes after completed teardown from recreating the entry.
+  await getRedis()
+    .zadd(
+      CLEANUP_QUEUE_KEY,
+      "XX",
+      Date.now() + ABANDONED_STREAM_GRACE_MS,
+      cleanupQueueMember("reclaim", streamId),
+    )
+    .catch((err) => logger.warn({ err, streamId }, "stream activity refresh failed"));
+  return status;
+}
+
+export async function stopStream(streamId: string): Promise<void> {
+  const redis = getRedis();
+  const stopMember = cleanupQueueMember("stop", streamId);
+
+  // Persist the finalization retry before touching Cloudflare. It is separate
+  // from the inactivity deadline, so an in-flight status poll cannot postpone
+  // an explicit stop and an empty recording list remains protected until a
+  // later stop retry observes the finalized recording.
+  await redis.zadd(CLEANUP_QUEUE_KEY, Date.now() + STOP_CLEANUP_RETRY_MS, stopMember);
+
+  const result = await getStreamProvider().stop(streamId);
+  if (result.input !== "retained") {
+    await redis.zrem(CLEANUP_QUEUE_KEY, ...cleanupQueueMembers(streamId));
+  }
+}
+
 // === Recording sweep loop ===
 
-/** How often to sweep. Cheap: one list call plus deletes for what it finds. */
-const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+/** How often to process the durable cleanup queue. */
+const SWEEP_INTERVAL_MS = STOP_CLEANUP_RETRY_MS;
 
-/**
- * How stale an input must be before the sweeper reclaims it. Comfortably longer
- * than any real session, so a long-running stream is never cut short.
- */
-const SWEEP_MIN_AGE_MS = 6 * 60 * 60 * 1000;
+let sweepTimer: ReturnType<typeof setTimeout> | null = null;
+let sweepLoopStarted = false;
+let nextLegacyDiscoveryAt = 0;
 
-let sweepTimer: ReturnType<typeof setInterval> | null = null;
+export async function sweepStreamsOnce(): Promise<{ recordings: number; inputs: number }> {
+  const p = getStreamProvider();
+  const redis = getRedis();
+  const now = Date.now();
+
+  // Best-effort migration for inputs created before the durable registry.
+  // Cloudflare's endpoint exposes only its first window, so the registry is
+  // authoritative for all newly provisioned streams. Queue processing runs
+  // every minute, but account-wide discovery remains hourly.
+  let discovered: StreamDiscoveryResult | undefined;
+  if (now >= nextLegacyDiscoveryAt) {
+    nextLegacyDiscoveryAt = now + LEGACY_DISCOVERY_INTERVAL_MS;
+    try {
+      discovered = await p.discover?.();
+    } catch (err) {
+      // Migration is advisory. A list-endpoint failure must never block cleanup
+      // of inputs already present in the authoritative queue.
+      logger.warn({ err }, "Cloudflare legacy input discovery failed");
+    }
+  }
+  if (discovered) {
+    const pipeline = redis.pipeline();
+    for (const input of discovered.inputs) {
+      pipeline.zadd(
+        CLEANUP_QUEUE_KEY,
+        "NX",
+        input.createdAt + ABANDONED_STREAM_GRACE_MS,
+        cleanupQueueMember("reclaim", input.streamId),
+      );
+    }
+    await pipeline.exec();
+    if (discovered.truncated) {
+      logger.warn(
+        { discovered: discovered.inputs.length },
+        "Cloudflare legacy input discovery is truncated; durable registry remains authoritative",
+      );
+    }
+  }
+
+  const claimed = await redis.zrangebyscore(
+    CLEANUP_QUEUE_KEY,
+    "-inf",
+    now,
+    "LIMIT",
+    0,
+    SWEEP_BATCH_SIZE,
+  );
+  if (claimed.length > 0) {
+    // Move the batch forward before touching Cloudflare. Concurrent pods may
+    // very occasionally select the same batch, but provider operations are
+    // idempotent and this avoids losing work if a pod exits mid-cleanup.
+    const pipeline = redis.pipeline();
+    for (const member of claimed) {
+      const { action } = parseCleanupQueueMember(member);
+      const retryMs = action === "stop" ? STOP_CLEANUP_RETRY_MS : SWEEP_RETRY_MS;
+      pipeline.zadd(CLEANUP_QUEUE_KEY, now + retryMs, member);
+    }
+    await pipeline.exec();
+  }
+
+  let recordings = 0;
+  let inputs = 0;
+  for (const member of claimed) {
+    const { action, streamId } = parseCleanupQueueMember(member);
+    try {
+      if (action === "reclaim" && !p.reclaim) continue;
+      const result = action === "stop" ? await p.stop(streamId) : await p.reclaim!(streamId);
+      recordings += result.recordings;
+      if (result.input === "deleted" || result.input === "missing") {
+        await redis.zrem(CLEANUP_QUEUE_KEY, ...cleanupQueueMembers(streamId), streamId);
+        if (result.input === "deleted") inputs += 1;
+      }
+      // Retained inputs already carry the claim's retry timestamp.
+    } catch (err) {
+      logger.warn({ err, streamId }, "stream cleanup retained input for retry");
+    }
+  }
+  return { recordings, inputs };
+}
 
 /**
  * Start the background sweep that reclaims abandoned live inputs and their
@@ -86,29 +254,33 @@ let sweepTimer: ReturnType<typeof setInterval> | null = null;
  * counts as success.
  */
 export function startStreamSweepLoop(): void {
-  if (sweepTimer) return;
+  if (sweepLoopStarted) return;
+  sweepLoopStarted = true;
 
   const run = async () => {
     try {
-      const p = getStreamProvider();
-      if (!p.sweep) return;
-      const { recordings, inputs } = await p.sweep(SWEEP_MIN_AGE_MS);
+      const { recordings, inputs } = await sweepStreamsOnce();
       if (recordings || inputs) {
         logger.info({ recordings, inputs }, "stream sweep reclaimed abandoned inputs");
       }
     } catch (err) {
       // A provider that is not configured, or a Cloudflare blip. Next tick retries.
       logger.warn({ err }, "stream sweep failed");
+    } finally {
+      // Schedule only after this run settles so slow account cleanup can never
+      // overlap itself and multiply Cloudflare API traffic.
+      if (sweepLoopStarted) sweepTimer = setTimeout(run, SWEEP_INTERVAL_MS);
     }
   };
 
-  sweepTimer = setInterval(run, SWEEP_INTERVAL_MS);
   void run();
 }
 
 /** Test/shutdown hook: stop the sweep loop. */
 export function stopStreamSweepLoop(): void {
+  sweepLoopStarted = false;
+  nextLegacyDiscoveryAt = 0;
   if (!sweepTimer) return;
-  clearInterval(sweepTimer);
+  clearTimeout(sweepTimer);
   sweepTimer = null;
 }

--- a/cloud-v2/tests/stream.cleanup-queue.test.ts
+++ b/cloud-v2/tests/stream.cleanup-queue.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const zadd = mock(async (..._args: unknown[]) => 1);
+const zrem = mock(async (..._args: unknown[]) => 1);
+const zrangebyscore = mock(async (..._args: unknown[]) => [] as string[]);
+const pipelineZadd = mock((..._args: unknown[]) => pipeline);
+const pipelineExec = mock(async () => []);
+const pipeline = { zadd: pipelineZadd, exec: pipelineExec };
+const redis = { zadd, zrem, zrangebyscore, pipeline: () => pipeline };
+
+const provision = mock(async () => ({
+  streamId: "input-1",
+  ingest: { protocol: "rtmps" as const, url: "rtmps://example", streamKey: "key" },
+  playback: { hls: "https://example/hls", dash: "https://example/dash" },
+}));
+const status = mock(async () => ({ streamId: "input-1", isConnected: false }));
+const stop = mock(async () => ({ recordings: 0, input: "retained" as const }));
+const reclaim = mock(async () => ({ recordings: 1, input: "deleted" as const }));
+const discover = mock(async () => ({ inputs: [], truncated: false }));
+const provider = { name: "test", provision, status, stop, reclaim, discover };
+
+mock.module("../packages/runtime/src/clients/redis.client", () => ({ getRedis: () => redis }));
+mock.module(
+  "../packages/runtime/src/services/stream/providers/cloudflare-stream.provider",
+  () => ({ createCloudflareStreamProvider: () => provider }),
+);
+
+let streamService: typeof import("../packages/runtime/src/services/stream/stream.service");
+
+beforeAll(async () => {
+  streamService = await import("../packages/runtime/src/services/stream/stream.service");
+});
+
+beforeEach(() => {
+  for (const fn of [
+    zadd,
+    zrem,
+    zrangebyscore,
+    pipelineZadd,
+    pipelineExec,
+    provision,
+    status,
+    stop,
+    reclaim,
+    discover,
+  ]) {
+    fn.mockClear();
+  }
+  zrangebyscore.mockResolvedValue([]);
+  stop.mockResolvedValue({ recordings: 0, input: "retained" });
+  reclaim.mockResolvedValue({ recordings: 1, input: "deleted" });
+  discover.mockResolvedValue({ inputs: [], truncated: false });
+  streamService.resetStreamProvider();
+});
+
+afterEach(() => {
+  streamService.stopStreamSweepLoop();
+});
+
+describe("managed stream cleanup queue", () => {
+  test("provision registers every input before returning it", async () => {
+    const before = Date.now();
+
+    const result = await streamService.provisionStream("user-1", {});
+
+    expect(result.streamId).toBe("input-1");
+    expect(zadd).toHaveBeenCalledTimes(1);
+    const [key, cleanupAt, member] = zadd.mock.calls[0]!;
+    expect(key).toBe("managed-stream:cleanup");
+    expect(cleanupAt as number).toBeGreaterThanOrEqual(before + 6 * 60 * 60 * 1000);
+    expect(member).toBe("reclaim:input-1");
+  });
+
+  test("provision reclaims an input when it cannot register recovery", async () => {
+    zadd.mockRejectedValueOnce(new Error("redis unavailable"));
+
+    await expect(streamService.provisionStream("user-1", {})).rejects.toThrow(
+      "redis unavailable",
+    );
+
+    expect(reclaim).toHaveBeenCalledWith("input-1");
+  });
+
+  test("an explicit stop pulls deferred cleanup forward", async () => {
+    const before = Date.now();
+
+    await streamService.stopStream("input-1");
+
+    expect(zrem).not.toHaveBeenCalled();
+    const [, retryAt, member] = zadd.mock.calls[0]!;
+    expect(retryAt as number).toBeGreaterThanOrEqual(before + 60 * 1000);
+    expect(member).toBe("stop:input-1");
+  });
+
+  test("successful status polling refreshes the inactivity deadline", async () => {
+    const before = Date.now();
+
+    await streamService.streamStatus("input-1");
+
+    const [key, mode, cleanupAt, member] = zadd.mock.calls[0]!;
+    expect(key).toBe("managed-stream:cleanup");
+    expect(mode).toBe("XX");
+    expect(cleanupAt as number).toBeGreaterThanOrEqual(before + 6 * 60 * 60 * 1000);
+    expect(member).toBe("reclaim:input-1");
+  });
+
+  test("a late status refresh cannot overwrite an explicit-stop retry", async () => {
+    await streamService.stopStream("input-1");
+    await streamService.streamStatus("input-1");
+
+    expect(zadd.mock.calls[0]?.[2]).toBe("stop:input-1");
+    expect(zadd.mock.calls[1]).toEqual([
+      "managed-stream:cleanup",
+      "XX",
+      expect.any(Number),
+      "reclaim:input-1",
+    ]);
+  });
+
+  test("completed explicit cleanup removes the queue entry", async () => {
+    stop.mockResolvedValueOnce({ recordings: 1, input: "deleted" });
+
+    await streamService.stopStream("input-1");
+
+    expect(zrem).toHaveBeenCalledWith("managed-stream:cleanup", "reclaim:input-1", "stop:input-1");
+  });
+
+  test("a sweep reschedules due inputs before removing reclaimed entries", async () => {
+    zrangebyscore.mockResolvedValue(["reclaim:input-1"]);
+
+    const result = await streamService.sweepStreamsOnce();
+
+    expect(zrangebyscore).toHaveBeenCalledTimes(1);
+    expect(pipelineZadd).toHaveBeenCalledWith(
+      "managed-stream:cleanup",
+      expect.any(Number),
+      "reclaim:input-1",
+    );
+    expect(reclaim).toHaveBeenCalledWith("input-1");
+    expect(zrem).toHaveBeenCalledWith(
+      "managed-stream:cleanup",
+      "reclaim:input-1",
+      "stop:input-1",
+      "input-1",
+    );
+    expect(result).toEqual({ recordings: 1, inputs: 1 });
+  });
+
+  test("a stop retry preserves an empty input instead of reclaiming it early", async () => {
+    zrangebyscore.mockResolvedValue(["stop:input-1"]);
+
+    const result = await streamService.sweepStreamsOnce();
+
+    expect(stop).toHaveBeenCalledWith("input-1");
+    expect(reclaim).not.toHaveBeenCalled();
+    expect(pipelineZadd).toHaveBeenCalledWith(
+      "managed-stream:cleanup",
+      expect.any(Number),
+      "stop:input-1",
+    );
+    expect(zrem).not.toHaveBeenCalled();
+    expect(result).toEqual({ recordings: 0, inputs: 0 });
+  });
+
+  test("legacy discovery seeds the queue without overwriting existing schedules", async () => {
+    discover.mockResolvedValue({
+      inputs: [{ streamId: "legacy", createdAt: 1_000 }],
+      truncated: false,
+    });
+
+    await streamService.sweepStreamsOnce();
+
+    expect(pipelineZadd).toHaveBeenCalledWith(
+      "managed-stream:cleanup",
+      "NX",
+      1_000 + 6 * 60 * 60 * 1000,
+      "reclaim:legacy",
+    );
+  });
+
+  test("legacy discovery failure cannot block the authoritative queue", async () => {
+    discover.mockRejectedValueOnce(new Error("list unavailable"));
+    zrangebyscore.mockResolvedValue(["reclaim:input-1"]);
+
+    const result = await streamService.sweepStreamsOnce();
+
+    expect(reclaim).toHaveBeenCalledWith("input-1");
+    expect(result).toEqual({ recordings: 1, inputs: 1 });
+  });
+});

--- a/cloud-v2/tests/stream.recording-cleanup.test.ts
+++ b/cloud-v2/tests/stream.recording-cleanup.test.ts
@@ -1,47 +1,106 @@
 /**
- * @fileoverview Recording cleanup on the Cloudflare Stream provider (stubbed fetch).
+ * @fileoverview Recording cleanup on the Cloudflare Stream provider.
  *
- * The account filled up because recordings outlive the live input that made
- * them: deleting an input orphans its recordings, which keep counting against
- * the storage quota until Cloudflare starts rejecting broadcasts at publish.
- * Recording cannot be turned off (HLS playback needs `mode: automatic`), so the
- * provider has to delete recordings itself.
- *
- * These assert the parts that are easy to get subtly wrong -- ordering, and
- * which things must never be deleted -- against a stubbed API rather than a
- * real account, so they run everywhere and cost nothing.
+ * Fixtures intentionally match Cloudflare's documented REST shapes. The live
+ * input list wraps entries in `result.liveInputs`, while connection status is
+ * available only from the per-input GET.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createCloudflareStreamProvider } from "../packages/runtime/src/services/stream/providers/cloudflare-stream.provider";
 
 const ACCT = "acct123";
+const LIVE_INPUTS_PATH = `/client/v4/accounts/${ACCT}/stream/live_inputs`;
 const realFetch = globalThis.fetch;
 
-/** Requests the stub saw, in order, as "METHOD /path". */
 let calls: string[] = [];
 
-interface Route {
-  videos?: Array<{ uid: string; status?: { state?: string } }>;
-  inputs?: Array<{
-    uid: string;
-    modified?: string;
-    status?: { current?: { state?: string | null } | null } | null;
-  }>;
+interface Video {
+  uid: string;
+  status?: { state?: string };
 }
 
-function stubFetch(routes: Route) {
+interface InputSummary {
+  uid: string;
+  created?: string;
+  modified?: string;
+  meta?: { name?: string };
+}
+
+interface InputDetail {
+  uid: string;
+  status?:
+    | string
+    | {
+        current?: {
+          state?: string | null;
+          statusEnteredAt?: string;
+          statusLastSeen?: string;
+          reason?: string;
+        } | null;
+      }
+    | null;
+}
+
+interface Routes {
+  videos?: Record<string, Video[]>;
+  inputs?: InputSummary[];
+  details?: Record<string, InputDetail>;
+  videoListStatus?: Record<string, number>;
+  videoDeleteStatus?: Record<string, number>;
+  listWindowSize?: number;
+}
+
+function stubFetch(routes: Routes) {
+  const deletedInputs = new Set<string>();
+
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
+    const path = new URL(url).pathname;
     const method = init?.method ?? "GET";
-    calls.push(`${method} ${new URL(url).pathname}`);
+    calls.push(`${method} ${path}`);
 
-    if (method === "GET" && url.endsWith("/videos")) {
-      return new Response(JSON.stringify({ success: true, result: routes.videos ?? [] }));
+    if (method === "GET" && path === LIVE_INPUTS_PATH) {
+      const remaining = (routes.inputs ?? []).filter((candidate) => !deletedInputs.has(candidate.uid));
+      const liveInputs = remaining.slice(0, routes.listWindowSize ?? remaining.length);
+      return new Response(
+        JSON.stringify({
+          success: true,
+          result: { liveInputs, range: liveInputs.length, total: remaining.length },
+        }),
+      );
     }
-    if (method === "GET" && url.endsWith("/live_inputs")) {
-      return new Response(JSON.stringify({ success: true, result: routes.inputs ?? [] }));
+
+    const videosMatch = path.match(/\/live_inputs\/([^/]+)\/videos$/);
+    if (method === "GET" && videosMatch) {
+      const inputUid = videosMatch[1]!;
+      const status = routes.videoListStatus?.[inputUid];
+      if (status) return new Response("upstream failure", { status });
+      return new Response(
+        JSON.stringify({ success: true, result: routes.videos?.[inputUid] ?? [] }),
+      );
     }
+
+    const inputMatch = path.match(/\/live_inputs\/([^/]+)$/);
+    if (method === "GET" && inputMatch) {
+      const inputUid = inputMatch[1]!;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          result: routes.details?.[inputUid] ?? { uid: inputUid, status: "client_disconnect" },
+        }),
+      );
+    }
+    if (method === "DELETE" && inputMatch) {
+      deletedInputs.add(inputMatch[1]!);
+    }
+
+    const videoMatch = path.match(/\/stream\/([^/]+)$/);
+    if (method === "DELETE" && videoMatch) {
+      const status = routes.videoDeleteStatus?.[videoMatch[1]!];
+      if (status) return new Response("upstream failure", { status });
+    }
+
     return new Response(JSON.stringify({ success: true, result: {} }));
   }) as typeof fetch;
 }
@@ -57,56 +116,144 @@ afterEach(() => {
 });
 
 describe("recording cleanup", () => {
-  test("stop() deletes recordings before deleting the input", async () => {
-    stubFetch({ videos: [{ uid: "vid1", status: { state: "ready" } }] });
+  test("stop disables the input, deletes ready recordings, then deletes the input", async () => {
+    stubFetch({ videos: { input1: [{ uid: "vid1", status: { state: "ready" } }] } });
 
     await createCloudflareStreamProvider().stop("input1");
 
+    const disable = calls.indexOf(`PUT ${LIVE_INPUTS_PATH}/input1`);
     const recording = calls.indexOf(`DELETE /client/v4/accounts/${ACCT}/stream/vid1`);
-    const input = calls.indexOf(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/input1`);
-
-    expect(recording).toBeGreaterThanOrEqual(0);
-    expect(input).toBeGreaterThanOrEqual(0);
-    // Order is the whole point: once the input is gone its recordings are no
-    // longer reachable through /videos, so deleting it first strands them.
-    expect(recording).toBeLessThan(input);
+    const input = calls.indexOf(`DELETE ${LIVE_INPUTS_PATH}/input1`);
+    expect(disable).toBeGreaterThanOrEqual(0);
+    expect(recording).toBeGreaterThan(disable);
+    expect(input).toBeGreaterThan(recording);
   });
 
-  test("a broadcast still in progress is never deleted", async () => {
+  test("stop retains the input while its recording is still finalizing", async () => {
     stubFetch({
-      videos: [
-        { uid: "live1", status: { state: "live-inprogress" } },
-        { uid: "done1", status: { state: "ready" } },
-      ],
+      videos: { input1: [{ uid: "live1", status: { state: "live-inprogress" } }] },
     });
 
-    const deleted = await createCloudflareStreamProvider().deleteRecordings!("input1");
+    await createCloudflareStreamProvider().stop("input1");
 
-    expect(deleted).toBe(1);
-    expect(calls).toContain(`DELETE /client/v4/accounts/${ACCT}/stream/done1`);
+    expect(calls).toContain(`PUT ${LIVE_INPUTS_PATH}/input1`);
     expect(calls).not.toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live1`);
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/input1`);
   });
 
-  test("sweep skips inputs that are too recent or still connected", async () => {
-    const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
-    const recent = new Date().toISOString();
+  test("stop retains the input when no recording is visible yet", async () => {
+    stubFetch({ videos: { input1: [] } });
 
+    await createCloudflareStreamProvider().stop("input1");
+
+    expect(calls).toContain(`PUT ${LIVE_INPUTS_PATH}/input1`);
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/input1`);
+  });
+
+  test("stop fails closed when recording enumeration fails", async () => {
+    stubFetch({ videoListStatus: { input1: 503 } });
+
+    await expect(createCloudflareStreamProvider().stop("input1")).rejects.toThrow(
+      "cloudflare recording list failed: 503",
+    );
+
+    expect(calls).toContain(`PUT ${LIVE_INPUTS_PATH}/input1`);
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/input1`);
+  });
+
+  test("queue recovery verifies status and reclaims a disconnected input", async () => {
+    stubFetch({
+      details: { stale: { uid: "stale", status: "client_disconnect" } },
+      videos: { stale: [{ uid: "done1", status: { state: "ready" } }] },
+    });
+
+    const result = await createCloudflareStreamProvider().reclaim!("stale");
+
+    expect(result).toEqual({ recordings: 1, input: "deleted" });
+    expect(calls).toContain(`GET ${LIVE_INPUTS_PATH}/stale`);
+    expect(calls).toContain(`PUT ${LIVE_INPUTS_PATH}/stale`);
+    expect(calls).toContain(`DELETE ${LIVE_INPUTS_PATH}/stale`);
+  });
+
+  test("queue recovery never disables or deletes an active input", async () => {
+    stubFetch({
+      details: { busy: { uid: "busy", status: "connected" } },
+    });
+
+    const result = await createCloudflareStreamProvider().reclaim!("busy");
+
+    expect(result).toEqual({ recordings: 0, input: "retained" });
+    expect(calls).toContain(`GET ${LIVE_INPUTS_PATH}/busy`);
+    expect(calls).not.toContain(`PUT ${LIVE_INPUTS_PATH}/busy`);
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/busy`);
+  });
+
+  test("queue recovery protects a reconnecting input without reporting it connected", async () => {
+    stubFetch({
+      details: { busy: { uid: "busy", status: "reconnecting" } },
+    });
+
+    const provider = createCloudflareStreamProvider();
+    const cleanup = await provider.reclaim!("busy");
+    const status = await provider.status("busy");
+
+    expect(cleanup).toEqual({ recordings: 0, input: "retained" });
+    expect(status).toMatchObject({
+      streamId: "busy",
+      isConnected: false,
+      state: "reconnecting",
+    });
+    expect(calls).not.toContain(`PUT ${LIVE_INPUTS_PATH}/busy`);
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/busy`);
+  });
+
+  test("legacy discovery parses the documented list shape and ignores foreign inputs", async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
     stubFetch({
       inputs: [
-        { uid: "stale", modified: old },
-        { uid: "fresh", modified: recent },
-        { uid: "busy", modified: old, status: { current: { state: "connected" } } },
+        { uid: "owned", created: old, meta: { name: "mentra-user1" } },
+        { uid: "foreign", created: old, meta: { name: "other-service" } },
       ],
-      videos: [],
+      listWindowSize: 1,
     });
 
-    const { inputs } = await createCloudflareStreamProvider().sweep!(6 * 60 * 60 * 1000);
+    const result = await createCloudflareStreamProvider().discover!();
 
-    expect(inputs).toBe(1);
-    expect(calls).toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/stale`);
-    // A live session must survive the sweep, and so must anything recent.
-    expect(calls).not.toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/busy`);
-    expect(calls).not.toContain(`DELETE /client/v4/accounts/${ACCT}/stream/live_inputs/fresh`);
+    expect(result).toEqual({
+      inputs: [{ streamId: "owned", createdAt: Date.parse(old) }],
+      truncated: true,
+    });
+    expect(calls).not.toContain(`GET ${LIVE_INPUTS_PATH}/foreign`);
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/foreign`);
+  });
+
+  test("queue recovery surfaces recording deletion failures and retains the input", async () => {
+    stubFetch({
+      videos: { stale: [{ uid: "failed-video", status: { state: "ready" } }] },
+      videoDeleteStatus: { "failed-video": 503 },
+    });
+
+    await expect(createCloudflareStreamProvider().reclaim!("stale")).rejects.toThrow(
+      "cloudflare recording cleanup failed for 1 recording(s)",
+    );
+    expect(calls).not.toContain(`DELETE ${LIVE_INPUTS_PATH}/stale`);
+  });
+
+  test("queue recovery deletes an empty input after the grace period", async () => {
+    stubFetch({ videos: { stale: [] } });
+
+    const result = await createCloudflareStreamProvider().reclaim!("stale");
+
+    expect(result).toEqual({ recordings: 0, input: "deleted" });
+    expect(calls).toContain(`DELETE ${LIVE_INPUTS_PATH}/stale`);
+  });
+
+  test("status accepts Cloudflare's root string status", async () => {
+    stubFetch({ details: { input1: { uid: "input1", status: "reconnected" } } });
+
+    const result = await createCloudflareStreamProvider().status("input1");
+
+    expect(result).toMatchObject({ streamId: "input1", isConnected: true, state: "reconnected" });
   });
 
   test("provision sets a retention floor for recordings it cannot delete itself", async () => {
@@ -119,7 +266,7 @@ describe("recording cleanup", () => {
     await createCloudflareStreamProvider().provision("user1", {});
 
     expect(JSON.parse(sentBody).deleteRecordingAfterDays).toBe(30);
-    // Recording must stay on: HLS playback does not work without it.
     expect(JSON.parse(sentBody).recording.mode).toBe("automatic");
+    expect(JSON.parse(sentBody).meta.name).toBe("mentra-user1");
   });
 });

--- a/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
@@ -813,12 +813,6 @@ export class PhoneStreamCoordinator {
       for (const reject of entry.hlsReadyRejecters) reject(pendingErr)
       entry.hlsReadyResolvers = []
       entry.hlsReadyRejecters = []
-      // Cloudflare DELETE is fire-and-forget — failing it doesn't undo the
-      // BLE stop we're about to do, and Cloudflare's idle-input scavenger
-      // will eventually clean up leaked inputs.
-      teardownManagedStream(entry.liveInputId).catch((err) => {
-        console.warn("[STREAM] teardownManagedStream failed:", err)
-      })
     }
 
     try {
@@ -833,6 +827,16 @@ export class PhoneStreamCoordinator {
       // Only clear if we're still the active entry (defensive — runExclusive
       // serializes us, so this should always be true).
       if (this.current === entry) this.current = null
+
+      if (entry.kind === "managed") {
+        // Start remote cleanup only after the publisher has stopped, but do not
+        // hold the local transition lock on an unbounded network request. The
+        // runtime's durable cleanup queue owns retries if this request fails or
+        // the app exits before Cloudflare finishes finalizing the recording.
+        void teardownManagedStream(entry.liveInputId).catch((err) => {
+          console.warn("[STREAM] teardownManagedStream failed:", err)
+        })
+      }
     }
   }
 }

--- a/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
@@ -337,6 +337,51 @@ describe("PhoneStreamCoordinator", () => {
       expect(stopStream).toHaveBeenCalled()
     })
 
+    test("stops the publisher before asking Cloudflare to clean up", async () => {
+      const order: string[] = []
+      stopStream.mockImplementationOnce(async () => {
+        order.push("publisher-stop")
+      })
+      teardownManagedStream.mockImplementationOnce(async () => {
+        order.push("cloud-teardown")
+      })
+      const coord = new PhoneStreamCoordinator({
+        hlsReadinessInitialDelayMs: 5,
+        hlsReadinessPollMs: 5,
+        cloudflareStatusPollMs: 1000,
+        keepAliveIntervalMs: 10_000,
+      })
+
+      const stream = await coord.startManaged("com.a", {})
+      await coord.stop("com.a", stream.streamId)
+
+      expect(order).toEqual(["publisher-stop", "cloud-teardown"])
+    })
+
+    test("does not hold the stream lock while remote cleanup is pending", async () => {
+      let finishRemoteCleanup!: () => void
+      teardownManagedStream.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRemoteCleanup = resolve
+          }),
+      )
+      const coord = new PhoneStreamCoordinator({
+        hlsReadinessInitialDelayMs: 5,
+        hlsReadinessPollMs: 5,
+        cloudflareStatusPollMs: 1000,
+        keepAliveIntervalMs: 10_000,
+      })
+
+      const first = await coord.startManaged("com.a", {})
+      await coord.stop("com.a", first.streamId)
+      const second = await coord.startManaged("com.b", {})
+
+      expect(second.streamId).not.toBe(first.streamId)
+      finishRemoteCleanup()
+      await coord.stop("com.b", second.streamId)
+    })
+
     test("managed cannot start while unmanaged is active", async () => {
       const coord = new PhoneStreamCoordinator({
         hlsReadinessInitialDelayMs: 5,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes managed-stream teardown and Cloudflare billing/storage behavior with a new Redis dependency on provision; mistakes could leak inputs or delete active streams, though reclaim guards and broad tests mitigate this.
> 
> **Overview**
> Replaces the hourly Cloudflare “sweep by age” with a **Redis sorted-set cleanup queue** that registers every provisioned live input, refreshes abandonment deadlines on status polls, and retries explicit stops until recordings finish materializing. The Cloudflare provider now **disables inputs before deletion**, **retains** inputs when recordings are pending or not yet listed, and exposes **`reclaim` / `discover`** (documented list shape, `mentra-*` meta) instead of blind deletes; `camera.service` routes through `provisionStream` / `stopStream` / `streamStatus`.
> 
> On mobile, **`PhoneStreamCoordinator`** stops the glasses publisher first, then kicks off remote teardown **without holding the transition lock**, relying on the runtime queue for retries.
> 
> The **iOS build workflow** splits CocoaPods caching (portable downloads vs runner-local `Pods` + DerivedData), quotes `GITHUB_OUTPUT`, and adds a **build attempt summary** (cache hit, outcomes, durations).
> 
> New/expanded tests cover the cleanup queue, Cloudflare cleanup edge cases, and coordinator stop ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5cd9f88a6a43db2f51f4ddd3c6a4b8f15d0fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->