### PR TITLE
Fix Google Play release naming option

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -10,6 +10,10 @@ function mobileScript(name) {
   return readFileSync(new URL(`../../mobile/scripts/${name}`, import.meta.url), "utf8")
 }
 
+function mobileFastfile(name) {
+  return readFileSync(new URL(`../../mobile/ci/${name}/Fastfile`, import.meta.url), "utf8")
+}
+
 function jobBlock(source, name) {
   const start = source.indexOf(`\n  ${name}:\n`)
   assert.notEqual(start, -1, `Missing workflow job ${name}`)
@@ -88,6 +92,9 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(mobile, /play_track: internal/)
   assert.match(mobile, /Mentra Production Candidates/)
   assert.match(mobile, /Mentra SDK Example Production Candidates/)
+  const androidFastfile = mobileFastfile("fastlane-android")
+  assert.match(androidFastfile, /version_name: ENV\["GOOGLE_PLAY_RELEASE_NAME"\]/)
+  assert.doesNotMatch(androidFastfile, /release_name:/)
   assert.match(mobile, /release_id: \$\{\{ needs\.load\.outputs\.promotion_release_id \}\}/)
   assert.match(mobile, /artifact_container_tag: \$\{\{ needs\.load\.outputs\.candidate_container_tag \}\}/)
   assert.match(mobile, /candidate_release_id: \$\{\{ needs\.load\.outputs\.promotion_release_id \}\}/)

--- a/mobile/ci/fastlane-android/Fastfile
+++ b/mobile/ci/fastlane-android/Fastfile
@@ -60,7 +60,7 @@ platform :android do
     upload_to_play_store(
       track: ENV.fetch("GOOGLE_PLAY_TRACK", "internal"),
       aab: ENV.fetch("GOOGLE_PLAY_AAB", "app/build/outputs/bundle/release/app-release.aab"),
-      release_name: ENV["GOOGLE_PLAY_RELEASE_NAME"],
+      version_name: ENV["GOOGLE_PLAY_RELEASE_NAME"],
       skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_images: true,


### PR DESCRIPTION
## Summary

- pass production-candidate Play release names through Fastlane's supported `version_name` option
- preserve the existing `GOOGLE_PLAY_RELEASE_NAME` contract used by isolated production candidates
- add a workflow-contract regression assertion that rejects the unsupported `release_name` option

## Root cause

The production promotion work added `release_name: ENV["GOOGLE_PLAY_RELEASE_NAME"]` to the shared `upload_to_play_store` call. Fastlane 2.235.0 does not expose a `release_name` action option, so every ordinary coordinated Android release failed before Google Play upload even when `GOOGLE_PLAY_RELEASE_NAME` was unset. The immutable GitHub APK/AAB had already been published, which is why Slack correctly showed `Android - failed` alongside a working APK URL.

Fastlane's supported `version_name` option is assigned directly to `AndroidPublisher::TrackRelease.name`. Using it preserves the intended `PRODUCTION CANDIDATE ...` Play Console label while allowing dev and staging uploads to proceed normally.

## Evidence

- dev.102 Android failure: `Could not find option 'release_name' in the list of available options`
- pinned Fastlane 2.235.0 source maps `Supply.config[:version_name]` to `AndroidPublisher::TrackRelease.new(name: ...)`
- coordinated release-script suite: 138 passed, 0 failed
- focused workflow-contract suite: 11 passed, 0 failed
- Fastfile Ruby syntax check passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-option fix in the Play upload lane plus a contract test; no auth, data, or workflow behavior changes beyond restoring successful uploads.
> 
> **Overview**
> Fixes coordinated and production-candidate **Android** uploads that were failing at the Fastlane step with `Could not find option 'release_name'`.
> 
> The shared `google_play` lane now passes `GOOGLE_PLAY_RELEASE_NAME` through **`version_name`** on `upload_to_play_store` (the option Fastlane maps to Play Console release name) instead of the unsupported **`release_name`** key. The env contract is unchanged, so production candidates can still get labels like `PRODUCTION CANDIDATE ...` while dev/staging uploads work when the name is unset.
> 
> The coordinated workflow contract test loads the Android Fastfile and asserts **`version_name`** is wired to that env var and that **`release_name:`** is not present, so this regression is caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced32c602e19dc3f4d759ed69fc332d86fe8aec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->