### PR TITLE
Promote dev to staging

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -10,6 +10,10 @@ function mobileScript(name) {
   return readFileSync(new URL(`../../mobile/scripts/${name}`, import.meta.url), "utf8")
 }
 
+function mobileFastfile(name) {
+  return readFileSync(new URL(`../../mobile/ci/${name}/Fastfile`, import.meta.url), "utf8")
+}
+
 function jobBlock(source, name) {
   const start = source.indexOf(`\n  ${name}:\n`)
   assert.notEqual(start, -1, `Missing workflow job ${name}`)
@@ -88,6 +92,9 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(mobile, /play_track: internal/)
   assert.match(mobile, /Mentra Production Candidates/)
   assert.match(mobile, /Mentra SDK Example Production Candidates/)
+  const androidFastfile = mobileFastfile("fastlane-android")
+  assert.match(androidFastfile, /version_name: ENV\["GOOGLE_PLAY_RELEASE_NAME"\]/)
+  assert.doesNotMatch(androidFastfile, /release_name:/)
   assert.match(mobile, /release_id: \$\{\{ needs\.load\.outputs\.promotion_release_id \}\}/)
   assert.match(mobile, /artifact_container_tag: \$\{\{ needs\.load\.outputs\.candidate_container_tag \}\}/)
   assert.match(mobile, /candidate_release_id: \$\{\{ needs\.load\.outputs\.promotion_release_id \}\}/)

--- a/mobile/ci/fastlane-android/Fastfile
+++ b/mobile/ci/fastlane-android/Fastfile
@@ -60,7 +60,7 @@ platform :android do
     upload_to_play_store(
       track: ENV.fetch("GOOGLE_PLAY_TRACK", "internal"),
       aab: ENV.fetch("GOOGLE_PLAY_AAB", "app/build/outputs/bundle/release/app-release.aab"),
-      release_name: ENV["GOOGLE_PLAY_RELEASE_NAME"],
+      version_name: ENV["GOOGLE_PLAY_RELEASE_NAME"],
       skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_images: true,


### PR DESCRIPTION
Promotes the latest dev commit to staging.

Includes #3896, which fixes the Google Play upload option used by coordinated Android releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Fastlane parameter correction for Play uploads, guarded by an existing workflow contract test with no auth or data-model changes.
> 
> **Overview**
> Fixes coordinated Android production candidate uploads by passing **`version_name`** (not **`release_name`**) to Fastlane’s `upload_to_play_store`, still sourced from `GOOGLE_PLAY_RELEASE_NAME`.
> 
> The coordinated workflow contract test now reads the Android Fastfile and asserts this option is set correctly and that **`release_name:`** is not used, so the Play upload API contract stays enforced in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd75f79478d9c5f6d2f4c11471ac23d5bdf0078c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->