### PR TITLE
Limit production promotion to Mentra App

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -1,8 +1,14 @@
 # Production release runbook
 
 This is the employee procedure for promoting one completed coordinated beta to
-production. It covers Cloud V2, the Mentra App on iOS and Android, and the
-Bluetooth SDK Starter Kit example on iOS and Android.
+production. It covers Cloud V2 and the Mentra App on iOS and Android.
+
+The Bluetooth SDK Starter Kit example app is explicitly outside this production
+promotion system. These workflows do not build it, upload it to TestFlight or
+Google Play, submit it for review, or release it publicly. Do not add the example
+app manually to a promotion attempt. Its coordinated beta pipeline remains
+separate and unchanged. Publishing it to app stores later requires a reviewed
+workflow and runbook change; it is not an operator-time option.
 
 The process is resumable. It records immutable state in a draft GitHub release
 named `mentra-production-promotion-vX.Y.Z-attempt-N`. Store review may take days;
@@ -57,12 +63,11 @@ Configure these GitHub environments:
 | `production-store-release`     | Public release and rollout evidence | Required reviewer different from initiator |
 
 Required secrets are the existing Porter, App Store Connect, Google Play,
-Android upload-signing, Apple Match, Doppler, Mapbox, Sentry, and Starter Kit
-checkout credentials used by the reusable release workflows. Operators do not
-download them locally.
+Android upload-signing, Apple Match, Doppler, Mapbox, and Sentry credentials
+used by the reusable release workflows. Operators do not download them locally.
 
-Before launch week, verify in App Store Connect and Play Console for both app
-records:
+Before launch week, verify the Mentra App record in App Store Connect and Play
+Console:
 
 - agreements, tax, banking, compliance, privacy, export, data safety, content
   rating, countries, support/privacy URLs, screenshots, and listing copy;
@@ -70,27 +75,9 @@ records:
 - internal tester membership and dedicated test devices;
 - a `Mentra Compatibility Lab` internal TestFlight group;
 - automatic TestFlight distribution is off for the production groups;
-- managed publishing is enabled for existing Google Play apps; and
+- managed publishing is enabled in Google Play; and
 - alerting, dashboards, incident channel, release owner, QA owner, approver, and
   rollback owner are staffed for the release window.
-
-### Starter Kit first release prerequisites
-
-The Starter Kit has not previously been public in the stores. Before starting:
-
-- finalize `com.mentra.bluetoothsdkexample` in source, App Store Connect, and
-  Google Play;
-- create the Play app record, enable Play App Signing and API access, and
-  bootstrap internal testing early;
-- ensure the stable `sdk-X.Y.Z` Starter Kit tag consumes exact public
-  `@mentra/bluetooth-sdk` and `@mentra/engine` version `X.Y.Z`;
-- complete the product-quality gate in the design document: this must be a
-  finished developer utility, not a placeholder/demo shell; and
-- arrange the hardware, account, instructions, and reviewer access Apple needs.
-
-Google Play does not support managed publishing or staged rollout for an app's
-first public release. Approval may make that first Starter Kit Android release
-public. Submit it only during a staffed release period and monitor continuously.
 
 ## Operator commands
 
@@ -122,7 +109,6 @@ Preparation fails if:
 - the beta is incomplete or its immutable artifacts fail verification;
 - its source is not contained in `main`;
 - the public Mentra App does not match the previous production manifest;
-- the stable Starter Kit tag is missing;
 - store build numbers cannot be allocated monotonically; or
 - the current production release lacks provenance. For a one-time provenance
   bootstrap, create and review an accurate immutable current-production record;
@@ -232,14 +218,12 @@ Run:
 ./scripts/production-release.mjs next --release X.Y.Z
 ```
 
-After `production-mobile-candidates` approval, the workflow rebuilds all four
-candidates. Mentra App targets production Cloud and uses the frozen OTA pin.
-Starter Kit source must already contain the final identifiers and exact stable
-SDK dependencies; the workflow refuses to rewrite them. Outputs go only to:
+After `production-mobile-candidates` approval, the workflow rebuilds the two
+Mentra App candidates. They target production Cloud and use the frozen OTA pin.
+Outputs go only to:
 
 - TestFlight `Mentra Production Candidates`;
-- TestFlight `Mentra SDK Example Production Candidates`; and
-- each app's isolated Play internal-testing track.
+- the Mentra App Play internal-testing track.
 
 They are normal customer-eligible candidates, never TestFlight Internal Only or
 Internal App Sharing artifacts. A retry reuses only an exact matching coordinate
@@ -251,8 +235,7 @@ Install through TestFlight and Play, not local archives. On iOS and Android test
 the Mentra App clean install/upgrade, production auth/session, pair/reconnect,
 Core/Runtime, transcription, media/BLE, OTA identity, permissions/background,
 telemetry environment, no staging endpoints, and every release-specific config
-check. Test Starter Kit launch, stable SDK identity, pair/reconnect, display,
-audio/transcription-local flow, media flow, permissions, and restart.
+check.
 
 Use `evidence/production-candidates.template.json` and attest:
 
@@ -272,10 +255,10 @@ numbers. For Apple select manual release; use phased release for normal Mentra
 App updates unless the approver documents an exception. For Play verify managed
 publishing before an existing-app production submission.
 
-Then run `next`. The protected workflow submits the exact iOS builds with manual
-release and creates/reconciles exact Google production drafts. If a store field
-blocks the API, finish only the equivalent UI action and rerun; the workflow
-must read back the same build.
+Then run `next`. The protected workflow submits the exact iOS build with manual
+release and creates or reconciles the exact Google production draft. If a store
+field blocks the API, finish only the equivalent UI action and rerun; the
+workflow must read back the same build.
 
 Apple UI fallback:
 
@@ -302,7 +285,7 @@ Record rejection messages and responses. Metadata-only corrections may reuse
 the exact binary. Any binary/config change requires a new candidate and full
 candidate acceptance.
 
-When Apple and Google show review complete for all four exact coordinates, fill
+When Apple and Google show review complete for both exact coordinates, fill
 `evidence/store-review-approved.template.json` and run:
 
 ```bash
@@ -322,12 +305,10 @@ Request the protected two-person release approval:
 This first appends approval only. It does not pretend that a GitHub approval
 clicked a store button. After approval, perform the exact UI actions:
 
-- Apple: release the exact approved versions; leave Mentra App phased release
+- Apple: release the exact approved version; leave Mentra App phased release
   enabled unless an exception was approved.
-- Google existing apps: Publishing overview -> Publish changes, then start the
+- Google: Publishing overview -> Publish changes, then start the
   approved staged rollout for the exact version code.
-- Starter Kit first Android release: approval may already have published it;
-  treat this as the documented first-release exception and monitor immediately.
 
 The verification workflow requires the exact Google version code to be in a
 production release whose status is `inProgress` with a nonzero rollout fraction
@@ -361,9 +342,10 @@ chain. If finalization is interrupted, rerun the same `--complete` command; it
 verifies identical existing assets and resumes. Do not abort or start a
 replacement attempt after `finalizing`: the 100 percent rollout is already
 public, so the only valid recovery is to finish reconciling this attempt.
-Do not complete until both store pages are publicly reachable in intended
-territories, install/update returns the exact coordinates, production Cloud is
-healthy, and the release owner has recorded the final observation window.
+Do not complete until both Mentra App store pages are publicly reachable in
+intended territories, install/update returns the exact coordinates, production
+Cloud is healthy, and the release owner has recorded the final observation
+window.
 
 After completion, inspect the two canonical assets and perform the final public
 availability checks. Publish the already-staged GitHub release manually; no
@@ -386,7 +368,8 @@ the 100 percent `finalizing` checkpoint. Preparation runs are serialized while
 they allocate attempts, so starting two beta selections does not create two
 active promotions. A retry resumes a zero-state container only when its selected
 beta, source commit, prior-production provenance, store inventories, release
-family, and Starter Kit commit match exactly through one deterministic digest.
+family, and Mentra App coordinates match exactly through one deterministic
+digest.
 
 Common stop conditions include source/lock mismatch, missing store provenance,
 unclassified Cloud config, non-backward-compatible migration, Mobile N failure,

--- a/.github/production-release/evidence/production-candidates.template.json
+++ b/.github/production-release/evidence/production-candidates.template.json
@@ -26,26 +26,6 @@
       "deviceModel": "MODEL",
       "osVersion": "VERSION",
       "notes": "Installed through Play internal testing; full acceptance passed against production Cloud."
-    },
-    {
-      "product": "starter-kit",
-      "platform": "ios",
-      "result": "pass",
-      "appVersion": "X.Y.Z",
-      "appBuild": "BUILD",
-      "deviceModel": "MODEL",
-      "osVersion": "VERSION",
-      "notes": "Installed through TestFlight; stable SDK identity, pair/reconnect, display, audio/transcription, media, permissions, and restart passed."
-    },
-    {
-      "product": "starter-kit",
-      "platform": "android",
-      "result": "pass",
-      "appVersion": "X.Y.Z",
-      "appBuild": "BUILD",
-      "deviceModel": "MODEL",
-      "osVersion": "VERSION",
-      "notes": "Installed through Play internal testing; stable SDK identity, pair/reconnect, display, audio/transcription, media, permissions, and restart passed."
     }
   ],
   "evidenceUrls": ["https://credential-free.example/evidence/index"],

--- a/.github/production-release/evidence/store-review-approved.template.json
+++ b/.github/production-release/evidence/store-review-approved.template.json
@@ -26,26 +26,6 @@
       "deviceModel": "Google Play Console",
       "osVersion": "N/A",
       "notes": "Exact version code approved and held in managed publishing."
-    },
-    {
-      "product": "starter-kit",
-      "platform": "ios",
-      "result": "pass",
-      "appVersion": "X.Y.Z",
-      "appBuild": "BUILD",
-      "deviceModel": "App Store Connect",
-      "osVersion": "N/A",
-      "notes": "Exact accepted build approved and held for manual release."
-    },
-    {
-      "product": "starter-kit",
-      "platform": "android",
-      "result": "pass",
-      "appVersion": "X.Y.Z",
-      "appBuild": "BUILD",
-      "deviceModel": "Google Play Console",
-      "osVersion": "N/A",
-      "notes": "Exact version code approved; first-public-release behavior and monitoring window acknowledged."
     }
   ],
   "evidenceUrls": ["https://credential-free.example/evidence/index"],

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -95,13 +95,16 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(mobile, /backend_environment: prod/)
   assert.match(mobile, /play_track: internal/)
   assert.match(mobile, /Mentra Production Candidates/)
-  assert.match(mobile, /Mentra SDK Example Production Candidates/)
+  for (const source of [prepare, mobile, submit, release, status]) {
+    assert.doesNotMatch(source, /com\.mentra\.bluetoothsdkexample|starterKitCommit/)
+  }
+  assert.doesNotMatch(mobile, /starter-kit-ios:|starter-kit-android:|reusable-production-starter-kit-android/)
+  assert.match(mobile, /needs: \[load, mentra-app\]/)
   const androidFastfile = mobileFastfile("fastlane-android")
   assert.match(androidFastfile, /version_name: ENV\["GOOGLE_PLAY_RELEASE_NAME"\]/)
   assert.doesNotMatch(androidFastfile, /release_name:/)
   assert.match(mobile, /release_id: \$\{\{ needs\.load\.outputs\.promotion_release_id \}\}/)
   assert.match(mobile, /artifact_container_tag: \$\{\{ needs\.load\.outputs\.candidate_container_tag \}\}/)
-  assert.match(mobile, /candidate_release_id: \$\{\{ needs\.load\.outputs\.promotion_release_id \}\}/)
   assert.doesNotMatch(mobile, /allocate stable artifact container/i)
   assert.match(submit, /GOOGLE_PLAY_RELEASE_STATUS=draft/)
   assert.doesNotMatch(submit, /automatic_release: true/)
@@ -125,14 +128,6 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.match(release, /validate-google-play-release\.mjs/)
   assert.match(release, /--required-state public/)
   assert.doesNotMatch(release, /\.tracks\.production \| map\(tonumber\)/)
-  const starterAndroid = workflow("reusable-production-starter-kit-android.yml")
-  assert.match(starterAndroid, /Persist and verify the exact App Bundle before Play upload/)
-  assert.match(starterAndroid, /publish-immutable-release-asset\.mjs/)
-  assert.match(starterAndroid, /GOOGLE_PLAY_AAB: \$\{\{ steps\.staged\.outputs\.aab \}\}/)
-  assert.match(
-    starterAndroid,
-    /Google Play contains this version code without this attempt's previously persisted App Bundle/,
-  )
   assert.equal(existsSync(new URL("../workflows/coordinated-production-promotion.yml", import.meta.url)), false)
   assert.equal(existsSync(new URL("../workflows/reusable-coordinated-mobile-promotion.yml", import.meta.url)), false)
 })

--- a/.github/scripts/finalize-production-promotion.mjs
+++ b/.github/scripts/finalize-production-promotion.mjs
@@ -80,10 +80,6 @@ export function finalizeProductionPromotion({plan, record, checkpointUrl}) {
     artifactContainerName: plan.artifactContainerName,
     applications: {
       mentraApp: record.coordinates.candidates.mentraApp,
-      starterKit: {
-        sourceCommit: record.source.starterKitCommit,
-        ...record.coordinates.candidates.starterKit,
-      },
     },
     releaseFamily: {
       members: Object.fromEntries(

--- a/.github/scripts/finalize-production-promotion.test.mjs
+++ b/.github/scripts/finalize-production-promotion.test.mjs
@@ -66,7 +66,7 @@ function finalizingRecord() {
       manifestUrl: "https://example.com/beta.json",
       manifestSha256: "b".repeat(64),
     },
-    source: {mentraosCommit: "a".repeat(40), starterKitCommit: "e".repeat(40)},
+    source: {mentraosCommit: "a".repeat(40)},
     coordinates: {
       currentMentraApp: {
         sourceCommit: "f".repeat(40),
@@ -82,10 +82,6 @@ function finalizingRecord() {
         mentraApp: {
           ios: {marketingVersion: baseVersion, buildNumber: 310000102},
           android: {marketingVersion: baseVersion, buildNumber: 310000102},
-        },
-        starterKit: {
-          ios: {marketingVersion: baseVersion, buildNumber: 310000103},
-          android: {marketingVersion: baseVersion, buildNumber: 310000103},
         },
       },
     },
@@ -125,7 +121,7 @@ test("creates the canonical production manifest from the finalizing checkpoint",
   assert.equal(manifest.kind, "mentra-production-release")
   assert.equal(manifest.releaseIdentity, baseVersion)
   assert.equal(manifest.native.buildNumber, 310000102)
-  assert.equal(manifest.applications.starterKit.ios.buildNumber, 310000103)
+  assert.deepEqual(Object.keys(manifest.applications), ["mentraApp"])
   assert.equal(manifest.promotion.attempt, 2)
   assert.equal(manifest.promotion.checkpoint.state, "finalizing")
   assert.equal(manifest.completedAt, record.createdAt)

--- a/.github/scripts/prepare-compatibility-lab.test.mjs
+++ b/.github/scripts/prepare-compatibility-lab.test.mjs
@@ -27,7 +27,7 @@ const record = {
     manifestUrl: "https://example.com/beta.json",
     manifestSha256: digest("b"),
   },
-  source: {mentraosCommit: commit("c"), starterKitCommit: commit("d")},
+  source: {mentraosCommit: commit("c")},
   coordinates: {
     currentMentraApp: {
       sourceCommit: currentSource,
@@ -43,10 +43,6 @@ const record = {
       mentraApp: {
         ios: {marketingVersion: "99.0.0", buildNumber: 102},
         android: {marketingVersion: "99.0.0", buildNumber: 102},
-      },
-      starterKit: {
-        ios: {marketingVersion: "99.0.0", buildNumber: 103},
-        android: {marketingVersion: "99.0.0", buildNumber: 103},
       },
     },
   },

--- a/.github/scripts/prepare-production-promotion.mjs
+++ b/.github/scripts/prepare-production-promotion.mjs
@@ -58,8 +58,6 @@ export function prepareProductionPromotion({
   betaManifestSha256,
   previousManifest,
   mentraInventory,
-  starterKitInventory,
-  starterKitCommit,
   attempt,
   actor,
   createdAt,
@@ -85,15 +83,7 @@ export function prepareProductionPromotion({
   ) {
     throw new Error("Selected beta has no immutable OTA manifest pin")
   }
-  const betaStarterKitCommit = betaManifest.starterKit?.starterKit?.releaseCommit
-  if (!COMMIT_PATTERN.test(betaStarterKitCommit || "")) {
-    throw new Error("Selected beta has no exact Starter Kit release commit")
-  }
-  if (!COMMIT_PATTERN.test(starterKitCommit || "")) {
-    throw new Error("Stable Starter Kit tag has no exact release commit")
-  }
   validateInventory(mentraInventory, {bundleId: "com.mentra.mentra", allowNoCurrent: false})
-  validateInventory(starterKitInventory, {bundleId: "com.mentra.bluetoothsdkexample", allowNoCurrent: true})
   const currentMentraApp = validateCurrentMentraApp(previousManifest, mentraInventory)
   const lastMentraBuildNumber = Math.max(
     mentraInventory.apple.maxBuildNumber,
@@ -102,8 +92,6 @@ export function prepareProductionPromotion({
   )
   const compatibilityLabBuildNumber = lastMentraBuildNumber + 1
   const mentraBuildNumber = lastMentraBuildNumber + 2
-  const starterKitBuildNumber =
-    Math.max(starterKitInventory.apple.maxBuildNumber, starterKitInventory.google.maxVersionCode, mentraBuildNumber) + 1
   const productionPlan = createReleasePlan({
     family,
     channel: "production",
@@ -126,7 +114,7 @@ export function prepareProductionPromotion({
       manifestUrl: betaManifestUrl,
       manifestSha256: betaManifestSha256,
     },
-    source: {mentraosCommit: betaPlan.sourceCommit, starterKitCommit},
+    source: {mentraosCommit: betaPlan.sourceCommit},
     coordinates: {
       currentMentraApp,
       compatibilityLab: {
@@ -140,10 +128,6 @@ export function prepareProductionPromotion({
         mentraApp: {
           ios: {marketingVersion: productionPlan.native.marketingVersion, buildNumber: mentraBuildNumber},
           android: {marketingVersion: productionPlan.native.marketingVersion, buildNumber: mentraBuildNumber},
-        },
-        starterKit: {
-          ios: {marketingVersion: productionPlan.native.marketingVersion, buildNumber: starterKitBuildNumber},
-          android: {marketingVersion: productionPlan.native.marketingVersion, buildNumber: starterKitBuildNumber},
         },
       },
     },
@@ -190,8 +174,6 @@ function main() {
     betaManifestSha256: sha256File(betaManifestPath),
     previousManifest,
     mentraInventory: readJson(args["mentra-inventory"]),
-    starterKitInventory: readJson(args["starter-kit-inventory"]),
-    starterKitCommit: args["starter-kit-commit"],
     attempt: Number(args.attempt),
     actor: args.actor,
     createdAt: args["created-at"],

--- a/.github/scripts/prepare-production-promotion.test.mjs
+++ b/.github/scripts/prepare-production-promotion.test.mjs
@@ -22,7 +22,6 @@ const betaManifest = {
   native: betaPlan.native,
   releasePlanSha256: releaseRecordSha256(betaPlan),
   completedAt: "2026-08-28T10:00:00.000Z",
-  starterKit: {starterKit: {releaseCommit: "c".repeat(40)}},
   otaManifest: {url: "https://example.com/ota.json", sha256: "d".repeat(64)},
 }
 const previousManifest = {
@@ -57,8 +56,6 @@ function prepare(overrides = {}) {
       310000060,
       310000059,
     ),
-    starterKitInventory: inventory("com.mentra.bluetoothsdkexample", null, 42, 0),
-    starterKitCommit: "d".repeat(40),
     attempt: 1,
     actor: "release-owner",
     createdAt: "2026-08-28T20:00:00.000Z",
@@ -73,8 +70,8 @@ test("freezes selected source and allocates new store build numbers", () => {
   assert.equal(record.coordinates.compatibilityLab.ios.buildNumber, 310000061)
   assert.equal(productionPlan.native.buildNumber, 310000062)
   assert.equal(record.coordinates.candidates.mentraApp.ios.buildNumber, 310000062)
-  assert.equal(record.coordinates.candidates.starterKit.android.buildNumber, 310000063)
-  assert.equal(record.source.starterKitCommit, "d".repeat(40))
+  assert.deepEqual(Object.keys(record.coordinates.candidates), ["mentraApp"])
+  assert.deepEqual(Object.keys(record.source), ["mentraosCommit"])
   assert.deepEqual(productionPlan.promotion.otaManifest, betaManifest.otaManifest)
   assert.equal(record.coordinates.currentMentraApp.sourceCommit, "f".repeat(40))
 })
@@ -94,7 +91,6 @@ test("rejects store state that does not match current production provenance", ()
   )
 })
 
-test("rejects an incomplete selected beta or missing Starter Kit provenance", () => {
+test("rejects an incomplete selected beta", () => {
   assert.throws(() => prepare({betaManifest: {...betaManifest, completedAt: undefined}}), /not complete/)
-  assert.throws(() => prepare({betaManifest: {...betaManifest, starterKit: undefined}}), /Starter Kit/)
 })

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -299,8 +299,6 @@ function main() {
       previousManifestSha256: fileSha256("previous-manifest"),
       previousManifestUrl: args["previous-manifest-url"],
       mentraInventory: readJson("mentra-inventory"),
-      starterKitInventory: readJson("starter-kit-inventory"),
-      starterKitCommit: args["starter-kit-commit"],
     })
     output({selection_digest: digest}, args["github-output"])
     return

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -117,7 +117,7 @@ function initialRecord() {
       manifestUrl: "https://example.com/beta.json",
       manifestSha256: "b".repeat(64),
     },
-    source: {mentraosCommit: "a".repeat(40), starterKitCommit: "c".repeat(40)},
+    source: {mentraosCommit: "a".repeat(40)},
     coordinates: {
       currentMentraApp: {
         sourceCommit: "f".repeat(40),
@@ -128,7 +128,6 @@ function initialRecord() {
       compatibilityLab: {ios: coordinate(2), android: coordinate(2)},
       candidates: {
         mentraApp: {ios: coordinate(3), android: coordinate(3)},
-        starterKit: {ios: coordinate(4), android: coordinate(4)},
       },
     },
     actor: "owner",
@@ -225,21 +224,19 @@ test("selection digests are canonical and cover every frozen input", () => {
   const selection = {
     betaPlan: {sourceCommit: "a".repeat(40), native: {buildNumber: 57}},
     previousManifestSha256: "b".repeat(64),
-    starterKitCommit: "c".repeat(40),
     mentraInventory: {apple: {maxBuildNumber: 57}},
   }
   assert.equal(
     productionPromotionSelectionDigest(selection),
     productionPromotionSelectionDigest({
       mentraInventory: selection.mentraInventory,
-      starterKitCommit: selection.starterKitCommit,
       previousManifestSha256: selection.previousManifestSha256,
       betaPlan: selection.betaPlan,
     }),
   )
   assert.notEqual(
     productionPromotionSelectionDigest(selection),
-    productionPromotionSelectionDigest({...selection, starterKitCommit: "d".repeat(40)}),
+    productionPromotionSelectionDigest({...selection, previousManifestSha256: "d".repeat(64)}),
   )
   assert.notEqual(
     productionPromotionSelectionDigest(selection),

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -46,12 +46,12 @@ export const ATTESTATION_CHECKS = Object.freeze({
   "production-mobile-candidate-acceptance": {
     from: "mobile-candidates-uploaded",
     to: "mobile-candidates-accepted",
-    coverage: ["mentra-app:ios", "mentra-app:android", "starter-kit:ios", "starter-kit:android"],
+    coverage: ["mentra-app:ios", "mentra-app:android"],
   },
   "store-review-approved": {
     from: "stores-submitted",
     to: "stores-approved",
-    coverage: ["mentra-app:ios", "mentra-app:android", "starter-kit:ios", "starter-kit:android"],
+    coverage: ["mentra-app:ios", "mentra-app:android"],
   },
 })
 
@@ -132,8 +132,10 @@ function validateAppCoordinate(value, label) {
 
 function validatePromotionSource(source) {
   if (!source || typeof source !== "object" || Array.isArray(source)) fail("source must be an object")
+  if (!isDeepStrictEqual(Object.keys(source).sort(), ["mentraosCommit"])) {
+    fail("source must contain only mentraosCommit")
+  }
   requireCommit(source.mentraosCommit, "source.mentraosCommit")
-  requireCommit(source.starterKitCommit, "source.starterKitCommit")
   return source
 }
 
@@ -196,10 +198,11 @@ export function validatePromotionRecord(record) {
   validateAppCoordinate(record.coordinates.currentMentraApp.android, "coordinates.currentMentraApp.android")
   validateAppCoordinate(record.coordinates.compatibilityLab.ios, "coordinates.compatibilityLab.ios")
   validateAppCoordinate(record.coordinates.compatibilityLab.android, "coordinates.compatibilityLab.android")
+  if (!isDeepStrictEqual(Object.keys(record.coordinates.candidates).sort(), ["mentraApp"])) {
+    fail("coordinates.candidates must contain only mentraApp")
+  }
   validateAppCoordinate(record.coordinates.candidates.mentraApp.ios, "coordinates.candidates.mentraApp.ios")
   validateAppCoordinate(record.coordinates.candidates.mentraApp.android, "coordinates.candidates.mentraApp.android")
-  validateAppCoordinate(record.coordinates.candidates.starterKit.ios, "coordinates.candidates.starterKit.ios")
-  validateAppCoordinate(record.coordinates.candidates.starterKit.android, "coordinates.candidates.starterKit.android")
   if (!Array.isArray(record.evidence)) fail("evidence must be an array")
   record.evidence.forEach((item, index) => validateEvidenceReference(item, `evidence[${index}]`))
   if (record.abort !== undefined) {
@@ -353,8 +356,7 @@ function attestationCoordinate(record, checkName, product, platform) {
   if (!check.coverage.includes(key)) fail(`attestation check ${checkName} does not cover ${key}`)
   if (checkName === "staging-mobile-n-compatibility") return record.coordinates.compatibilityLab[platform]
   if (checkName === "production-mobile-n-compatibility") return record.coordinates.currentMentraApp[platform]
-  const productKey = product === "mentra-app" ? "mentraApp" : "starterKit"
-  return record.coordinates.candidates[productKey][platform]
+  return record.coordinates.candidates.mentraApp[platform]
 }
 
 export function validateAttestation(attestation, record, expectedCheck) {
@@ -381,7 +383,7 @@ export function validateAttestation(attestation, record, expectedCheck) {
   if (!Array.isArray(attestation.tests)) fail("attestation.tests must be an array")
   const observed = new Set()
   for (const [index, item] of attestation.tests.entries()) {
-    if (!new Set(["mentra-app", "starter-kit"]).has(item?.product)) {
+    if (item?.product !== "mentra-app") {
       fail(`attestation.tests[${index}].product is unsupported`)
     }
     if (!new Set(["ios", "android"]).has(item?.platform)) {

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -33,7 +33,7 @@ function initial() {
       manifestUrl: "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/beta.json",
       manifestSha256: "b".repeat(64),
     },
-    source: {mentraosCommit: "a".repeat(40), starterKitCommit: "c".repeat(40)},
+    source: {mentraosCommit: "a".repeat(40)},
     coordinates: {
       currentMentraApp: {
         sourceCommit: "f".repeat(40),
@@ -44,7 +44,6 @@ function initial() {
       compatibilityLab: {ios: coordinate(310000090), android: coordinate(310000090)},
       candidates: {
         mentraApp: {ios: coordinate(310000100), android: coordinate(310000101)},
-        starterKit: {ios: coordinate(310000200), android: coordinate(310000201)},
       },
     },
     actor: "release-owner",
@@ -225,6 +224,14 @@ test("requires complete platform coverage and rejects credential-like evidence",
   assert.throws(
     () =>
       validateAttestation(
+        {...attestation, tests: [...attestation.tests, {...attestation.tests[0], product: "starter-kit"}]},
+        record,
+      ),
+    /product is unsupported/,
+  )
+  assert.throws(
+    () =>
+      validateAttestation(
         {...attestation, tests: [{...attestation.tests[0], appBuild: "BUILD"}, attestation.tests[1]]},
         record,
       ),
@@ -262,18 +269,12 @@ test("binds every human gate to its check-specific frozen coordinates", () => {
     {
       check: "production-mobile-candidate-acceptance",
       record: atState("mobile-candidates-uploaded"),
-      coordinates: {
-        "mentra-app": initialRecord.coordinates.candidates.mentraApp,
-        "starter-kit": initialRecord.coordinates.candidates.starterKit,
-      },
+      coordinates: {"mentra-app": initialRecord.coordinates.candidates.mentraApp},
     },
     {
       check: "store-review-approved",
       record: atState("stores-submitted"),
-      coordinates: {
-        "mentra-app": initialRecord.coordinates.candidates.mentraApp,
-        "starter-kit": initialRecord.coordinates.candidates.starterKit,
-      },
+      coordinates: {"mentra-app": initialRecord.coordinates.candidates.mentraApp},
     },
   ]
   for (const {check, record, coordinates} of cases) {
@@ -306,6 +307,28 @@ test("binds every human gate to its check-specific frozen coordinates", () => {
     wrong.tests[0].appBuild += 1
     assert.throws(() => validateAttestation(wrong, record), /does not match frozen/)
   }
+})
+
+test("rejects Starter Kit fields from the Mentra-App-only production schema", () => {
+  const record = initial()
+  assert.throws(
+    () => validatePromotionRecord({...record, source: {...record.source, starterKitCommit: "c".repeat(40)}}),
+    /source must contain only mentraosCommit/,
+  )
+  assert.throws(
+    () =>
+      validatePromotionRecord({
+        ...record,
+        coordinates: {
+          ...record.coordinates,
+          candidates: {
+            ...record.coordinates.candidates,
+            starterKit: {ios: coordinate(310000200), android: coordinate(310000201)},
+          },
+        },
+      }),
+    /coordinates.candidates must contain only mentraApp/,
+  )
 })
 
 test("aborting is terminal and preserves the previous digest", () => {

--- a/.github/scripts/record-production-compatibility-lab.test.mjs
+++ b/.github/scripts/record-production-compatibility-lab.test.mjs
@@ -22,7 +22,7 @@ const record = {
     manifestUrl: "https://example.com/beta.json",
     manifestSha256: sha("b"),
   },
-  source: {mentraosCommit: sha("a").slice(0, 40), starterKitCommit: sha("c").slice(0, 40)},
+  source: {mentraosCommit: sha("a").slice(0, 40)},
   coordinates: {
     currentMentraApp: {
       sourceCommit: sha("f").slice(0, 40),
@@ -38,10 +38,6 @@ const record = {
       mentraApp: {
         ios: {marketingVersion: "3.1.0", buildNumber: 102},
         android: {marketingVersion: "3.1.0", buildNumber: 102},
-      },
-      starterKit: {
-        ios: {marketingVersion: "3.1.0", buildNumber: 103},
-        android: {marketingVersion: "3.1.0", buildNumber: 103},
       },
     },
   },

--- a/.github/workflows/production-release-mobile.yml
+++ b/.github/workflows/production-release-mobile.yml
@@ -29,11 +29,8 @@ jobs:
     timeout-minutes: 10
     outputs:
       plan_artifact: ${{ steps.inputs.outputs.plan_artifact }}
-      starter_result_artifact: ${{ steps.inputs.outputs.starter_result_artifact }}
       source_commit: ${{ steps.inputs.outputs.source_commit }}
-      starter_kit_commit: ${{ steps.inputs.outputs.starter_kit_commit }}
       mentra_build: ${{ steps.inputs.outputs.mentra_build }}
-      starter_build: ${{ steps.inputs.outputs.starter_build }}
       ota_url: ${{ steps.inputs.outputs.ota_url }}
       ota_sha256: ${{ steps.inputs.outputs.ota_sha256 }}
       candidate_container_tag: ${{ steps.inputs.outputs.candidate_container_tag }}
@@ -71,7 +68,7 @@ jobs:
           name="production-release-plan-${{ inputs.release_identity }}.json"
           assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$release_id/assets?per_page=100" | jq 'add')
           asset_id=$(jq -er --arg name "$name" '[.[] | select(.name == $name)] | if length == 1 then .[0].id else error("production plan must be unique") end' <<< "$assets")
-          mkdir -p release-input/plan release-input/starter
+          mkdir -p release-input/plan
           gh api -H "Accept: application/octet-stream" "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > release-input/plan/release-plan.json
           plan=release-input/plan/release-plan.json
           [[ "$(jq -er .channel "$plan")" == "production" ]]
@@ -81,23 +78,11 @@ jobs:
           [[ "$(jq -r .draft <<< "$candidate_container")" == "true" ]]
           [[ "$(jq -r .prerelease <<< "$candidate_container")" == "false" ]]
           [[ "$(jq -r .target_commitish <<< "$candidate_container")" == "$source_commit" ]]
-          starter_commit=$(jq -er .source.starterKitCommit promotion-input/current.json)
-          jq -n \
-            --arg releaseSetId "$(jq -er .releaseSetId "$plan")" \
-            --arg releaseIdentity "${{ inputs.release_identity }}" \
-            --arg sourceCommit "$source_commit" \
-            --arg starterCommit "$starter_commit" \
-            '{schemaVersion: 1, releaseSetId: $releaseSetId, releaseIdentity: $releaseIdentity, mentraos: {sourceCommit: $sourceCommit}, starterKit: {releaseCommit: $starterCommit}}' \
-            > "release-input/starter/starter-kit-release-${{ inputs.release_identity }}.json"
           plan_artifact="production-plan-${GITHUB_RUN_ID}"
-          starter_artifact="production-starter-result-${GITHUB_RUN_ID}"
           {
             echo "plan_artifact=$plan_artifact"
-            echo "starter_result_artifact=$starter_artifact"
             echo "source_commit=$source_commit"
-            echo "starter_kit_commit=$starter_commit"
             echo "mentra_build=$(jq -er .coordinates.candidates.mentraApp.ios.buildNumber promotion-input/current.json)"
-            echo "starter_build=$(jq -er .coordinates.candidates.starterKit.ios.buildNumber promotion-input/current.json)"
             echo "ota_url=$(jq -er .promotion.otaManifest.url "$plan")"
             echo "ota_sha256=$(jq -er .promotion.otaManifest.sha256 "$plan")"
             echo "candidate_container_tag=$(jq -er .tag_name <<< "$candidate_container")"
@@ -108,13 +93,6 @@ jobs:
         with:
           name: ${{ steps.inputs.outputs.plan_artifact }}
           path: release-input/plan/release-plan.json
-          if-no-files-found: error
-          retention-days: 30
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.inputs.outputs.starter_result_artifact }}
-          path: release-input/starter
           if-no-files-found: error
           retention-days: 30
 
@@ -147,35 +125,9 @@ jobs:
       testflight_group: Mentra Production Candidates
     secrets: inherit
 
-  starter-kit-ios:
-    name: Rebuild Starter Kit iOS candidate
-    needs: [load, approve]
-    uses: ./.github/workflows/reusable-coordinated-example-testflight.yml
-    with:
-      source_commit: ${{ needs.load.outputs.source_commit }}
-      release_plan_artifact: ${{ needs.load.outputs.plan_artifact }}
-      starter_kit_result_artifact: ${{ needs.load.outputs.starter_result_artifact }}
-      testflight_group: Mentra SDK Example Production Candidates
-      testflight_audience: internal
-      production_build_number: ${{ fromJSON(needs.load.outputs.starter_build) }}
-    secrets: inherit
-
-  starter-kit-android:
-    name: Rebuild Starter Kit Android candidate
-    needs: [load, approve]
-    uses: ./.github/workflows/reusable-production-starter-kit-android.yml
-    with:
-      source_commit: ${{ needs.load.outputs.source_commit }}
-      release_plan_artifact: ${{ needs.load.outputs.plan_artifact }}
-      starter_kit_commit: ${{ needs.load.outputs.starter_kit_commit }}
-      build_number: ${{ fromJSON(needs.load.outputs.starter_build) }}
-      candidate_release_id: ${{ needs.load.outputs.promotion_release_id }}
-      candidate_container_tag: ${{ needs.load.outputs.candidate_container_tag }}
-    secrets: inherit
-
   record:
     name: Record exact uploaded production candidates
-    needs: [load, mentra-app, starter-kit-ios, starter-kit-android]
+    needs: [load, mentra-app]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -204,33 +156,16 @@ jobs:
           name: ${{ needs.mentra-app.outputs.result_artifact }}
           path: candidate-input/mentra
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.starter-kit-ios.outputs.result_artifact }}
-          path: candidate-input/starter-ios
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.starter-kit-android.outputs.result_artifact }}
-          path: candidate-input/starter-android
-
       - name: Validate candidate coordinates and append state
         id: next
         run: |
           set -euo pipefail
           [[ "$(jq -er .state promotion-input/current.json)" == "current-clients-accepted" ]]
           mentra=candidate-input/mentra/mobile-publications.json
-          starter_ios=candidate-input/starter-ios/example-testflight-publication.json
-          starter_android=candidate-input/starter-android/starter-kit-android-candidate.json
           [[ "$(jq -er '.publications.mentraos["google-play"].coordinate' "$mentra")" == "com.mentra.mentra:${{ needs.load.outputs.mentra_build }}:internal" ]]
           [[ "$(jq -er '.publications.mentraos["app-store-connect"].coordinate' "$mentra")" == "com.mentra.mentra:${{ inputs.release_identity }}:${{ needs.load.outputs.mentra_build }}:Mentra Production Candidates" ]]
-          [[ "$(jq -er .version.buildNumber "$starter_ios")" == "${{ needs.load.outputs.starter_build }}" ]]
-          [[ "$(jq -er .app.bundleId "$starter_ios")" == "com.mentra.bluetoothsdkexample" ]]
-          [[ "$(jq -er .build.processingState "$starter_ios")" == "VALID" ]]
-          [[ "$(jq -er .buildNumber "$starter_android")" == "${{ needs.load.outputs.starter_build }}" ]]
-          [[ "$(jq -er .packageId "$starter_android")" == "com.mentra.bluetoothsdkexample" ]]
           mkdir -p promotion-output
-          jq -s '{schemaVersion: 1, kind: "production-mobile-candidates", mentraApp: .[0], starterKit: {ios: .[1], android: .[2]}}' "$mentra" "$starter_ios" "$starter_android" > promotion-output/mobile-candidates.json
+          jq '{schemaVersion: 1, kind: "production-mobile-candidates", mentraApp: .}' "$mentra" > promotion-output/mobile-candidates.json
           node .github/scripts/production-promotion-assets.mjs prepare-evidence \
             --file promotion-output/mobile-candidates.json \
             --kind production-mobile-candidates \

--- a/.github/workflows/production-release-prepare.yml
+++ b/.github/workflows/production-release-prepare.yml
@@ -26,8 +26,6 @@ jobs:
     timeout-minutes: 30
     environment:
       name: production-store-status
-    env:
-      STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,17 +106,6 @@ jobs:
             echo "manifest_url=$url"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Resolve exact stable Starter Kit source
-        id: starter-kit
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_IDENTITY: ${{ steps.identity.outputs.release_identity }}
-        run: |
-          set -euo pipefail
-          commit=$(gh api "repos/$STARTER_KIT_REPOSITORY/commits/sdk-$RELEASE_IDENTITY" --jq .sha)
-          [[ "$commit" =~ ^[0-9a-f]{40}$ ]]
-          echo "commit=$commit" >> "$GITHUB_OUTPUT"
-
       - name: Inject read-only store credentials
         uses: ./.github/actions/inject-signing
         with:
@@ -147,13 +134,6 @@ jobs:
             --key-path "${{ steps.asc.outputs.key_path }}" \
             --bundle-id com.mentra.mentra \
             --output promotion-input/stores/mentra-apple.json
-          node mobile/scripts/app-store-connect-build.mjs inventory \
-            --issuer-id "${{ secrets.ASC_API_ISSUER_ID }}" \
-            --key-id "${{ secrets.ASC_API_KEY_ID }}" \
-            --key-path "${{ steps.asc.outputs.key_path }}" \
-            --app-id 6792839366 \
-            --bundle-id com.mentra.bluetoothsdkexample \
-            --output promotion-input/stores/starter-apple.json
 
       - name: Install pinned Google Play inventory tooling
         run: |
@@ -171,15 +151,9 @@ jobs:
           APP_PACKAGE_NAME=com.mentra.mentra \
             GOOGLE_PLAY_INVENTORY_OUTPUT=../stores/mentra-google.json \
             bundle exec fastlane google_play_inventory
-          APP_PACKAGE_NAME=com.mentra.bluetoothsdkexample \
-            GOOGLE_PLAY_INVENTORY_OUTPUT=../stores/starter-google.json \
-            bundle exec fastlane google_play_inventory
           jq -s '{apple: .[0], google: .[1]}' \
             ../stores/mentra-apple.json ../stores/mentra-google.json \
             > ../stores/mentra-inventory.json
-          jq -s '{apple: .[0], google: .[1]}' \
-            ../stores/starter-apple.json ../stores/starter-google.json \
-            > ../stores/starter-inventory.json
 
       - name: Fingerprint every frozen preparation input
         id: selection
@@ -196,8 +170,6 @@ jobs:
           --previous-manifest promotion-input/current/release-manifest.json
           --previous-manifest-url "${{ steps.previous.outputs.manifest_url }}"
           --mentra-inventory promotion-input/stores/mentra-inventory.json
-          --starter-kit-inventory promotion-input/stores/starter-inventory.json
-          --starter-kit-commit "${{ steps.starter-kit.outputs.commit }}"
           --github-output "$GITHUB_OUTPUT"
 
       - name: Allocate append-only promotion container
@@ -231,8 +203,6 @@ jobs:
             --previous-manifest promotion-input/current/release-manifest.json \
             --previous-manifest-url "${{ steps.previous.outputs.manifest_url }}" \
             --mentra-inventory promotion-input/stores/mentra-inventory.json \
-            --starter-kit-inventory promotion-input/stores/starter-inventory.json \
-            --starter-kit-commit "${{ steps.starter-kit.outputs.commit }}" \
             --attempt "${{ steps.container.outputs.attempt }}" \
             --actor "$GITHUB_ACTOR" \
             --created-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
@@ -280,7 +250,6 @@ jobs:
             echo "- Attempt: \`${{ steps.container.outputs.attempt }}\`"
             echo "- Selected beta: \`${{ inputs.beta_identity }}\`"
             echo "- MentraOS source: \`$(jq -er .source.mentraosCommit "$record")\`"
-            echo "- Starter Kit source: \`$(jq -er .source.starterKitCommit "$record")\`"
             echo "- State: \`selected\`"
             echo
             echo "No Cloud or app-store state was changed. The next action builds non-promotable Mobile N compatibility-lab apps."

--- a/.github/workflows/production-release-status.yml
+++ b/.github/workflows/production-release-status.yml
@@ -77,13 +77,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p store-status/apple
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then bundle_id=com.mentra.mentra; else bundle_id=com.mentra.bluetoothsdkexample; fi
-            build=$(jq -er ".coordinates.candidates.$product.ios.buildNumber" promotion-input/current.json)
-            GITHUB_OUTPUT="store-status/apple/$product.outputs" node mobile/scripts/app-store-connect-build.mjs production-status \
-              --issuer-id "$ASC_API_ISSUER_ID" --key-id "$ASC_API_KEY_ID" --key-path "$ASC_API_KEY_PATH" \
-              --bundle-id "$bundle_id" --build-number "$build" --app-version "${{ inputs.release_identity }}"
-          done
+          build=$(jq -er .coordinates.candidates.mentraApp.ios.buildNumber promotion-input/current.json)
+          GITHUB_OUTPUT=store-status/apple/mentraApp.outputs node mobile/scripts/app-store-connect-build.mjs production-status \
+            --issuer-id "$ASC_API_ISSUER_ID" --key-id "$ASC_API_KEY_ID" --key-path "$ASC_API_KEY_PATH" \
+            --bundle-id com.mentra.mentra --build-number "$build" --app-version "${{ inputs.release_identity }}"
 
       - name: Read Google Play track state
         run: |
@@ -93,10 +90,7 @@ jobs:
           cp mobile/Gemfile mobile/Gemfile.lock store-status/play/
           cd store-status/play
           bundle install
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then package=com.mentra.mentra; else package=com.mentra.bluetoothsdkexample; fi
-            APP_PACKAGE_NAME="$package" GOOGLE_PLAY_INVENTORY_OUTPUT="$product.json" bundle exec fastlane google_play_inventory
-          done
+          APP_PACKAGE_NAME=com.mentra.mentra GOOGLE_PLAY_INVENTORY_OUTPUT=mentraApp.json bundle exec fastlane google_play_inventory
 
       - name: Summarize observed state and exact next action
         run: |
@@ -106,14 +100,12 @@ jobs:
             echo "## Production store status"
             echo
             echo "- Promotion state: \`$state\`"
-            for product in mentraApp starterKit; do
-              apple_state=$(sed -n 's/^state=//p' "store-status/apple/$product.outputs")
-              apple_build=$(sed -n 's/^build_id=//p' "store-status/apple/$product.outputs")
-              production_releases=$(jq -c .releases.production "store-status/play/$product.json")
-              echo "- $product Apple: \`$apple_state\` (build id \`$apple_build\`)"
-              echo "- $product Google production releases: \`$production_releases\`"
-            done
+            apple_state=$(sed -n 's/^state=//p' store-status/apple/mentraApp.outputs)
+            apple_build=$(sed -n 's/^build_id=//p' store-status/apple/mentraApp.outputs)
+            production_releases=$(jq -c .releases.production store-status/play/mentraApp.json)
+            echo "- Mentra App Apple: \`$apple_state\` (build id \`$apple_build\`)"
+            echo "- Mentra App Google production releases: \`$production_releases\`"
             echo
             echo "This workflow is read-only and does not infer approval from a Play track entry."
-            echo "When both consoles show review complete for the exact builds, attach the store-review-approved evidence template."
+            echo "When Apple and Google show review complete for the exact Mentra App builds, attach the store-review-approved evidence template."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/production-release-store-release.yml
+++ b/.github/workflows/production-release-store-release.yml
@@ -81,29 +81,23 @@ jobs:
           set -euo pipefail
           key_path=$(sed -n 's/^ASC_API_KEY_PATH=//p' "$MENTRA_ASC_CONFIG_PATH")
           mkdir -p promotion-output/public-status play-status/fastlane
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then bundle_id=com.mentra.mentra; package=com.mentra.mentra; else bundle_id=com.mentra.bluetoothsdkexample; package=com.mentra.bluetoothsdkexample; fi
-            build=$(jq -er ".coordinates.candidates.$product.ios.buildNumber" promotion-input/current.json)
-            GITHUB_OUTPUT="promotion-output/public-status/$product.outputs" node mobile/scripts/app-store-connect-build.mjs production-status \
-              --issuer-id "$ASC_API_ISSUER_ID" --key-id "$ASC_API_KEY_ID" --key-path "$key_path" \
-              --bundle-id "$bundle_id" --build-number "$build" --app-version "${{ inputs.release_identity }}"
-            apple_state=$(sed -n 's/^state=//p' "promotion-output/public-status/$product.outputs")
-            [[ "$apple_state" == READY_FOR_SALE || "$apple_state" == READY_FOR_DISTRIBUTION || "$apple_state" == PROCESSING_FOR_DISTRIBUTION ]]
-          done
+          build=$(jq -er .coordinates.candidates.mentraApp.ios.buildNumber promotion-input/current.json)
+          GITHUB_OUTPUT=promotion-output/public-status/mentraApp.outputs node mobile/scripts/app-store-connect-build.mjs production-status \
+            --issuer-id "$ASC_API_ISSUER_ID" --key-id "$ASC_API_KEY_ID" --key-path "$key_path" \
+            --bundle-id com.mentra.mentra --build-number "$build" --app-version "${{ inputs.release_identity }}"
+          apple_state=$(sed -n 's/^state=//p' promotion-output/public-status/mentraApp.outputs)
+          [[ "$apple_state" == READY_FOR_SALE || "$apple_state" == READY_FOR_DISTRIBUTION || "$apple_state" == PROCESSING_FOR_DISTRIBUTION ]]
           cp mobile/ci/fastlane-android/Fastfile mobile/ci/fastlane-android/Appfile play-status/fastlane/
           cp mobile/Gemfile mobile/Gemfile.lock play-status/
           cd play-status
           bundle install
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then package=com.mentra.mentra; else package=com.mentra.bluetoothsdkexample; fi
-            expected=$(jq -er ".coordinates.candidates.$product.android.buildNumber" ../promotion-input/current.json)
-            APP_PACKAGE_NAME="$package" GOOGLE_PLAY_INVENTORY_OUTPUT="$product.json" bundle exec fastlane google_play_inventory
-            node ../.github/scripts/validate-google-play-release.mjs \
-              --inventory "$product.json" \
-              --version-code "$expected" \
-              --required-state public \
-              --output "../promotion-output/public-status/$product-google.json"
-          done
+          expected=$(jq -er .coordinates.candidates.mentraApp.android.buildNumber ../promotion-input/current.json)
+          APP_PACKAGE_NAME=com.mentra.mentra GOOGLE_PLAY_INVENTORY_OUTPUT=mentraApp.json bundle exec fastlane google_play_inventory
+          node ../.github/scripts/validate-google-play-release.mjs \
+            --inventory mentraApp.json \
+            --version-code "$expected" \
+            --required-state public \
+            --output ../promotion-output/public-status/mentraApp-google.json
 
       - name: Append protected approval or observed rollout state
         id: next

--- a/.github/workflows/production-release-store-submit.yml
+++ b/.github/workflows/production-release-store-submit.yml
@@ -95,19 +95,12 @@ jobs:
           ASC_API_KEY_PATH: ${{ steps.asc.outputs.key_path }}
         run: |
           set -euo pipefail
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then
-              bundle_id=com.mentra.mentra
-            else
-              bundle_id=com.mentra.bluetoothsdkexample
-            fi
-            build=$(jq -er ".coordinates.candidates.$product.ios.buildNumber" "$GITHUB_WORKSPACE/promotion-input/current.json")
-            APP_IDENTIFIER="$bundle_id" \
-              MENTRA_MARKETING_VERSION="${{ inputs.release_identity }}" \
-              MENTRA_BUILD_NUMBER="$build" \
-              MENTRA_PHASED_RELEASE=true \
-              bundle exec fastlane promote_app_store
-          done
+          build=$(jq -er .coordinates.candidates.mentraApp.ios.buildNumber "$GITHUB_WORKSPACE/promotion-input/current.json")
+          APP_IDENTIFIER=com.mentra.mentra \
+            MENTRA_MARKETING_VERSION="${{ inputs.release_identity }}" \
+            MENTRA_BUILD_NUMBER="$build" \
+            MENTRA_PHASED_RELEASE=true \
+            bundle exec fastlane promote_app_store
 
       - name: Create or reconcile Google Play production drafts
         run: |
@@ -117,33 +110,22 @@ jobs:
           cp mobile/Gemfile mobile/Gemfile.lock play-tools/
           cd play-tools
           bundle install
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then
-              package=com.mentra.mentra
-              output=../promotion-output/play/mentra.json
-              observed=../promotion-output/play/mentra-observed.json
-            else
-              package=com.mentra.bluetoothsdkexample
-              output=../promotion-output/play/starter.json
-              observed=../promotion-output/play/starter-observed.json
-            fi
-            build=$(jq -er ".coordinates.candidates.$product.android.buildNumber" ../promotion-input/current.json)
-            APP_PACKAGE_NAME="$package" \
-              GOOGLE_PLAY_SOURCE_TRACK=internal \
-              GOOGLE_PLAY_TARGET_TRACK=production \
-              GOOGLE_PLAY_VERSION_CODE="$build" \
-              GOOGLE_PLAY_RELEASE_STATUS=draft \
-              GOOGLE_PLAY_PROMOTION_OUTPUT="$output" \
-              bundle exec fastlane promote_google_play
-            APP_PACKAGE_NAME="$package" \
-              GOOGLE_PLAY_INVENTORY_OUTPUT="$product-inventory.json" \
-              bundle exec fastlane google_play_inventory
-            node ../.github/scripts/validate-google-play-release.mjs \
-              --inventory "$product-inventory.json" \
-              --version-code "$build" \
-              --required-state draft \
-              --output "$observed"
-          done
+          build=$(jq -er .coordinates.candidates.mentraApp.android.buildNumber ../promotion-input/current.json)
+          APP_PACKAGE_NAME=com.mentra.mentra \
+            GOOGLE_PLAY_SOURCE_TRACK=internal \
+            GOOGLE_PLAY_TARGET_TRACK=production \
+            GOOGLE_PLAY_VERSION_CODE="$build" \
+            GOOGLE_PLAY_RELEASE_STATUS=draft \
+            GOOGLE_PLAY_PROMOTION_OUTPUT=../promotion-output/play/mentra.json \
+            bundle exec fastlane promote_google_play
+          APP_PACKAGE_NAME=com.mentra.mentra \
+            GOOGLE_PLAY_INVENTORY_OUTPUT=mentraApp-inventory.json \
+            bundle exec fastlane google_play_inventory
+          node ../.github/scripts/validate-google-play-release.mjs \
+            --inventory mentraApp-inventory.json \
+            --version-code "$build" \
+            --required-state draft \
+            --output ../promotion-output/play/mentra-observed.json
 
       - name: Read back exact submitted coordinates and append state
         id: next
@@ -154,19 +136,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p promotion-output/apple
-          for product in mentraApp starterKit; do
-            if [[ "$product" == mentraApp ]]; then bundle_id=com.mentra.mentra; else bundle_id=com.mentra.bluetoothsdkexample; fi
-            build=$(jq -er ".coordinates.candidates.$product.ios.buildNumber" promotion-input/current.json)
-            GITHUB_OUTPUT="promotion-output/apple/$product.outputs" node mobile/scripts/app-store-connect-build.mjs production-status \
-              --issuer-id "$ASC_API_ISSUER_ID" --key-id "$ASC_API_KEY_ID" --key-path "$ASC_API_KEY_PATH" \
-              --bundle-id "$bundle_id" --build-number "$build" --app-version "${{ inputs.release_identity }}"
-            grep -q '^promoted=true$' "promotion-output/apple/$product.outputs"
-          done
+          build=$(jq -er .coordinates.candidates.mentraApp.ios.buildNumber promotion-input/current.json)
+          GITHUB_OUTPUT=promotion-output/apple/mentraApp.outputs node mobile/scripts/app-store-connect-build.mjs production-status \
+            --issuer-id "$ASC_API_ISSUER_ID" --key-id "$ASC_API_KEY_ID" --key-path "$ASC_API_KEY_PATH" \
+            --bundle-id com.mentra.mentra --build-number "$build" --app-version "${{ inputs.release_identity }}"
+          grep -q '^promoted=true$' promotion-output/apple/mentraApp.outputs
           jq -n \
             --arg url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --slurpfile mentra promotion-output/play/mentra-observed.json \
-            --slurpfile starter promotion-output/play/starter-observed.json \
-            '{schemaVersion: 1, kind: "production-store-submissions", provenanceUrl: $url, apple: {mentraApp: "submitted-manual-release", starterKit: "submitted-manual-release"}, google: {mentraApp: $mentra[0], starterKit: $starter[0]}, publicReleasePerformed: false}' \
+            '{schemaVersion: 1, kind: "production-store-submissions", provenanceUrl: $url, apple: {mentraApp: "submitted-manual-release"}, google: {mentraApp: $mentra[0]}, publicReleasePerformed: false}' \
             > promotion-output/store-submissions.json
           node .github/scripts/production-promotion-assets.mjs prepare-evidence \
             --file promotion-output/store-submissions.json \

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -27,7 +27,7 @@ const baseRecord = {
     manifestUrl: "https://example.com/beta.json",
     manifestSha256: "b".repeat(64),
   },
-  source: {mentraosCommit: "a".repeat(40), starterKitCommit: "c".repeat(40)},
+  source: {mentraosCommit: "a".repeat(40)},
   coordinates: {
     currentMentraApp: {
       sourceCommit: "f".repeat(40),
@@ -43,10 +43,6 @@ const baseRecord = {
       mentraApp: {
         ios: {marketingVersion: "3.1.0", buildNumber: 3},
         android: {marketingVersion: "3.1.0", buildNumber: 4},
-      },
-      starterKit: {
-        ios: {marketingVersion: "3.1.0", buildNumber: 5},
-        android: {marketingVersion: "3.1.0", buildNumber: 6},
       },
     },
   },


### PR DESCRIPTION
## Summary

- remove the Starter Kit example app from production promotion source, coordinates, evidence, and final manifests
- prevent production candidate, store submission, status, and public rollout workflows from invoking or inspecting the example app
- make the employee runbook explicit that production promotion covers only Cloud V2 and the Mentra App; coordinated beta/example releases remain unchanged

## Validation

- `node --test .github/scripts/*.test.mjs` (142/142 passed)
- `actionlint` on all changed production workflows
- parsed every production evidence template with `jq`
- `git diff --check`

No production, store, Cloud, or release workflow was dispatched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows production release automation and immutable promotion schema—incorrect rollout could still affect live Mentra App and Cloud, but coordinated beta/Starter Kit paths are intentionally unchanged.
> 
> **Overview**
> **Production promotion now covers only Cloud V2 and the Mentra App (iOS/Android).** The Bluetooth SDK Starter Kit example app is removed from preparation, state, evidence, final manifests, and all production GitHub workflows; the runbook states it stays on the separate coordinated-beta path and must not be added at operator time.
> 
> **Schema and automation:** Promotion records keep only `mentraosCommit` and `candidates.mentraApp`; Starter Kit inventory, stable-tag resolution, extra build numbers, and `starter-kit-ios` / `starter-kit-android` jobs are gone. Prepare, mobile-candidates, store submit/status/release, and selection digests operate on Mentra App store coordinates only. Attestation coverage and evidence templates drop the four `starter-kit` platform rows. Finalization writes `applications.mentraApp` only.
> 
> **Tests:** Contract tests assert production workflows no longer reference `com.mentra.bluetoothsdkexample` or Starter Kit reusable workflows; unit tests enforce the Mentra-only schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2298cfd340f5ede1698657c3b047a55fa31e3a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->