### PR TITLE
Expand OTA completion changelog

### DIFF
--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-raw-text -- BodyText and PercentText are local Text wrappers. */
-import React, {useMemo} from "react"
+import React, {useMemo, useState} from "react"
 import {
   ActivityIndicator,
   Pressable,
@@ -99,6 +99,7 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:updateLater": "Later",
   "ota:updateComplete": "Update complete",
   "ota:whatsNew": "What's new",
+  "ota:scrollForMore": "Scroll for more",
   "ota:upToDate": "Up To Date",
   "ota:devBuild": "Development Build",
   "ota:devBuildNoOta":
@@ -322,7 +323,12 @@ function OtaFlowContent({
             {translate("ota:updatedToVersion", {version: state.releaseTransition.toVersion})}
           </BodyText>
         ) : null}
-        <ChangelogList changelogs={state.changelogs} colors={colors} title={translate("ota:whatsNew")} />
+        <ChangelogList
+          changelogs={state.changelogs}
+          colors={colors}
+          scrollHint={translate("ota:scrollForMore")}
+          title={translate("ota:whatsNew")}
+        />
       </FlowPage>
     )
   }
@@ -456,7 +462,12 @@ function OtaFlowContent({
             {translate("ota:updatedToVersion", {version: state.releaseTransition.toVersion})}
           </BodyText>
         ) : null}
-        <ChangelogList changelogs={state.changelogs} colors={colors} title={translate("ota:whatsNew")} />
+        <ChangelogList
+          changelogs={state.changelogs}
+          colors={colors}
+          scrollHint={translate("ota:scrollForMore")}
+          title={translate("ota:whatsNew")}
+        />
       </FlowPage>
     )
   }
@@ -621,19 +632,39 @@ function ChangelogMarkdown({colors, markdown}: {colors: MentraLiveOtaFlowTheme; 
 export function ChangelogList({
   changelogs,
   colors,
+  scrollHint,
   title,
 }: {
   changelogs: MentraLiveOtaController["state"]["changelogs"]
   colors: MentraLiveOtaFlowTheme
+  scrollHint: string
   title: string
 }) {
+  const [contentHeight, setContentHeight] = useState(0)
+  const [viewportHeight, setViewportHeight] = useState(0)
+  const [isAtEnd, setIsAtEnd] = useState(false)
+
   if (changelogs.length === 0) return null
+
+  const showScrollHint = viewportHeight > 0 && contentHeight > viewportHeight + 1 && !isAtEnd
+
   return (
     <View style={[styles.changelogCard, {borderColor: colors.border}]} testID="ota-changelog-card">
       <Text style={[styles.changelogTitle, {color: colors.foreground}]}>{title}</Text>
       <ScrollView
         contentContainerStyle={styles.changelogContent}
         nestedScrollEnabled
+        onContentSizeChange={(_width, height) => {
+          setContentHeight(height)
+          setIsAtEnd(false)
+        }}
+        onLayout={({nativeEvent}) => setViewportHeight(nativeEvent.layout.height)}
+        onScroll={({nativeEvent}) => {
+          const distanceFromEnd =
+            nativeEvent.contentSize.height - (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height)
+          setIsAtEnd(distanceFromEnd <= 8)
+        }}
+        scrollEventThrottle={16}
         showsVerticalScrollIndicator
         style={styles.changelogList}
         testID="ota-changelog-scroll">
@@ -652,6 +683,13 @@ export function ChangelogList({
           </View>
         ))}
       </ScrollView>
+      <View style={styles.changelogScrollHintSlot}>
+        {showScrollHint ? (
+          <Text style={[styles.changelogScrollHint, {color: colors.textDim}]} testID="ota-changelog-scroll-hint">
+            {scrollHint} ↓
+          </Text>
+        ) : null}
+      </View>
     </View>
   )
 }
@@ -716,7 +754,7 @@ const styles = StyleSheet.create({
   },
   page: {flex: 1, paddingBottom: 24, paddingHorizontal: 24},
   centerContent: {alignItems: "center", flex: 1, gap: 16, justifyContent: "center"},
-  topContent: {justifyContent: "flex-start", paddingTop: 12},
+  topContent: {justifyContent: "flex-start", paddingBottom: 16, paddingTop: 12},
   actionSpacer: {height: 48},
   actions: {gap: 12},
   icon: {fontSize: 64, fontWeight: "500", lineHeight: 72, textAlign: "center"},
@@ -728,20 +766,21 @@ const styles = StyleSheet.create({
   changelogCard: {
     borderRadius: 16,
     borderWidth: 1,
-    flexShrink: 1,
+    flex: 1,
     gap: 12,
-    maxHeight: 300,
     maxWidth: 420,
     padding: 16,
     width: "100%",
   },
   changelogTitle: {fontSize: 16, fontWeight: "700"},
-  changelogList: {flexShrink: 1, maxHeight: 232, width: "100%"},
-  changelogContent: {gap: 20, paddingBottom: 2},
+  changelogList: {flex: 1, width: "100%"},
+  changelogContent: {gap: 20, paddingBottom: 4},
   changelogEntry: {gap: 8},
   changelogEntryDivider: {borderTopWidth: StyleSheet.hairlineWidth, paddingTop: 20},
   changelogVersion: {fontSize: 14, fontWeight: "600"},
   changelogMarkdownContent: {gap: 10},
+  changelogScrollHintSlot: {alignItems: "center", height: 18, justifyContent: "center"},
+  changelogScrollHint: {fontSize: 12, fontWeight: "500", lineHeight: 16},
   button: {
     alignItems: "center",
     borderRadius: 50,

--- a/mobile/src/app/ota/__tests__/changelog-presentation.test.tsx
+++ b/mobile/src/app/ota/__tests__/changelog-presentation.test.tsx
@@ -1,4 +1,4 @@
-import {render} from "@testing-library/react-native"
+import {act, render} from "@testing-library/react-native"
 
 import {ChangelogList, type MentraLiveOtaFlowTheme} from "@/../modules/engine/src/react/MentraLiveOtaFlow"
 
@@ -14,7 +14,7 @@ const colors: MentraLiveOtaFlowTheme = {
 
 describe("OTA changelog presentation", () => {
   it("places release notes in a scrollable card and renders standard Markdown", () => {
-    const {getAllByTestId, getByRole, getByTestId, getByText, queryByText} = render(
+    const {getAllByTestId, getByRole, getByTestId, getByText, queryByTestId, queryByText} = render(
       <ChangelogList
         changelogs={[
           {
@@ -34,12 +34,14 @@ Use \`safe mode\`.`,
           },
         ]}
         colors={colors}
+        scrollHint="Scroll for more"
         title="What's new"
       />,
     )
 
     expect(getByTestId("ota-changelog-card")).toBeDefined()
-    expect(getByTestId("ota-changelog-scroll")).toHaveStyle({maxHeight: 232})
+    expect(getByTestId("ota-changelog-card")).toHaveStyle({flex: 1})
+    expect(getByTestId("ota-changelog-scroll")).toHaveStyle({flex: 1})
     expect(getByTestId("ota-changelog-markdown")).toBeDefined()
     expect(getByText("What's new")).toBeDefined()
     expect(getByText("Highlights")).toBeDefined()
@@ -51,5 +53,23 @@ Use \`safe mode\`.`,
     expect(getAllByTestId("marked-list-item")).toHaveLength(3)
     expect(queryByText("# Highlights")).toBeNull()
     expect(queryByText("**overview**")).toBeNull()
+
+    const scrollView = getByTestId("ota-changelog-scroll")
+    act(() => {
+      scrollView.props.onLayout({nativeEvent: {layout: {height: 200}}})
+      scrollView.props.onContentSizeChange(320, 400)
+    })
+    expect(getByTestId("ota-changelog-scroll-hint")).toHaveTextContent("Scroll for more ↓")
+
+    act(() => {
+      scrollView.props.onScroll({
+        nativeEvent: {
+          contentOffset: {y: 200},
+          contentSize: {height: 400},
+          layoutMeasurement: {height: 200},
+        },
+      })
+    })
+    expect(queryByTestId("ota-changelog-scroll-hint")).toBeNull()
   })
 })

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -465,6 +465,7 @@ const en = {
     updateComplete: "Update Complete",
     updateCompleteMessage: "Your glasses have been updated successfully.",
     whatsNew: "What's new",
+    scrollForMore: "Scroll for more",
     updateFailed: "Update Failed",
     updateFailedMessage: "The update could not be completed. You can try again later from Settings.",
     glassesDisconnected: "Glasses Disconnected",


### PR DESCRIPTION
## Summary

- let the OTA completion changelog use the available height above Done instead of stopping at a fixed 232-point viewport
- keep a 16-point margin before the action area
- show an overflow-only “Scroll for more” cue and hide it once the reader reaches the bottom
- cover flexible sizing and cue behavior in the focused changelog presentation test

## Validation

- bun run compile
- bun run test -- --runInBand src/app/ota/__tests__/changelog-presentation.test.tsx src/app/ota/__tests__/shared-flow.test.tsx src/app/ota/__tests__/progress.test.tsx (37 tests)
- focused ESLint on the three changed files
- repository-pinned Prettier 3.6.2
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OTA completion UI and presentation tests only; no update logic, networking, or data handling changes.
> 
> **Overview**
> The OTA **What's new** changelog on **up to date** and **complete** screens now **grows with available space** above the action buttons instead of capping the scroll area at a fixed height. Layout uses **`flex: 1`** on the changelog card and scroll view, with extra **padding** on top-aligned flow content so there is margin before **Done**.
> 
> **`ChangelogList`** takes a required **`scrollHint`** string and tracks scroll viewport vs content size. When release notes overflow, it shows a dim **"Scroll for more ↓"** cue (`ota:scrollForMore` / app `en.ts`); the hint hides after the user scrolls within ~8px of the bottom and resets when content size changes.
> 
> Tests assert **`flex: 1`** styling and simulate layout, content size, and scroll to verify hint show/hide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f28ab02ef6c3d9cd9cc390ff0382fd8ab334c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->