### PR TITLE
test: keep Engine native peer pins aligned

### DIFF
--- a/.github/scripts/prepare-external-engine-fixture.test.mjs
+++ b/.github/scripts/prepare-external-engine-fixture.test.mjs
@@ -3,6 +3,7 @@ import {mkdtempSync, mkdirSync, readFileSync, writeFileSync} from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import test from "node:test"
+import {fileURLToPath} from "node:url"
 
 import {prepareExternalEngineFixture} from "./prepare-external-engine-fixture.mjs"
 
@@ -35,4 +36,17 @@ test("removes every monorepo shortcut from the external Engine fixture", () => {
   assert.deepEqual(tsconfig.compilerOptions, {strict: true})
   assert.match(readFileSync(path.join(output, "metro.config.js"), "utf8"), /getDefaultConfig\(__dirname\)/)
   assert.throws(() => readFileSync(path.join(output, "node_modules", "ignored")))
+})
+
+test("pins external Engine native peers to the app's verified version", () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+  const readPackage = (relativePath) => JSON.parse(readFileSync(path.join(root, relativePath), "utf8"))
+  const versions = [
+    readPackage("mobile/package.json").dependencies["react-native-zip-archive"],
+    readPackage("mobile/modules/engine/package.json").peerDependencies["react-native-zip-archive"],
+    readPackage("sdk/example-oem-app/package.json").dependencies["react-native-zip-archive"],
+  ]
+
+  assert.match(versions[0], /^\d+\.\d+\.\d+$/)
+  assert.equal(new Set(versions).size, 1)
 })


### PR DESCRIPTION
The clean external Engine host must install the same exact native peer version verified by MentraOS. This adds a focused contract check that the mobile app, public Engine peer declaration, and OEM consumer fixture all use one exact `react-native-zip-archive` version.

This prevents a future wildcard or caret range from silently admitting another broken native patch during a coordinated release. It also creates a fresh dev source after the canceled `dev.114` run raced with completion of the orphaned Starter Kit `dev.113` candidate, so the next release will freeze the current Starter Kit branch head.

Validation: all 144 release script tests pass; `git diff --check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in release scripts; no runtime or dependency manifest edits in this diff.
> 
> **Overview**
> Adds a **contract test** next to the existing external Engine fixture checks in `prepare-external-engine-fixture.test.mjs`.
> 
> The new case reads `react-native-zip-archive` from the mobile app, Engine module `peerDependencies`, and the OEM example app, then fails if the value is not an **exact** semver pin or if the three declarations diverge. That guards coordinated releases so wildcard/caret ranges cannot slip in and break native peer alignment for external Engine hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06ffe9f14404d3ca8cb6a2311cbe0a1ce1fb9af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->