### PR TITLE
Fix iOS stream keep-alive recovery

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -240,7 +240,10 @@ public final class MentraBluetoothSDK {
     private static let otaMtkVersionWaitMs = 2_000
     private static let otaVersionPollMs = 100
     private static let defaultStreamKeepAliveIntervalSeconds = 5
-    private static let streamRecoveryStatusTimeoutNanoseconds: UInt64 = 15_000_000_000
+    // The glasses' RTMP retry schedule reaches roughly 39 seconds at its last
+    // exponential-backoff attempt. Keep the orphaned-recovery guard above that
+    // bound so an in-progress retry cannot discard the keep-alive monitor.
+    private static let streamRecoveryStatusTimeoutNanoseconds: UInt64 = 60_000_000_000
 
     public weak var delegate: MentraBluetoothSDKDelegate?
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -5,6 +5,7 @@ import Foundation
 final class ActiveStreamKeepAlive {
     enum StatusDisposition: Equatable {
         case preserve
+        case awaitRecovery
         case stop
     }
 
@@ -13,6 +14,7 @@ final class ActiveStreamKeepAlive {
     var pendingAckId: String?
     var missedAckCount = 0
     var task: Task<Void, Never>?
+    var recoveryStopTask: Task<Void, Never>?
     /// Missed-ACK counting only begins once the stream is confirmed live/coming up, so a slow
     /// startup (glasses can't ACK until they reach starting/streaming) can't trip a false
     /// keep-alive timeout before the stream is ever up.
@@ -39,9 +41,11 @@ final class ActiveStreamKeepAlive {
             return .preserve
         case .stopped where retryPending:
             // Some publisher implementations report a stopped transition
-            // between the retryable error and their reconnect attempt.
+            // between the retryable error and their reconnect attempt. Give
+            // that reconnect a bounded window instead of preserving a dead
+            // monitor indefinitely if no recovery status follows.
             suspendMissDetection()
-            return .preserve
+            return .awaitRecovery
         case .reconnected, .streaming:
             retryPending = false
             armMissDetection()
@@ -234,6 +238,7 @@ public final class MentraBluetoothSDK {
     private static let otaMtkVersionWaitMs = 2_000
     private static let otaVersionPollMs = 100
     private static let defaultStreamKeepAliveIntervalSeconds = 5
+    private static let streamRecoveryStatusTimeoutNanoseconds: UInt64 = 15_000_000_000
 
     public weak var delegate: MentraBluetoothSDKDelegate?
 
@@ -1605,6 +1610,7 @@ public final class MentraBluetoothSDK {
 
     private func stopStreamKeepAliveMonitor() {
         activeStreamKeepAlive?.task?.cancel()
+        activeStreamKeepAlive?.recoveryStopTask?.cancel()
         activeStreamKeepAlive = nil
     }
 
@@ -1668,8 +1674,24 @@ public final class MentraBluetoothSDK {
         switch tracker.handle(event) {
         case .stop:
             stopStreamKeepAliveMonitor()
+        case .awaitRecovery:
+            tracker.recoveryStopTask?.cancel()
+            tracker.recoveryStopTask = Task { @MainActor [weak self, weak tracker] in
+                try? await Task.sleep(nanoseconds: Self.streamRecoveryStatusTimeoutNanoseconds)
+                guard !Task.isCancelled,
+                      let self, let tracker,
+                      self.activeStreamKeepAlive === tracker,
+                      tracker.retryPending
+                else {
+                    return
+                }
+                self.stopStreamKeepAliveMonitor()
+            }
         case .preserve:
-            break
+            if event.state == .reconnecting || event.state == .reconnected || event.state == .streaming {
+                tracker.recoveryStopTask?.cancel()
+                tracker.recoveryStopTask = nil
+            }
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -2,20 +2,74 @@ import CoreBluetooth
 import Foundation
 
 @MainActor
-private final class ActiveStreamKeepAlive {
+final class ActiveStreamKeepAlive {
+    enum StatusDisposition: Equatable {
+        case preserve
+        case stop
+    }
+
     let streamId: String
     let intervalSeconds: Int
     var pendingAckId: String?
     var missedAckCount = 0
     var task: Task<Void, Never>?
-    // Missed-ACK counting only begins once the stream is confirmed live/coming up, so a slow
-    // startup (glasses can't ACK until they reach starting/streaming) can't trip a false
-    // keep-alive timeout before the stream is ever up.
+    /// Missed-ACK counting only begins once the stream is confirmed live/coming up, so a slow
+    /// startup (glasses can't ACK until they reach starting/streaming) can't trip a false
+    /// keep-alive timeout before the stream is ever up.
     var armed = false
+    /// A retryable publisher error can be followed by a transient `stopped`
+    /// before `reconnecting`. Remember that recovery is still in flight so the
+    /// intermediate status does not permanently discard this monitor.
+    var retryPending = false
 
     init(streamId: String, intervalSeconds: Int) {
         self.streamId = streamId
         self.intervalSeconds = intervalSeconds
+    }
+
+    func handle(_ event: StreamStatusEvent) -> StatusDisposition {
+        switch event.state {
+        case .error where event.willRetry == true:
+            retryPending = true
+            suspendMissDetection()
+            return .preserve
+        case .reconnecting:
+            retryPending = true
+            suspendMissDetection()
+            return .preserve
+        case .stopped where retryPending:
+            // Some publisher implementations report a stopped transition
+            // between the retryable error and their reconnect attempt.
+            suspendMissDetection()
+            return .preserve
+        case .reconnected, .streaming:
+            retryPending = false
+            armMissDetection()
+            return .preserve
+        case .initializing:
+            // A fresh start does not have a monitor until its request resolves.
+            // During recovery, initializing is still pre-live and must not make
+            // missed ACKs terminal before the publisher is connected again.
+            if !retryPending {
+                armMissDetection()
+            }
+            return .preserve
+        case .stopped, .stopping, .error, .reconnectFailed:
+            return .stop
+        }
+    }
+
+    private func suspendMissDetection() {
+        armed = false
+        pendingAckId = nil
+        missedAckCount = 0
+    }
+
+    private func armMissDetection() {
+        guard !armed else { return }
+        armed = true
+        pendingAckId = nil
+        missedAckCount = 0
     }
 }
 
@@ -1603,26 +1657,19 @@ public final class MentraBluetoothSDK {
         return true
     }
 
-    private func handleStreamStatusForKeepAlive(_ status: StreamStatus) {
-        guard let streamId = status.streamId,
+    private func handleStreamStatusForKeepAlive(_ event: StreamStatusEvent) {
+        guard let streamId = event.streamId,
               activeStreamKeepAlive?.streamId == streamId
         else {
             return
         }
 
-        switch status.state {
-        case .stopped, .stopping, .error, .reconnectFailed:
+        guard let tracker = activeStreamKeepAlive else { return }
+        switch tracker.handle(event) {
+        case .stop:
             stopStreamKeepAliveMonitor()
-        default:
-            // A non-terminal status means the stream is live or coming up and the glasses can
-            // now ACK; arm the missed-ACK detector from here so a slow startup before the first
-            // ACK can't trip a false keep-alive timeout. On the arming transition, drop any
-            // pre-arm bookkeeping so a stale unacked id can't immediately count as a miss.
-            if let tracker = activeStreamKeepAlive, !tracker.armed {
-                tracker.armed = true
-                tracker.pendingAckId = nil
-                tracker.missedAckCount = 0
-            }
+        case .preserve:
+            break
         }
     }
 
@@ -2203,7 +2250,7 @@ private func dispatchDiscoveredDevices(_ rawSearchResults: Any?) {
         case "stream_status":
             let event = StreamStatusEvent(values: data)
             handleStreamStatusForRequests(event)
-            handleStreamStatusForKeepAlive(event.status)
+            handleStreamStatusForKeepAlive(event)
             delegate?.mentraBluetoothSDK(self, didReceive: .streamStatus(event))
         case "keep_alive_ack":
             let event = KeepAliveAckEvent(values: data)

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -5,7 +5,8 @@ import Foundation
 final class ActiveStreamKeepAlive {
     enum StatusDisposition: Equatable {
         case preserve
-        case awaitRecovery
+        case restartRecoveryDeadline
+        case cancelRecoveryDeadline
         case stop
     }
 
@@ -34,30 +35,31 @@ final class ActiveStreamKeepAlive {
         case .error where event.willRetry == true:
             retryPending = true
             suspendMissDetection()
-            return .preserve
+            return .restartRecoveryDeadline
         case .reconnecting:
             retryPending = true
             suspendMissDetection()
-            return .preserve
+            return .restartRecoveryDeadline
         case .stopped where retryPending:
             // Some publisher implementations report a stopped transition
             // between the retryable error and their reconnect attempt. Give
             // that reconnect a bounded window instead of preserving a dead
             // monitor indefinitely if no recovery status follows.
             suspendMissDetection()
-            return .awaitRecovery
+            return .restartRecoveryDeadline
         case .reconnected, .streaming:
             retryPending = false
             armMissDetection()
-            return .preserve
+            return .cancelRecoveryDeadline
         case .initializing:
             // A fresh start does not have a monitor until its request resolves.
             // During recovery, initializing is still pre-live and must not make
             // missed ACKs terminal before the publisher is connected again.
             if !retryPending {
                 armMissDetection()
+                return .preserve
             }
-            return .preserve
+            return .restartRecoveryDeadline
         case .stopped, .stopping, .error, .reconnectFailed:
             return .stop
         }
@@ -1674,7 +1676,7 @@ public final class MentraBluetoothSDK {
         switch tracker.handle(event) {
         case .stop:
             stopStreamKeepAliveMonitor()
-        case .awaitRecovery:
+        case .restartRecoveryDeadline:
             tracker.recoveryStopTask?.cancel()
             tracker.recoveryStopTask = Task { @MainActor [weak self, weak tracker] in
                 try? await Task.sleep(nanoseconds: Self.streamRecoveryStatusTimeoutNanoseconds)
@@ -1687,11 +1689,11 @@ public final class MentraBluetoothSDK {
                 }
                 self.stopStreamKeepAliveMonitor()
             }
+        case .cancelRecoveryDeadline:
+            tracker.recoveryStopTask?.cancel()
+            tracker.recoveryStopTask = nil
         case .preserve:
-            if event.state == .reconnecting || event.state == .reconnected || event.state == .streaming {
-                tracker.recoveryStopTask?.cancel()
-                tracker.recoveryStopTask = nil
-            }
+            break
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Tests/StreamKeepAliveLifecycleTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/StreamKeepAliveLifecycleTests.swift
@@ -6,13 +6,13 @@ final class StreamKeepAliveLifecycleTests: XCTestCase {
     func testRetryableErrorPreservesMonitorThroughTransientStoppedStatus() {
         let tracker = makeArmedTracker()
 
-        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .restartRecoveryDeadline)
         XCTAssertFalse(tracker.armed)
         XCTAssertTrue(tracker.retryPending)
         XCTAssertNil(tracker.pendingAckId)
         XCTAssertEqual(tracker.missedAckCount, 0)
 
-        XCTAssertEqual(tracker.handle(event(status: "stopped")), .awaitRecovery)
+        XCTAssertEqual(tracker.handle(event(status: "stopped")), .restartRecoveryDeadline)
         XCTAssertFalse(tracker.armed)
         XCTAssertTrue(tracker.retryPending)
     }
@@ -20,17 +20,17 @@ final class StreamKeepAliveLifecycleTests: XCTestCase {
     func testReconnectLifecycleRearmsExistingMonitorWithoutAnotherStart() {
         let tracker = makeArmedTracker()
 
-        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .preserve)
-        XCTAssertEqual(tracker.handle(event(status: "reconnecting")), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "reconnecting")), .restartRecoveryDeadline)
         XCTAssertFalse(tracker.armed)
 
-        XCTAssertEqual(tracker.handle(event(status: "reconnected")), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "reconnected")), .cancelRecoveryDeadline)
         XCTAssertTrue(tracker.armed)
         XCTAssertFalse(tracker.retryPending)
 
         tracker.pendingAckId = "ack-new"
         tracker.missedAckCount = 1
-        XCTAssertEqual(tracker.handle(event(status: "streaming")), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "streaming")), .cancelRecoveryDeadline)
         XCTAssertEqual(tracker.pendingAckId, "ack-new")
         XCTAssertEqual(tracker.missedAckCount, 1)
     }
@@ -38,8 +38,8 @@ final class StreamKeepAliveLifecycleTests: XCTestCase {
     func testStreamingStatusCanRearmDirectlyAfterRetryableError() {
         let tracker = makeArmedTracker()
 
-        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .preserve)
-        XCTAssertEqual(tracker.handle(event(status: "streaming")), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "streaming")), .cancelRecoveryDeadline)
         XCTAssertTrue(tracker.armed)
         XCTAssertFalse(tracker.retryPending)
     }
@@ -49,6 +49,31 @@ final class StreamKeepAliveLifecycleTests: XCTestCase {
             let tracker = makeArmedTracker()
             XCTAssertEqual(tracker.handle(event(status: status)), .stop, status)
         }
+    }
+
+    func testRetryableErrorAfterTransientStoppedRestartsRecoveryDeadline() {
+        let tracker = makeArmedTracker()
+
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "stopped")), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .restartRecoveryDeadline)
+        XCTAssertTrue(tracker.retryPending)
+        XCTAssertFalse(tracker.armed)
+    }
+
+    func testRetryProgressRestartsDeadlineUntilStreamIsLive() {
+        let tracker = makeArmedTracker()
+
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "stopped")), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "reconnecting")), .restartRecoveryDeadline)
+        XCTAssertEqual(tracker.handle(event(status: "initializing")), .restartRecoveryDeadline)
+        XCTAssertTrue(tracker.retryPending)
+        XCTAssertFalse(tracker.armed)
+
+        XCTAssertEqual(tracker.handle(event(status: "reconnected")), .cancelRecoveryDeadline)
+        XCTAssertFalse(tracker.retryPending)
+        XCTAssertTrue(tracker.armed)
     }
 
     private func makeArmedTracker() -> ActiveStreamKeepAlive {

--- a/mobile/modules/bluetooth-sdk/ios/Tests/StreamKeepAliveLifecycleTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/StreamKeepAliveLifecycleTests.swift
@@ -12,7 +12,7 @@ final class StreamKeepAliveLifecycleTests: XCTestCase {
         XCTAssertNil(tracker.pendingAckId)
         XCTAssertEqual(tracker.missedAckCount, 0)
 
-        XCTAssertEqual(tracker.handle(event(status: "stopped")), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "stopped")), .awaitRecovery)
         XCTAssertFalse(tracker.armed)
         XCTAssertTrue(tracker.retryPending)
     }

--- a/mobile/modules/bluetooth-sdk/ios/Tests/StreamKeepAliveLifecycleTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/StreamKeepAliveLifecycleTests.swift
@@ -1,0 +1,73 @@
+@testable import MentraBluetoothSDK
+import XCTest
+
+@MainActor
+final class StreamKeepAliveLifecycleTests: XCTestCase {
+    func testRetryableErrorPreservesMonitorThroughTransientStoppedStatus() {
+        let tracker = makeArmedTracker()
+
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .preserve)
+        XCTAssertFalse(tracker.armed)
+        XCTAssertTrue(tracker.retryPending)
+        XCTAssertNil(tracker.pendingAckId)
+        XCTAssertEqual(tracker.missedAckCount, 0)
+
+        XCTAssertEqual(tracker.handle(event(status: "stopped")), .preserve)
+        XCTAssertFalse(tracker.armed)
+        XCTAssertTrue(tracker.retryPending)
+    }
+
+    func testReconnectLifecycleRearmsExistingMonitorWithoutAnotherStart() {
+        let tracker = makeArmedTracker()
+
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "reconnecting")), .preserve)
+        XCTAssertFalse(tracker.armed)
+
+        XCTAssertEqual(tracker.handle(event(status: "reconnected")), .preserve)
+        XCTAssertTrue(tracker.armed)
+        XCTAssertFalse(tracker.retryPending)
+
+        tracker.pendingAckId = "ack-new"
+        tracker.missedAckCount = 1
+        XCTAssertEqual(tracker.handle(event(status: "streaming")), .preserve)
+        XCTAssertEqual(tracker.pendingAckId, "ack-new")
+        XCTAssertEqual(tracker.missedAckCount, 1)
+    }
+
+    func testStreamingStatusCanRearmDirectlyAfterRetryableError() {
+        let tracker = makeArmedTracker()
+
+        XCTAssertEqual(tracker.handle(event(status: "error", willRetry: true)), .preserve)
+        XCTAssertEqual(tracker.handle(event(status: "streaming")), .preserve)
+        XCTAssertTrue(tracker.armed)
+        XCTAssertFalse(tracker.retryPending)
+    }
+
+    func testTerminalStatusesStopMonitor() {
+        for status in ["stopping", "stopped", "error", "reconnect_failed"] {
+            let tracker = makeArmedTracker()
+            XCTAssertEqual(tracker.handle(event(status: status)), .stop, status)
+        }
+    }
+
+    private func makeArmedTracker() -> ActiveStreamKeepAlive {
+        let tracker = ActiveStreamKeepAlive(streamId: "stream-1", intervalSeconds: 5)
+        tracker.armed = true
+        tracker.pendingAckId = "ack-old"
+        tracker.missedAckCount = 2
+        return tracker
+    }
+
+    private func event(status: String, willRetry: Bool? = nil) -> StreamStatusEvent {
+        var values: [String: Any] = [
+            "type": "stream_status",
+            "status": status,
+            "streamId": "stream-1",
+        ]
+        if let willRetry {
+            values["willRetry"] = willRetry
+        }
+        return StreamStatusEvent(values: values)
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the active iOS stream keep-alive monitor when a publisher error is explicitly retryable
- suspend missed-ACK accounting through retryable error, reconnecting, and the retry path's transient stopped status
- re-arm the existing monitor on reconnected or streaming without issuing another start_stream command
- retain teardown for terminal errors, explicit stopping/stopped states, and reconnect exhaustion
- add focused iOS lifecycle regression coverage

## Testing

- `xcodebuild test -scheme MentraBluetoothSDK -destination 'platform=iOS Simulator,id=C5961C3D-9F6B-4E8F-A323-9C47FA0D8E36' -derivedDataPath /tmp/codex-s1-stream-keepalive-derived -only-testing:MentraBluetoothSDKTests/StreamKeepAliveLifecycleTests CODE_SIGNING_ALLOWED=NO` (4 tests passed)
- full `MentraBluetoothSDK` Swift Package test suite on the same iOS simulator (passed)
- `git diff --check`

## Caveat

- not validated against a live glasses reconnect; regression coverage exercises the native lifecycle state transitions that previously discarded the monitor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-stream keep-alive and recovery timing on iOS; behavior is bounded by a 60s guard and covered by unit tests, but not validated on hardware reconnect.
> 
> **Overview**
> Fixes iOS **stream keep-alive** tearing down too early when the glasses publisher reports a **retryable error** or goes through **reconnecting** / a transient **`stopped`** before recovery.
> 
> **`ActiveStreamKeepAlive`** now maps **`StreamStatusEvent`** (including **`willRetry`**) to explicit dispositions: suspend missed-ACK counting during recovery, **re-arm** the same monitor on **`reconnected`** / **`streaming`** without another **`start_stream`**, and still **stop** on terminal **`stopped`**, **`stopping`**, non-retryable **`error`**, or **`reconnect_failed`**. **`MentraBluetoothSDK`** runs a **60s** recovery guard (above the glasses RTMP backoff) so a stuck retry cannot leave the monitor alive forever, and cancels that task on successful recovery.
> 
> Adds **`StreamKeepAliveLifecycleTests`** for these state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77dd5ae8c796e494137b460c0ac6fc8ad6102777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->