### PR TITLE
Fix Mentra Live GATT reconnect sequencing

### DIFF
--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -511,9 +511,3 @@ jobs:
             echo "Both build attempts failed"
             exit 1
           fi
-
-      - name: Upload Device Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-device-build
-          path: mobile/ios/build-device/Build/Products/Release-iphoneos/Mentra.app

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -568,8 +568,8 @@ class MentraLive : SGCManager() {
     private var bluetoothScanner: BluetoothLeScanner? = null
     @Volatile private var bluetoothGatt: BluetoothGatt? = null
     private val gattLifecycleHandler = Handler(Looper.getMainLooper())
-    private var gattTeardownToken: Long? = null
-    private var gattTeardownTimeoutRunnable: Runnable? = null
+    @Volatile private var gattTeardownToken: Long? = null
+    @Volatile private var gattTeardownTimeoutRunnable: Runnable? = null
     private var connectedDevice: BluetoothDevice? = null
     private var txCharacteristic: BluetoothGattCharacteristic? = null
     private var rxCharacteristic: BluetoothGattCharacteristic? = null

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -2177,12 +2177,16 @@ class MentraLive : SGCManager() {
                         return
                     }
                     val teardownToken = gattTeardownToken
-                    if (
-                            teardownToken != null &&
-                                    (newState == BluetoothProfile.STATE_DISCONNECTED ||
-                                            status != BluetoothGatt.GATT_SUCCESS)
-                    ) {
-                        completeGattTeardown(gatt, teardownToken, "disconnected_callback")
+                    if (teardownToken != null) {
+                        if (
+                                newState == BluetoothProfile.STATE_DISCONNECTED ||
+                                        status != BluetoothGatt.GATT_SUCCESS
+                        ) {
+                            completeGattTeardown(gatt, teardownToken, "disconnected_callback")
+                        }
+                        // Once teardown starts, a queued successful CONNECTED callback belongs to
+                        // the closing transport. It must not resurrect application connection
+                        // state while the disconnect callback is still pending.
                         return
                     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -1629,11 +1629,21 @@ class MentraLive : SGCManager() {
             return
         }
         bluetoothGatt = null
+        releaseGattSessionMedia()
         try {
             gatt.close()
         } catch (e: Exception) {
             Log.w(TAG, "🔌 closeGattQuietly: close threw " + e)
         }
+    }
+
+    /** Release side channels on every teardown, including missing disconnect callbacks. */
+    private fun releaseGattSessionMedia() {
+        closeL2capFileChannel()
+        fileProcessingHandler.removeCallbacksAndMessages(null)
+        clearFilePacketBuffer()
+        closeLc3Logging()
+        lc3AudioPlayer?.stopPlay()
     }
 
     private fun beginGattTeardown(gatt: BluetoothGatt) {
@@ -1668,6 +1678,7 @@ class MentraLive : SGCManager() {
         stopHeartbeat()
         stopSignalStrengthPolling()
         stopMicBeat()
+        releaseGattSessionMedia()
         updateConnectionState(ConnTypes.DISCONNECTED)
         val timeout =
                 Runnable {
@@ -2351,11 +2362,6 @@ class MentraLive : SGCManager() {
                             // Stop micbeat mechanism
                             stopMicBeat()
 
-                            // Close the L2CAP file channel (if the fast path was open)
-                            closeL2capFileChannel()
-                            fileProcessingHandler.removeCallbacksAndMessages(null)
-                            clearFilePacketBuffer()
-
                             // Clean up GATT resources
                             closeGattQuietly(false)
 
@@ -2365,13 +2371,6 @@ class MentraLive : SGCManager() {
                                 handleReconnection()
                             }
 
-                            // Close LC3 audio logging
-                            closeLc3Logging()
-
-                            // stop LC3 player
-                            if (lc3AudioPlayer != null) {
-                                lc3AudioPlayer!!.stopPlay()
-                            }
                         }
                     } else {
                         // Connection error

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -141,6 +141,9 @@ class MentraLive : SGCManager() {
         private const val A2DP_CONNECT_MAX_ATTEMPTS = 5
         private const val A2DP_CONNECT_RETRY_MS = 800L
         private const val UNPAIR_FLUSH_MS = 400L
+        private const val GATT_DISCONNECT_TIMEOUT_MS = 2_000L
+        private const val MTU_CALLBACK_TIMEOUT_MS = 3_000L
+        private val gattTeardownBarrier = MentraLiveGattTeardownBarrier()
 
         // L2CAP CoC fast path: new BES2700 firmware registers an LE L2CAP CoC server on this
         // PSM. When the phone opens the channel, the glasses send file packets over it instead
@@ -564,6 +567,9 @@ class MentraLive : SGCManager() {
     private var bluetoothAdapter: BluetoothAdapter? = null
     private var bluetoothScanner: BluetoothLeScanner? = null
     @Volatile private var bluetoothGatt: BluetoothGatt? = null
+    private val gattLifecycleHandler = Handler(Looper.getMainLooper())
+    private var gattTeardownToken: Long? = null
+    private var gattTeardownTimeoutRunnable: Runnable? = null
     private var connectedDevice: BluetoothDevice? = null
     private var txCharacteristic: BluetoothGattCharacteristic? = null
     private var rxCharacteristic: BluetoothGattCharacteristic? = null
@@ -643,6 +649,9 @@ class MentraLive : SGCManager() {
     private var isDescriptorWriteInProgress = false
     private var notificationsEnabled =
             false // Track if enableNotifications was already called this connection
+    private val mtuSetupGate = MentraLiveMtuSetupGate()
+    private var mtuSetupToken: Long? = null
+    private var mtuWatchdogRunnable: Runnable? = null
     private var connectionTimeoutRunnable: Runnable? = null
     private var connectionTimeoutHandler = Handler(Looper.getMainLooper())
     private var processSendQueueRunnable: Runnable? = null
@@ -1588,30 +1597,76 @@ class MentraLive : SGCManager() {
         }
     }
 
-    /**
-     * Safely tear down the GATT reference. Avoids NPE / races with gatt callbacks disconnecting on
-     * a binder thread while a queued teardown runnable fires. Pass disconnect=true to call
-     * disconnect() before close().
-     */
+    /** Safely close GATT, waiting for Android to finish a requested disconnect when possible. */
     @Synchronized
     private fun closeGattQuietly(disconnect: Boolean) {
         val gatt = bluetoothGatt
-        bluetoothGatt = null
         if (gatt == null) {
             return
         }
-        try {
-            if (disconnect) {
-                gatt.disconnect()
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "🔌 closeGattQuietly: disconnect threw " + e)
+        cancelMtuWatchdog()
+        if (disconnect) {
+            beginGattTeardown(gatt)
+            return
         }
+        bluetoothGatt = null
         try {
             gatt.close()
         } catch (e: Exception) {
             Log.w(TAG, "🔌 closeGattQuietly: close threw " + e)
         }
+    }
+
+    @Synchronized
+    private fun beginGattTeardown(gatt: BluetoothGatt) {
+        if (gatt !== bluetoothGatt || gattTeardownToken != null) {
+            return
+        }
+        val token = gattTeardownBarrier.beginTeardown()
+        gattTeardownToken = token
+        val timeout =
+                Runnable {
+                    Bridge.log(
+                            "LIVE: 🔌 GATT disconnect callback timed out after ${GATT_DISCONNECT_TIMEOUT_MS}ms; closing transport"
+                    )
+                    completeGattTeardown(gatt, token, "timeout")
+                }
+        gattTeardownTimeoutRunnable = timeout
+        gattLifecycleHandler.postDelayed(timeout, GATT_DISCONNECT_TIMEOUT_MS)
+        try {
+            Bridge.log("LIVE: 🔌 Waiting for GATT disconnected callback before close")
+            gatt.disconnect()
+        } catch (e: Exception) {
+            Log.w(TAG, "🔌 GATT disconnect threw " + e)
+            completeGattTeardown(gatt, token, "disconnect_exception")
+        }
+    }
+
+    @Synchronized
+    private fun completeGattTeardown(gatt: BluetoothGatt, token: Long, reason: String) {
+        if (gattTeardownToken != token) {
+            return
+        }
+        gattTeardownTimeoutRunnable?.let { gattLifecycleHandler.removeCallbacks(it) }
+        gattTeardownTimeoutRunnable = null
+        gattTeardownToken = null
+        if (gatt === bluetoothGatt) {
+            bluetoothGatt = null
+        }
+        try {
+            gatt.close()
+        } catch (e: Exception) {
+            Log.w(TAG, "🔌 GATT close after $reason threw " + e)
+        }
+        Bridge.log("LIVE: 🔌 GATT teardown complete ($reason)")
+        gattTeardownBarrier.completeTeardown(token)
+    }
+
+    private fun cancelMtuWatchdog() {
+        mtuWatchdogRunnable?.let { gattLifecycleHandler.removeCallbacks(it) }
+        mtuWatchdogRunnable = null
+        mtuSetupToken = null
+        mtuSetupGate.cancel()
     }
 
     /**
@@ -1632,6 +1687,11 @@ class MentraLive : SGCManager() {
             Log.w(TAG, "🔌 Failed to close stale BluetoothGatt: " + e)
         }
         return false
+    }
+
+    /** Ignore all non-disconnect work once this GATT is stale or tearing down. */
+    private fun isActiveGattCallback(gatt: BluetoothGatt): Boolean {
+        return isCurrentGattCallback(gatt) && gattTeardownToken == null
     }
 
     private fun beginPairingTiming(reason: String) {
@@ -1669,6 +1729,19 @@ class MentraLive : SGCManager() {
             Bridge.log("LIVE: connectToDevice blocked — pairing yield active")
             isConnecting = false
             isReconnecting = false
+            return
+        }
+        if (
+                gattTeardownBarrier.deferUntilIdle {
+                    handler.post {
+                        if (!isKilled && !pairingYieldActive) {
+                            Bridge.log("LIVE: 🔌 Prior GATT teardown complete; resuming connection")
+                            connectToDevice(device)
+                        }
+                    }
+                }
+        ) {
+            Bridge.log("LIVE: 🔌 Deferring connection until prior GATT teardown completes")
             return
         }
 
@@ -2103,6 +2176,15 @@ class MentraLive : SGCManager() {
                     if (!isCurrentGattCallback(gatt)) {
                         return
                     }
+                    val teardownToken = gattTeardownToken
+                    if (
+                            teardownToken != null &&
+                                    (newState == BluetoothProfile.STATE_DISCONNECTED ||
+                                            status != BluetoothGatt.GATT_SUCCESS)
+                    ) {
+                        completeGattTeardown(gatt, teardownToken, "disconnected_callback")
+                        return
+                    }
 
                     // Cancel the connection timeout
                     if (connectionTimeoutRunnable != null) {
@@ -2335,6 +2417,9 @@ class MentraLive : SGCManager() {
                 }
 
                 override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+                    if (!isActiveGattCallback(gatt)) {
+                        return
+                    }
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         Bridge.log("LIVE: GATT services discovered")
 
@@ -2397,7 +2482,17 @@ class MentraLive : SGCManager() {
                                 // This ensures no concurrent GATT operations on older Android BLE
                                 // stacks.
                                 if (checkPermission()) {
-                                    val mtuRequested = gatt.requestMtu(512)
+                                    val mtuToken = mtuSetupGate.begin()
+                                    mtuSetupToken = mtuToken
+                                    val mtuRequested =
+                                            try {
+                                                gatt.requestMtu(512)
+                                            } catch (e: SecurityException) {
+                                                Bridge.log(
+                                                        "LIVE: ⚠️ MTU request denied; continuing with notification setup"
+                                                )
+                                                false
+                                            }
                                     Bridge.log(
                                             "LIVE: 🔄 Requested MTU size 512, success: " +
                                                     mtuRequested
@@ -2405,12 +2500,18 @@ class MentraLive : SGCManager() {
                                     if (!mtuRequested) {
                                         // MTU request failed to even start, enable notifications
                                         // directly
-                                        enableNotifications()
+                                        completeMtuSetup(
+                                                gatt,
+                                                mtuToken,
+                                                "request_not_started"
+                                        )
+                                    } else {
+                                        startMtuWatchdog(gatt, mtuToken)
                                     }
                                     // Otherwise, enableNotifications() will be called from
                                     // onMtuChanged
                                 } else {
-                                    enableNotifications()
+                                    enableNotificationsAfterMtu(gatt, "permission_fallback")
                                 }
 
                                 // NOTE: Send queue and readiness loop are started AFTER descriptor
@@ -2442,6 +2543,9 @@ class MentraLive : SGCManager() {
                         characteristic: BluetoothGattCharacteristic,
                         status: Int
                 ) {
+                    if (!isActiveGattCallback(gatt)) {
+                        return
+                    }
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         Bridge.log("LIVE: Characteristic read successful")
                         // Process the read data if needed
@@ -2451,6 +2555,9 @@ class MentraLive : SGCManager() {
                 }
 
                 override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
+                    if (!isActiveGattCallback(gatt)) {
+                        return
+                    }
                     rssiReadInProgress = false
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         if (isConnected && bluetoothGatt != null && gatt === bluetoothGatt) {
@@ -2466,6 +2573,9 @@ class MentraLive : SGCManager() {
                         characteristic: BluetoothGattCharacteristic,
                         status: Int
                 ) {
+                    if (!isActiveGattCallback(gatt)) {
+                        return
+                    }
                     val trace = inFlightBleWriteTrace
                     val callbackAtMs = System.currentTimeMillis()
                     val callbackDelayMs =
@@ -2531,7 +2641,7 @@ class MentraLive : SGCManager() {
                         gatt: BluetoothGatt,
                         characteristic: BluetoothGattCharacteristic
                 ) {
-                    if (!isCurrentGattCallback(gatt)) {
+                    if (!isActiveGattCallback(gatt)) {
                         return
                     }
 
@@ -2589,6 +2699,9 @@ class MentraLive : SGCManager() {
                         descriptor: BluetoothGattDescriptor,
                         status: Int
                 ) {
+                    if (!isActiveGattCallback(gatt)) {
+                        return
+                    }
                     val threadId = Thread.currentThread().id
 
                     if (status == BluetoothGatt.GATT_SUCCESS) {
@@ -2617,41 +2730,89 @@ class MentraLive : SGCManager() {
                 }
 
                 override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
-                    if (status == BluetoothGatt.GATT_SUCCESS) {
-                        Bridge.log(
-                                "LIVE: 🔵 MTU negotiation successful - changed to " + mtu + " bytes"
-                        )
-                        val effectivePayload = mtu - 3
-                        Bridge.log(
-                                "LIVE:    Effective payload size: " + effectivePayload + " bytes"
-                        )
-
-                        // Store the new MTU value
-                        currentMtu = mtu
-
-                        // If the negotiated MTU is sufficient for LC3 audio packets (typically
-                        // 40-60 bytes)
-                        if (mtu >= 64) {
-                            Bridge.log("LIVE: ✅ MTU size is sufficient for LC3 audio data packets")
-                        } else {
-                            Log.w(TAG, "⚠️ MTU size may be too small for LC3 audio data packets")
+                    handler.post {
+                        if (!isActiveGattCallback(gatt)) {
+                            return@post
+                        }
+                        if (status == BluetoothGatt.GATT_SUCCESS) {
                             Bridge.log(
-                                    "LIVE: 📊 Effective MTU payload: " + effectivePayload + " bytes"
+                                    "LIVE: 🔵 MTU negotiation successful - changed to " +
+                                            mtu +
+                                            " bytes"
+                            )
+                            val effectivePayload = mtu - 3
+                            Bridge.log(
+                                    "LIVE:    Effective payload size: " +
+                                            effectivePayload +
+                                            " bytes"
+                            )
+
+                            currentMtu = mtu
+
+                            if (mtu >= 64) {
+                                Bridge.log(
+                                        "LIVE: ✅ MTU size is sufficient for LC3 audio data packets"
+                                )
+                            } else {
+                                Log.w(
+                                        TAG,
+                                        "⚠️ MTU size may be too small for LC3 audio data packets"
+                                )
+                                Bridge.log(
+                                        "LIVE: 📊 Effective MTU payload: " +
+                                                effectivePayload +
+                                                " bytes"
+                                )
+                            }
+                        } else {
+                            Log.e(TAG, "❌ MTU change failed with status: " + status)
+                            Log.w(
+                                    TAG,
+                                    "   Will continue with default MTU (23 bytes, 20 byte payload)"
                             )
                         }
-                    } else {
-                        Log.e(TAG, "❌ MTU change failed with status: " + status)
-                        Log.w(TAG, "   Will continue with default MTU (23 bytes, 20 byte payload)")
-                    }
 
-                    // Now that MTU operation is complete, enable notifications
-                    // (descriptor writes are GATT operations and can't overlap with MTU request)
-                    if (!notificationsEnabled) {
-                        notificationsEnabled = true
-                        enableNotifications()
+                        mtuSetupToken?.let { completeMtuSetup(gatt, it, "callback") }
                     }
                 }
             }
+
+    private fun startMtuWatchdog(gatt: BluetoothGatt, token: Long) {
+        mtuWatchdogRunnable?.let { gattLifecycleHandler.removeCallbacks(it) }
+        val watchdog =
+                Runnable {
+                    handler.post {
+                        if (!isActiveGattCallback(gatt)) {
+                            return@post
+                        }
+                        Bridge.log(
+                                "LIVE: ⚠️ MTU callback timed out after ${MTU_CALLBACK_TIMEOUT_MS}ms; continuing with notification setup"
+                        )
+                        completeMtuSetup(gatt, token, "watchdog")
+                    }
+                }
+        mtuWatchdogRunnable = watchdog
+        gattLifecycleHandler.postDelayed(watchdog, MTU_CALLBACK_TIMEOUT_MS)
+    }
+
+    private fun completeMtuSetup(gatt: BluetoothGatt, token: Long, reason: String) {
+        if (!mtuSetupGate.complete(token)) {
+            return
+        }
+        mtuWatchdogRunnable?.let { gattLifecycleHandler.removeCallbacks(it) }
+        mtuWatchdogRunnable = null
+        mtuSetupToken = null
+        enableNotificationsAfterMtu(gatt, reason)
+    }
+
+    private fun enableNotificationsAfterMtu(gatt: BluetoothGatt, reason: String) {
+        if (!isActiveGattCallback(gatt) || notificationsEnabled) {
+            return
+        }
+        notificationsEnabled = true
+        Bridge.log("LIVE: 🔔 Continuing GATT setup after MTU ($reason)")
+        enableNotifications()
+    }
 
     /**
      * Write the next queued descriptor, or mark the queue as idle. Must be called after each

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -568,6 +568,9 @@ class MentraLive : SGCManager() {
     private var bluetoothScanner: BluetoothLeScanner? = null
     @Volatile private var bluetoothGatt: BluetoothGatt? = null
     private val gattLifecycleHandler = Handler(Looper.getMainLooper())
+    // Owned exclusively by the main looper, including callback validation and mutation.
+    private var gattEpoch = 0L
+    private var connectionRequestEpoch = 0L
     @Volatile private var gattTeardownToken: Long? = null
     @Volatile private var gattTeardownTimeoutRunnable: Runnable? = null
     private var connectedDevice: BluetoothDevice? = null
@@ -1242,6 +1245,7 @@ class MentraLive : SGCManager() {
 
     /** Starts BLE scanning for Mentra Live glasses */
     private fun startScan() {
+        if (postGattLifecycle { startScan() }) return
         if (pairingYieldActive) {
             Bridge.log("LIVE: startScan blocked — pairing yield active")
             return
@@ -1306,6 +1310,7 @@ class MentraLive : SGCManager() {
 
             val generation = ++scanGeneration
             isScanning = true
+            scanCallback = createScanCallback(generation)
             bluetoothScanner!!.startScan(filters, settings, scanCallback)
 
             // Set a timeout to stop scanning
@@ -1358,6 +1363,7 @@ class MentraLive : SGCManager() {
 
     /** Stops BLE scanning */
     override fun stopScan() {
+        if (postGattLifecycle { stopScan() }) return
         manualDiscoveryActive = false
         if (bluetoothAdapter == null || bluetoothScanner == null || !isScanning) {
             return
@@ -1433,9 +1439,13 @@ class MentraLive : SGCManager() {
     var seenDevices: MutableSet<String> = HashSet()
 
     /** BLE Scan callback */
-    private val scanCallback: ScanCallback =
+    private var scanCallback: ScanCallback? = null
+
+    private fun createScanCallback(generation: Int): ScanCallback =
             object : ScanCallback() {
                 override fun onScanResult(callbackType: Int, result: ScanResult) {
+                    if (postGattLifecycle { onScanResult(callbackType, result) }) return
+                    if (!isScanning || generation != scanGeneration) return
                     // Check if the object has been destroyed to prevent NPE
                     if (context == null || isKilled) {
                         Bridge.log("LIVE: Ignoring scan result - object destroyed or killed")
@@ -1568,6 +1578,8 @@ class MentraLive : SGCManager() {
                 }
 
                 override fun onScanFailed(errorCode: Int) {
+                    if (postGattLifecycle { onScanFailed(errorCode) }) return
+                    if (generation != scanGeneration || !isScanning) return
                     Log.e(TAG, "BLE scan failed with error: " + errorCode)
                     isScanning = false
                     if (isReconnecting && !isKilled) {
@@ -1597,9 +1609,16 @@ class MentraLive : SGCManager() {
         }
     }
 
+    /** Return true when work was handed to the single process-wide lifecycle queue. */
+    private fun postGattLifecycle(work: () -> Unit): Boolean {
+        if (Looper.myLooper() == gattLifecycleHandler.looper) return false
+        gattLifecycleHandler.post { work() }
+        return true
+    }
+
     /** Safely close GATT, waiting for Android to finish a requested disconnect when possible. */
-    @Synchronized
     private fun closeGattQuietly(disconnect: Boolean) {
+        check(Looper.myLooper() == gattLifecycleHandler.looper)
         val gatt = bluetoothGatt
         if (gatt == null) {
             return
@@ -1617,13 +1636,39 @@ class MentraLive : SGCManager() {
         }
     }
 
-    @Synchronized
     private fun beginGattTeardown(gatt: BluetoothGatt) {
+        check(Looper.myLooper() == gattLifecycleHandler.looper)
         if (gatt !== bluetoothGatt || gattTeardownToken != null) {
             return
         }
         val token = gattTeardownBarrier.beginTeardown()
         gattTeardownToken = token
+        // Teardown owns session invalidation, including the timeout/replacement paths that do
+        // not receive the normal remote-disconnect cleanup callback.
+        cancelMtuWatchdog()
+        isConnected = false
+        isConnecting = false
+        connectedDevice = null
+        glassesReady = false
+        glassesSessionId = null
+        readinessCompletedThisBleSession = false
+        glassesReadyReceived = false
+        ctkdInitiatedThisGattSession = false
+        audioConnected = false
+        notificationsEnabled = false
+        currentMtu = 23
+        pendingDescriptorWrites.clear()
+        isDescriptorWriteInProgress = false
+        txCharacteristic = null
+        rxCharacteristic = null
+        lc3ReadCharacteristic = null
+        lc3WriteCharacteristic = null
+        handler.removeCallbacks(processSendQueueRunnable!!)
+        stopReadinessCheckLoop()
+        stopHeartbeat()
+        stopSignalStrengthPolling()
+        stopMicBeat()
+        updateConnectionState(ConnTypes.DISCONNECTED)
         val timeout =
                 Runnable {
                     Bridge.log(
@@ -1642,8 +1687,8 @@ class MentraLive : SGCManager() {
         }
     }
 
-    @Synchronized
     private fun completeGattTeardown(gatt: BluetoothGatt, token: Long, reason: String) {
+        check(Looper.myLooper() == gattLifecycleHandler.looper)
         if (gattTeardownToken != token) {
             return
         }
@@ -1722,28 +1767,32 @@ class MentraLive : SGCManager() {
 
     /** Connect to a specific BLE device */
     private fun connectToDevice(device: BluetoothDevice?) {
+        if (postGattLifecycle { connectToDevice(device) }) return
         if (device == null) {
             return
         }
-        if (pairingYieldActive) {
+        if (isKilled || pairingYieldActive) {
             Bridge.log("LIVE: connectToDevice blocked — pairing yield active")
             isConnecting = false
             isReconnecting = false
             return
         }
-        if (
-                gattTeardownBarrier.deferUntilIdle {
-                    handler.post {
-                        if (!isKilled && !pairingYieldActive) {
-                            Bridge.log("LIVE: 🔌 Prior GATT teardown complete; resuming connection")
-                            connectToDevice(device)
-                        }
-                    }
-                }
-        ) {
-            Bridge.log("LIVE: 🔌 Deferring connection until prior GATT teardown completes")
-            return
+        val requestEpoch = ++connectionRequestEpoch
+        // Never replace a still-open GATT. Its disconnect/close must finish first.
+        bluetoothGatt?.let { beginGattTeardown(it) }
+        gattTeardownBarrier.runWhenIdle {
+            if (requestEpoch == connectionRequestEpoch && !isKilled && !pairingYieldActive) {
+                connectToDeviceWhenIdle(device)
+            }
         }
+    }
+
+    private fun connectToDeviceWhenIdle(device: BluetoothDevice) {
+        check(Looper.myLooper() == gattLifecycleHandler.looper)
+        check(bluetoothGatt == null)
+        val epoch = ++gattEpoch
+        currentMtu = 23
+        val gattCallback = createGattCallback(epoch)
 
         beginPairingTiming(
                 "connectToDevice addr=${device.address} name=${safeDeviceName(device)} attempt=$reconnectAttempts"
@@ -1756,7 +1805,7 @@ class MentraLive : SGCManager() {
 
         // Set connection timeout
         connectionTimeoutRunnable = Runnable {
-            if (isConnecting && !isConnected) {
+            if (epoch == gattEpoch && isConnecting && !isConnected) {
                 Log.w(
                         TAG,
                         "🔌 ⏰ CONNECTION TIMEOUT after " +
@@ -1848,6 +1897,8 @@ class MentraLive : SGCManager() {
     // }
 
     private fun enterPairingYield(windowMs: Long) {
+        if (postGattLifecycle { enterPairingYield(windowMs) }) return
+        connectionRequestEpoch++
         pairingYieldActive = true
         pairingYieldAwaitingReclaim = false
         isReconnecting = false
@@ -1928,6 +1979,7 @@ class MentraLive : SGCManager() {
 
     /** Handle reconnection with exponential backoff */
     private fun handleReconnection() {
+        if (postGattLifecycle { handleReconnection() }) return
         // Don't attempt reconnection if we've been killed/forgotten
         if (isKilled) {
             Bridge.log("LIVE: 🔌 RECONNECT ABORTED - device has been killed/forgotten")
@@ -2166,9 +2218,13 @@ class MentraLive : SGCManager() {
     }
 
     /** GATT callback for BLE operations */
-    private val gattCallback: BluetoothGattCallback =
-            object : BluetoothGattCallback() {
-                override fun onConnectionStateChange(
+    private fun createGattCallback(epoch: Long): BluetoothGattCallback =
+            object : SerializedGattCallback({ work ->
+                // Always enqueue, even for an inline platform callback during connectGatt().
+                // This lets connectGatt return and install the identity before validation.
+                gattLifecycleHandler.post { work() }
+            }, { gatt -> epoch == gattEpoch && isCurrentGattCallback(gatt) }) {
+                override fun handleConnectionStateChange(
                         gatt: BluetoothGatt,
                         status: Int,
                         newState: Int
@@ -2388,7 +2444,7 @@ class MentraLive : SGCManager() {
                     }
                 }
 
-                override fun onPhyUpdate(
+                override fun handlePhyUpdate(
                         gatt: BluetoothGatt,
                         txPhy: Int,
                         rxPhy: Int,
@@ -2404,7 +2460,7 @@ class MentraLive : SGCManager() {
                     )
                 }
 
-                override fun onPhyRead(
+                override fun handlePhyRead(
                         gatt: BluetoothGatt,
                         txPhy: Int,
                         rxPhy: Int,
@@ -2420,7 +2476,7 @@ class MentraLive : SGCManager() {
                     )
                 }
 
-                override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+                override fun handleServicesDiscovered(gatt: BluetoothGatt, status: Int) {
                     if (!isActiveGattCallback(gatt)) {
                         return
                     }
@@ -2542,7 +2598,7 @@ class MentraLive : SGCManager() {
                     }
                 }
 
-                override fun onCharacteristicRead(
+                override fun handleCharacteristicRead(
                         gatt: BluetoothGatt,
                         characteristic: BluetoothGattCharacteristic,
                         status: Int
@@ -2558,7 +2614,7 @@ class MentraLive : SGCManager() {
                     }
                 }
 
-                override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
+                override fun handleReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
                     if (!isActiveGattCallback(gatt)) {
                         return
                     }
@@ -2572,7 +2628,7 @@ class MentraLive : SGCManager() {
                     }
                 }
 
-                override fun onCharacteristicWrite(
+                override fun handleCharacteristicWrite(
                         gatt: BluetoothGatt,
                         characteristic: BluetoothGattCharacteristic,
                         status: Int
@@ -2641,9 +2697,10 @@ class MentraLive : SGCManager() {
                     }
                 }
 
-                override fun onCharacteristicChanged(
+                override fun handleCharacteristicChanged(
                         gatt: BluetoothGatt,
-                        characteristic: BluetoothGattCharacteristic
+                        characteristic: BluetoothGattCharacteristic,
+                        data: ByteArray
                 ) {
                     if (!isActiveGattCallback(gatt)) {
                         return
@@ -2653,8 +2710,7 @@ class MentraLive : SGCManager() {
                     val threadId = Thread.currentThread().id
                     val uuid = characteristic.uuid
 
-                    val data = characteristic.value
-                    if (data == null || data.isEmpty()) {
+                    if (data.isEmpty()) {
                         return
                     }
 
@@ -2698,7 +2754,7 @@ class MentraLive : SGCManager() {
                     processReceivedData(data, data.size)
                 }
 
-                override fun onDescriptorWrite(
+                override fun handleDescriptorWrite(
                         gatt: BluetoothGatt,
                         descriptor: BluetoothGattDescriptor,
                         status: Int
@@ -2733,7 +2789,7 @@ class MentraLive : SGCManager() {
                     writeNextDescriptor()
                 }
 
-                override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
+                override fun handleMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
                     handler.post {
                         if (!isActiveGattCallback(gatt)) {
                             return@post
@@ -2825,6 +2881,12 @@ class MentraLive : SGCManager() {
      * subsequent writes to silently fail.
      */
     private fun writeNextDescriptor() {
+        val gatt = bluetoothGatt ?: return
+        if (!isActiveGattCallback(gatt)) return
+        val epoch = gattEpoch
+        val continueSetup = Runnable {
+            if (epoch == gattEpoch && isActiveGattCallback(gatt)) writeNextDescriptor()
+        }
         val next = pendingDescriptorWrites.poll()
         if (next == null) {
             isDescriptorWriteInProgress = false
@@ -2868,12 +2930,12 @@ class MentraLive : SGCManager() {
                                 uuid +
                                 ", continuing queue"
                 )
-                handler.postDelayed(this::writeNextDescriptor, 50L)
+                handler.postDelayed(continueSetup, 50L)
             }
         } catch (e: Exception) {
             val threadId = Thread.currentThread().id
             Log.e(TAG, "Thread-" + threadId + ": ⚠️ Error writing descriptor: " + e.message)
-            handler.postDelayed(this::writeNextDescriptor, 50L)
+            handler.postDelayed(continueSetup, 50L)
         }
     }
 
@@ -6103,6 +6165,8 @@ class MentraLive : SGCManager() {
     // SmartGlassesCommunicator interface implementation
 
     override fun findCompatibleDevices() {
+        if (postGattLifecycle { findCompatibleDevices() }) return
+        connectionRequestEpoch++
         Bridge.log("LIVE: Finding compatible Mentra Live glasses")
 
         // A fresh user scan owns the radio. Invalidate delayed reconnect callbacks
@@ -6167,6 +6231,7 @@ class MentraLive : SGCManager() {
     }
 
     override fun connectById(id: String) {
+        if (postGattLifecycle { connectById(id) }) return
         if (pairingYieldActive) {
             Bridge.log("LIVE: connectById blocked — pairing yield active")
             return
@@ -6196,6 +6261,7 @@ class MentraLive : SGCManager() {
     }
 
     override fun forget() {
+        if (postGattLifecycle { forget() }) return
         Bridge.log("LIVE: Forgetting Mentra Live glasses")
 
         // Clear saved device name so a leftover name can't bypass the pairing-mode
@@ -6240,6 +6306,7 @@ class MentraLive : SGCManager() {
     }
 
     override fun disconnect() {
+        if (postGattLifecycle { disconnect() }) return
         if (unpairFlushPending) {
             Bridge.log("LIVE: disconnect deferred — waiting for unpair write")
             return
@@ -6281,6 +6348,7 @@ class MentraLive : SGCManager() {
     }
 
     fun connectToSmartGlasses() {
+        if (postGattLifecycle { connectToSmartGlasses() }) return
         if (pairingYieldActive) {
             Bridge.log("LIVE: connectToSmartGlasses blocked — pairing yield active")
             return
@@ -7412,6 +7480,8 @@ class MentraLive : SGCManager() {
     }
 
     fun destroy() {
+        if (postGattLifecycle { destroy() }) return
+        connectionRequestEpoch++
         Bridge.log("LIVE: Destroying MentraLiveSGC")
 
         // Mark as killed to prevent reconnection attempts

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycle.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycle.kt
@@ -1,0 +1,75 @@
+package com.mentra.bluetoothsdk.sgcs
+
+/**
+ * Process-wide barrier between Mentra Live GATT teardown and the next connection attempt.
+ *
+ * Android can keep the physical link alive after a disconnect request until it delivers the
+ * disconnected callback. Starting another GATT session before that callback can reuse the old link,
+ * including its already-consumed MTU exchange. Callers queue connection work here and release it
+ * only after every outstanding teardown has completed or timed out.
+ */
+internal class MentraLiveGattTeardownBarrier {
+    private val activeTeardowns = mutableSetOf<Long>()
+    private val waitingConnections = ArrayDeque<() -> Unit>()
+    private var nextToken = 1L
+
+    @Synchronized
+    fun beginTeardown(): Long {
+        val token = nextToken++
+        activeTeardowns.add(token)
+        return token
+    }
+
+    /** Returns true when [work] was deferred behind an active teardown. */
+    @Synchronized
+    fun deferUntilIdle(work: () -> Unit): Boolean {
+        if (activeTeardowns.isEmpty()) {
+            return false
+        }
+        waitingConnections.addLast(work)
+        return true
+    }
+
+    fun completeTeardown(token: Long) {
+        val ready =
+            synchronized(this) {
+                if (!activeTeardowns.remove(token) || activeTeardowns.isNotEmpty()) {
+                    return
+                }
+                buildList {
+                    while (waitingConnections.isNotEmpty()) {
+                        add(waitingConnections.removeFirst())
+                    }
+                }
+            }
+        ready.forEach { it() }
+    }
+}
+
+/** One-shot guard shared by the MTU callback and its watchdog fallback. */
+internal class MentraLiveMtuSetupGate {
+    private var nextToken = 1L
+    private var pendingToken: Long? = null
+
+    @Synchronized
+    fun begin(): Long {
+        val token = nextToken++
+        pendingToken = token
+        return token
+    }
+
+    /** Returns true exactly once for the current setup operation. */
+    @Synchronized
+    fun complete(token: Long): Boolean {
+        if (pendingToken != token) {
+            return false
+        }
+        pendingToken = null
+        return true
+    }
+
+    @Synchronized
+    fun cancel() {
+        pendingToken = null
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycle.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycle.kt
@@ -6,11 +6,12 @@ package com.mentra.bluetoothsdk.sgcs
  * Android can keep the physical link alive after a disconnect request until it delivers the
  * disconnected callback. Starting another GATT session before that callback can reuse the old link,
  * including its already-consumed MTU exchange. Callers queue connection work here and release it
- * only after every outstanding teardown has completed or timed out.
+ * only after every outstanding teardown has completed or timed out. A newer deferred connection
+ * replaces the previous one so reconnect retries cannot start multiple GATT sessions together.
  */
 internal class MentraLiveGattTeardownBarrier {
     private val activeTeardowns = mutableSetOf<Long>()
-    private val waitingConnections = ArrayDeque<() -> Unit>()
+    private var waitingConnection: (() -> Unit)? = null
     private var nextToken = 1L
 
     @Synchronized
@@ -26,7 +27,7 @@ internal class MentraLiveGattTeardownBarrier {
         if (activeTeardowns.isEmpty()) {
             return false
         }
-        waitingConnections.addLast(work)
+        waitingConnection = work
         return true
     }
 
@@ -36,13 +37,9 @@ internal class MentraLiveGattTeardownBarrier {
                 if (!activeTeardowns.remove(token) || activeTeardowns.isNotEmpty()) {
                     return
                 }
-                buildList {
-                    while (waitingConnections.isNotEmpty()) {
-                        add(waitingConnections.removeFirst())
-                    }
-                }
+                waitingConnection.also { waitingConnection = null }
             }
-        ready.forEach { it() }
+        ready?.invoke()
     }
 }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycle.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycle.kt
@@ -21,24 +21,16 @@ internal class MentraLiveGattTeardownBarrier {
         return token
     }
 
-    /** Returns true when [work] was deferred behind an active teardown. */
+    /** Admission and execution are one operation; production callers all use the main looper. */
     @Synchronized
-    fun deferUntilIdle(work: () -> Unit): Boolean {
-        if (activeTeardowns.isEmpty()) {
-            return false
-        }
-        waitingConnection = work
-        return true
+    fun runWhenIdle(work: () -> Unit) {
+        if (activeTeardowns.isEmpty()) work() else waitingConnection = work
     }
 
+    @Synchronized
     fun completeTeardown(token: Long) {
-        val ready =
-            synchronized(this) {
-                if (!activeTeardowns.remove(token) || activeTeardowns.isNotEmpty()) {
-                    return
-                }
-                waitingConnection.also { waitingConnection = null }
-            }
+        if (!activeTeardowns.remove(token) || activeTeardowns.isNotEmpty()) return
+        val ready = waitingConnection.also { waitingConnection = null }
         ready?.invoke()
     }
 }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SerializedGattCallback.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SerializedGattCallback.kt
@@ -1,0 +1,76 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+
+/**
+ * Binder callbacks only capture their arguments. Session validation and all callback effects run
+ * on the lifecycle owner, in the same queue as connect and teardown. Notification bytes must be
+ * copied before dispatch: Android reuses the mutable characteristic between notifications.
+ */
+internal abstract class SerializedGattCallback(
+    private val enqueue: (() -> Unit) -> Unit,
+    private val isCurrent: (BluetoothGatt) -> Boolean,
+) : BluetoothGattCallback() {
+    private fun dispatch(gatt: BluetoothGatt, work: () -> Unit) {
+        enqueue { if (isCurrent(gatt)) work() }
+    }
+
+    final override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) =
+        dispatch(gatt) { handleConnectionStateChange(gatt, status, newState) }
+
+    final override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) =
+        dispatch(gatt) { handleServicesDiscovered(gatt, status) }
+
+    final override fun onPhyUpdate(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int) =
+        dispatch(gatt) { handlePhyUpdate(gatt, txPhy, rxPhy, status) }
+
+    final override fun onPhyRead(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int) =
+        dispatch(gatt) { handlePhyRead(gatt, txPhy, rxPhy, status) }
+
+    final override fun onCharacteristicRead(
+        gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int,
+    ) = dispatch(gatt) { handleCharacteristicRead(gatt, characteristic, status) }
+
+    final override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) =
+        dispatch(gatt) { handleReadRemoteRssi(gatt, rssi, status) }
+
+    final override fun onCharacteristicWrite(
+        gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int,
+    ) = dispatch(gatt) { handleCharacteristicWrite(gatt, characteristic, status) }
+
+    @Suppress("DEPRECATION")
+    final override fun onCharacteristicChanged(
+        gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic,
+    ) {
+        val value = characteristic.value?.copyOf() ?: return
+        dispatch(gatt) { handleCharacteristicChanged(gatt, characteristic, value) }
+    }
+
+    final override fun onCharacteristicChanged(
+        gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray,
+    ) {
+        val snapshot = value.copyOf()
+        dispatch(gatt) { handleCharacteristicChanged(gatt, characteristic, snapshot) }
+    }
+
+    final override fun onDescriptorWrite(
+        gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int,
+    ) = dispatch(gatt) { handleDescriptorWrite(gatt, descriptor, status) }
+
+    final override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) =
+        dispatch(gatt) { handleMtuChanged(gatt, mtu, status) }
+
+    protected abstract fun handleConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int)
+    protected abstract fun handleServicesDiscovered(gatt: BluetoothGatt, status: Int)
+    protected abstract fun handlePhyUpdate(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int)
+    protected abstract fun handlePhyRead(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int)
+    protected abstract fun handleCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int)
+    protected abstract fun handleReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int)
+    protected abstract fun handleCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int)
+    protected abstract fun handleCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, data: ByteArray)
+    protected abstract fun handleDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int)
+    protected abstract fun handleMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int)
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattCallbackTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattCallbackTest.kt
@@ -1,0 +1,94 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import java.util.UUID
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class MentraLiveGattCallbackTest {
+    private fun gatt(): BluetoothGatt =
+        BluetoothAdapter.getDefaultAdapter().getRemoteDevice("AA:BB:CC:DD:EE:FF")
+            .connectGatt(RuntimeEnvironment.getApplication(), false, object : BluetoothGattCallback() {})
+
+    private class RecordingCallback(
+        enqueue: (() -> Unit) -> Unit,
+        isCurrent: (BluetoothGatt) -> Boolean = { true },
+    ) : SerializedGattCallback(enqueue, isCurrent) {
+        val events = mutableListOf<String>()
+        val packets = mutableListOf<ByteArray>()
+        override fun handleConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) { events.add("connection") }
+        override fun handleServicesDiscovered(gatt: BluetoothGatt, status: Int) { events.add("services") }
+        override fun handlePhyUpdate(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int) { events.add("phyUpdate") }
+        override fun handlePhyRead(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int) { events.add("phyRead") }
+        override fun handleCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) { events.add("read") }
+        override fun handleReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) { events.add("rssi") }
+        override fun handleCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) { events.add("write") }
+        override fun handleCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, data: ByteArray) { packets.add(data) }
+        override fun handleDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) { events.add("descriptor") }
+        override fun handleMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) { events.add("mtu") }
+    }
+
+    @Test
+    fun `all callbacks defer effects until the lifecycle owner executes them`() {
+        val queue = ArrayDeque<() -> Unit>()
+        val callback = RecordingCallback({ work -> queue.addLast(work) })
+        val gatt = gatt()
+        val characteristic = BluetoothGattCharacteristic(UUID.randomUUID(), 0, 0)
+        val descriptor = BluetoothGattDescriptor(UUID.randomUUID(), 0)
+        callback.onConnectionStateChange(gatt, 0, 2)
+        callback.onServicesDiscovered(gatt, 0)
+        callback.onPhyUpdate(gatt, 1, 1, 0)
+        callback.onPhyRead(gatt, 1, 1, 0)
+        callback.onCharacteristicRead(gatt, characteristic, 0)
+        callback.onReadRemoteRssi(gatt, -50, 0)
+        callback.onCharacteristicWrite(gatt, characteristic, 0)
+        callback.onDescriptorWrite(gatt, descriptor, 0)
+        callback.onMtuChanged(gatt, 512, 0)
+        assertEquals(emptyList<String>(), callback.events)
+        while (queue.isNotEmpty()) queue.removeFirst().invoke()
+        assertEquals(listOf("connection", "services", "phyUpdate", "phyRead", "read", "rssi", "write", "descriptor", "mtu"), callback.events)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `queued notifications retain their own bytes when Android reuses characteristic`() {
+        val queue = ArrayDeque<() -> Unit>()
+        val callback = RecordingCallback({ work -> queue.addLast(work) })
+        val gatt = gatt()
+        val characteristic = BluetoothGattCharacteristic(UUID.randomUUID(), 0, 0)
+        val buffer = byteArrayOf(1, 2)
+        characteristic.value = buffer
+        callback.onCharacteristicChanged(gatt, characteristic)
+        buffer[0] = 3
+        callback.onCharacteristicChanged(gatt, characteristic)
+        buffer[0] = 4
+        while (queue.isNotEmpty()) queue.removeFirst().invoke()
+        assertArrayEquals(byteArrayOf(1, 2), callback.packets[0])
+        assertArrayEquals(byteArrayOf(3, 2), callback.packets[1])
+    }
+
+    @Test
+    fun `replacement invalidates callbacks already waiting on the lifecycle queue`() {
+        val queue = ArrayDeque<() -> Unit>()
+        var epoch = 1
+        val callback = RecordingCallback({ work -> queue.addLast(work) }, { epoch == 1 })
+        val gatt = gatt()
+        callback.onConnectionStateChange(gatt, 0, 0)
+        callback.onServicesDiscovered(gatt, 0)
+        callback.onMtuChanged(gatt, 512, 0)
+        epoch = 2
+        while (queue.isNotEmpty()) queue.removeFirst().invoke()
+        assertEquals(emptyList<String>(), callback.events)
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycleTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycleTest.kt
@@ -37,6 +37,19 @@ class MentraLiveGattLifecycleTest {
     }
 
     @Test
+    fun `newest deferred connection replaces an older retry`() {
+        val barrier = MentraLiveGattTeardownBarrier()
+        val events = mutableListOf<String>()
+        val teardown = barrier.beginTeardown()
+
+        assertTrue(barrier.deferUntilIdle { events.add("stale reconnect") })
+        assertTrue(barrier.deferUntilIdle { events.add("current user retry") })
+        barrier.completeTeardown(teardown)
+
+        assertEquals(listOf("current user retry"), events)
+    }
+
+    @Test
     fun `timeout releases connection and late disconnect cannot release it twice`() {
         val barrier = MentraLiveGattTeardownBarrier()
         var connections = 0

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycleTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycleTest.kt
@@ -1,0 +1,74 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MentraLiveGattLifecycleTest {
+    @Test
+    fun `replacement connection waits for disconnect completion`() {
+        val barrier = MentraLiveGattTeardownBarrier()
+        val events = mutableListOf<String>()
+        val teardown = barrier.beginTeardown()
+
+        assertTrue(barrier.deferUntilIdle { events.add("connect") })
+        assertEquals(emptyList<String>(), events)
+
+        events.add("disconnect")
+        barrier.completeTeardown(teardown)
+
+        assertEquals(listOf("disconnect", "connect"), events)
+    }
+
+    @Test
+    fun `all active teardowns must finish before connections resume`() {
+        val barrier = MentraLiveGattTeardownBarrier()
+        val events = mutableListOf<String>()
+        val first = barrier.beginTeardown()
+        val second = barrier.beginTeardown()
+
+        assertTrue(barrier.deferUntilIdle { events.add("connect") })
+        barrier.completeTeardown(first)
+        assertTrue(events.isEmpty())
+
+        barrier.completeTeardown(second)
+        assertEquals(listOf("connect"), events)
+    }
+
+    @Test
+    fun `timeout releases connection and late disconnect cannot release it twice`() {
+        val barrier = MentraLiveGattTeardownBarrier()
+        var connections = 0
+        val teardown = barrier.beginTeardown()
+
+        barrier.deferUntilIdle { connections++ }
+        barrier.completeTeardown(teardown)
+        barrier.completeTeardown(teardown)
+
+        assertEquals(1, connections)
+        val connectImmediately: () -> Unit = { connections += 1 }
+        assertFalse(barrier.deferUntilIdle(connectImmediately))
+        connectImmediately()
+        assertEquals(2, connections)
+    }
+
+    @Test
+    fun `mtu callback and watchdog share one completion`() {
+        val gate = MentraLiveMtuSetupGate()
+        val setup = gate.begin()
+
+        assertTrue(gate.complete(setup))
+        assertFalse(gate.complete(setup))
+    }
+
+    @Test
+    fun `cancelled mtu setup rejects a late callback`() {
+        val gate = MentraLiveMtuSetupGate()
+        val setup = gate.begin()
+
+        gate.cancel()
+
+        assertFalse(gate.complete(setup))
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycleTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/MentraLiveGattLifecycleTest.kt
@@ -12,7 +12,7 @@ class MentraLiveGattLifecycleTest {
         val events = mutableListOf<String>()
         val teardown = barrier.beginTeardown()
 
-        assertTrue(barrier.deferUntilIdle { events.add("connect") })
+        barrier.runWhenIdle { events.add("connect") }
         assertEquals(emptyList<String>(), events)
 
         events.add("disconnect")
@@ -28,7 +28,7 @@ class MentraLiveGattLifecycleTest {
         val first = barrier.beginTeardown()
         val second = barrier.beginTeardown()
 
-        assertTrue(barrier.deferUntilIdle { events.add("connect") })
+        barrier.runWhenIdle { events.add("connect") }
         barrier.completeTeardown(first)
         assertTrue(events.isEmpty())
 
@@ -42,8 +42,8 @@ class MentraLiveGattLifecycleTest {
         val events = mutableListOf<String>()
         val teardown = barrier.beginTeardown()
 
-        assertTrue(barrier.deferUntilIdle { events.add("stale reconnect") })
-        assertTrue(barrier.deferUntilIdle { events.add("current user retry") })
+        barrier.runWhenIdle { events.add("stale reconnect") }
+        barrier.runWhenIdle { events.add("current user retry") }
         barrier.completeTeardown(teardown)
 
         assertEquals(listOf("current user retry"), events)
@@ -55,15 +55,40 @@ class MentraLiveGattLifecycleTest {
         var connections = 0
         val teardown = barrier.beginTeardown()
 
-        barrier.deferUntilIdle { connections++ }
+        barrier.runWhenIdle { connections++ }
         barrier.completeTeardown(teardown)
         barrier.completeTeardown(teardown)
 
         assertEquals(1, connections)
         val connectImmediately: () -> Unit = { connections += 1 }
-        assertFalse(barrier.deferUntilIdle(connectImmediately))
-        connectImmediately()
+        barrier.runWhenIdle(connectImmediately)
         assertEquals(2, connections)
+    }
+
+    @Test
+    fun `admitted connection runs inline before another teardown can begin`() {
+        val barrier = MentraLiveGattTeardownBarrier()
+        val events = mutableListOf<String>()
+        barrier.runWhenIdle { events.add("connect") }
+        barrier.beginTeardown()
+        events.add("teardown")
+        assertEquals(listOf("connect", "teardown"), events)
+    }
+
+    @Test
+    fun `resumed connection can open another teardown without losing newer work`() {
+        val barrier = MentraLiveGattTeardownBarrier()
+        val first = barrier.beginTeardown()
+        var next = 0L
+        val events = mutableListOf<String>()
+        barrier.runWhenIdle {
+            next = barrier.beginTeardown()
+            barrier.runWhenIdle { events.add("next") }
+        }
+        barrier.completeTeardown(first)
+        assertTrue(events.isEmpty())
+        barrier.completeTeardown(next)
+        assertEquals(listOf("next"), events)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- wait for the previous Mentra Live GATT session to report disconnected before allowing a replacement connection, with a 2-second forced-close fallback
- continue notification setup when Android accepts an MTU request but never delivers onMtuChanged
- reject non-disconnect callbacks from stale or tearing-down GATT sessions
- cover teardown ordering, timeout release, duplicate callbacks, and MTU one-shot behavior

## Test evidence

- ./scripts/check-android-compile.sh bluetooth-sdk
- ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest -PmentraPublicSdk=true --no-daemon (134 tests)
- ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.sgcs.MentraLiveGattLifecycleTest -PmentraPublicSdk=true --no-daemon (5 tests)
- git diff --check

## Validation boundary

The state-machine regression is unit-tested and the public Android SDK compiles. Hardware reproduction of the rapid reconnect sequence is still required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core BLE connect/disconnect sequencing for Mentra Live; regressions could affect pairing and reconnect reliability, though behavior is guarded by timeouts and unit tests.
> 
> **Overview**
> Fixes **rapid reconnect** races on Android Mentra Live by not starting a new GATT session until the previous one has fully torn down.
> 
> **GATT teardown** now calls `disconnect()` and waits for `STATE_DISCONNECTED` (or failure) before `close()`, with a **2s timeout** that force-closes if the callback never arrives. A shared **`MentraLiveGattTeardownBarrier`** defers `connectToDevice` until all teardowns finish; the latest deferred retry replaces older ones so multiple sessions cannot stack.
> 
> **MTU setup** uses a one-shot **`MentraLiveMtuSetupGate`** plus a **3s watchdog** so notification setup still runs when `requestMtu` succeeds but `onMtuChanged` never fires. GATT callbacks during teardown are ignored via **`isActiveGattCallback`**, and teardown mode blocks late `CONNECTED` callbacks from reviving app state.
> 
> Unit tests in **`MentraLiveGattLifecycleTest`** cover barrier ordering, retry replacement, and MTU gate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51a0d991c0f3f08f0fd4d83aa61b21e8c249d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review repair update

Rebased onto dev and replaced check-then-act protection with a serialized Android GATT lifecycle owner and connection epochs. Teardown, reconnect, and callback mutation share the owner. Local Android compile and focused GATT regression tests pass.

Remote checks are running on the updated head. Physical-device qualification remains pending; no merge, release, or install is claimed.