### PR TITLE
Fix Android Classic audio connection status

### DIFF
--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -511,9 +511,3 @@ jobs:
             echo "Both build attempts failed"
             exit 1
           fi
-
-      - name: Upload Device Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-device-build
-          path: mobile/ios/build-device/Build/Products/Release-iphoneos/Mentra.app

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
@@ -55,6 +55,14 @@ internal class ClassicAudioConnectionTracker(
     fun clear(address: String): Boolean {
         if (targetAddress != address.normalizedBluetoothAddress()) return false
 
+        clearConnectedProfiles()
+        return true
+    }
+
+    @Synchronized
+    fun invalidate(address: String): Boolean {
+        if (targetAddress != address.normalizedBluetoothAddress()) return false
+
         targetAddress = null
         clearConnectedProfiles()
         return true

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
@@ -1,5 +1,7 @@
 package com.mentra.bluetoothsdk.sgcs
 
+import android.bluetooth.BluetoothProfile
+
 internal enum class ClassicAudioProfile {
     A2DP,
     HEADSET,
@@ -76,5 +78,12 @@ internal class ClassicAudioConnectionTracker(
         }
     }
 }
+
+internal fun classicProfileConnectedState(state: Int): Boolean? =
+        when (state) {
+            BluetoothProfile.STATE_CONNECTED -> true
+            BluetoothProfile.STATE_DISCONNECTED -> false
+            else -> null
+        }
 
 private fun String.normalizedBluetoothAddress(): String = trim().uppercase()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
@@ -18,9 +18,11 @@ internal class ClassicAudioConnectionTracker(
     private var targetAddress: String? = null
     private val connectedProfiles = mutableSetOf<ClassicAudioProfile>()
 
+    @get:Synchronized
     val connected: Boolean
         get() = connectedProfiles.isNotEmpty()
 
+    @Synchronized
     fun setTarget(address: String) {
         val normalizedAddress = address.normalizedBluetoothAddress()
         if (targetAddress == normalizedAddress) return
@@ -29,6 +31,7 @@ internal class ClassicAudioConnectionTracker(
         clearConnectedProfiles()
     }
 
+    @Synchronized
     fun update(
         profile: ClassicAudioProfile,
         address: String,
@@ -46,13 +49,16 @@ internal class ClassicAudioConnectionTracker(
         return true
     }
 
+    @Synchronized
     fun clear(address: String): Boolean {
         if (targetAddress != address.normalizedBluetoothAddress()) return false
 
+        targetAddress = null
         clearConnectedProfiles()
         return true
     }
 
+    @Synchronized
     fun reset() {
         targetAddress = null
         clearConnectedProfiles()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
@@ -1,0 +1,74 @@
+package com.mentra.bluetoothsdk.sgcs
+
+internal enum class ClassicAudioProfile {
+    A2DP,
+    HEADSET,
+}
+
+/**
+ * Tracks the Android Classic audio profiles for one dual-mode glasses device.
+ *
+ * Android reports A2DP and HFP independently. Keeping both states prevents an A2DP disconnect from
+ * publishing a false negative while HFP is still connected, and scoping every update to the target
+ * address prevents late broadcasts from a previous glasses session from corrupting current state.
+ */
+internal class ClassicAudioConnectionTracker(
+    private val onConnectedChanged: (Boolean) -> Unit,
+) {
+    private var targetAddress: String? = null
+    private val connectedProfiles = mutableSetOf<ClassicAudioProfile>()
+
+    val connected: Boolean
+        get() = connectedProfiles.isNotEmpty()
+
+    fun setTarget(address: String) {
+        val normalizedAddress = address.normalizedBluetoothAddress()
+        if (targetAddress == normalizedAddress) return
+
+        targetAddress = normalizedAddress
+        clearConnectedProfiles()
+    }
+
+    fun update(
+        profile: ClassicAudioProfile,
+        address: String,
+        connected: Boolean,
+    ): Boolean {
+        if (targetAddress != address.normalizedBluetoothAddress()) return false
+
+        val wasConnected = this.connected
+        if (connected) {
+            connectedProfiles.add(profile)
+        } else {
+            connectedProfiles.remove(profile)
+        }
+        publishIfChanged(wasConnected)
+        return true
+    }
+
+    fun clear(address: String): Boolean {
+        if (targetAddress != address.normalizedBluetoothAddress()) return false
+
+        clearConnectedProfiles()
+        return true
+    }
+
+    fun reset() {
+        targetAddress = null
+        clearConnectedProfiles()
+    }
+
+    private fun clearConnectedProfiles() {
+        val wasConnected = connected
+        connectedProfiles.clear()
+        publishIfChanged(wasConnected)
+    }
+
+    private fun publishIfChanged(wasConnected: Boolean) {
+        if (wasConnected != connected) {
+            onConnectedChanged(connected)
+        }
+    }
+}
+
+private fun String.normalizedBluetoothAddress(): String = trim().uppercase()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
@@ -5,6 +5,12 @@ internal enum class ClassicAudioProfile {
     HEADSET,
 }
 
+/** A confirmed connection is sufficient; declaring disconnection requires both profile reads. */
+internal fun readyClassicAudioSnapshot(states: Map<ClassicAudioProfile, Boolean>): Set<ClassicAudioProfile>? {
+    val connected = states.filterValues { it }.keys
+    return if (connected.isNotEmpty() || states.size == ClassicAudioProfile.entries.size) connected else null
+}
+
 /**
  * Tracks the Android Classic audio profiles for one dual-mode glasses device.
  *

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTracker.kt
@@ -1,7 +1,5 @@
 package com.mentra.bluetoothsdk.sgcs
 
-import android.bluetooth.BluetoothProfile
-
 internal enum class ClassicAudioProfile {
     A2DP,
     HEADSET,
@@ -11,13 +9,14 @@ internal enum class ClassicAudioProfile {
  * Tracks the Android Classic audio profiles for one dual-mode glasses device.
  *
  * Android reports A2DP and HFP independently. Keeping both states prevents an A2DP disconnect from
- * publishing a false negative while HFP is still connected, and scoping every update to the target
- * address prevents late broadcasts from a previous glasses session from corrupting current state.
+ * publishing a false negative while HFP is still connected. Snapshot tickets reject obsolete
+ * queries, including a previous session with the same MAC address. Broadcast payloads are not truth.
  */
 internal class ClassicAudioConnectionTracker(
     private val onConnectedChanged: (Boolean) -> Unit,
 ) {
     private var targetAddress: String? = null
+    private var revision = 0L
     private val connectedProfiles = mutableSetOf<ClassicAudioProfile>()
 
     @get:Synchronized
@@ -27,6 +26,7 @@ internal class ClassicAudioConnectionTracker(
     @Synchronized
     fun setTarget(address: String) {
         val normalizedAddress = address.normalizedBluetoothAddress()
+        revision++
         if (targetAddress == normalizedAddress) return
 
         targetAddress = normalizedAddress
@@ -34,27 +34,33 @@ internal class ClassicAudioConnectionTracker(
     }
 
     @Synchronized
-    fun update(
-        profile: ClassicAudioProfile,
-        address: String,
-        connected: Boolean,
-    ): Boolean {
-        if (targetAddress != address.normalizedBluetoothAddress()) return false
+    fun beginSnapshot(address: String): Long? {
+        if (targetAddress != address.normalizedBluetoothAddress()) return null
+        return ++revision
+    }
 
+    /** Both profile queries must belong to the newest request for this session. */
+    @Synchronized
+    fun applySnapshot(
+        ticket: Long,
+        address: String,
+        profiles: Set<ClassicAudioProfile>,
+        onAccepted: () -> Unit = {},
+    ): Boolean {
+        if (ticket != revision || targetAddress != address.normalizedBluetoothAddress()) return false
         val wasConnected = this.connected
-        if (connected) {
-            connectedProfiles.add(profile)
-        } else {
-            connectedProfiles.remove(profile)
-        }
+        connectedProfiles.clear()
+        connectedProfiles.addAll(profiles)
         publishIfChanged(wasConnected)
+        // Audio routing notifications must not race a target invalidation after validation.
+        onAccepted()
         return true
     }
 
     @Synchronized
     fun clear(address: String): Boolean {
         if (targetAddress != address.normalizedBluetoothAddress()) return false
-
+        revision++
         clearConnectedProfiles()
         return true
     }
@@ -64,6 +70,7 @@ internal class ClassicAudioConnectionTracker(
         if (targetAddress != address.normalizedBluetoothAddress()) return false
 
         targetAddress = null
+        revision++
         clearConnectedProfiles()
         return true
     }
@@ -71,6 +78,7 @@ internal class ClassicAudioConnectionTracker(
     @Synchronized
     fun reset() {
         targetAddress = null
+        revision++
         clearConnectedProfiles()
     }
 
@@ -86,12 +94,5 @@ internal class ClassicAudioConnectionTracker(
         }
     }
 }
-
-internal fun classicProfileConnectedState(state: Int): Boolean? =
-        when (state) {
-            BluetoothProfile.STATE_CONNECTED -> true
-            BluetoothProfile.STATE_DISCONNECTED -> false
-            else -> null
-        }
 
 private fun String.normalizedBluetoothAddress(): String = trim().uppercase()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -7303,10 +7303,10 @@ class MentraLive : SGCManager() {
                         device.address +
                         ")"
         )
-        val isActiveDevice =
-                connectedDevice?.address?.equals(device.address, ignoreCase = true) == true
-        if (isActiveDevice) {
-            classicAudioConnectionTracker.clear(device.address)
+        // The BLE device reference may already be cleared after a GATT drop. The tracker owns the
+        // authoritative target address, so let it decide whether this teardown belongs to the
+        // active Classic session instead of consulting connectedDevice.
+        if (classicAudioConnectionTracker.clear(device.address)) {
             audioConnected = false
         }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -6917,7 +6917,19 @@ class MentraLive : SGCManager() {
     ) {
         if (isKilled) return
 
-        val connected = state == BluetoothProfile.STATE_CONNECTED
+        val connected = classicProfileConnectedState(state)
+        if (connected == null) {
+            Bridge.log(
+                    "LIVE: Classic: ignoring transitional " +
+                            profile.name +
+                            " state=" +
+                            state +
+                            " (" +
+                            source +
+                            ")"
+            )
+            return
+        }
         if (!classicAudioConnectionTracker.update(profile, device.address, connected)) {
             Bridge.log(
                     "LIVE: Classic: ignoring stale " +

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -591,9 +591,14 @@ class MentraLive : SGCManager() {
 
     // CTKD (Cross-Transport Key Derivation) support for BES devices
     private var isBondingReceiverRegistered = false
-    private var isBtClassicConnected = false
     private var bondingReceiver: BroadcastReceiver? = null
     private var bondingRetryCount = 0
+    private var classicAudioReceiver: BroadcastReceiver? = null
+    private var isClassicAudioReceiverRegistered = false
+    private val classicAudioConnectionTracker =
+            ClassicAudioConnectionTracker { connected ->
+                DeviceStore.apply("glasses", "bluetoothClassicConnected", connected)
+            }
 
     // Pairing timing diagnostics (filter logcat: PAIRING_TIMING)
     private var pairingTimingActive = false
@@ -992,6 +997,8 @@ class MentraLive : SGCManager() {
 
         // Initialize CTKD bonding receiver
         initializeBondingReceiver()
+        initializeClassicAudioReceiver()
+        registerClassicAudioReceiver()
 
         // Initialize the send queue processor
         processSendQueueRunnable = Runnable {
@@ -2119,6 +2126,8 @@ class MentraLive : SGCManager() {
                             isConnecting = false
                             isConnected = true
                             connectedDevice = gatt.device
+                            classicAudioConnectionTracker.setTarget(gatt.device.address)
+                            refreshHeadsetConnectionState(gatt.device)
                             emitConnectedPendingDeviceForPairingScan()
 
                             DeviceStore.apply("glasses", "bluetoothName", connectedDevice!!.name)
@@ -6741,7 +6750,7 @@ class MentraLive : SGCManager() {
                                                 "ctkd_bond_none",
                                                 "prev=$previousBondState queueSize=${sendQueue.size}"
                                         )
-                                        isBtClassicConnected = false
+                                        classicAudioConnectionTracker.clear(device.address)
                                         audioConnected = false
                                         if (previousBondState == BluetoothDevice.BOND_BONDING) {
                                             // User cancelled or bonding failed - retry up to
@@ -6841,6 +6850,152 @@ class MentraLive : SGCManager() {
         }
     }
 
+    /** Observe the two Android Classic audio profiles that Mentra Live exposes. */
+    private fun initializeClassicAudioReceiver() {
+        classicAudioReceiver =
+                object : BroadcastReceiver() {
+                    override fun onReceive(context: Context?, intent: Intent?) {
+                        val profile =
+                                when (intent?.action) {
+                                    BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED ->
+                                            ClassicAudioProfile.A2DP
+                                    BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED ->
+                                            ClassicAudioProfile.HEADSET
+                                    else -> return
+                                }
+                        val device = intent.bluetoothDeviceExtra() ?: return
+                        val state =
+                                intent.getIntExtra(
+                                        BluetoothProfile.EXTRA_STATE,
+                                        BluetoothProfile.STATE_DISCONNECTED
+                                )
+                        handleClassicAudioProfileState(profile, device, state, "broadcast")
+                    }
+                }
+    }
+
+    private fun registerClassicAudioReceiver() {
+        val ctx = context ?: return
+        val receiver = classicAudioReceiver ?: return
+        if (isClassicAudioReceiverRegistered) return
+
+        try {
+            val filter =
+                    IntentFilter().apply {
+                        addAction(BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED)
+                        addAction(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED)
+                    }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                ctx.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+            } else {
+                ctx.registerReceiver(receiver, filter)
+            }
+            isClassicAudioReceiverRegistered = true
+            Bridge.log("LIVE: Classic: A2DP/HFP status receiver registered")
+        } catch (e: Exception) {
+            Bridge.log("LIVE: Classic: failed to register status receiver: " + e.message)
+        }
+    }
+
+    private fun unregisterClassicAudioReceiver() {
+        if (!isClassicAudioReceiverRegistered || classicAudioReceiver == null) return
+
+        try {
+            context?.unregisterReceiver(classicAudioReceiver)
+        } catch (e: Exception) {
+            Bridge.log("LIVE: Classic: failed to unregister status receiver: " + e.message)
+        } finally {
+            isClassicAudioReceiverRegistered = false
+        }
+    }
+
+    private fun handleClassicAudioProfileState(
+            profile: ClassicAudioProfile,
+            device: BluetoothDevice,
+            state: Int,
+            source: String
+    ) {
+        if (isKilled) return
+
+        val connected = state == BluetoothProfile.STATE_CONNECTED
+        if (!classicAudioConnectionTracker.update(profile, device.address, connected)) {
+            Bridge.log(
+                    "LIVE: Classic: ignoring stale " +
+                            profile.name +
+                            " state=" +
+                            state +
+                            " for " +
+                            device.address +
+                            " (" +
+                            source +
+                            ")"
+            )
+            return
+        }
+
+        Bridge.log(
+                "LIVE: Classic: " +
+                        profile.name +
+                        " state=" +
+                        state +
+                        " connected=" +
+                        classicAudioConnectionTracker.connected +
+                        " (" +
+                        source +
+                        ")"
+        )
+        if (profile != ClassicAudioProfile.A2DP) return
+
+        if (connected) {
+            markAudioConnected(device)
+        } else if (audioConnected) {
+            audioConnected = false
+            Bridge.sendAudioDisconnected()
+        }
+    }
+
+    /** Snapshot HFP because it may already be connected before this SGC registers its receiver. */
+    private fun refreshHeadsetConnectionState(device: BluetoothDevice) {
+        val adapter = bluetoothAdapter ?: return
+        val ctx = context ?: return
+        try {
+            adapter.getProfileProxy(
+                    ctx,
+                    object : BluetoothProfile.ServiceListener {
+                        override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
+                            if (profile != BluetoothProfile.HEADSET) return
+                            try {
+                                handleClassicAudioProfileState(
+                                        ClassicAudioProfile.HEADSET,
+                                        device,
+                                        proxy.getConnectionState(device),
+                                        "snapshot"
+                                )
+                            } finally {
+                                try {
+                                    adapter.closeProfileProxy(BluetoothProfile.HEADSET, proxy)
+                                } catch (_: Exception) {
+                                }
+                            }
+                        }
+
+                        override fun onServiceDisconnected(profile: Int) {}
+                    },
+                    BluetoothProfile.HEADSET
+            )
+        } catch (e: Exception) {
+            Bridge.log("LIVE: Classic: failed to snapshot HFP state: " + e.message)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun Intent.bluetoothDeviceExtra(): BluetoothDevice? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+            } else {
+                getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+            }
+
     /**
      * Start CTKD Classic bonding / A2DP only after BLE notifications are ready. Calling this from
      * onConnectionStateChange(CONNECTED) races dual-mode stacks and frequently yields GATT 19
@@ -6917,7 +7072,7 @@ class MentraLive : SGCManager() {
             val method = device.javaClass.getMethod("removeBond")
             val result = method.invoke(device) as Boolean
             Bridge.log("LIVE: CTKD: Bond removal initiated, result: " + result)
-            isBtClassicConnected = false
+            classicAudioConnectionTracker.clear(device.address)
             return result
         } catch (e: Exception) {
             Bridge.log("LIVE: CTKD: Error removing bond: " + e.message)
@@ -6927,7 +7082,7 @@ class MentraLive : SGCManager() {
 
     /** Check if BT Classic is connected via CTKD */
     fun isBtClassicConnected(): Boolean {
-        return isBtClassicConnected
+        return classicAudioConnectionTracker.connected
     }
 
     /** A2DP profile service listener for connecting to already-bonded devices */
@@ -6986,11 +7141,16 @@ class MentraLive : SGCManager() {
         try {
             val state = a2dpProfile!!.getConnectionState(device)
             Bridge.log("LIVE: A2DP: Current connection state: " + state)
+            handleClassicAudioProfileState(
+                    ClassicAudioProfile.A2DP,
+                    device,
+                    state,
+                    "snapshot"
+            )
 
             if (state == BluetoothProfile.STATE_CONNECTED) {
                 Bridge.log("LIVE: A2DP: Already connected to " + device.name)
                 a2dpConnectAttempts = 0
-                markAudioConnected(device.name)
             } else if (state == BluetoothProfile.STATE_DISCONNECTED) {
                 Bridge.log("LIVE: A2DP: Connecting to " + device.name)
                 // Use reflection to call connect() as it's a hidden API
@@ -7043,16 +7203,24 @@ class MentraLive : SGCManager() {
     }
 
     /** Helper to mark audio as connected and notify */
-    private fun markAudioConnected(deviceName: String?) {
+    private fun markAudioConnected(device: BluetoothDevice) {
         if (isKilled) {
             Bridge.log(
                     "LIVE: A2DP: Ignoring markAudioConnected — SGC destroyed (would confuse DeviceManager)"
             )
             return
         }
-        isBtClassicConnected = true
+        classicAudioConnectionTracker.setTarget(device.address)
+        classicAudioConnectionTracker.update(
+                ClassicAudioProfile.A2DP,
+                device.address,
+                connected = true
+        )
+        val wasAudioConnected = audioConnected
         audioConnected = true
-        Bridge.sendAudioConnected(deviceName!!)
+        if (!wasAudioConnected) {
+            Bridge.sendAudioConnected(safeDeviceName(device))
+        }
         if (glassesReadyReceived) {
             Bridge.log(
                     "LIVE: A2DP: Both audio and glasses_ready confirmed - marking as fully connected"
@@ -7138,7 +7306,7 @@ class MentraLive : SGCManager() {
         val isActiveDevice =
                 connectedDevice?.address?.equals(device.address, ignoreCase = true) == true
         if (isActiveDevice) {
-            isBtClassicConnected = false
+            classicAudioConnectionTracker.clear(device.address)
             audioConnected = false
         }
 
@@ -7268,12 +7436,15 @@ class MentraLive : SGCManager() {
 
         // CTKD Implementation: Unregister bonding receiver
         unregisterBondingReceiver()
+        unregisterClassicAudioReceiver()
 
         // Tear down Classic (A2DP/HFP) before GATT close. Closing only the proxy left the
         // phone's system Bluetooth UI showing Mentra Live still connected.
         val classicDevice = connectedDevice
         disconnectClassicProfiles(classicDevice)
         closeA2dpProxy()
+        classicAudioConnectionTracker.reset()
+        DeviceStore.apply("glasses", "bluetoothClassicConnected", false)
 
         // Stop readiness check loop
         stopReadinessCheckLoop()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -7084,7 +7084,7 @@ class MentraLive : SGCManager() {
             val method = device.javaClass.getMethod("removeBond")
             val result = method.invoke(device) as Boolean
             Bridge.log("LIVE: CTKD: Bond removal initiated, result: " + result)
-            classicAudioConnectionTracker.clear(device.address)
+            classicAudioConnectionTracker.invalidate(device.address)
             return result
         } catch (e: Exception) {
             Bridge.log("LIVE: CTKD: Error removing bond: " + e.message)
@@ -7318,7 +7318,7 @@ class MentraLive : SGCManager() {
         // The BLE device reference may already be cleared after a GATT drop. The tracker owns the
         // authoritative target address, so let it decide whether this teardown belongs to the
         // active Classic session instead of consulting connectedDevice.
-        if (classicAudioConnectionTracker.clear(device.address)) {
+        if (classicAudioConnectionTracker.invalidate(device.address)) {
             audioConnected = false
         }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -2127,7 +2127,7 @@ class MentraLive : SGCManager() {
                             isConnected = true
                             connectedDevice = gatt.device
                             classicAudioConnectionTracker.setTarget(gatt.device.address)
-                            refreshHeadsetConnectionState(gatt.device)
+                            refreshClassicAudioConnectionState(gatt.device)
                             emitConnectedPendingDeviceForPairingScan()
 
                             DeviceStore.apply("glasses", "bluetoothName", connectedDevice!!.name)
@@ -6864,21 +6864,10 @@ class MentraLive : SGCManager() {
         classicAudioReceiver =
                 object : BroadcastReceiver() {
                     override fun onReceive(context: Context?, intent: Intent?) {
-                        val profile =
-                                when (intent?.action) {
-                                    BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED ->
-                                            ClassicAudioProfile.A2DP
-                                    BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED ->
-                                            ClassicAudioProfile.HEADSET
-                                    else -> return
-                                }
+                        if (intent?.action != BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED &&
+                                intent?.action != BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED) return
                         val device = intent.bluetoothDeviceExtra() ?: return
-                        val state =
-                                intent.getIntExtra(
-                                        BluetoothProfile.EXTRA_STATE,
-                                        BluetoothProfile.STATE_DISCONNECTED
-                                )
-                        handleClassicAudioProfileState(profile, device, state, "broadcast")
+                        refreshClassicAudioConnectionState(device)
                     }
                 }
     }
@@ -6918,94 +6907,57 @@ class MentraLive : SGCManager() {
         }
     }
 
-    private fun handleClassicAudioProfileState(
-            profile: ClassicAudioProfile,
-            device: BluetoothDevice,
-            state: Int,
-            source: String
-    ) {
+    /**
+     * Broadcast payloads are hints, never current truth (even when the MAC matches). Query both
+     * profiles and publish one combined snapshot. A newer refresh or teardown invalidates all
+     * outstanding results, including a previous connection to the same physical glasses.
+     */
+    private fun refreshClassicAudioConnectionState(device: BluetoothDevice) {
+        if (Looper.myLooper() != handler.looper) {
+            handler.post { refreshClassicAudioConnectionState(device) }
+            return
+        }
         if (isKilled) return
-
-        val connected = classicProfileConnectedState(state)
-        if (connected == null) {
-            Bridge.log(
-                    "LIVE: Classic: ignoring transitional " +
-                            profile.name +
-                            " state=" +
-                            state +
-                            " (" +
-                            source +
-                            ")"
-            )
-            return
-        }
-        if (!classicAudioConnectionTracker.update(profile, device.address, connected)) {
-            Bridge.log(
-                    "LIVE: Classic: ignoring stale " +
-                            profile.name +
-                            " state=" +
-                            state +
-                            " for " +
-                            device.address +
-                            " (" +
-                            source +
-                            ")"
-            )
-            return
-        }
-
-        Bridge.log(
-                "LIVE: Classic: " +
-                        profile.name +
-                        " state=" +
-                        state +
-                        " connected=" +
-                        classicAudioConnectionTracker.connected +
-                        " (" +
-                        source +
-                        ")"
-        )
-        if (profile != ClassicAudioProfile.A2DP) return
-
-        if (connected) {
-            markAudioConnected(device)
-        } else if (audioConnected) {
-            audioConnected = false
-            Bridge.sendAudioDisconnected()
-        }
-    }
-
-    /** Snapshot HFP because it may already be connected before this SGC registers its receiver. */
-    private fun refreshHeadsetConnectionState(device: BluetoothDevice) {
         val adapter = bluetoothAdapter ?: return
         val ctx = context ?: return
-        try {
-            adapter.getProfileProxy(
-                    ctx,
-                    object : BluetoothProfile.ServiceListener {
-                        override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
-                            if (profile != BluetoothProfile.HEADSET) return
+        val ticket = classicAudioConnectionTracker.beginSnapshot(device.address) ?: return
+        val states = mutableMapOf<ClassicAudioProfile, Boolean>()
+        for ((profileId, audioProfile) in listOf(
+            BluetoothProfile.A2DP to ClassicAudioProfile.A2DP,
+            BluetoothProfile.HEADSET to ClassicAudioProfile.HEADSET,
+        )) {
+            try {
+                adapter.getProfileProxy(ctx, object : BluetoothProfile.ServiceListener {
+                    override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
+                        handler.post {
                             try {
-                                handleClassicAudioProfileState(
-                                        ClassicAudioProfile.HEADSET,
-                                        device,
-                                        proxy.getConnectionState(device),
-                                        "snapshot"
-                                )
-                            } finally {
-                                try {
-                                    adapter.closeProfileProxy(BluetoothProfile.HEADSET, proxy)
-                                } catch (_: Exception) {
+                                if (isKilled || profile != profileId) return@post
+                                states[audioProfile] =
+                                    proxy.getConnectionState(device) == BluetoothProfile.STATE_CONNECTED
+                                if (states.size != 2) return@post
+                                val connected = states.filterValues { it }.keys
+                                classicAudioConnectionTracker.applySnapshot(
+                                        ticket, device.address, connected) {
+                                    if (ClassicAudioProfile.A2DP in connected) {
+                                        markAudioConnected(device)
+                                    } else if (audioConnected) {
+                                        audioConnected = false
+                                        Bridge.sendAudioDisconnected()
+                                    }
                                 }
+                            } catch (e: Exception) {
+                                Bridge.log("LIVE: Classic: snapshot unavailable: " + e.message)
+                            } finally {
+                                try { adapter.closeProfileProxy(profileId, proxy) }
+                                catch (_: Exception) {}
                             }
                         }
-
-                        override fun onServiceDisconnected(profile: Int) {}
-                    },
-                    BluetoothProfile.HEADSET
-            )
-        } catch (e: Exception) {
-            Bridge.log("LIVE: Classic: failed to snapshot HFP state: " + e.message)
+                    }
+                    override fun onServiceDisconnected(profile: Int) {}
+                }, profileId)
+            } catch (e: Exception) {
+                Bridge.log("LIVE: Classic: profile query unavailable: " + e.message)
+            }
         }
     }
 
@@ -7162,12 +7114,7 @@ class MentraLive : SGCManager() {
         try {
             val state = a2dpProfile!!.getConnectionState(device)
             Bridge.log("LIVE: A2DP: Current connection state: " + state)
-            handleClassicAudioProfileState(
-                    ClassicAudioProfile.A2DP,
-                    device,
-                    state,
-                    "snapshot"
-            )
+            refreshClassicAudioConnectionState(device)
 
             if (state == BluetoothProfile.STATE_CONNECTED) {
                 Bridge.log("LIVE: A2DP: Already connected to " + device.name)
@@ -7231,12 +7178,6 @@ class MentraLive : SGCManager() {
             )
             return
         }
-        classicAudioConnectionTracker.setTarget(device.address)
-        classicAudioConnectionTracker.update(
-                ClassicAudioProfile.A2DP,
-                device.address,
-                connected = true
-        )
         val wasAudioConnected = audioConnected
         audioConnected = true
         if (!wasAudioConnected) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -6927,34 +6927,42 @@ class MentraLive : SGCManager() {
             BluetoothProfile.HEADSET to ClassicAudioProfile.HEADSET,
         )) {
             try {
-                adapter.getProfileProxy(ctx, object : BluetoothProfile.ServiceListener {
+                val requested = adapter.getProfileProxy(ctx, object : BluetoothProfile.ServiceListener {
                     override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
+                        // Close before dispatch: destroy() may discard queued handler work.
+                        val connectedState = try {
+                            if (profile != profileId) null
+                            else proxy.getConnectionState(device) == BluetoothProfile.STATE_CONNECTED
+                        } catch (e: Exception) {
+                            Bridge.log("LIVE: Classic: snapshot unavailable: " + e.message)
+                            null
+                        } finally {
+                            try { adapter.closeProfileProxy(profileId, proxy) }
+                            catch (_: Exception) {}
+                        }
+                        if (connectedState == null) return
                         handler.post {
-                            try {
                                 if (isKilled || profile != profileId) return@post
-                                states[audioProfile] =
-                                    proxy.getConnectionState(device) == BluetoothProfile.STATE_CONNECTED
-                                if (states.size != 2) return@post
-                                val connected = states.filterValues { it }.keys
+                                states[audioProfile] = connectedState
+                                val connected = readyClassicAudioSnapshot(states) ?: return@post
                                 classicAudioConnectionTracker.applySnapshot(
                                         ticket, device.address, connected) {
                                     if (ClassicAudioProfile.A2DP in connected) {
                                         markAudioConnected(device)
-                                    } else if (audioConnected) {
+                                    } else if (states[ClassicAudioProfile.A2DP] == false && audioConnected) {
                                         audioConnected = false
                                         Bridge.sendAudioDisconnected()
                                     }
                                 }
-                            } catch (e: Exception) {
-                                Bridge.log("LIVE: Classic: snapshot unavailable: " + e.message)
-                            } finally {
-                                try { adapter.closeProfileProxy(profileId, proxy) }
-                                catch (_: Exception) {}
-                            }
                         }
                     }
                     override fun onServiceDisconnected(profile: Int) {}
                 }, profileId)
+                if (!requested) {
+                    // Unknown is not disconnected. A successful other-profile read can still
+                    // publish connected without waiting for this unavailable service.
+                    Bridge.log("LIVE: Classic: profile service unavailable: $profileId")
+                }
             } catch (e: Exception) {
                 Bridge.log("LIVE: Classic: profile query unavailable: " + e.message)
             }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -6750,7 +6750,16 @@ class MentraLive : SGCManager() {
                                                 "ctkd_bond_none",
                                                 "prev=$previousBondState queueSize=${sendQueue.size}"
                                         )
-                                        classicAudioConnectionTracker.clear(device.address)
+                                        if (previousBondState == BluetoothDevice.BOND_BONDED) {
+                                            // A real unpair ends this Classic session. Invalidate
+                                            // the target so delayed profile broadcasts cannot
+                                            // make pairing look connected again.
+                                            classicAudioConnectionTracker.invalidate(device.address)
+                                        } else {
+                                            // A failed/cancelled bond may be retried below, so keep
+                                            // the target while clearing any partial profile state.
+                                            classicAudioConnectionTracker.clear(device.address)
+                                        }
                                         audioConnected = false
                                         if (previousBondState == BluetoothDevice.BOND_BONDING) {
                                             // User cancelled or bonding failed - retry up to

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/GlassesStatusClassicAudioTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/GlassesStatusClassicAudioTest.kt
@@ -1,0 +1,14 @@
+package com.mentra.bluetoothsdk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class GlassesStatusClassicAudioTest {
+    @Test
+    fun `serializes connected Classic audio state for React Native`() {
+        val serialized =
+                GlassesStatus.fromMap(mapOf("bluetoothClassicConnected" to true)).toMap()
+
+        assertThat(serialized["bluetoothClassicConnected"]).isEqualTo(true)
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -1,9 +1,24 @@
 package com.mentra.bluetoothsdk.sgcs
 
+import java.lang.reflect.Modifier
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ClassicAudioConnectionTrackerTest {
+    @Test
+    fun `serializes every public state access`() {
+        val synchronizedMethods = setOf("getConnected", "setTarget", "update", "clear", "reset")
+
+        val methods =
+                ClassicAudioConnectionTracker::class.java.declaredMethods.associateBy { it.name }
+
+        synchronizedMethods.forEach { name ->
+            assertThat(Modifier.isSynchronized(methods.getValue(name).modifiers))
+                    .describedAs("%s must synchronize tracker state", name)
+                    .isTrue()
+        }
+    }
+
     @Test
     fun `publishes A2DP connect and disconnect transitions`() {
         val changes = mutableListOf<Boolean>()
@@ -85,6 +100,26 @@ class ClassicAudioConnectionTrackerTest {
         tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
 
         assertThat(tracker.clear("AA:BB:CC:DD:EE:FF")).isTrue()
+        assertThat(changes).containsExactly(true, false)
+        assertThat(tracker.connected).isFalse()
+    }
+
+    @Test
+    fun `target teardown rejects delayed callbacks from the cleared session`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
+
+        assertThat(tracker.clear("AA:BB:CC:DD:EE:FF")).isTrue()
+        val accepted =
+                tracker.update(
+                        ClassicAudioProfile.HEADSET,
+                        "AA:BB:CC:DD:EE:FF",
+                        connected = true
+                )
+
+        assertThat(accepted).isFalse()
         assertThat(changes).containsExactly(true, false)
         assertThat(tracker.connected).isFalse()
     }

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -16,7 +16,8 @@ class ClassicAudioConnectionTrackerTest {
 
     @Test
     fun `serializes every public state access`() {
-        val synchronizedMethods = setOf("getConnected", "setTarget", "update", "clear", "reset")
+        val synchronizedMethods =
+                setOf("getConnected", "setTarget", "update", "clear", "invalidate", "reset")
 
         val methods =
                 ClassicAudioConnectionTracker::class.java.declaredMethods.associateBy { it.name }
@@ -114,13 +115,34 @@ class ClassicAudioConnectionTrackerTest {
     }
 
     @Test
-    fun `target teardown rejects delayed callbacks from the cleared session`() {
+    fun `profile reset retains target for a reconnect`() {
         val changes = mutableListOf<Boolean>()
         val tracker = ClassicAudioConnectionTracker(changes::add)
         tracker.setTarget("AA:BB:CC:DD:EE:FF")
         tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
 
         assertThat(tracker.clear("AA:BB:CC:DD:EE:FF")).isTrue()
+        assertThat(
+                        tracker.update(
+                                ClassicAudioProfile.HEADSET,
+                                "AA:BB:CC:DD:EE:FF",
+                                connected = true
+                        )
+                )
+                .isTrue()
+
+        assertThat(changes).containsExactly(true, false, true)
+        assertThat(tracker.connected).isTrue()
+    }
+
+    @Test
+    fun `target teardown rejects delayed callbacks from the invalidated session`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
+
+        assertThat(tracker.invalidate("AA:BB:CC:DD:EE:FF")).isTrue()
         val accepted =
                 tracker.update(
                         ClassicAudioProfile.HEADSET,

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -1,10 +1,19 @@
 package com.mentra.bluetoothsdk.sgcs
 
+import android.bluetooth.BluetoothProfile
 import java.lang.reflect.Modifier
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ClassicAudioConnectionTrackerTest {
+    @Test
+    fun `maps only terminal Android profile states`() {
+        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_CONNECTED)).isTrue()
+        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_DISCONNECTED)).isFalse()
+        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_CONNECTING)).isNull()
+        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_DISCONNECTING)).isNull()
+    }
+
     @Test
     fun `serializes every public state access`() {
         val synchronizedMethods = setOf("getConnected", "setTarget", "update", "clear", "reset")

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -76,4 +76,16 @@ class ClassicAudioConnectionTrackerTest {
         assertThat(changes).containsExactly(true, false)
         assertThat(tracker.connected).isFalse()
     }
+
+    @Test
+    fun `target teardown clears profiles without an external device reference`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
+
+        assertThat(tracker.clear("AA:BB:CC:DD:EE:FF")).isTrue()
+        assertThat(changes).containsExactly(true, false)
+        assertThat(tracker.connected).isFalse()
+    }
 }

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -1,0 +1,79 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ClassicAudioConnectionTrackerTest {
+    @Test
+    fun `publishes A2DP connect and disconnect transitions`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+
+        assertThat(
+                tracker.update(
+                        ClassicAudioProfile.A2DP,
+                        "aa:bb:cc:dd:ee:ff",
+                        connected = true
+                )
+        ).isTrue()
+        tracker.update(
+                ClassicAudioProfile.A2DP,
+                "AA:BB:CC:DD:EE:FF",
+                connected = false
+        )
+
+        assertThat(changes).containsExactly(true, false)
+        assertThat(tracker.connected).isFalse()
+    }
+
+    @Test
+    fun `stays connected while either A2DP or HFP is connected`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+
+        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
+        tracker.update(ClassicAudioProfile.HEADSET, "AA:BB:CC:DD:EE:FF", connected = true)
+        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = false)
+
+        assertThat(changes).containsExactly(true)
+        assertThat(tracker.connected).isTrue()
+
+        tracker.update(ClassicAudioProfile.HEADSET, "AA:BB:CC:DD:EE:FF", connected = false)
+        assertThat(changes).containsExactly(true, false)
+    }
+
+    @Test
+    fun `ignores late callbacks from a previous device`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
+
+        tracker.setTarget("11:22:33:44:55:66")
+        val accepted =
+                tracker.update(
+                        ClassicAudioProfile.A2DP,
+                        "AA:BB:CC:DD:EE:FF",
+                        connected = true
+                )
+
+        assertThat(accepted).isFalse()
+        assertThat(changes).containsExactly(true, false)
+        assertThat(tracker.connected).isFalse()
+    }
+
+    @Test
+    fun `reset clears a connected profile`() {
+        val changes = mutableListOf<Boolean>()
+        val tracker = ClassicAudioConnectionTracker(changes::add)
+        tracker.setTarget("AA:BB:CC:DD:EE:FF")
+        tracker.update(ClassicAudioProfile.HEADSET, "AA:BB:CC:DD:EE:FF", connected = true)
+
+        tracker.reset()
+
+        assertThat(changes).containsExactly(true, false)
+        assertThat(tracker.connected).isFalse()
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -4,6 +4,21 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ClassicAudioConnectionTrackerTest {
+    @Test
+    fun `available connected profile is sufficient even if the other query fails or never answers`() {
+        assertThat(readyClassicAudioSnapshot(mapOf(ClassicAudioProfile.A2DP to true)))
+            .containsExactly(ClassicAudioProfile.A2DP)
+        assertThat(readyClassicAudioSnapshot(mapOf(ClassicAudioProfile.HEADSET to true)))
+            .containsExactly(ClassicAudioProfile.HEADSET)
+    }
+
+    @Test
+    fun `missing profile never fabricates a disconnect during a profile switch`() {
+        assertThat(readyClassicAudioSnapshot(mapOf(ClassicAudioProfile.A2DP to false))).isNull()
+        assertThat(readyClassicAudioSnapshot(mapOf(ClassicAudioProfile.A2DP to false,
+            ClassicAudioProfile.HEADSET to false))).isEmpty()
+    }
+
     private val address = "AA:BB:CC:DD:EE:FF"
 
     private fun snapshot(tracker: ClassicAudioConnectionTracker, vararg profiles: ClassicAudioProfile) {

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/ClassicAudioConnectionTrackerTest.kt
@@ -1,157 +1,116 @@
 package com.mentra.bluetoothsdk.sgcs
 
-import android.bluetooth.BluetoothProfile
-import java.lang.reflect.Modifier
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ClassicAudioConnectionTrackerTest {
-    @Test
-    fun `maps only terminal Android profile states`() {
-        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_CONNECTED)).isTrue()
-        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_DISCONNECTED)).isFalse()
-        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_CONNECTING)).isNull()
-        assertThat(classicProfileConnectedState(BluetoothProfile.STATE_DISCONNECTING)).isNull()
+    private val address = "AA:BB:CC:DD:EE:FF"
+
+    private fun snapshot(tracker: ClassicAudioConnectionTracker, vararg profiles: ClassicAudioProfile) {
+        val ticket = tracker.beginSnapshot(address)!!
+        assertThat(tracker.applySnapshot(ticket, address, profiles.toSet())).isTrue()
     }
 
     @Test
-    fun `serializes every public state access`() {
-        val synchronizedMethods =
-                setOf("getConnected", "setTarget", "update", "clear", "invalidate", "reset")
-
-        val methods =
-                ClassicAudioConnectionTracker::class.java.declaredMethods.associateBy { it.name }
-
-        synchronizedMethods.forEach { name ->
-            assertThat(Modifier.isSynchronized(methods.getValue(name).modifiers))
-                    .describedAs("%s must synchronize tracker state", name)
-                    .isTrue()
-        }
-    }
-
-    @Test
-    fun `publishes A2DP connect and disconnect transitions`() {
+    fun `publishes complete A2DP and HFP snapshots without intermediate false negative`() {
         val changes = mutableListOf<Boolean>()
         val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-
-        assertThat(
-                tracker.update(
-                        ClassicAudioProfile.A2DP,
-                        "aa:bb:cc:dd:ee:ff",
-                        connected = true
-                )
-        ).isTrue()
-        tracker.update(
-                ClassicAudioProfile.A2DP,
-                "AA:BB:CC:DD:EE:FF",
-                connected = false
-        )
-
+        tracker.setTarget(address)
+        snapshot(tracker, ClassicAudioProfile.A2DP)
+        snapshot(tracker, ClassicAudioProfile.HEADSET)
+        snapshot(tracker)
         assertThat(changes).containsExactly(true, false)
-        assertThat(tracker.connected).isFalse()
     }
 
     @Test
-    fun `stays connected while either A2DP or HFP is connected`() {
-        val changes = mutableListOf<Boolean>()
-        val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-
-        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
-        tracker.update(ClassicAudioProfile.HEADSET, "AA:BB:CC:DD:EE:FF", connected = true)
-        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = false)
-
-        assertThat(changes).containsExactly(true)
+    fun `address comparison is case insensitive`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address.lowercase())
+        snapshot(tracker, ClassicAudioProfile.A2DP)
         assertThat(tracker.connected).isTrue()
-
-        tracker.update(ClassicAudioProfile.HEADSET, "AA:BB:CC:DD:EE:FF", connected = false)
-        assertThat(changes).containsExactly(true, false)
     }
 
     @Test
-    fun `ignores late callbacks from a previous device`() {
-        val changes = mutableListOf<Boolean>()
-        val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
+    fun `another device cannot request a snapshot`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        assertThat(tracker.beginSnapshot("11:22:33:44:55:66")).isNull()
+    }
 
+    @Test
+    fun `late result for previous device cannot replace current profiles`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        val ticket = tracker.beginSnapshot(address)!!
         tracker.setTarget("11:22:33:44:55:66")
-        val accepted =
-                tracker.update(
-                        ClassicAudioProfile.A2DP,
-                        "AA:BB:CC:DD:EE:FF",
-                        connected = true
-                )
-
-        assertThat(accepted).isFalse()
-        assertThat(changes).containsExactly(true, false)
+        assertThat(tracker.applySnapshot(ticket, address, setOf(ClassicAudioProfile.A2DP))).isFalse()
         assertThat(tracker.connected).isFalse()
     }
 
     @Test
-    fun `reset clears a connected profile`() {
-        val changes = mutableListOf<Boolean>()
-        val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-        tracker.update(ClassicAudioProfile.HEADSET, "AA:BB:CC:DD:EE:FF", connected = true)
-
-        tracker.reset()
-
-        assertThat(changes).containsExactly(true, false)
+    fun `old response cannot resurrect reconnected session with same MAC`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        val ticket = tracker.beginSnapshot(address)!!
+        tracker.invalidate(address)
+        tracker.setTarget(address)
+        snapshot(tracker)
+        assertThat(tracker.applySnapshot(ticket, address, setOf(ClassicAudioProfile.A2DP))).isFalse()
         assertThat(tracker.connected).isFalse()
     }
 
     @Test
-    fun `target teardown clears profiles without an external device reference`() {
-        val changes = mutableListOf<Boolean>()
-        val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
-
-        assertThat(tracker.clear("AA:BB:CC:DD:EE:FF")).isTrue()
-        assertThat(changes).containsExactly(true, false)
-        assertThat(tracker.connected).isFalse()
+    fun `newer query invalidates in flight snapshot even before its response arrives`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        val first = tracker.beginSnapshot(address)!!
+        val second = tracker.beginSnapshot(address)!!
+        assertThat(tracker.applySnapshot(first, address, setOf(ClassicAudioProfile.A2DP))).isFalse()
+        assertThat(tracker.applySnapshot(second, address, emptySet())).isTrue()
     }
 
     @Test
-    fun `profile reset retains target for a reconnect`() {
-        val changes = mutableListOf<Boolean>()
-        val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
-
-        assertThat(tracker.clear("AA:BB:CC:DD:EE:FF")).isTrue()
-        assertThat(
-                        tracker.update(
-                                ClassicAudioProfile.HEADSET,
-                                "AA:BB:CC:DD:EE:FF",
-                                connected = true
-                        )
-                )
-                .isTrue()
-
-        assertThat(changes).containsExactly(true, false, true)
+    fun `late disconnect snapshot cannot overwrite newer connected snapshot`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        val old = tracker.beginSnapshot(address)!!
+        snapshot(tracker, ClassicAudioProfile.HEADSET)
+        assertThat(tracker.applySnapshot(old, address, emptySet())).isFalse()
         assertThat(tracker.connected).isTrue()
     }
 
     @Test
-    fun `target teardown rejects delayed callbacks from the invalidated session`() {
+    fun `clear invalidates queries but retains target for retry`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        val old = tracker.beginSnapshot(address)!!
+        assertThat(tracker.clear(address)).isTrue()
+        assertThat(tracker.applySnapshot(old, address, setOf(ClassicAudioProfile.A2DP))).isFalse()
+        snapshot(tracker, ClassicAudioProfile.A2DP)
+        assertThat(tracker.connected).isTrue()
+    }
+
+    @Test
+    fun `reset clears truth and prevents pending results from applying`() {
         val changes = mutableListOf<Boolean>()
         val tracker = ClassicAudioConnectionTracker(changes::add)
-        tracker.setTarget("AA:BB:CC:DD:EE:FF")
-        tracker.update(ClassicAudioProfile.A2DP, "AA:BB:CC:DD:EE:FF", connected = true)
-
-        assertThat(tracker.invalidate("AA:BB:CC:DD:EE:FF")).isTrue()
-        val accepted =
-                tracker.update(
-                        ClassicAudioProfile.HEADSET,
-                        "AA:BB:CC:DD:EE:FF",
-                        connected = true
-                )
-
-        assertThat(accepted).isFalse()
+        tracker.setTarget(address)
+        snapshot(tracker, ClassicAudioProfile.A2DP)
+        val ticket = tracker.beginSnapshot(address)!!
+        tracker.reset()
+        assertThat(tracker.applySnapshot(ticket, address, setOf(ClassicAudioProfile.A2DP))).isFalse()
+        assertThat(tracker.beginSnapshot(address)).isNull()
         assertThat(changes).containsExactly(true, false)
-        assertThat(tracker.connected).isFalse()
+    }
+
+    @Test
+    fun `stale snapshot cannot emit audio routing notifications`() {
+        val tracker = ClassicAudioConnectionTracker {}
+        tracker.setTarget(address)
+        val old = tracker.beginSnapshot(address)!!
+        tracker.setTarget(address)
+        var notifications = 0
+        tracker.applySnapshot(old, address, setOf(ClassicAudioProfile.A2DP)) { notifications++ }
+        assertThat(notifications).isZero()
     }
 }


### PR DESCRIPTION
## Summary

- publish Mentra Live A2DP and HFP connection changes to `glasses.bluetoothClassicConnected`
- aggregate both Classic audio profiles while scoping callbacks to the active glasses address
- snapshot existing profile state, clear teardown state, and ignore stale callbacks from earlier sessions
- keep A2DP audio-connected events idempotent and cover React Native status serialization

## Testing

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `cd mobile/android && ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest -PmentraPublicSdk=true --no-daemon` (134 tests)

## Validation caveat

- Not hardware-tested in this worktree; Android compile/assemble and the complete Bluetooth SDK unit-test suite pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dual-mode Bluetooth pairing/teardown and published connection state in Mentra Live; incorrect aggregation or stale broadcasts could misreport Classic audio to React Native, though logic is scoped by device address and covered by unit tests.
> 
> **Overview**
> **Replaces a single `isBtClassicConnected` flag** with a **`ClassicAudioConnectionTracker`** that treats Mentra Live Classic audio as connected when **either A2DP or HFP** is up, and drives **`glasses.bluetoothClassicConnected`** in `DeviceStore` from that aggregate.
> 
> **`MentraLive`** now registers an A2DP/HFP broadcast receiver, routes profile updates through the tracker (ignoring transitional states and non-target MACs), snapshots HFP on BLE GATT connect, and folds A2DP proxy snapshots into the same path. Bond removal/unpair **invalidates** the tracker target so delayed profile events cannot resurrect “connected”; failed bonding **clears** profile state while keeping the target for retries. **`markAudioConnected`** is idempotent for bridge events; teardown uses the tracker instead of `connectedDevice` when BLE is already gone. SGC destroy resets the tracker and clears stored Classic status.
> 
> Unit tests cover tracker behavior and **`GlassesStatus`** serialization of `bluetoothClassicConnected`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f30bd87f8fcc577e134182499ac60c0ffeafc4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review repair update

Rebased onto dev. Profile broadcasts now trigger authoritative A2DP/HFP snapshots; stale-session work is rejected instead of treating matching MAC addresses as current profile truth. Local Android compile and focused Classic Bluetooth regression tests pass.

Remote checks are running on the updated head. Physical-device qualification remains pending; no merge, release, or install is claimed.