### PR TITLE
Make iOS ANCS pairing optional

### DIFF
--- a/mintlify-docs/bluetooth-sdk/api-reference.mdx
+++ b/mintlify-docs/bluetooth-sdk/api-reference.mdx
@@ -337,6 +337,13 @@ these hints alongside their retry controls.
 
 Use `scan()` for user-facing device pickers. The progressive result callback is for UI: render the nearby-device list every time it changes during scanning. The returned final result is for control flow: after the timeout/completion, choose a device from the last list and connect. In multi-device environments, do not auto-connect to the first nearby glasses; present an explicit picker.
 
+Mentra Live connections on iOS require Apple Notification Center Service
+(ANCS) authorization by default. Apps that do not use notification relay can
+set `requiresAncs: false` in the `connect` or `connectDefault` options to skip
+that system authorization requirement. The option defaults to `true` and is an
+intentional no-op on Android. Native iOS callers pass
+`ConnectOptions(requiresAncs: false)`.
+
 ## Device Identity
 
 `Device.id` is the stable app-facing key for a scan result, within the limits of the platform identifier available to the SDK. Use it as a list key, selected-device key, and persisted default-device key.
@@ -440,7 +447,7 @@ For React Native status UI, use `useMentraBluetooth()` from `@mentra/bluetooth-s
 Important defaults:
 
 - `scan(model, options)` reports progressive results through `options.onResults`, resolves with the final matching `Device[]`, and times out after 15 seconds unless `options.timeoutMs` is set.
-- `connect` and `connectDefault` default `saveAsDefault` and `cancelExistingConnectionAttempt` to `true`.
+- `connect` and `connectDefault` default `saveAsDefault`, `cancelExistingConnectionAttempt`, and `requiresAncs` to `true`. `requiresAncs` only changes Mentra Live connections on iOS; Android accepts it as a no-op.
 - `setDashboardContent(content)` keeps the standard time, date, battery, and connection status header. It stores content for the current SDK session and renders it immediately only when the contextual dashboard is visible; otherwise it appears on the next head-up. Pass the exact empty string to restore the status-only dashboard.
 - `setMicState(enabled)` defaults to glasses microphone on, transcript events off, and LC3 events off. Microphone audio events are continuous while capture is enabled. Use `setVoiceActivityDetectionEnabled(...)` for glasses-side Voice Activity Detection and `setLoudnessGateEnabled(...)` for Mentra Live's center-microphone loudness gate ("Barrier"). With VAD disabled and Barrier enabled, quiet input is represented as silence while audio frames continue. The standalone public Bluetooth SDK defaults are VAD disabled and Barrier enabled, and both settings are reapplied after reconnect. The Mentra App manages separate persisted OS-level microphone preferences. `voice_activity_detection_status` reports whether VAD is enabled, and `speaking_status` reports speaking/not-speaking when supported. Microphone audio events include the latest `voiceActivityDetectionEnabled` value.
 - `requestPhoto({authToken, ...})` omits the `Authorization` header when `authToken` is `null` or empty.

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -144,6 +144,17 @@ normal empty completion unchanged. React hooks expose it as `scan.diagnostic`
 on `useMentraBluetooth()`, or `diagnostic` on `useBluetoothScan()`. Clear the hint
 when retrying or connecting.
 
+On iOS, Mentra Live connections require Apple Notification Center Service
+(ANCS) authorization by default. Apps that do not use notification relay can
+skip that system authorization requirement for a connection:
+
+```ts
+await BluetoothSdk.connect(device, {requiresAncs: false})
+```
+
+The option defaults to `true` for backward compatibility and is an intentional
+no-op on Android.
+
 In multi-device environments, present an explicit picker instead of
 auto-connecting to the first nearby device.
 

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -966,9 +966,9 @@ private extension ConnectOptions {
     init(dictionary values: [String: Any]?) {
         self.init(
             saveAsDefault: values?["saveAsDefault"] as? Bool ?? true,
-            cancelExistingConnectionAttempt: values?["cancelExistingConnectionAttempt"] as? Bool ?? true
+            cancelExistingConnectionAttempt: values?["cancelExistingConnectionAttempt"] as? Bool ?? true,
+            requiresAncs: values?["requiresAncs"] as? Bool ?? true
         )
     }
 }
-
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1823,7 +1823,7 @@ struct ViewState {
         sgc.requestPhoto(routed)
     }
 
-    func connectDefault() {
+    func connectDefault(requiresAncs: Bool = true) {
         if defaultWearable.isEmpty {
             Bridge.log("MAN: No default wearable, returning")
             return
@@ -1839,6 +1839,7 @@ struct ViewState {
             return
         }
         initSGC(defaultWearable)
+        (sgc as? MentraLive)?.setRequiresAncs(requiresAncs)
         if let live = sgc as? MentraLive, live.isPairingYieldActive() {
             Bridge.log("MAN: connectDefault skipped — Mentra Live pairing yield active")
             return
@@ -1862,7 +1863,7 @@ struct ViewState {
         controller?.connectById(controllerDeviceName)
     }
 
-    func connectByName(_ dName: String) {
+    func connectByName(_ dName: String, requiresAncs: Bool = true) {
         Bridge.log("MAN: Connecting to wearable: \(dName)")
         var name = dName
 
@@ -1895,6 +1896,7 @@ struct ViewState {
             self.pendingDeviceName = name
 
             initSGC(self.pendingWearable)
+            (sgc as? MentraLive)?.setRequiresAncs(requiresAncs)
             sgc?.connectById(name)
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -191,6 +191,7 @@ public final class MentraBluetoothSDK {
     private var bluetoothAvailabilityListenerId: UUID?
     private var shouldRestoreGlassesOnBluetoothRestore = false
     private var shouldRestoreControllerOnBluetoothRestore = false
+    private var requiresAncsForBluetoothRestore = true
     private var bridgeEventSinkId: String?
     private var storeListenerId: String?
     private let defaultDeviceKeys: Set<String> = ["default_wearable", "device_name", "device_address", "project_name"]
@@ -408,6 +409,9 @@ public final class MentraBluetoothSDK {
             try BluetoothAvailability.shared.requirePoweredOn(operation: "connect to glasses")
         }
         let isController = ControllerTypes.ALL.contains(device.model.deviceType)
+        if !isController {
+            requiresAncsForBluetoothRestore = options.requiresAncs
+        }
         if options.cancelExistingConnectionAttempt {
             if isController {
                 DeviceManager.shared.disconnectController()
@@ -427,11 +431,12 @@ public final class MentraBluetoothSDK {
             )
         }
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_wearable", device.model.deviceType)
-        DeviceManager.shared.connectByName(device.name)
+        DeviceManager.shared.connectByName(device.name, requiresAncs: options.requiresAncs)
     }
 
     public func connectDefault(options: ConnectOptions = ConnectOptions()) throws {
         clearBluetoothRestoreIntent()
+        requiresAncsForBluetoothRestore = options.requiresAncs
         guard let device = currentDefaultDevice() else {
             throw BluetoothSdkError(
                 code: "default_device_missing",
@@ -444,7 +449,7 @@ public final class MentraBluetoothSDK {
         if options.cancelExistingConnectionAttempt {
             cancelConnectionAttempt()
         }
-        DeviceManager.shared.connectDefault()
+        DeviceManager.shared.connectDefault(requiresAncs: options.requiresAncs)
     }
 
     public func cancelConnectionAttempt() {
@@ -1552,7 +1557,9 @@ public final class MentraBluetoothSDK {
         clearBluetoothRestoreIntent()
 
         if restoreGlasses, !glassesStatus.connected, glassesStatus.connectionState == .disconnected {
-            DeviceManager.shared.connectDefault() // also restores the controller
+            DeviceManager.shared.connectDefault(
+                requiresAncs: requiresAncsForBluetoothRestore
+            ) // also restores the controller
         } else if restoreController, !glassesStatus.controllerConnected {
             DeviceManager.shared.connectDefaultController()
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1384,6 +1384,13 @@ enum MentraLiveConnectionState {
     case connected
 }
 
+enum MentraLiveConnectionOptions {
+    static func coreBluetoothOptions(requiresAncs: Bool) -> [String: Any]? {
+        guard requiresAncs else { return nil }
+        return [CBConnectPeripheralOptionRequiresANCS: true]
+    }
+}
+
 /// Type aliases for compatibility
 typealias JSONObject = [String: Any]
 
@@ -1743,6 +1750,7 @@ class MentraLive: NSObject, SGCManager {
 
     private var connectionTimeoutTimer: Timer?
     private var reconnectionWorkItem: DispatchWorkItem?
+    private var requiresAncs = true
 
     // MARK: - Initialization
 
@@ -1773,6 +1781,10 @@ class MentraLive: NSObject, SGCManager {
 
     func cleanup() {
         destroy()
+    }
+
+    func setRequiresAncs(_ requiresAncs: Bool) {
+        self.requiresAncs = requiresAncs
     }
 
     // MARK: - React Native Interface
@@ -2448,11 +2460,12 @@ class MentraLive: NSObject, SGCManager {
         centralManager?.connect(peripheral, options: nil)
         #else
         // ANCS is hosted by iOS and is only exposed to authorized accessories.
-        // Requiring it at connect time lets the system complete that authorization
-        // flow before the glasses subscribe to the ANCS characteristics.
+        // The default requirement lets the system complete that authorization flow
+        // before the glasses subscribe; apps that do not relay notifications can opt out.
+        Bridge.log("LIVE: ANCS connection requirement \(requiresAncs ? "enabled" : "disabled")")
         centralManager?.connect(
             peripheral,
-            options: [CBConnectPeripheralOptionRequiresANCS: true]
+            options: MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: requiresAncs)
         )
         #endif
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1386,8 +1386,12 @@ enum MentraLiveConnectionState {
 
 enum MentraLiveConnectionOptions {
     static func coreBluetoothOptions(requiresAncs: Bool) -> [String: Any]? {
-        guard requiresAncs else { return nil }
-        return [CBConnectPeripheralOptionRequiresANCS: true]
+        #if os(macOS)
+            return nil
+        #else
+            guard requiresAncs else { return nil }
+            return [CBConnectPeripheralOptionRequiresANCS: true]
+        #endif
     }
 }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/types/DeviceModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/types/DeviceModels.swift
@@ -169,9 +169,17 @@ public struct Device: Identifiable, Equatable, CustomStringConvertible {
 public struct ConnectOptions {
     public let saveAsDefault: Bool
     public let cancelExistingConnectionAttempt: Bool
+    /// Mentra Live on iOS only. Whether CoreBluetooth should require ANCS
+    /// authorization while establishing the connection.
+    public let requiresAncs: Bool
 
-    public init(saveAsDefault: Bool = true, cancelExistingConnectionAttempt: Bool = true) {
+    public init(
+        saveAsDefault: Bool = true,
+        cancelExistingConnectionAttempt: Bool = true,
+        requiresAncs: Bool = true
+    ) {
         self.saveAsDefault = saveAsDefault
         self.cancelExistingConnectionAttempt = cancelExistingConnectionAttempt
+        self.requiresAncs = requiresAncs
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Tests/MentraLiveConnectionOptionsTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/MentraLiveConnectionOptionsTests.swift
@@ -1,0 +1,24 @@
+import CoreBluetooth
+@testable import MentraBluetoothSDK
+import XCTest
+
+final class MentraLiveConnectionOptionsTests: XCTestCase {
+    func testConnectOptionsRequireAncsByDefault() {
+        XCTAssertTrue(ConnectOptions().requiresAncs)
+    }
+
+    func testConnectOptionsCanDisableAncsRequirement() {
+        XCTAssertFalse(ConnectOptions(requiresAncs: false).requiresAncs)
+    }
+
+    func testCoreBluetoothOptionsRequireAncsWhenEnabled() {
+        let options = MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: true)
+
+        XCTAssertEqual(options?.count, 1)
+        XCTAssertEqual(options?[CBConnectPeripheralOptionRequiresANCS] as? Bool, true)
+    }
+
+    func testCoreBluetoothOptionsAreOmittedWhenAncsIsDisabled() {
+        XCTAssertNil(MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: false))
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Tests/MentraLiveConnectionOptionsTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/MentraLiveConnectionOptionsTests.swift
@@ -11,12 +11,18 @@ final class MentraLiveConnectionOptionsTests: XCTestCase {
         XCTAssertFalse(ConnectOptions(requiresAncs: false).requiresAncs)
     }
 
-    func testCoreBluetoothOptionsRequireAncsWhenEnabled() {
-        let options = MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: true)
+    #if os(macOS)
+        func testCoreBluetoothOptionsOmitAncsOnMacOS() {
+            XCTAssertNil(MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: true))
+        }
+    #else
+        func testCoreBluetoothOptionsRequireAncsWhenEnabled() {
+            let options = MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: true)
 
-        XCTAssertEqual(options?.count, 1)
-        XCTAssertEqual(options?[CBConnectPeripheralOptionRequiresANCS] as? Bool, true)
-    }
+            XCTAssertEqual(options?.count, 1)
+            XCTAssertEqual(options?[CBConnectPeripheralOptionRequiresANCS] as? Bool, true)
+        }
+    #endif
 
     func testCoreBluetoothOptionsAreOmittedWhenAncsIsDisabled() {
         XCTAssertNil(MentraLiveConnectionOptions.coreBluetoothOptions(requiresAncs: false))

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -1485,6 +1485,13 @@ export interface Device {
 export interface ConnectOptions {
   saveAsDefault?: boolean
   cancelExistingConnectionAttempt?: boolean
+  /**
+   * iOS Mentra Live only. When true, CoreBluetooth requires ANCS authorization
+   * as part of the connection. Set false when the app does not use notification
+   * relay and must avoid the system ANCS authorization flow. Defaults to true.
+   * Android accepts this option as a no-op.
+   */
+  requiresAncs?: boolean
 }
 
 export type ScanResultsCallback = (devices: Device[]) => void

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -291,6 +291,7 @@ const NativeBluetoothSdkModule = requireNativeModule<BluetoothSdkNativeModule>("
 const DEFAULT_CONNECT_OPTIONS: Required<ConnectOptions> = {
   saveAsDefault: true,
   cancelExistingConnectionAttempt: true,
+  requiresAncs: true,
 }
 
 const DEFAULT_SCAN_TIMEOUT_MS = 15_000

--- a/mobile/modules/bluetooth-sdk/src/react/useGlassesConnection.ts
+++ b/mobile/modules/bluetooth-sdk/src/react/useGlassesConnection.ts
@@ -22,6 +22,11 @@ export type UseGlassesConnectionOptions = {
   autoConnectDefault?: boolean
   defaultDeviceStorage?: DefaultDeviceStorage
   onError?: (error: unknown) => void
+  /**
+   * Whether iOS should require ANCS authorization when automatically connecting.
+   * Defaults to true. Android accepts this option as a no-op.
+   */
+  requiresAncs?: boolean
   scanModel?: DeviceModel
   scanTimeoutMs?: number
 }
@@ -117,8 +122,8 @@ export function useGlassesConnection(
     }
 
     autoConnectAttemptedRef.current = true
-    void connectDefault().catch(() => undefined)
-  }, [defaultDevice, options.autoConnectDefault, status.connected])
+    void connectDefault({requiresAncs: options.requiresAncs ?? true}).catch(() => undefined)
+  }, [defaultDevice, options.autoConnectDefault, options.requiresAncs, status.connected])
 
   async function runConnectionAction<T>(
     nextAction: Exclude<GlassesConnectionAction, "idle" | "scanning">,

--- a/mobile/modules/bluetooth-sdk/src/react/useMentraBluetooth.ts
+++ b/mobile/modules/bluetooth-sdk/src/react/useMentraBluetooth.ts
@@ -121,6 +121,11 @@ export type UseMentraBluetoothOptions = {
   defaultDeviceStorage?: DefaultDeviceStorage
   defaultModel?: DeviceModel
   onError?: (error: unknown) => void
+  /**
+   * Whether iOS should require ANCS authorization when automatically connecting.
+   * Defaults to true. Android accepts this option as a no-op.
+   */
+  requiresAncs?: boolean
   scanTimeoutMs?: number
 }
 
@@ -269,6 +274,7 @@ export function useMentraBluetooth(options: UseMentraBluetoothOptions = {}): Men
     autoConnectDefault: options.autoConnectDefault,
     defaultDeviceStorage: options.defaultDeviceStorage,
     onError: options.onError,
+    requiresAncs: options.requiresAncs,
     scanModel: options.defaultModel ?? DeviceModels.MentraLive,
     scanTimeoutMs: options.scanTimeoutMs,
   })


### PR DESCRIPTION
## Summary

- add a public `requiresAncs` connection option for React Native and Swift, defaulting to `true`
- apply the option to Mentra Live CoreBluetooth connections and preserve it across Bluetooth power restoration
- omit `CBConnectPeripheralOptionRequiresANCS` when callers opt out; Android intentionally ignores the React Native map key without changing its native public ABI
- document the option and cover the default/opt-out CoreBluetooth mapping

## Validation

- `bun run compile` (mobile)
- `bun run build` (`mobile/modules/bluetooth-sdk`)
- `xcodebuild -scheme MentraBluetoothSDK -destination "platform=iOS Simulator,id=A8B9F03C-610A-4AF2-8A3D-68F47A256300" test` (13 tests, 0 failures)
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `swiftformat --lint` on the changed public options type and new test
- `git diff --check`

## Caveat

This validates the option mapping and both platform builds, but does not exercise the opt-out path on physical Mentra Live glasses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS Mentra Live connection and Bluetooth-restore reconnect behavior around ANCS authorization, which can affect pairing UX and notification relay; default remains enabled to limit regressions.
> 
> **Overview**
> Adds a **`requiresAncs`** option on **`connect`** / **`connectDefault`** (Swift, React Native, and docs) so apps that do not use notification relay can skip the iOS ANCS authorization step when pairing to Mentra Live. The flag **defaults to `true`** for backward compatibility and is a **no-op on Android**.
> 
> On iOS, the option is applied before CoreBluetooth connect: when `false`, **`CBConnectPeripheralOptionRequiresANCS`** is omitted; when `true`, behavior stays as today. The choice is threaded through **`DeviceManager`** / **`MentraLive`**, stored for **Bluetooth power restore** reconnects, and exposed on **`useGlassesConnection`** / **`useMentraBluetooth`** for **`autoConnectDefault`**. Unit tests cover defaults and the CoreBluetooth options mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9adf80de3ed5ac3f85368e4379f6182f4bdc22c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->