### PR TITLE
Select ACS hardware H.264 on compatible Android devices

### DIFF
--- a/mobile/modules/acs-meeting/android/build.gradle
+++ b/mobile/modules/acs-meeting/android/build.gradle
@@ -23,6 +23,11 @@ if (useManagedAndroidSdkVersions) {
     defaultConfig {
       minSdkVersion safeExtGet("minSdkVersion", 24)
       targetSdkVersion safeExtGet("targetSdkVersion", 36)
+      externalNativeBuild {
+        cmake {
+          cppFlags "-std=c++17"
+        }
+      }
     }
   }
 }
@@ -45,6 +50,12 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+    }
+  }
+  externalNativeBuild {
+    cmake {
+      path "src/main/cpp/CMakeLists.txt"
+      version "3.22.1"
     }
   }
 }

--- a/mobile/modules/acs-meeting/android/src/main/cpp/CMakeLists.txt
+++ b/mobile/modules/acs-meeting/android/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(mentra_acs_encoder_override)
+
+add_library(
+  mentra_acs_encoder_override
+  SHARED
+  acs_encoder_override.cpp
+)
+
+find_library(log_lib log)
+
+target_link_libraries(
+  mentra_acs_encoder_override
+  ${CMAKE_DL_LIBS}
+  ${log_lib}
+)

--- a/mobile/modules/acs-meeting/android/src/main/cpp/acs_encoder_override.cpp
+++ b/mobile/modules/acs-meeting/android/src/main/cpp/acs_encoder_override.cpp
@@ -1,0 +1,132 @@
+#include <android/log.h>
+#include <jni.h>
+#include <link.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace {
+
+constexpr char kLogTag[] = "ACS-HW-OVERRIDE";
+
+// ACS Calling 2.16.0, arm64-v8a. The offset is deliberately part of the
+// signature check so an updated ACS media engine is never patched merely
+// because it happens to contain a similar instruction sequence elsewhere.
+constexpr uintptr_t kExpectedFactoryBranchOffset = 0xDFE070;
+constexpr uint32_t kMovX20X0 = 0xaa0003f4;
+constexpr uint32_t kBranchToSoftware = 0x36000143;
+constexpr uint32_t kHardwareAllocTag = 0x528e6ec1;
+constexpr uint32_t kHardwareObjectSize = 0x52806100;
+constexpr uint32_t kNop = 0xd503201f;
+
+struct FactoryPatchContext {
+  bool libraryFound = false;
+  bool signatureMatched = false;
+  bool patched = false;
+  std::string error;
+};
+
+int patchHardwareFactoryBranch(dl_phdr_info* info, size_t /* size */, void* data) {
+  if (info->dlpi_name == nullptr ||
+      std::strstr(info->dlpi_name, "libRtmMediaManagerDyn.so") == nullptr) {
+    return 0;
+  }
+
+  auto* context = static_cast<FactoryPatchContext*>(data);
+  context->libraryFound = true;
+
+#if !defined(__aarch64__)
+  context->error = "unsupported ABI; ACS encoder patch is arm64-only";
+  return 1;
+#else
+  for (ElfW(Half) index = 0; index < info->dlpi_phnum; ++index) {
+    const ElfW(Phdr)& segment = info->dlpi_phdr[index];
+    if (segment.p_type != PT_LOAD || (segment.p_flags & PF_X) == 0) continue;
+
+    const uintptr_t segmentStart = segment.p_vaddr;
+    const uintptr_t segmentEnd = segmentStart + segment.p_memsz;
+    if (kExpectedFactoryBranchOffset < segmentStart + sizeof(uint32_t) ||
+        kExpectedFactoryBranchOffset + (2 * sizeof(uint32_t)) >= segmentEnd) {
+      continue;
+    }
+
+    auto* branch = reinterpret_cast<uint32_t*>(
+      info->dlpi_addr + kExpectedFactoryBranchOffset
+    );
+    if (branch[-1] != kMovX20X0 ||
+        branch[0] != kBranchToSoftware ||
+        branch[1] != kHardwareAllocTag ||
+        branch[2] != kHardwareObjectSize) {
+      context->error = "ACS encoder factory signature mismatch; library left untouched";
+      return 1;
+    }
+    context->signatureMatched = true;
+
+    const long pageSize = sysconf(_SC_PAGESIZE);
+    if (pageSize <= 0) {
+      context->error = "could not determine system page size";
+      return 1;
+    }
+    const uintptr_t address = reinterpret_cast<uintptr_t>(branch);
+    const uintptr_t page = address & ~(static_cast<uintptr_t>(pageSize) - 1);
+    if (mprotect(
+          reinterpret_cast<void*>(page),
+          static_cast<size_t>(pageSize),
+          PROT_READ | PROT_WRITE | PROT_EXEC
+        ) != 0) {
+      context->error = "could not make ACS encoder factory writable";
+      return 1;
+    }
+
+    branch[0] = kNop;
+    __builtin___clear_cache(
+      reinterpret_cast<char*>(branch),
+      reinterpret_cast<char*>(branch + 1)
+    );
+    if (mprotect(
+          reinterpret_cast<void*>(page),
+          static_cast<size_t>(pageSize),
+          PROT_READ | PROT_EXEC
+        ) != 0) {
+      context->error = "patched ACS encoder factory but could not restore RX protection";
+      return 1;
+    }
+
+    context->patched = true;
+    __android_log_print(
+      ANDROID_LOG_WARN,
+      kLogTag,
+      "selected ACS H264 hardware factory at relative offset=0x%zx",
+      static_cast<size_t>(kExpectedFactoryBranchOffset)
+    );
+    return 1;
+  }
+
+  context->error = "expected ACS encoder factory address is not executable";
+  return 1;
+#endif
+}
+
+std::string applyOverride() {
+  FactoryPatchContext context;
+  dl_iterate_phdr(patchHardwareFactoryBranch, &context);
+
+  if (context.patched) return "ACS hardware H264 encoder selected";
+  if (!context.libraryFound) return "ACS media engine is not loaded; library left untouched";
+  if (!context.error.empty()) return context.error;
+  return "ACS hardware encoder patch was not applied";
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_mentra_acsmeeting_AcsEncoderOverride_nativeApply(
+  JNIEnv* env,
+  jobject /* receiver */
+) {
+  const std::string result = applyOverride();
+  return env->NewStringUTF(result.c_str());
+}

--- a/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsEncoderOverride.kt
+++ b/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsEncoderOverride.kt
@@ -1,0 +1,69 @@
+package com.mentra.acsmeeting
+
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.os.Build
+import android.util.Log
+
+/**
+ * Selects ACS's hardware H.264 implementation when the phone exposes a real
+ * hardware AVC encoder and the loaded ACS binary exactly matches our verified
+ * ACS 2.16.0 arm64 instruction signature.
+ *
+ * If either gate fails, ACS is left untouched and retains its normal behavior.
+ */
+internal object AcsEncoderOverride {
+  private const val TAG = "ACS-HW-OVERRIDE"
+
+  private val nativeLoaded = runCatching {
+    System.loadLibrary("mentra_acs_encoder_override")
+  }.onFailure {
+    Log.e(TAG, "failed to load override JNI library", it)
+  }.isSuccess
+
+  private val result: String by lazy {
+    if (!nativeLoaded) {
+      "override JNI library unavailable"
+    } else {
+      runCatching {
+        val encoder = findHardwareAvcEncoder()
+          ?: return@runCatching "no hardware AVC encoder found; ACS left untouched"
+        System.loadLibrary("c++_shared")
+        System.loadLibrary("skypert")
+        System.loadLibrary("RtmMediaManagerDyn")
+        val result = nativeApply()
+        Class.forName("com.azure.android.communication.calling.CallClient", true, javaClass.classLoader)
+        "$result; Android encoder=$encoder"
+      }.onSuccess {
+        Log.w(TAG, it)
+      }.onFailure {
+        Log.e(TAG, "hardware encoder override failed", it)
+      }.getOrElse { error ->
+        "hardware encoder override failed: ${error.message ?: error.javaClass.simpleName}"
+      }
+    }
+  }
+
+  fun apply(): String = result
+
+  private fun findHardwareAvcEncoder(): String? = MediaCodecList(MediaCodecList.ALL_CODECS)
+    .codecInfos
+    .firstOrNull { codec ->
+      codec.isEncoder &&
+        codec.supportedTypes.any { it.equals("video/avc", ignoreCase = true) } &&
+        isHardware(codec)
+    }
+    ?.name
+
+  private fun isHardware(codec: MediaCodecInfo): Boolean {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      return codec.isHardwareAccelerated && !codec.isSoftwareOnly
+    }
+    val name = codec.name.lowercase()
+    return !name.startsWith("omx.google.") &&
+      !name.startsWith("c2.android.") &&
+      !name.contains("software")
+  }
+
+  private external fun nativeApply(): String
+}

--- a/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsMeetingSession.kt
+++ b/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsMeetingSession.kt
@@ -165,6 +165,8 @@ class AcsMeetingSession(
         emit("connecting")
         pcmBridge = PcmBridge(context.cacheDir, dumpWav)
         val credential = CommunicationTokenCredential(token)
+        val encoderOverride = AcsEncoderOverride.apply()
+        Log.w(TAG, "ACS hardware encoder selection: $encoderOverride")
         callClient = CallClient()
         val agentOptions = CallAgentOptions()
         agentOptions.displayName = displayName ?: "Mentra Call"

--- a/notes/acs-android-hardware-h264-handoff.md
+++ b/notes/acs-android-hardware-h264-handoff.md
@@ -1,0 +1,176 @@
+---
+status: draft
+owner: Nicolo
+---
+
+# ACS Android hardware H.264 encoding
+
+Implementation: [MentraOS PR #3920](https://github.com/Mentra-Community/MentraOS/pull/3920), currently a draft stacked on [Nicolo's ACS/Teams PR #3840](https://github.com/Mentra-Community/MentraOS/pull/3840).
+
+## Summary
+
+We confirmed that Azure Communication Services (ACS) Calling SDK 2.16.0 can send video through Android's hardware H.264 encoder. The SDK does not select it on the tested Qualcomm phones, even when its documented and internal encoder feature flags are enabled. However, the ACS media library contains both software and hardware H.264 implementations. A small, version-specific runtime patch can select the hardware implementation before ACS initializes.
+
+On a Motorola Razr Plus 2024, the patched ACS pipeline used `OMX.qcom.video.encoder.avc`, backed by `c2.qti.avc.encoder`, for the sustained outgoing stream. This establishes technical feasibility; it is not yet a recommendation to enable the patch globally on every Android device.
+
+The intended production flow remains:
+
+```text
+Mentra Live -> Cloudflare WHEP -> Mentra App -> ACS -> Microsoft Teams
+```
+
+ACS still receives raw video frames. The change only makes ACS encode those frames using the phone's hardware AVC component instead of its software H.264 encoder.
+
+## What was confirmed
+
+- The Razr exposes a real Qualcomm hardware AVC encoder:
+  - `OMX.qcom.video.encoder.avc`
+  - canonical Codec2 component: `c2.qti.avc.encoder`
+- ACS 2.16.0 contains separate `H264SkypeEncoder_SW` and `H264SkypeEncoder_HW` implementations.
+- ACS's encoder factory chooses between them using an ARM64 conditional branch.
+- Making the factory take its hardware path resulted in sustained hardware encoding.
+- The outgoing stream reached Teams at roughly 14-15 FPS. ACS adapted the test stream to approximately 320x180 at 102-103 kbps.
+- Android MediaCodec logs showed continuous input/output on the Qualcomm component. A `c2.android.avc.encoder` instance appeared only briefly for an ACS capability probe and was torn down after a few frames.
+
+ACS telemetry continued to label the codec as `h264 sw`. That label describes ACS's internal classification and is not reliable after the runtime patch. The authoritative evidence is Android's MediaCodec/CCodec log showing which component is actually processing the sustained stream.
+
+## Why configuration flags were not enough
+
+The following ACS/ECS settings were tried individually and in combinations:
+
+- `EnableAndroidHwEncoder`
+- `EnableAndroidSurfaceHwEncoder`
+- `EnableAndroidHWEncoderBySoc`
+- `AndroidAdditionalSupportedEncoders`
+- `AndroidAdditionalUnsupportedEncoders`
+- `DisableSwEncoder`
+- `LimitedConfigForRealwear`
+
+We tried boolean values expressed as both `true` and `1`, Qualcomm component names and prefixes, and the short and fully qualified `VideoDSP\MLE` setting paths. None caused ACS to cross its internal hardware-selection gate.
+
+This explains how a phone can expose a working hardware H.264 encoder while ACS still uses software encoding: encoder availability and ACS's decision to instantiate its hardware encoder class are separate decisions.
+
+## Working approach
+
+### 1. Apply the override before ACS initializes
+
+The native ACS media libraries must be loaded and patched before `CallClient` or other ACS classes initialize shared media state.
+
+The current integration does this immediately before constructing `CallClient`:
+
+```kotlin
+val encoderOverride = AcsEncoderOverride.apply()
+Log.w(TAG, "ACS hardware encoder selection: $encoderOverride")
+callClient = CallClient()
+```
+
+`AcsEncoderOverride.apply()` is lazy and idempotent, so it executes at most once per process.
+
+### 2. Check that Android exposes hardware AVC
+
+Before touching ACS, query `MediaCodecList.ALL_CODECS` for an encoder supporting `video/avc`. On Android 10 and newer, require `isHardwareAccelerated` and reject `isSoftwareOnly`. On older versions, reject known software component prefixes such as `OMX.google.` and `c2.android.`.
+
+If no hardware AVC component is present, do not patch ACS. Let the SDK retain its normal behavior.
+
+For a production rollout, this check should be strengthened to validate the required resolution, frame rate, color/input format, and known-good codec implementation.
+
+### 3. Patch the verified ACS factory branch
+
+For the tested ACS 2.16.0 ARM64 `libRtmMediaManagerDyn.so`:
+
+- File size: `22,683,240` bytes
+- SHA-256: `e15916eb73d7f56725865bcb439261972ca4099ac94d7e601a69735ac70addb3`
+- Encoder factory branch offset: `0xDFE070` relative to the library load address
+
+The verified instruction signature is:
+
+```text
+0xaa0003f4  mov x20, x0
+0x36000143  tbz w3, #0, <software path>
+0x528e6ec1  <start of hardware allocation path>
+0x52806100  <hardware object allocation setup>
+```
+
+Hardware is the fall-through path. Replacing the `tbz` instruction with an ARM64 NOP selects it:
+
+```text
+0xd503201f  nop
+```
+
+The native implementation should:
+
+1. Find the loaded `libRtmMediaManagerDyn.so` with `dl_iterate_phdr`.
+2. Require ARM64.
+3. Require the expected relative offset to be inside an executable `PT_LOAD` segment.
+4. Compare all four instruction words exactly.
+5. Make only the containing code page writable with `mprotect`.
+6. Replace the branch with the NOP.
+7. Flush the instruction cache with `__builtin___clear_cache`.
+8. Restore the page to read/execute protection.
+
+If any validation fails, leave the library untouched. Do not scan broadly for a partial signature and patch the first approximate match.
+
+## Current implementation locations
+
+- Native patch: `mobile/modules/acs-meeting/android/src/main/cpp/acs_encoder_override.cpp`
+- Native build: `mobile/modules/acs-meeting/android/src/main/cpp/CMakeLists.txt`
+- Android capability gate and initialization: `mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsEncoderOverride.kt`
+- Call initialization: `mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsMeetingSession.kt`
+- CMake integration and ACS dependency: `mobile/modules/acs-meeting/android/build.gradle`
+
+There is no ADB/system-property switch in the intended implementation. The property used during the configuration matrix was only temporary test instrumentation and has been removed.
+
+## Cross-device safety
+
+The patch changes ACS's selection logic, not the vendor MediaCodec implementation. It could therefore fail on a phone that advertises hardware AVC but cannot satisfy the exact format ACS requests. Because the patched factory always takes the hardware branch, ACS may not fall back cleanly to software on such a device.
+
+Recommended rollout:
+
+1. Keep the exact ACS version, ABI, offset, and instruction-signature gates.
+2. Add a known-good device/codec allowlist initially.
+3. Test at least the Razr Plus 2024, Samsung S26 Ultra, Samsung A54, and any proposed minimum-spec device.
+4. Verify actual MediaCodec component selection, outgoing Teams video, thermals, and a call of meaningful duration.
+5. Add a remotely controlled kill switch before broad release.
+6. Expand the allowlist only after each hardware/OS combination passes.
+7. Revalidate and update the patch whenever the ACS SDK changes; a signature mismatch must safely disable it.
+
+A future implementation could run a short hardware encoder compatibility test before initializing ACS, but that test must use the same size, frame rate, and input format ACS will request to be meaningful.
+
+## How to validate a device
+
+Use a normal second Teams participant on another device. Do not have the test phone join the same meeting a second time to receive and render its own video; that adds a decoder, renderer, and second ACS call and makes CPU results misleading.
+
+Useful evidence in `adb logcat` includes:
+
+```text
+ACS-HW-OVERRIDE: selected ACS H264 hardware factory ...
+OMX.qcom.video.encoder.avc
+Component Allocated (c2.qti.avc.encoder)
+```
+
+Then confirm that the same component continuously enqueues input and dequeues encoded output while the remote Teams participant receives video. Ignore ACS's `codec=h264 sw` label if the Android component logs prove sustained hardware use.
+
+For each device, record:
+
+- Manufacturer, model, SoC, and Android version
+- MediaCodec component name
+- Requested and received resolution/FPS/bitrate
+- Process CPU with preview off and on
+- Thermal behavior over at least 10-15 minutes
+- Whether start/stop audio remains normal
+- Whether video recovers after backgrounding, network changes, and a second call
+
+## What not to include in the production version
+
+- The temporary ADB property/configuration selector
+- The experimental ECS flag matrix
+- MediaCodec name-substitution hooks
+- Vendor capability-field sanitization hooks
+- A hidden second ACS participant or renderer
+- A patch that accepts an unknown ACS binary or approximate signature
+
+The minimal solution is the automatic capability gate, the exact version-specific factory patch, safe fallback to untouched ACS behavior when the gates fail, and normal single-participant Mentra Call operation.
+
+## Maintenance note
+
+This relies on an internal ACS implementation detail and may break whenever Microsoft updates the native media engine. Treat it as version-pinned native compatibility code, not a stable ACS API. The team should retain the Microsoft authorization for this work and review distribution requirements before shipping it broadly.


### PR DESCRIPTION
## Summary

- Select ACS 2.16.0's existing hardware H.264 encoder path when Android reports a hardware AVC encoder.
- Validate the exact ARM64 library offset and four-instruction signature before applying the one-instruction in-memory override.
- Leave ACS untouched when the ABI, hardware capability, library layout, or signature does not match.

The official ACS AAR is not modified on disk. The override runs once, immediately before `CallClient` initialization.

This is a draft stacked on #3840 because it depends on the ACS/Teams integration in `nicolo/acs-teams-v1`.

## Validation

- `./gradlew :mentra-acs-meeting:testReleaseUnitTest --no-daemon`
- `./gradlew :mentra-acs-meeting:assembleRelease --no-daemon`
- Motorola Razr Plus 2024 end-to-end Teams test: sustained outgoing encoding used `OMX.qcom.video.encoder.avc` / `c2.qti.avc.encoder` at approximately 14-15 FPS.

## Rollout notes

This relies on an internal ACS 2.16.0 implementation detail. Before broad release, add a remotely controlled kill switch and start with a tested device/codec allowlist. Any ACS update must be revalidated; signature mismatch fails closed.

No Mentra Call miniapp changes or diagnostic second-participant code are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selects ACS's hardware H.264 encoder path on Android devices that expose a hardware AVC encoder, so outgoing video uses hardware encoding instead of the software path.

- Runs once right before `CallClient` initialization, without modifying the ACS AAR on disk.
- Applies the one-instruction in-memory override only when `libRtmMediaManagerDyn.so` matches the exact ARM64 library offset and four-instruction signature; anything else is left untouched.
- Limits the override to arm64 devices.
- Adds a handoff doc with the verified ACS 2.16.0 signature, test evidence, and rollout guidance.

**Rollout notes**
- Add a remotely controlled kill switch and start with a tested device/codec allowlist before broad release.
- Revalidate after any ACS update; signature mismatch fails closed.

<sup>Written for commit 143543fa91228dedf7958b14c3988d100fcee958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

