### PR TITLE
Update live BES firmware to 26.9.4.0

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.9.3.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.3.0.bin",
-    "sha256": "601fcd187feb338cf73b3829bc7b592e5658d3952a3547736f4c9b2b353ec165"
+    "version": "26.9.4.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.4.0.bin",
+    "sha256": "17c0b8e784cc02ca65f4b2b111f40434ceb774fa86aff71bfc5a648341a49941"
   }
 }

--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.8.27.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.8.27.0.bin",
-    "sha256": "8d9e49569ba25e45d0b9c79b63244a3d413026b74523b63b7ebd1f84bf74c05e"
+    "version": "26.9.3.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.3.0.bin",
+    "sha256": "601fcd187feb338cf73b3829bc7b592e5658d3952a3547736f4c9b2b353ec165"
   }
 }


### PR DESCRIPTION
## Summary

- update firmware_live.json on staging to BES 26.9.4.0
- use the URL and SHA-256 published by firmwarecdn.mentraglass.com/latest.json
- preserve the existing staging MTK patch list

## Validation

- downloaded the published BES binary and verified size 1,144,838 bytes
- verified SHA-256: 17c0b8e784cc02ca65f4b2b111f40434ceb774fa86aff71bfc5a648341a49941
- jq empty asg_client/ota_manifests/firmware_live.json
- git diff --check
- confirmed only firmware_live.json changed and all seven MTK patches are unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Live OTA manifest changes affect which BES binary ships to production glasses; incorrect URL or hash would block or corrupt updates.
> 
> **Overview**
> Updates the **live** OTA manifest (`firmware_live.json`) so devices pull **BES firmware 26.9.4.0** instead of **26.8.27.0**, with the matching `firmwarecdn.mentraglass.com` download URL and SHA-256.
> 
> The **MTK patch list** is unchanged—all seven patch entries are left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c233a3ca32d2081c17c286e58d2365f67e0978f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->