### PR TITLE
Clarify Miniapp SDK distribution limitations in production docs

### DIFF
--- a/mintlify-docs/app-devs/core-concepts/miniapp-manifest.mdx
+++ b/mintlify-docs/app-devs/core-concepts/miniapp-manifest.mdx
@@ -93,8 +93,9 @@ Each entry is `{ "type": "...", "level": "...", "description"?: "..." }`.
 |---|---|
 | `CAMERA`, `DISPLAY`, `MICROPHONE`, `SPEAKER`, `IMU`, `BUTTON`, `LIGHT`, `WIFI` | `REQUIRED` or `OPTIONAL` |
 
-- **`REQUIRED`**: glasses without this hardware can't install the miniapp (it's
-  hidden in the Mentra Miniapp Store and launcher on incompatible devices).
+- **`REQUIRED`**: glasses without this hardware can't install the miniapp (when
+  Store distribution becomes available, it will be hidden in the Mentra Miniapp
+  Store and launcher on incompatible devices).
 - **`OPTIONAL`**: incompatible glasses still run the miniapp, in a degraded state.
 
 ## Editing the manifest

--- a/mintlify-docs/app-devs/getting-started/distribution.mdx
+++ b/mintlify-docs/app-devs/getting-started/distribution.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Distribution"
-description: "Pack a release and get your miniapp onto users' glasses."
+description: "Prepare and install miniapp builds for local testing."
 icon: "upload"
 ---
 
@@ -10,13 +10,13 @@ import BetaNote from '/snippets/beta-note.mdx'
 <BetaNote />
 
 A miniapp is a **bundle that runs on the user's phone**: there's no server to
-host, no domain, no uptime to manage. Distribution means producing that bundle
-and getting it installed. There are three ways to get a miniapp onto a device,
-from quickest to widest reach.
+host, no domain, no uptime to manage. MentraOS 3.0 supports local development
+and testing, but it does not provide a supported way to distribute a miniapp to
+users.
 
 <LegacyCloudNote />
 
-## 1. Dev install (you, iterating)
+## Dev install (you, iterating)
 
 While you're building, [`mentra-miniapp dev`](/app-devs/reference/cli#dev) serves
 your project over the LAN with hot reload. Scan the QR from the Mentra App and
@@ -30,9 +30,10 @@ test multiple dev miniapps together. Rescanning the same package updates that
 entry. Use a release install when you want the miniapp to run without the
 computer.
 
-## 2. Release install (sharing a build over LAN)
+## Release install (local testing over LAN)
 
-To put a real, installed build on one or more phones without going through the Mentra Miniapp Store, run:
+To put a real, installed build on one or more test phones on your local network,
+run:
 
 ```bash
 mentra-miniapp release
@@ -41,24 +42,30 @@ mentra-miniapp release
 This builds, packs, and serves the bundle behind a `miniapp://release` QR. Anyone
 on the same network can scan it to install. The miniapp installs on the device,
 **runs offline, and persists across restarts**: no laptop required once it's
-installed. Great for testers, demos, and dogfooding.
+installed. This is intended for local testing, demos, and dogfooding; it is not
+a supported distribution channel.
 
 Each install is logged in your terminal, and the server stays up so multiple
 devices can install from the same QR.
 
-## 3. Store submission (reaching everyone)
+## Future distribution
 
-To reach users who aren't on your network, publish to the Mentra Miniapp Store.
-The artifact is the ZIP produced by:
+In a future release, developers will upload miniapps through the
+[Mentra Developer Console](https://console.mentraglass.com), and users will
+download them from the
+[Mentra Miniapp Store](https://apps.mentraglass.com). The Developer Console and
+Mentra Miniapp Store do not support Miniapp SDK distribution in MentraOS 3.0.
+
+The CLI can already produce the ZIP artifact intended for that future workflow:
 
 ```bash
 mentra-miniapp pack
 ```
 
-Submit `build/<packageName>-<version>.zip` through the Developer Console. Make
-sure your [`miniapp.json`](/app-devs/core-concepts/miniapp-manifest) is accurate
-before you pack: its `hardwareRequirements` decide which glasses can see your
-miniapp, and its `permissions` drive the OS prompts users see.
+The artifact is written to `build/<packageName>-<version>.zip`. Make sure your
+[`miniapp.json`](/app-devs/core-concepts/miniapp-manifest) is accurate before you
+pack: its `hardwareRequirements` will decide which glasses can see your miniapp,
+and its `permissions` will drive the OS prompts users see.
 
 <Note>
 Camera, photo, and live-streaming features run through the on-glasses Bluetooth
@@ -68,10 +75,10 @@ for those workflows.
 
 ## Versioning
 
-Bump `version` in `miniapp.json` for every release you distribute. The CLI names
-the artifact `<packageName>-<version>.zip`, and installed miniapps are stored per
-version (`lmas/<package>/<version>/`), so a new version installs cleanly alongside
-or over the old one.
+Bump `version` in `miniapp.json` for every release build. The CLI names the
+artifact `<packageName>-<version>.zip`, and installed miniapps are stored per
+version (`lmas/<package>/<version>/`), so a new version installs cleanly
+alongside or over the old one.
 
 ## Next steps
 
@@ -80,6 +87,6 @@ or over the old one.
     `dev`, `release`, and `pack` in detail.
   </Card>
   <Card title="The manifest" icon="file-code" href="/app-devs/core-concepts/miniapp-manifest">
-    Get permissions and hardware requirements right before you ship.
+    Get permissions and hardware requirements right before you build a release.
   </Card>
 </CardGroup>

--- a/mintlify-docs/app-devs/getting-started/overview.mdx
+++ b/mintlify-docs/app-devs/getting-started/overview.mdx
@@ -11,8 +11,9 @@ import BetaNote from '/snippets/beta-note.mdx'
 
 MentraOS is the operating system for smart glasses. A **miniapp** is an app that
 runs on the user's phone, inside the Mentra App, and drives the glasses through the
-Mentra Miniapp SDK (`@mentra/miniapp`). You write a bundle, the user installs it
-from the Mentra Miniapp Store, and it runs on their device.
+Mentra Miniapp SDK (`@mentra/miniapp`). You write a bundle that runs on the
+user's device. Public distribution through the Mentra Miniapp Store is planned
+for a future release and is not available in MentraOS 3.0.
 
 <Info>
 Building a mobile app that connects directly to glasses over Bluetooth? Use the

--- a/mintlify-docs/app-devs/getting-started/quickstart.mdx
+++ b/mintlify-docs/app-devs/getting-started/quickstart.mdx
@@ -142,7 +142,7 @@ export interface Channels {
   <Card title="The manifest" icon="file-code" href="/app-devs/core-concepts/miniapp-manifest">
     Permissions, hardware requirements, and entry points.
   </Card>
-  <Card title="Ship it" icon="upload" href="/app-devs/getting-started/distribution">
-    Pack a release and put it in front of users.
+  <Card title="Test a release" icon="upload" href="/app-devs/getting-started/distribution">
+    Pack a release and install it on local test devices.
   </Card>
 </CardGroup>

--- a/mintlify-docs/app-devs/reference/cli.mdx
+++ b/mintlify-docs/app-devs/reference/cli.mdx
@@ -85,10 +85,12 @@ mentra-miniapp pack
 mentra-miniapp pack --no-build   # zip the existing dist/ as-is
 ```
 
-Produces the distributable artifact only (`release` calls this internally). It
+Produces the release artifact only (`release` calls this internally). It
 builds with `NODE_ENV=production`, verifies `dist/`, validates the manifest,
 copies `miniapp.json` + `icon.png` into `dist/`, and zips to
-`build/<pkg>-<version>.zip`. This ZIP is what you submit to the Mentra Miniapp Store.
+`build/<pkg>-<version>.zip`. In a future release, this ZIP will be uploaded
+through the Mentra Developer Console for distribution in the Mentra Miniapp
+Store. That distribution workflow is not available in MentraOS 3.0.
 
 <Note>
 `pack` requires the `zip` binary on `PATH` (preinstalled on macOS and most Linux;

--- a/mintlify-docs/snippets/beta-note.mdx
+++ b/mintlify-docs/snippets/beta-note.mdx
@@ -1,7 +1,16 @@
-<Note>
+<Warning>
   **Mentra Miniapp SDK beta**
 
   The SDK is in beta, so its APIs may change before general availability.
+
+  There is currently no way to distribute a miniapp built with the Miniapp SDK.
+  In a future release, developers will upload miniapps through the
+  [Mentra Developer Console](https://console.mentraglass.com), and users will
+  download them from the
+  [Mentra Miniapp Store](https://apps.mentraglass.com). Neither service supports
+  Miniapp SDK distribution in MentraOS 3.0.
+
+  Only use the Miniapp SDK if you are comfortable with these limitations.
 
   Developing on Mentra Live? We recommend using the
   [Mentra Bluetooth SDK](/bluetooth-sdk/overview).
@@ -14,4 +23,4 @@
   Share feedback with an in-app bug report, on
   [Discord](https://discord.gg/5ukNvkEAqT), or by email at
   [help@mentra.glass](mailto:help@mentra.glass).
-</Note>
+</Warning>


### PR DESCRIPTION
## Summary

- publish the Miniapp SDK distribution warning to the production docs source on main
- explain that MentraOS 3.0 has no supported Miniapp SDK distribution channel
- describe the future Mentra Developer Console and Mentra Miniapp Store workflow without presenting it as currently available
- update related manifest, quickstart, overview, and CLI language for consistency

This is a docs-only transplant of the already-reviewed staging documentation. It is based directly on main and does not merge staging or include the Android release hotfix.

## Validation

- git diff --check origin/main...HEAD
- npx --yes mint@latest export --output /tmp/mentraos-prod-docs-export-3923-node.zip
- verified the exported distribution page contains the limitation warning and both future-service links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Updates production Miniapp SDK docs so they no longer read as if developers can ship to users via the Mentra Miniapp Store today.
> 
> The shared **beta** snippet is promoted from a `Note` to a **`Warning`** and now states there is **no supported Miniapp SDK distribution** in MentraOS 3.0, with Developer Console / Miniapp Store described as a **future** workflow and a clear “use only if you accept these limits” caveat.
> 
> The **Distribution** page is reframed around **local dev and testing** (`dev`, LAN `release`); store submission is replaced by a **Future distribution** section, and `pack` is documented as producing a ZIP for that future upload path. **Overview**, **Quickstart**, **CLI `pack`**, and manifest **hardware `REQUIRED`** copy are aligned (e.g. “Test a release” instead of “Ship it”, conditional store visibility when distribution exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c76882514910b166399c15acd03be5f4746503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that MentraOS 3.0 has no supported Miniapp SDK distribution channel and updates all production docs to present the future Developer Console and Miniapp Store as planned, not currently available. The beta note is now a Warning with explicit limitation language.

- Updates `distribution.mdx`, `overview.mdx`, `quickstart.mdx`, `cli.mdx`, and `miniapp-manifest.mdx` to consistently state that MentraOS 3.0 only supports local dev and release installs.
- Frames the `pack` artifact as intended for a future workflow and clarifies the future services are not yet available.

<sup>Written for commit 23c76882514910b166399c15acd03be5f4746503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

