### PR TITLE
Clarify iOS and Android beta example app installs

### DIFF
--- a/mintlify-docs/bluetooth-sdk/software-update.mdx
+++ b/mintlify-docs/bluetooth-sdk/software-update.mdx
@@ -33,14 +33,23 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. Build an example app with SDK `{{release-version}}` to install the matching glasses software.
 
-Prebuilt Starter Kit apps are validated against SDK `{{example-app-version}}`. The Android link names the exact coordinated build. The iPhone link opens the channel's TestFlight group; during beta review it continues to serve the latest Apple-approved build.
+Prebuilt Starter Kit apps are validated against SDK `{{example-app-version}}`.
+Choose the installation for your phone:
 
-- Android: [download the React Native example APK for SDK `{{example-app-version}}`]({{example-app-url}})
-- iPhone: [open the React Native example's TestFlight group]({{example-app-ios-url}})
+### iOS: iPhone Or iPad
+
+[Install the React Native example from TestFlight]({{example-app-ios-url}}).
+For external TestFlight channels, a newly uploaded build appears after Beta App
+Review. Until then, the link continues to serve the latest approved build.
+
+### Android: Phone Or Tablet
+
+[Download the React Native example APK for SDK `{{example-app-version}}`]({{example-app-url}}).
+This is the exact Android build produced by the coordinated release.
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
-### Install A Prebuilt App On Android
+### Complete The Android Installation
 
 The simplest installation path is to open an APK link on the Android phone:
 

--- a/mintlify-docs/bluetooth-sdk/software-update.mdx
+++ b/mintlify-docs/bluetooth-sdk/software-update.mdx
@@ -34,13 +34,23 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. Build an example app with SDK `{{release-version}}` to install the matching glasses software.
 
 Prebuilt Starter Kit apps are validated against SDK `{{example-app-version}}`.
-Choose the installation for your phone:
+Choose the installation for your device:
 
-### iOS: iPhone Or iPad
+### iOS: iPhone
 
 [Install the React Native example from TestFlight]({{example-app-ios-url}}).
 For external TestFlight channels, a newly uploaded build appears after Beta App
 Review. Until then, the link continues to serve the latest approved build.
+
+### macOS: Apple Silicon Mac
+
+The same TestFlight build runs on Mac computers with Apple silicon. Install
+[TestFlight from the Mac App Store](https://apps.apple.com/app/testflight/id899247664),
+then [open the React Native example in TestFlight]({{example-app-ios-url}}) and
+select **Install**.
+
+The Mac build has been verified with Mentra Live for Bluetooth connection, OTA
+updates, and photo capture. Intel-based Macs cannot run this iPhone build.
 
 ### Android: Phone Or Tablet
 

--- a/mintlify-docs/bluetooth-sdk/software-update.mdx
+++ b/mintlify-docs/bluetooth-sdk/software-update.mdx
@@ -49,8 +49,9 @@ The same TestFlight build runs on Mac computers with Apple silicon. Install
 then [open the React Native example in TestFlight]({{example-app-ios-url}}) and
 select **Install**.
 
-The Mac build has been verified with Mentra Live for Bluetooth connection, OTA
-updates, and photo capture. Intel-based Macs cannot run this iPhone build.
+This TestFlight build has been verified on Mac with Mentra Live for Bluetooth
+connection, OTA updates, and photo capture. Intel-based Macs cannot run the
+iPhone and iPad app.
 
 ### Android: Phone Or Tablet
 

--- a/mintlify-docs/preserve-anchor-scroll.js
+++ b/mintlify-docs/preserve-anchor-scroll.js
@@ -1,5 +1,6 @@
 (() => {
-  const retryDelaysMs = [0, 100, 300, 700, 1200, 2000];
+  const stabilizationDurationMs = 2000;
+  const retryIntervalMs = 200;
   const userEvents = ["wheel", "touchstart", "pointerdown", "keydown"];
 
   let cancelCurrentAttempt = () => {};
@@ -18,12 +19,14 @@
     }
 
     let cancelled = false;
-    const timers = [];
+    let intervalId;
+    let timeoutId;
 
     const cancel = () => {
       if (cancelled) return;
       cancelled = true;
-      timers.forEach(window.clearTimeout);
+      window.clearInterval(intervalId);
+      window.clearTimeout(timeoutId);
       userEvents.forEach((eventName) =>
         window.removeEventListener(eventName, cancel, true),
       );
@@ -38,7 +41,12 @@
     );
 
     const restoreAnchor = () => {
-      if (cancelled || window.location.hash !== expectedHash) return;
+      if (cancelled) return;
+
+      if (window.location.hash !== expectedHash) {
+        cancel();
+        return;
+      }
 
       const target = document.getElementById(anchorId);
       if (!target) return;
@@ -53,21 +61,15 @@
       }
     };
 
-    retryDelaysMs.forEach((delayMs) => {
-      timers.push(
-        window.setTimeout(
-          () => window.requestAnimationFrame(restoreAnchor),
-          delayMs,
-        ),
-      );
-    });
-    timers.push(
-      window.setTimeout(cancel, retryDelaysMs[retryDelaysMs.length - 1] + 100),
+    restoreAnchor();
+    intervalId = window.setInterval(
+      () => window.requestAnimationFrame(restoreAnchor),
+      retryIntervalMs,
     );
+    timeoutId = window.setTimeout(cancel, stabilizationDurationMs);
   }
 
   window.addEventListener("hashchange", preserveCurrentAnchor);
-  window.addEventListener("pageshow", preserveCurrentAnchor);
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", preserveCurrentAnchor, {

--- a/mintlify-docs/preserve-anchor-scroll.js
+++ b/mintlify-docs/preserve-anchor-scroll.js
@@ -1,0 +1,79 @@
+(() => {
+  const retryDelaysMs = [0, 100, 300, 700, 1200, 2000];
+  const userEvents = ["wheel", "touchstart", "pointerdown", "keydown"];
+
+  let cancelCurrentAttempt = () => {};
+
+  function preserveCurrentAnchor() {
+    cancelCurrentAttempt();
+
+    const expectedHash = window.location.hash;
+    if (!expectedHash || expectedHash === "#") return;
+
+    let anchorId;
+    try {
+      anchorId = decodeURIComponent(expectedHash.slice(1));
+    } catch {
+      anchorId = expectedHash.slice(1);
+    }
+
+    let cancelled = false;
+    const timers = [];
+
+    const cancel = () => {
+      if (cancelled) return;
+      cancelled = true;
+      timers.forEach(window.clearTimeout);
+      userEvents.forEach((eventName) =>
+        window.removeEventListener(eventName, cancel, true),
+      );
+    };
+
+    cancelCurrentAttempt = cancel;
+    userEvents.forEach((eventName) =>
+      window.addEventListener(eventName, cancel, {
+        capture: true,
+        passive: true,
+      }),
+    );
+
+    const restoreAnchor = () => {
+      if (cancelled || window.location.hash !== expectedHash) return;
+
+      const target = document.getElementById(anchorId);
+      if (!target) return;
+
+      const scrollMarginTop = Number.parseFloat(
+        window.getComputedStyle(target).scrollMarginTop,
+      );
+      const expectedTop = Number.isFinite(scrollMarginTop) ? scrollMarginTop : 0;
+
+      if (Math.abs(target.getBoundingClientRect().top - expectedTop) > 4) {
+        target.scrollIntoView({block: "start"});
+      }
+    };
+
+    retryDelaysMs.forEach((delayMs) => {
+      timers.push(
+        window.setTimeout(
+          () => window.requestAnimationFrame(restoreAnchor),
+          delayMs,
+        ),
+      );
+    });
+    timers.push(
+      window.setTimeout(cancel, retryDelaysMs[retryDelaysMs.length - 1] + 100),
+    );
+  }
+
+  window.addEventListener("hashchange", preserveCurrentAnchor);
+  window.addEventListener("pageshow", preserveCurrentAnchor);
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", preserveCurrentAnchor, {
+      once: true,
+    });
+  } else {
+    preserveCurrentAnchor();
+  }
+})();


### PR DESCRIPTION
## Summary

Make the Bluetooth SDK software-update page explicit about which prebuilt React Native example app each platform should install:

- iPhone users install the example app from the public TestFlight group: https://testflight.apple.com/join/NpSqBZnA
- Apple-silicon Mac users install TestFlight from the Mac App Store and use the same public group
- Android users download the exact APK generated for the coordinated SDK release
- explain that an external TestFlight link serves the latest approved build while a newer upload is in Beta App Review
- preserve direct section links when Safari resets scroll position during Mintlify hydration

The Mac path was verified on hardware with Mentra Live for Bluetooth connection, a complete OTA update, and photo capture. Intel-based Macs are explicitly excluded because they cannot run the iPhone build.

The source keeps the coordinated `{{example-app-ios-url}}`, `{{example-app-url}}`, and `{{example-app-version}}` placeholders. On the beta docs pipeline, the Apple placeholder currently resolves to the public `Mentra Staging Public` invitation above and the Android placeholder resolves to the exact beta APK.

## Verification

- `node --test .github/scripts/render-coordinated-docs.test.mjs`
- `git diff --check`
- `bunx --bun mint export --output /tmp/mentraos-anchor-fix.zip`
- Safari: verified the exported deep link remains on `#use-the-exact-mentra-app-ota-pages` after hydration
- Browser regression: a late programmatic scroll reset is corrected; real user input cancels correction
- Confirmed the currently deployed beta page resolves `{{example-app-ios-url}}` to `https://testflight.apple.com/join/NpSqBZnA`
- Hardware: Apple-silicon MacBook connected to Mentra Live, completed OTA, and captured a photo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a small docs-site client script only; no product auth, data, or SDK runtime changes.
> 
> **Overview**
> **Restructures the Bluetooth SDK software-update guide** so prebuilt Starter Kit installs are split by platform (iPhone TestFlight, Apple-silicon Mac via the same TestFlight group, Android coordinated APK), with clearer TestFlight beta-review timing, Mac hardware verification notes, and Intel Mac exclusion. The Android subsection is renamed to **Complete The Android Installation**; coordinated `{{example-app-*}}` placeholders are unchanged.
> 
> **Adds `preserve-anchor-scroll.js`** for Mintlify/Safari: after load or `hashchange`, it briefly re-applies `scrollIntoView` for the URL hash (respecting `scroll-margin-top`) and stops after ~2s or when the user scrolls/types, so deep links (e.g. OTA integration sections) stay in view after hydration scroll jumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271264c674251f70aa193e8ebc38dfd3b68084b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

