### PR TITLE
feat(bluetooth-sdk): add native macOS support

### DIFF
--- a/.github/workflows/bluetooth-sdk-apple.yml
+++ b/.github/workflows/bluetooth-sdk-apple.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "mobile/modules/bluetooth-sdk/Package.swift"
+      - "mobile/modules/bluetooth-sdk/package.json"
       - "mobile/modules/bluetooth-sdk/ios/**"
       - "scripts/export-bluetooth-sdk-ios-spm.sh"
       - ".github/workflows/bluetooth-sdk-apple.yml"

--- a/.github/workflows/bluetooth-sdk-apple.yml
+++ b/.github/workflows/bluetooth-sdk-apple.yml
@@ -1,0 +1,31 @@
+name: Bluetooth SDK Apple Platforms
+
+on:
+  pull_request:
+    paths:
+      - "mobile/modules/bluetooth-sdk/Package.swift"
+      - "mobile/modules/bluetooth-sdk/ios/**"
+      - "scripts/export-bluetooth-sdk-ios-spm.sh"
+      - ".github/workflows/bluetooth-sdk-apple.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bluetooth-sdk-apple-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-package:
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Test native macOS SDK
+        run: swift test --package-path mobile/modules/bluetooth-sdk
+      - name: Verify exported Swift package on macOS and iOS
+        run: bash scripts/export-bluetooth-sdk-ios-spm.sh --target "$RUNNER_TEMP/mentra-bluetooth-sdk-apple" --verify

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -65,6 +65,7 @@ on:
       - "OEM Host Boundary Gate"
       - "Coordinated Release Family Checks"
       - "Bun Lockfile Checks"
+      - "Bluetooth SDK Apple Platforms"
       - "Cloud V2 Validation"
     types: [completed]
 
@@ -118,6 +119,7 @@ jobs:
               "OEM Host Boundary Gate",
               "Coordinated Release Family Checks",
               "Bun Lockfile Checks",
+              "Bluetooth SDK Apple Platforms",
               "Cloud V2 Validation",
             ]);
 

--- a/mintlify-docs/bluetooth-sdk/build-from-scratch.mdx
+++ b/mintlify-docs/bluetooth-sdk/build-from-scratch.mdx
@@ -37,6 +37,9 @@ software release with the same version number.
     Add the Swift package, configure iOS permissions and background modes, and
     connect from Swift.
   </Card>
+  <Card title="Native macOS" icon="desktop" href="/bluetooth-sdk/macos">
+    Build an AppKit, SwiftUI, or react-native-macos host with the shared Apple SDK.
+  </Card>
 </CardGroup>
 
 ## Integration Sequence

--- a/mintlify-docs/bluetooth-sdk/ios.mdx
+++ b/mintlify-docs/bluetooth-sdk/ios.mdx
@@ -6,6 +6,10 @@ icon: "apple"
 
 Native iOS apps use the `MentraBluetoothSDK` Swift package.
 
+The same package also supports [native macOS with AppKit or SwiftUI](/bluetooth-sdk/macos).
+The permissions and background modes below apply to iOS, including iOS apps
+running on Apple silicon Macs. Native Mac apps use the separate macOS setup.
+
 ## Requirements
 
 - iOS deployment target `15.1` or newer.

--- a/mintlify-docs/bluetooth-sdk/macos.mdx
+++ b/mintlify-docs/bluetooth-sdk/macos.mdx
@@ -145,7 +145,11 @@ dependencies or arbitrary Expo packages support native macOS.
   connection; reconnect through the normal SDK lifecycle after wake.
 - Select the Mac's Bluetooth audio output in System Settings. The SDK does not
   change the system-wide audio route. Host microphone selection uses CoreAudio
-  for the SDK's own recording engine.
+  for the SDK's own recording engine. Bluetooth microphone modes use the
+  Bluetooth input selected in System Settings > Sound > Input, not the first
+  connected headset. Internal microphone mode uses a built-in input only.
+  Input changes are observed while recording; glasses audio availability is
+  tracked independently of the selected output.
 - macOS has no iOS `AVAudioSession` audio-focus contract. The SDK tracks explicit
   own-app playback, but does not detect every other app's playback to suspend
   the glasses microphone. A host app must coordinate simultaneous audio use.

--- a/mintlify-docs/bluetooth-sdk/macos.mdx
+++ b/mintlify-docs/bluetooth-sdk/macos.mdx
@@ -1,0 +1,162 @@
+---
+title: "macOS"
+description: "Use the Bluetooth SDK in native AppKit, SwiftUI, or react-native-macos apps."
+icon: "desktop"
+---
+
+The Apple SDK supports native macOS apps through the same `MentraBluetoothSDK`
+Swift package used on iOS. The npm package exposes that implementation to
+`react-native-macos` through Expo Modules.
+
+<Note>
+Native macOS support is new on the `dev` branch. Until a coordinated SDK release
+containing this change is published, use the local source overrides below.
+Older published packages are iOS-only.
+</Note>
+
+## Native macOS Versus iOS On Mac
+
+The iOS example distributed through TestFlight can run on compatible Apple
+silicon Macs. That is an iOS app running on Mac, not an AppKit or
+`react-native-macos` build. It continues to use the iOS SDK implementation.
+
+Use the native examples below when building a macOS application. CoreBluetooth,
+camera requests, OTA commands, status, and events share the existing Apple SDK
+implementation. The Mac adapters use CoreAudio for host microphone input and
+ImageIO for image decoding instead of iOS-only APIs.
+
+## Swift: AppKit Or SwiftUI
+
+Requirements: macOS 13 or newer, Xcode with Swift 5.9 or newer, and a Mac with
+Bluetooth for device testing. Add the `MentraBluetoothSDK` product to your macOS
+app target from:
+
+```text
+https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
+```
+
+The repository keeps its existing name for compatibility; it supplies both
+Apple platforms. For unpublished changes, add this folder as a local package
+in Xcode instead:
+
+```text
+/path/to/MentraOS/mobile/modules/bluetooth-sdk
+```
+
+The [Swift connection API](/bluetooth-sdk/ios#basic-flow) is unchanged. Own the SDK
+on the main actor in your AppKit controller or SwiftUI model, observe its
+delegate, and call `invalidate()` when the owning session ends. Do not configure
+`AVAudioSession` or `UIBackgroundModes` in a native Mac app.
+
+### Permissions And Sandbox
+
+Add usage descriptions to your app's `Info.plist`:
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>Connect to your smart glasses.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>Capture audio when microphone recording is enabled.</string>
+<key>NSLocalNetworkUsageDescription</key>
+<string>Access glasses and media servers on your local network.</string>
+```
+
+For a sandboxed app, enable these capabilities in the app target, not the SDK:
+
+```xml
+<key>com.apple.security.app-sandbox</key>
+<true/>
+<key>com.apple.security.device.bluetooth</key>
+<true/>
+<key>com.apple.security.device.audio-input</key>
+<true/>
+<key>com.apple.security.network.client</key>
+<true/>
+<key>com.apple.security.network.server</key>
+<true/>
+```
+
+Audio input is only needed for the Mac microphone. Network server access is
+only needed when hosting a local photo receiver or OTA server. Request host
+microphone permission from your app, for example with
+`await AVCaptureDevice.requestAccess(for: .audio)`, before enabling that input.
+The SDK checks permission but does not show a microphone permission dialog.
+
+For local HTTP photo webhooks, allow local networking with
+`NSAppTransportSecurity.NSAllowsLocalNetworking`. Prefer HTTPS for remote servers.
+
+### Run The AppKit Example From Source
+
+From the Starter Kit `dev` branch:
+
+```bash
+cd examples/macos
+export MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/absolute/path/to/MentraOS/mobile/modules/bluetooth-sdk
+bash run.sh
+```
+
+The script builds and ad-hoc signs a sandboxed `.app` with usage descriptions.
+Running the raw SwiftPM executable is not equivalent to running this app bundle.
+The focused sample demonstrates scan/connect, photo upload and preview, and OTA
+availability checking. It does not duplicate the complete phone example OTA UI.
+
+## React Native macOS
+
+Use `examples/react-native-macos` in the Starter Kit, not `expo run:ios` and not
+the phone example's generated project. This native Mac host currently pairs
+React Native macOS 0.81 with React Native 0.81 and Expo Modules from Expo SDK 54;
+it requires macOS 14 or newer. Keep the native host, React Native, and Expo
+versions compatible when upgrading them.
+
+```bash
+cd examples/react-native-macos
+bun install --frozen-lockfile
+export MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/absolute/path/to/MentraOS/mobile/modules/bluetooth-sdk
+cd macos
+pod install
+cd ..
+bun run macos
+```
+
+Use the same source override in both the `pod install` shell and the Metro
+shell. After the native-macOS SDK is published, remove the override to use the
+package pinned in `package.json`.
+
+The example's Podfile enables Expo Modules autolinking for the macOS target,
+sets `MENTRA_BLUETOOTH_SDK_INCLUDE_EXPO_ADAPTER=1`, and uses the
+`react-native-macos` native dependency scripts. Its Metro configuration resolves
+`react-native` to `react-native-macos`. The existing JavaScript imports and SDK
+React hooks are unchanged:
+
+```tsx
+import BluetoothSdk from '@mentra/bluetooth-sdk';
+import {useMentraBluetooth} from '@mentra/bluetooth-sdk/react';
+```
+
+Expo Go and Expo's iOS/Android prebuild plugin do not generate this Mac host.
+Microsoft documents Expo Modules support on `react-native-macos` as
+[experimental](https://microsoft.github.io/react-native-macos/docs/guides/installing-expo-modules).
+This is support for the Bluetooth SDK, not a claim that all Mentra Engine
+dependencies or arbitrary Expo packages support native macOS.
+
+## Platform Differences
+
+- Bluetooth testing requires a real Mac. Sleeping the Mac can interrupt the
+  connection; reconnect through the normal SDK lifecycle after wake.
+- Select the Mac's Bluetooth audio output in System Settings. The SDK does not
+  change the system-wide audio route. Host microphone selection uses CoreAudio
+  for the SDK's own recording engine.
+- macOS has no iOS `AVAudioSession` audio-focus contract. The SDK tracks explicit
+  own-app playback, but does not detect every other app's playback to suspend
+  the glasses microphone. A host app must coordinate simultaneous audio use.
+- A playback device reconfiguration rejects pending PCM stream operations;
+  reopen the stream after selecting the new route.
+- iOS ANCS notification relay is not available on native macOS.
+- Optional MentraOS local STT/TTS, Vuzix, and Mentra Nex dependencies are not
+  part of this native macOS package.
+- Glasses Wi-Fi/hotspot commands work through the shared SDK. Joining that
+  hotspot from the Mac remains a host/system Wi-Fi action. The Android-only
+  `otaLocalNetwork` scoped networking adapter remains unavailable on macOS.
+- Source-built SDKs do not gain a production OTA pin. Use the existing
+  `debug.setOtaVersionUrl(...)` override when deliberately testing OTA from
+  source, and use a published coordinated SDK for its matching release pin.

--- a/mintlify-docs/bluetooth-sdk/overview.mdx
+++ b/mintlify-docs/bluetooth-sdk/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Mentra Bluetooth SDK"
-description: "Connect mobile apps directly to Mentra Live over Bluetooth."
+description: "Connect mobile and native macOS apps directly to Mentra Live over Bluetooth."
 icon: "bluetooth"
 ---
 
-The Mentra Bluetooth SDK is the base SDK for building mobile apps that control Mentra Live directly over Bluetooth. It gives Android, iOS, and React Native apps access to scanning, pairing, device status, microphone audio, camera capture, speaker playback, streaming, Wi-Fi, and hardware events.
+The Mentra Bluetooth SDK connects Android, iOS, macOS, and React Native apps to Mentra Live directly over Bluetooth. It provides scanning, pairing, device status, microphone audio, camera capture, speaker playback, streaming, Wi-Fi, and hardware events. See the [native macOS setup and platform differences](/bluetooth-sdk/macos) for AppKit, SwiftUI, and react-native-macos.
 
 Use this SDK when your app owns the mobile experience and needs a direct phone-to-glasses connection.
 
@@ -13,8 +13,8 @@ Use this SDK when your app owns the mobile experience and needs a direct phone-t
 | Platform | Package | Import |
 | --- | --- | --- |
 | Android | `com.mentraglass:bluetooth-sdk` | `import com.mentra.bluetoothsdk.*` |
-| iOS | `MentraBluetoothSDK` Swift package | `import MentraBluetoothSDK` |
-| React Native / Expo | `@mentra/bluetooth-sdk` | `import BluetoothSdk from '@mentra/bluetooth-sdk'` |
+| iOS / macOS | `MentraBluetoothSDK` Swift package | `import MentraBluetoothSDK` |
+| React Native / Expo / react-native-macos | `@mentra/bluetooth-sdk` | `import BluetoothSdk from '@mentra/bluetooth-sdk'` |
 
 ## Quickstart
 
@@ -38,9 +38,10 @@ You can also [open the starter kit directly on GitHub](https://github.com/Mentra
 ## Requirements
 
 - The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `{{release-version}}`.
-- A physical Android phone or iPhone for real Bluetooth testing.
+- A physical Android phone, iPhone, or Mac for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
+- Native macOS deployment target `13` or newer; the react-native-macos example requires `14` or newer.
 - React Native / Expo apps must use a development build or production native build. Expo Go cannot load the native SDK.
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 

--- a/mintlify-docs/bluetooth-sdk/overview.mdx
+++ b/mintlify-docs/bluetooth-sdk/overview.mdx
@@ -30,7 +30,7 @@ You can also [open the starter kit directly on GitHub](https://github.com/Mentra
 
 ## What You Can Build
 
-- Native Android, iOS, or React Native apps that scan for and connect to Mentra Live.
+- Native Android, iOS, macOS, or React Native apps that scan for and connect to Mentra Live.
 - Apps that receive button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, audio, and SDK log events.
 - Apps that control Mentra Live features such as gallery mode, camera settings, speaker playback, RGB LEDs, Wi-Fi, hotspot, microphone, camera, and streaming.
 - Photo upload to your own webhook and RTMP, SRT, or WebRTC streaming to your own ingest endpoint. The starter kit also includes optional local demo helpers for trying these flows on a LAN.
@@ -53,7 +53,7 @@ Bluetooth connection alone does not confirm version compatibility. Before testin
 
 <CardGroup cols={2}>
   <Card title="Build from Scratch" icon="screwdriver-wrench" href="/bluetooth-sdk/build-from-scratch">
-    Add the SDK to your own Android, iOS, or React Native app.
+    Add the SDK to your own Android, iOS, macOS, or React Native app.
   </Card>
   <Card title="Update Mentra Live" icon="download" href="/bluetooth-sdk/software-update">
     Install the glasses software that matches your Bluetooth SDK release.

--- a/mintlify-docs/bluetooth-sdk/quickstart.mdx
+++ b/mintlify-docs/bluetooth-sdk/quickstart.mdx
@@ -56,6 +56,13 @@ open MentraExample.xcodeproj
 Choose a physical iPhone as the run destination in Xcode. The iOS example is a
 SwiftUI app that installs the `MentraBluetoothSDK` Swift package.
 
+### Native macOS
+
+Use the Starter Kit `dev` branch's `examples/macos` (AppKit/SwiftPM) or
+`examples/react-native-macos` for a native Mac host. See [macOS setup](/bluetooth-sdk/macos)
+for source overrides, permissions, compatible versions, and the distinction
+from running the iOS TestFlight example on Apple silicon.
+
 ### React Native / Expo
 
 ```bash

--- a/mintlify-docs/bluetooth-sdk/react-native-expo.mdx
+++ b/mintlify-docs/bluetooth-sdk/react-native-expo.mdx
@@ -6,6 +6,10 @@ icon: "mobile-screen-button"
 
 React Native apps use the JavaScript package `@mentra/bluetooth-sdk`. The package contains native Android and iOS code, so it must run in a development build or production native build.
 
+For a native Mac app, use the [react-native-macos setup](/bluetooth-sdk/macos#react-native-macos).
+The phone setup below also runs on compatible Apple silicon Macs as an iOS app;
+that is distinct from native macOS support.
+
 <Warning>
 Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the SDK's native modules.
 </Warning>

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -138,7 +138,7 @@
           {
             "group": "Platform Setup",
             "icon": "gears",
-            "pages": ["bluetooth-sdk/react-native-expo", "bluetooth-sdk/android", "bluetooth-sdk/ios"]
+            "pages": ["bluetooth-sdk/react-native-expo", "bluetooth-sdk/android", "bluetooth-sdk/ios", "bluetooth-sdk/macos"]
           },
           {
             "group": "Core APIs",

--- a/mobile/modules/bluetooth-sdk/Package.swift
+++ b/mobile/modules/bluetooth-sdk/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
   name: "MentraBluetoothSDK",
   platforms: [
-    .iOS("15.1")
+    .iOS("15.1"),
+    .macOS(.v13)
   ],
   products: [
     .library(

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -8,7 +8,8 @@ The package includes:
 - React hooks under `@mentra/bluetooth-sdk/react` for common scan,
   connection, status, and event lifecycles.
 - Native Android code published as `com.mentraglass:bluetooth-sdk`.
-- Native iOS code available as the `MentraBluetoothSDK` Swift package.
+- Native iOS and macOS code available as the `MentraBluetoothSDK` Swift package.
+- Native macOS Expo Modules adapter for `react-native-macos` hosts.
 - An Expo config plugin that wires the native dependencies into generated Android and iOS projects.
 
 Use a development build or production native build. Expo Go cannot load this package because the SDK contains native code.
@@ -19,6 +20,9 @@ Use a development build or production native build. Expo Go cannot load this pac
 - Expo `49+` when using Expo.
 - Android min SDK `28+`.
 - iOS deployment target `15.1+`.
+- Native macOS deployment target `13+`. The Starter Kit's separate
+  `react-native-macos` host requires macOS `14+` and a matching React Native / Expo
+  Modules toolchain; the iOS/Android config plugin does not generate a Mac host.
 - A physical phone for real Bluetooth testing.
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
@@ -526,13 +530,15 @@ project, not the local Gradle entrypoint. The check script prepares
 `mobile/android` and uses its Gradle wrapper with `-PmentraPublicSdk=true`,
 matching the CI release workflow's public SDK dependency mode.
 
-For bare native iOS apps, use the public SwiftPM repository:
+For bare native iOS or macOS apps, use the public SwiftPM repository:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.20`, then add the `MentraBluetoothSDK` product to your app target.
+Select a coordinated SDK version that includes your target platform, then add
+the `MentraBluetoothSDK` product to your app target. Native macOS support is new
+on `dev`; use the local source override until a supporting release is published.
 
 For local SDK development, add this package folder directly in Xcode:
 
@@ -541,6 +547,14 @@ For local SDK development, add this package folder directly in Xcode:
 ```
 
 The core Swift package intentionally excludes optional local STT, Nex/SwiftProtobuf, Vuzix/Ultralite, and tar.bz2 extraction code paths.
+
+Native Mac hosts need Bluetooth and local-network usage descriptions, and
+sandbox entitlements for Bluetooth and outbound networking. Add microphone
+permission/audio-input capability for host microphone capture and network-server
+capability for local SDK servers. macOS uses CoreAudio instead of
+`AVAudioSession`; it does not provide iOS background modes or ANCS relay. See
+[the macOS integration guide](../../../mintlify-docs/bluetooth-sdk/macos.mdx)
+and the Starter Kit's `examples/macos` and `examples/react-native-macos` hosts.
 
 Maintainers publishing the public SwiftPM mirror should follow
 [RELEASING_IOS_SPM.md](./RELEASING_IOS_SPM.md).

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -34,7 +34,7 @@ add an explicit exclusion with a short explanation in the export script.
   ../mentra-bluetooth-sdk-ios
   ```
 
-- Xcode with the iOS platform installed.
+- macOS with Xcode, Swift 5.9 or newer, and the iOS platform installed.
 - Push permission to `Mentra-Community/mentra-bluetooth-sdk-ios`.
 - For CI, a `MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN` repository secret with write
   access to the SwiftPM mirror repository.
@@ -51,8 +51,8 @@ scripts/export-bluetooth-sdk-ios-spm.sh --target ../mentra-bluetooth-sdk-ios --v
 ```
 
 The script rewrites the target checkout except for `.git`. The `--verify` flag
-runs SwiftPM package description and a generic iOS Xcode build in the exported
-package. It reads `mobile/modules/bluetooth-sdk/package.json` and inserts that
+runs SwiftPM package description, a native macOS build, and a generic iOS Xcode
+build in the exported package. It reads `mobile/modules/bluetooth-sdk/package.json` and inserts that
 version into the generated README examples.
 
 ## Inspect the Target Diff

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -695,6 +695,7 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
 
         // MARK: - STT Model Management
 
+        #if !os(macOS)
         AsyncFunction("setSttModelDetails") { (path: String, languageCode: String) in
             STTTools.setSttModelDetails(path, languageCode)
         }
@@ -747,6 +748,7 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
                 speed: speed
             )
         }
+        #endif
     }
 
     @MainActor
@@ -933,7 +935,6 @@ private extension ConnectOptions {
         )
     }
 }
-
 
 
 

--- a/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
+++ b/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :osx => '13.0'
   }
   s.swift_version  = '5.9'
   s.source         = {
@@ -23,10 +24,10 @@ Pod::Spec.new do |s|
 
   # External dependencies required by Bluetooth SDK native code
   s.dependency 'ExpoModulesCore' if include_expo_adapter
-  s.dependency 'SWCompression', '~> 4.8.0'
-  s.dependency 'SwiftProtobuf', '~> 1.0'
-  s.dependency 'onnxruntime-objc', '1.18.0'
-  s.dependency 'UltraliteSDK'
+  s.ios.dependency 'SWCompression', '~> 4.8.0'
+  s.ios.dependency 'SwiftProtobuf', '~> 1.0'
+  s.ios.dependency 'onnxruntime-objc', '1.18.0'
+  s.ios.dependency 'UltraliteSDK'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
@@ -39,13 +40,14 @@ Pod::Spec.new do |s|
   # iOS frameworks required by Bluetooth SDK
   ios_frameworks = ['AVFoundation', 'CoreBluetooth', 'UIKit', 'CoreGraphics']
   ios_frameworks << 'Network' if include_expo_adapter
-  s.frameworks = ios_frameworks
+  s.ios.frameworks = ios_frameworks
+  s.osx.frameworks = ['AVFoundation', 'CoreBluetooth', 'CoreAudio', 'AudioToolbox', 'ImageIO', 'JavaScriptCore', 'Network']
 
   # System libraries required by MentraOS
-  s.library = 'bz2'
+  s.ios.library = 'bz2'
 
   # Vendored frameworks
-  s.vendored_frameworks = 'Packages/SherpaOnnx/sherpa-onnx.xcframework'
+  s.ios.vendored_frameworks = 'Packages/SherpaOnnx/sherpa-onnx.xcframework'
 
   s.resource_bundles = {
     'BluetoothSDKPrivacy' => ['Source/PrivacyInfo.xcprivacy']
@@ -60,7 +62,7 @@ Pod::Spec.new do |s|
     "Packages/SherpaOnnx/sherpa-onnx.xcframework/Headers/**/*.{h,hpp}",
     "Packages/libbz2/shim.h"
   ]
-  native_source_files.concat([
+  adapter_source_files = [
     "BluetoothSdkModule.swift",
     "LocalPhotoUploadServer.swift",
     "MentraPhotoReceiverModule.swift",
@@ -68,8 +70,24 @@ Pod::Spec.new do |s|
     "LocalOtaServer.swift",
     "BackgroundOtaArtifactDownloader.swift",
     "MentraOtaServerModule.swift"
-  ]) if include_expo_adapter
-  s.source_files = native_source_files
+  ]
+  native_source_files.concat(adapter_source_files) if include_expo_adapter
+  s.ios.source_files = native_source_files
+  s.osx.source_files = [
+    'Source/**/*.{h,m,mm,swift,hpp,cpp,c}',
+    'Packages/CoreObjC/**/*.{h,m,mm,hpp,cpp,c}'
+  ] + (include_expo_adapter ? adapter_source_files : [])
+  s.osx.exclude_files = [
+    'Source/Bridging-Header.h',
+    'Source/sgcs/Mach1.swift',
+    'Source/sgcs/MentraNex.swift',
+    'Source/sgcs/mentraos_ble.pb.swift',
+    'Source/stt/**/*',
+    'Source/tts/**/*',
+    'Source/utils/TarBz2Extractor.swift',
+    'Source/BridgeModule.{h,m}',
+    'Source/Bridge.m'
+  ]
 
   # Explicitly mark C++ headers and internal headers as private to prevent exposure in public interface
   s.private_header_files = [

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -9,7 +9,9 @@ import AVFoundation
 import Combine
 import CoreBluetooth
 import Foundation
+#if canImport(UIKit)
 import UIKit
+#endif
 #if SWIFT_PACKAGE
 import MentraBluetoothSDKCoreObjC
 #endif
@@ -74,6 +76,13 @@ struct ViewState {
         // Check if device is paired (don't activate to preserve A2DP music playback)
         let isPaired = AudioSessionMonitor.isDevicePaired(devicePattern: audioDevicePattern)
 
+        #if os(macOS)
+        AudioSessionMonitor.startMonitoring(devicePattern: audioDevicePattern) { [weak self] _, _ in
+            self?.checkCurrentAudioDevice()
+            self?.updateMicState()
+        }
+        #endif
+
         if isPaired {
             // Device is paired! Don't activate it - let PhoneMic.swift activate when recording starts
             Bridge.log("Audio: Mentra Live is paired (preserving A2DP for music)")
@@ -83,6 +92,7 @@ struct ViewState {
             // Not found in availableInputs - not paired yet
 
             // Start monitoring for when user pairs manually
+            #if !os(macOS)
             AudioSessionMonitor.startMonitoring(devicePattern: audioDevicePattern) {
                 [weak self] (connected: Bool, _: String?) in
                 guard let self = self else { return }
@@ -96,6 +106,7 @@ struct ViewState {
                     self.glassesBluetoothClassicConnected = false
                 }
             }
+            #endif
         }
     }
 
@@ -314,7 +325,7 @@ struct ViewState {
     private var micReinitTimer: Timer?
 
     /// STT:
-    #if !SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT
+    #if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT)
     private var transcriber: SherpaOnnxTranscriber?
     #endif
 
@@ -351,7 +362,7 @@ struct ViewState {
         // MemoryMonitor.start()
 
         // Initialize SherpaOnnx Transcriber
-        #if !SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT
+        #if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT)
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let window = windowScene.windows.first,
            let rootViewController = window.rootViewController
@@ -500,7 +511,7 @@ struct ViewState {
         handleSendingPcm(pcmData)
 
         // Send PCM to local transcriber.
-#if !SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT
+#if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT)
         if shouldSendTranscript || localSttFallbackActive {
             transcriber?.acceptAudio(pcm16le: pcmData)
         }
@@ -517,11 +528,13 @@ struct ViewState {
 
         var phoneMicUnavailable = systemMicUnavailable
 
+        #if !os(macOS)
         let appState = UIApplication.shared.applicationState
         if appState == .background {
             // Bridge.log("App is in background - onboard mic unavailable to start!")
             phoneMicUnavailable = true
         }
+        #endif
 
         if micEnabled {
             for micMode in micRanking {
@@ -710,12 +723,12 @@ struct ViewState {
         } else if wearable.contains(DeviceTypes.FRAME) {
             // sgc = FrameManager()
         }
-#if !SWIFT_PACKAGE || MENTRA_FEATURE_NEX
+#if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_NEX)
         if sgc == nil && wearable.contains(DeviceTypes.NEX) {
             sgc = MentraNexSGC.getInstance()
         }
 #endif
-#if !SWIFT_PACKAGE || MENTRA_FEATURE_VUZIX
+#if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_VUZIX)
         if sgc == nil {
             if wearable.contains(DeviceTypes.MACH1) {
                 sgc = Mach1()
@@ -948,17 +961,14 @@ struct ViewState {
 
         let isPaired = AudioSessionMonitor.isDevicePaired(devicePattern: audioDevicePattern)
         if isPaired {
-            let session = AVAudioSession.sharedInstance()
-            let deviceName = session.availableInputs?.first(where: {
-                $0.portName.localizedCaseInsensitiveContains(audioDevicePattern)
-            })?.portName
-            Bridge.log("MAN: Successfully detected newly paired device '\(deviceName)'")
+            Bridge.log("MAN: Successfully detected newly paired device '\(audioDevicePattern)'")
             glassesBluetoothClassicConnected = true
         } else {
             glassesBluetoothClassicConnected = false
         }
     }
 
+    #if !os(macOS)
     func onRouteChange(
         reason: AVAudioSession.RouteChangeReason, availableInputs: [AVAudioSessionPortDescription]
     ) {
@@ -980,6 +990,7 @@ struct ViewState {
 
         updateMicState()
     }
+    #endif
 
     func onInterruption(began: Bool) {
         Bridge.log("MAN: Interruption: \(began)")
@@ -988,7 +999,7 @@ struct ViewState {
     }
 
     func restartTranscriber() {
-        #if !SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT
+        #if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT)
         Bridge.log("MAN: Restarting SherpaOnnxTranscriber via command")
         transcriber?.restart()
         #else
@@ -1933,7 +1944,7 @@ struct ViewState {
 
     func cleanup() {
         // Clean up transcriber resources
-#if !SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT
+#if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT)
         transcriber?.shutdown()
         transcriber = nil
 #endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -9,6 +9,9 @@ import AVFoundation
 import Combine
 import CoreBluetooth
 import Foundation
+#if os(macOS)
+import CoreAudio
+#endif
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -45,6 +48,9 @@ struct ViewState {
     // MARK: - Unique (iOS)
 
     private var cancellables = Set<AnyCancellable>()
+    #if os(macOS)
+    private var audioRouteObserver: MacAudioRouteObserver?
+    #endif
     var sendStateWorkItem: DispatchWorkItem?
     let sendStateQueue = DispatchQueue(label: "sendStateQueue", qos: .userInitiated)
 
@@ -53,6 +59,7 @@ struct ViewState {
      * Attempts to automatically activate Mentra Live as the system audio device
      * If not paired yet, prompts user to pair in Settings
      */
+    #if !os(macOS)
     func setupAudioPairing(deviceName _: String) {
         // Don't configure audio session - PhoneMic.swift handles that
         // Just check if audio session supports Bluetooth (informational only)
@@ -75,13 +82,6 @@ struct ViewState {
 
         // Check if device is paired (don't activate to preserve A2DP music playback)
         let isPaired = AudioSessionMonitor.isDevicePaired(devicePattern: audioDevicePattern)
-
-        #if os(macOS)
-        AudioSessionMonitor.startMonitoring(devicePattern: audioDevicePattern) { [weak self] _, _ in
-            self?.checkCurrentAudioDevice()
-            self?.updateMicState()
-        }
-        #endif
 
         if isPaired {
             // Device is paired! Don't activate it - let PhoneMic.swift activate when recording starts
@@ -109,6 +109,8 @@ struct ViewState {
             #endif
         }
     }
+
+    #endif
 
     // MARK: - End Unique
 
@@ -940,6 +942,10 @@ struct ViewState {
             return
         }
 
+        #if os(macOS)
+        glassesBluetoothClassicConnected = AudioSessionMonitor.isAudioDeviceConnected(devicePattern: audioDevicePattern)
+        otherBtConnected = AudioSessionMonitor.isOtherAudioDeviceConnected(devicePattern: audioDevicePattern)
+        #else
         // check if the device disconnected:
         let isConnected = AudioSessionMonitor.isAudioDeviceConnected(
             devicePattern: audioDevicePattern
@@ -966,6 +972,7 @@ struct ViewState {
         } else {
             glassesBluetoothClassicConnected = false
         }
+        #endif
     }
 
     #if !os(macOS)
@@ -1065,6 +1072,16 @@ struct ViewState {
         }
 
         // check current audio device:
+        #if os(macOS)
+        audioRouteObserver = MacAudioRouteObserver(selectors: [kAudioHardwarePropertyDevices,
+            kAudioHardwarePropertyDefaultInputDevice, kAudioHardwarePropertyDefaultOutputDevice]) { [weak self] in
+            Task { @MainActor in
+                guard let self, self.audioRouteObserver != nil else { return }
+                self.checkCurrentAudioDevice()
+                self.updateMicState()
+            }
+        }
+        #endif
         checkCurrentAudioDevice()
 
         // save the default_wearable now that we're connected:
@@ -1836,6 +1853,11 @@ struct ViewState {
     }
 
     func disconnect(clearPendingConnection: Bool = true) {
+        #if os(macOS)
+        audioRouteObserver = nil
+        glassesBluetoothClassicConnected = false
+        otherBtConnected = false
+        #endif
         sgc?.clearDisplay() // clear the screen
         sgc?.disconnect()
         sgc = nil // Clear the SGC reference after disconnect
@@ -1943,6 +1965,10 @@ struct ViewState {
     }
 
     func cleanup() {
+        #if os(macOS)
+        audioRouteObserver = nil
+        PhoneMic.shared.cleanup()
+        #endif
         // Clean up transcriber resources
 #if !os(macOS) && (!SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT)
         transcriber?.shutdown()

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1174,6 +1174,9 @@ struct ViewState {
 
     func handleDeviceDisconnected() {
         Bridge.log("MAN: Device disconnected")
+        #if os(macOS)
+        audioRouteObserver = nil
+        #endif
         resetSystemTimeSync()
         resetMicHealth()
         DeviceStore.shared.apply("glasses", "headUp", false)

--- a/mobile/modules/bluetooth-sdk/ios/Source/audio/PcmStreamPlayer.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/audio/PcmStreamPlayer.swift
@@ -261,6 +261,17 @@ final class PcmStreamPlayer: @unchecked Sendable {
 
     private func installAudioSessionObservers() {
         let center = NotificationCenter.default
+        #if os(macOS)
+        observers.append(center.addObserver(
+            forName: .AVAudioEngineConfigurationChange, object: engine, queue: nil
+        ) { [weak self] _ in
+            self?.stateQueue.async {
+                // A device change invalidates scheduled buffers. Reject pending writes/close
+                // instead of leaving callers waiting for callbacks that cannot arrive.
+                self?.fail(PcmStreamError.native("Audio device changed; reopen the PCM stream"))
+            }
+        })
+        #else
         observers.append(
             center.addObserver(
                 forName: AVAudioSession.interruptionNotification,
@@ -294,6 +305,7 @@ final class PcmStreamPlayer: @unchecked Sendable {
                 }
             }
         )
+        #endif
     }
 
     private func removeAudioSessionObservers() {
@@ -301,6 +313,7 @@ final class PcmStreamPlayer: @unchecked Sendable {
         observers.removeAll()
     }
 
+    #if !os(macOS)
     private func handleInterruption(_ notification: Notification) {
         guard
             let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
@@ -321,6 +334,7 @@ final class PcmStreamPlayer: @unchecked Sendable {
             break
         }
     }
+    #endif
 }
 
 /// Process-wide registry matching the Android PCM stream bridge contract.

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift
@@ -1,6 +1,8 @@
 import Foundation
 import os.log
+#if canImport(UIKit)
 import UIKit
+#endif
 
 enum BleTraceLogger {
     private static let log = OSLog(subsystem: "com.mentra.bluetoothsdk", category: "MentraBleTrace")
@@ -66,9 +68,14 @@ enum BleTraceLogger {
             "event": event,
             "component": component,
             "pid": ProcessInfo.processInfo.processIdentifier,
-            "model": UIDevice.current.model,
-            "systemVersion": UIDevice.current.systemVersion,
         ]
+        #if os(macOS)
+        payload["model"] = "Mac"
+        payload["systemVersion"] = ProcessInfo.processInfo.operatingSystemVersionString
+        #else
+        payload["model"] = UIDevice.current.model
+        payload["systemVersion"] = UIDevice.current.systemVersion
+        #endif
         for (key, value) in extra {
             payload[key] = value
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
@@ -145,14 +145,19 @@ final class BluetoothSdkAnalytics {
     }
 
     private func baseProperties(configuration: BluetoothSdkAnalyticsConfiguration) -> [String: Any] {
+        #if os(macOS)
+        let platform = "macos"
+        #else
+        let platform = "ios"
+        #endif
         var properties: [String: Any] = [
             "$process_person_profile": false,
             "event_source": "mentra_bluetooth_sdk",
-            "sdk_platform": "ios",
+            "sdk_platform": platform,
             "sdk_surface": configuration.surface,
             "app_identifier": Bundle.main.bundleIdentifier ?? "",
             "app_bundle_identifier": Bundle.main.bundleIdentifier ?? "",
-            "os_platform": "ios",
+            "os_platform": platform,
             "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
         ]
         if let sdkVersion = BluetoothSdkDefaults.sdkVersion {

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
@@ -8,7 +8,11 @@ public struct BluetoothSdkAnalyticsConfiguration {
 
     public init(enabled: Bool = true) {
         self.enabled = enabled
+        #if os(macOS)
+        surface = "macos"
+        #else
         surface = "ios"
+        #endif
     }
 
     var isReady: Bool {

--- a/mobile/modules/bluetooth-sdk/ios/Source/services/MacAudioDevices.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/services/MacAudioDevices.swift
@@ -12,6 +12,20 @@
             transport == kAudioDeviceTransportTypeBluetooth || transport == kAudioDeviceTransportTypeBluetoothLE
         }
 
+        static func input(for mode: String, devices: [MacAudioDevice], defaultInput: AudioDeviceID?) -> AudioDeviceID? {
+            let inputs = devices.filter(\.hasInput)
+            switch mode {
+            case MicTypes.PHONE_INTERNAL:
+                let builtIn = inputs.filter { $0.transport == kAudioDeviceTransportTypeBuiltIn }
+                return builtIn.first { $0.id == defaultInput }?.id ?? builtIn.map(\.id).min()
+            case MicTypes.BLUETOOTH, MicTypes.BLUETOOTH_CLASSIC:
+                // Respect the user's Sound settings; never pick an arbitrary nearby headset.
+                return inputs.first { $0.id == defaultInput && $0.isBluetooth }?.id
+            default:
+                return nil
+            }
+        }
+
         static var available: [MacAudioDevice] {
             var address = address(kAudioHardwarePropertyDevices)
             var size: UInt32 = 0
@@ -62,14 +76,12 @@
         private let listener: AudioObjectPropertyListenerBlock
         private var selectors: [AudioObjectPropertySelector] = []
 
-        init(onChange: @escaping () -> Void) {
+        init(selectors: [AudioObjectPropertySelector], onChange: @escaping () -> Void) {
             listener = { _, _ in onChange() }
-            for selector in [kAudioHardwarePropertyDevices, kAudioHardwarePropertyDefaultInputDevice,
-                             kAudioHardwarePropertyDefaultOutputDevice]
-            {
+            for selector in selectors {
                 var address = MacAudioDevice.address(selector)
                 if AudioObjectAddPropertyListenerBlock(AudioObjectID(kAudioObjectSystemObject), &address, .main, listener) == noErr {
-                    selectors.append(selector)
+                    self.selectors.append(selector)
                 }
             }
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/services/MacAudioDevices.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/services/MacAudioDevices.swift
@@ -1,0 +1,84 @@
+#if os(macOS)
+    import CoreAudio
+    import Foundation
+
+    struct MacAudioDevice {
+        let id: AudioDeviceID
+        let name: String
+        let transport: UInt32
+        let hasInput: Bool
+
+        var isBluetooth: Bool {
+            transport == kAudioDeviceTransportTypeBluetooth || transport == kAudioDeviceTransportTypeBluetoothLE
+        }
+
+        static var available: [MacAudioDevice] {
+            var address = address(kAudioHardwarePropertyDevices)
+            var size: UInt32 = 0
+            guard AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size) == noErr
+            else { return [] }
+            var ids = [AudioDeviceID](repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size)
+            guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &ids) == noErr
+            else { return [] }
+            return ids.compactMap { id in
+                var nameAddress = self.address(kAudioObjectPropertyName)
+                var name: Unmanaged<CFString>?
+                var nameSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+                guard AudioObjectGetPropertyData(id, &nameAddress, 0, nil, &nameSize, &name) == noErr
+                else { return nil }
+                guard let name = name?.takeRetainedValue() else { return nil }
+                var inputAddress = self.address(kAudioDevicePropertyStreams, scope: kAudioObjectPropertyScopeInput)
+                var inputSize: UInt32 = 0
+                let hasInput = AudioObjectGetPropertyDataSize(id, &inputAddress, 0, nil, &inputSize) == noErr && inputSize > 0
+                return MacAudioDevice(id: id, name: name as String,
+                                      transport: value(id, kAudioDevicePropertyTransportType) ?? 0, hasInput: hasInput)
+            }
+        }
+
+        static var defaultInput: AudioDeviceID? {
+            value(AudioObjectID(kAudioObjectSystemObject), kAudioHardwarePropertyDefaultInputDevice)
+        }
+
+        static var defaultOutput: AudioDeviceID? {
+            value(AudioObjectID(kAudioObjectSystemObject), kAudioHardwarePropertyDefaultOutputDevice)
+        }
+
+        static func value(_ object: AudioObjectID, _ selector: AudioObjectPropertySelector) -> UInt32? {
+            var address = address(selector)
+            var value: UInt32 = 0
+            var size = UInt32(MemoryLayout<UInt32>.size)
+            return AudioObjectGetPropertyData(object, &address, 0, nil, &size, &value) == noErr ? value : nil
+        }
+
+        static func address(_ selector: AudioObjectPropertySelector,
+                            scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal) -> AudioObjectPropertyAddress
+        {
+            AudioObjectPropertyAddress(mSelector: selector, mScope: scope, mElement: kAudioObjectPropertyElementMain)
+        }
+    }
+
+    /// Observe route changes without selecting a system-wide audio device.
+    final class MacAudioRouteObserver {
+        private let listener: AudioObjectPropertyListenerBlock
+        private var selectors: [AudioObjectPropertySelector] = []
+
+        init(onChange: @escaping () -> Void) {
+            listener = { _, _ in onChange() }
+            for selector in [kAudioHardwarePropertyDevices, kAudioHardwarePropertyDefaultInputDevice,
+                             kAudioHardwarePropertyDefaultOutputDevice]
+            {
+                var address = MacAudioDevice.address(selector)
+                if AudioObjectAddPropertyListenerBlock(AudioObjectID(kAudioObjectSystemObject), &address, .main, listener) == noErr {
+                    selectors.append(selector)
+                }
+            }
+        }
+
+        deinit {
+            for selector in selectors {
+                var address = MacAudioDevice.address(selector)
+                AudioObjectRemovePropertyListenerBlock(AudioObjectID(kAudioObjectSystemObject), &address, .main, listener)
+            }
+        }
+    }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/services/MacPhoneMic.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/services/MacPhoneMic.swift
@@ -1,0 +1,151 @@
+#if os(macOS)
+    import AudioUnit
+    import AVFoundation
+    import CoreAudio
+    import Foundation
+
+    @MainActor
+    final class PhoneMic {
+        static let shared = PhoneMic()
+        private var engine: AVAudioEngine?
+        private var configurationObserver: NSObjectProtocol?
+        private var currentMode = ""
+        private var preferredDevice: AudioDeviceID?
+        private var activeDevice: AudioDeviceID?
+        var isRecording: Bool {
+            engine?.isRunning == true
+        }
+
+        func checkPermissions() -> Bool {
+            AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        }
+
+        func requestPermissions() async -> Bool {
+            checkPermissions()
+        }
+
+        func getAvailableInputDevices() -> [String: String] {
+            Dictionary(uniqueKeysWithValues: MacAudioDevice.available.filter(\.hasInput).map { (String($0.id), $0.name) })
+        }
+
+        func setPreferredInputDevice(named name: String) -> Bool {
+            guard let device = MacAudioDevice.available.first(where: { $0.hasInput && $0.name.localizedCaseInsensitiveContains(name) })
+            else { return false }
+            preferredDevice = device.id
+            if isRecording {
+                let mode = currentMode
+                stopRecording()
+                return startMode(mode)
+            }
+            return true
+        }
+
+        func isRecordingWithMode(_ mode: String) -> Bool {
+            isRecording && currentMode == mode
+        }
+
+        func startMode(_ mode: String) -> Bool {
+            if isRecordingWithMode(mode) { return true }
+            guard !isRecording, checkPermissions() else { return false }
+            let inputs = MacAudioDevice.available.filter(\.hasInput)
+            let device: AudioDeviceID?
+            switch mode {
+            case MicTypes.PHONE_INTERNAL:
+                device = inputs.first(where: { $0.id == preferredDevice })?.id
+                    ?? inputs.first(where: { $0.transport == kAudioDeviceTransportTypeBuiltIn })?.id
+                    ?? MacAudioDevice.defaultInput
+            case MicTypes.BLUETOOTH, MicTypes.BLUETOOTH_CLASSIC:
+                device = inputs.first(where: { $0.isBluetooth && $0.id == preferredDevice })?.id
+                    ?? inputs.first(where: \.isBluetooth)?.id
+            default:
+                return false
+            }
+            guard let device else { return false }
+            return start(device: device, mode: mode)
+        }
+
+        func startRecording() -> Bool {
+            startMode(MicTypes.PHONE_INTERNAL)
+        }
+
+        private func start(device: AudioDeviceID, mode: String) -> Bool {
+            let engine = AVAudioEngine()
+            let input = engine.inputNode
+            guard let unit = input.audioUnit else { return false }
+            var device = device
+            guard AudioUnitSetProperty(unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
+                                       0, &device, UInt32(MemoryLayout<AudioDeviceID>.size)) == noErr
+            else { return false }
+            let format = input.outputFormat(forBus: 0)
+            guard format.sampleRate > 0, format.channelCount > 0,
+                  let output = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: false),
+                  let converter = AVAudioConverter(from: format, to: output)
+            else { return false }
+            input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self, weak engine] buffer, _ in
+                let capacity = AVAudioFrameCount(ceil(Double(buffer.frameLength) * output.sampleRate / format.sampleRate))
+                guard let converted = AVAudioPCMBuffer(pcmFormat: output, frameCapacity: capacity) else { return }
+                var supplied = false
+                var error: NSError?
+                let result = converter.convert(to: converted, error: &error) { _, status in
+                    guard !supplied else { status.pointee = .noDataNow; return nil }
+                    supplied = true
+                    status.pointee = .haveData
+                    return buffer
+                }
+                guard result != .error, error == nil, converted.frameLength > 0,
+                      let samples = converted.int16ChannelData?[0] else { return }
+                let pcm = Data(bytes: samples, count: Int(converted.frameLength) * MemoryLayout<Int16>.size)
+                Task { @MainActor [weak self, weak engine] in
+                    guard let engine, self?.engine === engine else { return }
+                    DeviceManager.shared.handlePcm(pcm)
+                }
+            }
+            do {
+                try engine.start()
+            } catch {
+                input.removeTap(onBus: 0)
+                Bridge.log("MIC: macOS input failed: \(error.localizedDescription)")
+                return false
+            }
+            self.engine = engine
+            activeDevice = device
+            currentMode = mode
+            configurationObserver = NotificationCenter.default.addObserver(
+                forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main
+            ) { [weak self, weak engine] _ in
+                Task { @MainActor in
+                    guard let engine, self?.engine === engine else { return }
+                    self?.stopRecording()
+                    DeviceManager.shared.updateMicState()
+                }
+            }
+            return true
+        }
+
+        func getActiveInputDevice() -> String? {
+            MacAudioDevice.available.first(where: { $0.id == activeDevice })?.name
+        }
+
+        func stopMode(_ mode: String) -> Bool {
+            guard currentMode == mode else { return false }
+            stopRecording()
+            return true
+        }
+
+        func stopRecording() {
+            if let configurationObserver {
+                NotificationCenter.default.removeObserver(configurationObserver)
+            }
+            configurationObserver = nil
+            engine?.inputNode.removeTap(onBus: 0)
+            engine?.stop()
+            engine = nil
+            currentMode = ""
+            activeDevice = nil
+        }
+
+        func cleanup() {
+            stopRecording()
+        }
+    }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/services/MacPhoneMic.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/services/MacPhoneMic.swift
@@ -9,8 +9,8 @@
         static let shared = PhoneMic()
         private var engine: AVAudioEngine?
         private var configurationObserver: NSObjectProtocol?
+        private var routeObserver: MacAudioRouteObserver?
         private var currentMode = ""
-        private var preferredDevice: AudioDeviceID?
         private var activeDevice: AudioDeviceID?
         var isRecording: Bool {
             engine?.isRunning == true
@@ -28,18 +28,6 @@
             Dictionary(uniqueKeysWithValues: MacAudioDevice.available.filter(\.hasInput).map { (String($0.id), $0.name) })
         }
 
-        func setPreferredInputDevice(named name: String) -> Bool {
-            guard let device = MacAudioDevice.available.first(where: { $0.hasInput && $0.name.localizedCaseInsensitiveContains(name) })
-            else { return false }
-            preferredDevice = device.id
-            if isRecording {
-                let mode = currentMode
-                stopRecording()
-                return startMode(mode)
-            }
-            return true
-        }
-
         func isRecordingWithMode(_ mode: String) -> Bool {
             isRecording && currentMode == mode
         }
@@ -47,20 +35,8 @@
         func startMode(_ mode: String) -> Bool {
             if isRecordingWithMode(mode) { return true }
             guard !isRecording, checkPermissions() else { return false }
-            let inputs = MacAudioDevice.available.filter(\.hasInput)
-            let device: AudioDeviceID?
-            switch mode {
-            case MicTypes.PHONE_INTERNAL:
-                device = inputs.first(where: { $0.id == preferredDevice })?.id
-                    ?? inputs.first(where: { $0.transport == kAudioDeviceTransportTypeBuiltIn })?.id
-                    ?? MacAudioDevice.defaultInput
-            case MicTypes.BLUETOOTH, MicTypes.BLUETOOTH_CLASSIC:
-                device = inputs.first(where: { $0.isBluetooth && $0.id == preferredDevice })?.id
-                    ?? inputs.first(where: \.isBluetooth)?.id
-            default:
-                return false
-            }
-            guard let device else { return false }
+            guard let device = MacAudioDevice.input(for: mode, devices: MacAudioDevice.available,
+                                                    defaultInput: MacAudioDevice.defaultInput) else { return false }
             return start(device: device, mode: mode)
         }
 
@@ -110,6 +86,16 @@
             self.engine = engine
             activeDevice = device
             currentMode = mode
+            routeObserver = MacAudioRouteObserver(selectors: [kAudioHardwarePropertyDevices, kAudioHardwarePropertyDefaultInputDevice]) { [weak self, weak engine] in
+                Task { @MainActor in
+                    guard let self, let engine, self.engine === engine else { return }
+                    let desired = MacAudioDevice.input(for: self.currentMode, devices: MacAudioDevice.available,
+                                                       defaultInput: MacAudioDevice.defaultInput)
+                    guard desired != self.activeDevice else { return }
+                    self.stopRecording()
+                    DeviceManager.shared.updateMicState()
+                }
+            }
             configurationObserver = NotificationCenter.default.addObserver(
                 forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main
             ) { [weak self, weak engine] _ in
@@ -133,6 +119,7 @@
         }
 
         func stopRecording() {
+            routeObserver = nil
             if let configurationObserver {
                 NotificationCenter.default.removeObserver(configurationObserver)
             }

--- a/mobile/modules/bluetooth-sdk/ios/Source/services/PhoneMic.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/services/PhoneMic.swift
@@ -5,6 +5,7 @@
 //  Created on 3/8/25.
 //
 
+#if !os(macOS)
 import AVFoundation
 import Combine
 import Foundation
@@ -661,3 +662,4 @@ class PhoneMic {
         stopRecording()
     }
 }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -8,7 +8,7 @@
 import Combine
 import CoreBluetooth
 import Foundation
-import UIKit
+import CoreGraphics
 
 extension Data {
     func chunked(into size: Int) -> [Data] {
@@ -1822,7 +1822,7 @@ extension G1 {
     /// Mirrors G2.convertToG2Bmp() for local miniapp bitmap display support.
     /// G1 uses 1-bit monochrome BMP at 640x400 (576x135 active area).
     func convertToG1Bmp(_ imageData: Data, width: Int = 576, height: Int = 135) -> Data? {
-        guard let image = UIImage(data: imageData), let cgImage = image.cgImage else {
+        guard let image = SdkImage(data: imageData), let cgImage = image.cgImage else {
             Bridge.log("G1: convertToG1Bmp - could not decode image")
             return nil
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -9,7 +9,7 @@
 import Combine
 import CoreBluetooth
 import Foundation
-import UIKit
+import CoreGraphics
 
 /// Keep a low-rate, non-audio EvenHub sensor stream active so iOS continues receiving BLE
 /// notifications while the Mentra App is backgrounded. The samples stay internal unless IMU was
@@ -2565,7 +2565,7 @@ class G2: NSObject, SGCManager {
     /// (aspect-fit, centered on black) — the front half of `convertToG2Bmp`,
     /// exposed for the tiler which encodes per-tile BMPs from one render.
     private func renderG2Grayscale(_ data: Data, targetWidth: Int, targetHeight: Int) -> Data? {
-        guard let image = UIImage(data: data), let cgImage = image.cgImage else { return nil }
+        guard let image = SdkImage(data: data), let cgImage = image.cgImage else { return nil }
         let scale = min(
             Double(targetWidth) / Double(cgImage.width), Double(targetHeight) / Double(cgImage.height)
         )
@@ -3101,7 +3101,7 @@ class G2: NSObject, SGCManager {
     /// Scale source image to fit within containerWidth x containerHeight (maintaining aspect ratio),
     /// centered on a black background. Output BMP always matches container dimensions exactly.
     private func convertToG2Bmp(_ data: Data, containerWidth: Int, containerHeight: Int) -> Data? {
-        guard let image = UIImage(data: data), let cgImage = image.cgImage else {
+        guard let image = SdkImage(data: data), let cgImage = image.cgImage else {
             Bridge.log("G2: convertToG2Bmp - could not decode image")
             return nil
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -16,7 +16,6 @@ import Combine
 import CoreBluetooth
 import Foundation
 import ImageIO
-import UIKit
 
 // MARK: - Supporting Types
 
@@ -355,11 +354,11 @@ class BlePhotoUploadService {
     }
 
     /**
-     * Decode image data (AVIF or JPEG) to UIImage.
+     * Decode image data (AVIF or JPEG).
      * AVIF arriving from glasses has a TIFF EXIF block appended to {@code mdat}; iOS ImageIO
      * rejects those bytes the same way Android does. Strip the Exif tail before decoding.
      */
-    private static func decodeImage(imageData: Data) -> UIImage? {
+    private static func decodeImage(imageData: Data) -> SdkImage? {
         let isAvif = isAvifData(imageData)
         var decodeData = imageData
         if isAvif && containsExifMarker(in: imageData) {
@@ -372,13 +371,13 @@ class BlePhotoUploadService {
             }
         }
 
-        if let image = UIImage(data: decodeData) {
+        if let image = SdkImage(data: decodeData) {
             return image
         }
 
         if isAvif {
-            if #available(iOS 16.0, *) {
-                return UIImage(data: decodeData)
+            if #available(iOS 16.0, macOS 13.0, *) {
+                return SdkImage(data: decodeData)
             } else {
                 Bridge.log("\(TAG): AVIF decoding not supported on iOS < 16")
                 return nil
@@ -1022,6 +1021,7 @@ extension MentraLive: CBCentralManagerDelegate {
         }
     }
 
+    #if !os(macOS)
     nonisolated func centralManager(
         _: CBCentralManager, didUpdateANCSAuthorizationFor peripheral: CBPeripheral
     ) {
@@ -1033,6 +1033,7 @@ extension MentraLive: CBCentralManagerDelegate {
             self.enableAncsRelayIfAuthorized()
         }
     }
+    #endif
 
     nonisolated func centralManager(
         _: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?
@@ -2443,6 +2444,9 @@ class MentraLive: NSObject, SGCManager {
         // Set connection timeout
         startConnectionTimeout()
 
+        #if os(macOS)
+        centralManager?.connect(peripheral, options: nil)
+        #else
         // ANCS is hosted by iOS and is only exposed to authorized accessories.
         // Requiring it at connect time lets the system complete that authorization
         // flow before the glasses subscribe to the ANCS characteristics.
@@ -2450,12 +2454,14 @@ class MentraLive: NSObject, SGCManager {
             peripheral,
             options: [CBConnectPeripheralOptionRequiresANCS: true]
         )
+        #endif
     }
 
     /// Opt the firmware into ANCS only after iOS has authorized this accessory.
     /// Old firmware safely ignores the command, while new firmware stays inert
     /// for old mobile clients that never send it.
     private func enableAncsRelayIfAuthorized() {
+        #if !os(macOS)
         guard !ancsRelayEnableRequested,
               let peripheral = connectedPeripheral,
               txCharacteristic != nil,
@@ -2473,6 +2479,7 @@ class MentraLive: NSObject, SGCManager {
             ancsRelayEnableRequested = true
             Bridge.log("LIVE: Requested ANCS relay from compatible firmware")
         }
+        #endif
     }
 
     private func handleReconnection() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Nimo.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Nimo.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Compression
 import CoreBluetooth
 import Foundation
-import UIKit
+import CoreGraphics
 
 // MARK: - Nimo BLE Constants
 
@@ -846,7 +846,7 @@ class Nimo: NSObject, SGCManager {
         let targetHeight = NimoProtocol.NAV_LARGE_MAP_HEIGHT
         Bridge.log("NIMO: displayBitmap → nav large map (navAppEntered=\(navAppEntered))")
         guard let imageData = Data(base64Encoded: base64ImageData),
-              let image = UIImage(data: imageData)
+              let image = SdkImage(data: imageData)
         else {
             Bridge.log("NIMO: displayBitmap — could not decode image")
             return false
@@ -1640,7 +1640,7 @@ class Nimo: NSObject, SGCManager {
     // MARK: - Bitmap Helpers
 
     /// Aspect-fit the image into `width`x`height` on black, then convert to L8 grayscale.
-    private func bitmapToGrayscale(_ image: UIImage, width: Int, height: Int) -> Data? {
+    private func bitmapToGrayscale(_ image: SdkImage, width: Int, height: Int) -> Data? {
         guard let cgImage = image.cgImage else { return nil }
         let colorSpace = CGColorSpaceCreateDeviceGray()
         guard let context = CGContext(

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/AudioSessionMonitor.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/AudioSessionMonitor.swift
@@ -6,6 +6,7 @@
 //  Used to detect when Mentra Live glasses are paired/connected for audio
 //
 
+#if !os(macOS)
 import AVFoundation
 import Foundation
 import UIKit
@@ -281,3 +282,4 @@ class AudioSessionMonitor {
         }
     }
 }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/JSCExperiment.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/JSCExperiment.swift
@@ -102,7 +102,7 @@ private func jlog(_ message: String) {
             ctx.name = "MentraJS: \(id)"
             // Inspectable in dev builds only. iOS 16.4+ guarded.
             #if DEBUG
-        if #available(iOS 16.4, macOS 13.3, *) {
+                if #available(iOS 16.4, macOS 13.3, *) {
                     ctx.isInspectable = true
                 }
             #endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/JSCExperiment.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/JSCExperiment.swift
@@ -102,7 +102,7 @@ private func jlog(_ message: String) {
             ctx.name = "MentraJS: \(id)"
             // Inspectable in dev builds only. iOS 16.4+ guarded.
             #if DEBUG
-                if #available(iOS 16.4, *) {
+        if #available(iOS 16.4, macOS 13.3, *) {
                     ctx.isInspectable = true
                 }
             #endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/MacAudioSessionMonitor.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/MacAudioSessionMonitor.swift
@@ -1,0 +1,38 @@
+#if os(macOS)
+    import Foundation
+
+    enum AudioSessionMonitor {
+        private static var observer: MacAudioRouteObserver?
+
+        static func isAudioSessionConfigured() -> Bool {
+            true
+        }
+
+        static func isAudioDeviceConnected(devicePattern: String) -> Bool {
+            MacAudioDevice.available.contains {
+                $0.id == MacAudioDevice.defaultOutput && $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern)
+            }
+        }
+
+        static func isOtherAudioDeviceConnected(devicePattern: String) -> Bool {
+            MacAudioDevice.available.contains {
+                $0.id == MacAudioDevice.defaultOutput && $0.isBluetooth && !$0.name.localizedCaseInsensitiveContains(devicePattern)
+            }
+        }
+
+        static func isDevicePaired(devicePattern: String) -> Bool {
+            MacAudioDevice.available.contains { $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern) }
+        }
+
+        static func startMonitoring(devicePattern: String, callback: @escaping (Bool, String?) -> Void) {
+            observer = MacAudioRouteObserver {
+                let device = MacAudioDevice.available.first { $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern) }
+                callback(device != nil, device?.name)
+            }
+        }
+
+        static func stopMonitoring() {
+            observer = nil
+        }
+    }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/MacAudioSessionMonitor.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/MacAudioSessionMonitor.swift
@@ -2,37 +2,17 @@
     import Foundation
 
     enum AudioSessionMonitor {
-        private static var observer: MacAudioRouteObserver?
-
-        static func isAudioSessionConfigured() -> Bool {
-            true
-        }
-
         static func isAudioDeviceConnected(devicePattern: String) -> Bool {
             MacAudioDevice.available.contains {
-                $0.id == MacAudioDevice.defaultOutput && $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern)
+                $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern)
             }
         }
 
         static func isOtherAudioDeviceConnected(devicePattern: String) -> Bool {
-            MacAudioDevice.available.contains {
-                $0.id == MacAudioDevice.defaultOutput && $0.isBluetooth && !$0.name.localizedCaseInsensitiveContains(devicePattern)
+            let output = MacAudioDevice.defaultOutput
+            return MacAudioDevice.available.contains {
+                $0.id == output && $0.isBluetooth && !$0.name.localizedCaseInsensitiveContains(devicePattern)
             }
-        }
-
-        static func isDevicePaired(devicePattern: String) -> Bool {
-            MacAudioDevice.available.contains { $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern) }
-        }
-
-        static func startMonitoring(devicePattern: String, callback: @escaping (Bool, String?) -> Void) {
-            observer = MacAudioRouteObserver {
-                let device = MacAudioDevice.available.first { $0.isBluetooth && $0.name.localizedCaseInsensitiveContains(devicePattern) }
-                callback(device != nil, device?.name)
-            }
-        }
-
-        static func stopMonitoring() {
-            observer = nil
         }
     }
 #endif

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/PhoneAudioMonitor.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/PhoneAudioMonitor.swift
@@ -50,9 +50,15 @@ class PhoneAudioMonitor {
 
     /// Check if any audio is currently playing on the device (including our own app)
     func isPlaying() -> Bool {
+        #if os(macOS)
+        // macOS has no AVAudioSession audio-focus contract. Explicit SDK playback
+        // is tracked; other applications retain independent system audio routes.
+        return ownAppAudioPlaying
+        #else
         let session = AVAudioSession.sharedInstance()
         // Combine: other apps playing OR our own app playing
         return session.isOtherAudioPlaying || ownAppAudioPlaying
+        #endif
     }
 
     func isOwnAppAudioPlaying() -> Bool {
@@ -88,6 +94,7 @@ class PhoneAudioMonitor {
             "PhoneAudioMonitor: Starting audio playback monitoring (initial state: \(lastKnownState ? "playing" : "not playing"))"
         )
 
+        #if !os(macOS)
         // Register for silenceSecondaryAudioHint notification
         // This is fired when other apps start/stop playing audio
         NotificationCenter.default.addObserver(
@@ -108,6 +115,7 @@ class PhoneAudioMonitor {
         // Start polling as a fallback mechanism
         // Some audio sources might not trigger notifications reliably
         startPolling()
+        #endif
     }
 
     /// Stop monitoring for phone audio playback changes
@@ -119,6 +127,7 @@ class PhoneAudioMonitor {
 
         Bridge.log("PhoneAudioMonitor: Stopping audio playback monitoring")
 
+        #if !os(macOS)
         NotificationCenter.default.removeObserver(
             self,
             name: AVAudioSession.silenceSecondaryAudioHintNotification,
@@ -132,11 +141,13 @@ class PhoneAudioMonitor {
         )
 
         stopPolling()
+        #endif
 
         listener = nil
         isMonitoring = false
     }
 
+    #if !os(macOS)
     /// Handle silenceSecondaryAudioHint notification
     @objc private func handleSilenceSecondaryAudioHint(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
@@ -190,6 +201,8 @@ class PhoneAudioMonitor {
             break
         }
     }
+
+    #endif
 
     /// Start polling isOtherAudioPlaying as a fallback mechanism
     private func startPolling() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/SdkImage.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/SdkImage.swift
@@ -1,41 +1,37 @@
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 
-#if os(macOS)
-    import ImageIO
-    import UniformTypeIdentifiers
-
-    /// Image decoding and JPEG encoding without a UI framework dependency on macOS.
-    struct SdkImage {
-        let cgImage: CGImage?
-        private let orientation: Int?
-        var size: CGSize {
-            CGSize(width: cgImage?.width ?? 0, height: cgImage?.height ?? 0)
-        }
-
-        init?(data: Data) {
-            guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-                  let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
-            else { return nil }
-            cgImage = image
-            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
-            orientation = properties?[kCGImagePropertyOrientation] as? Int
-        }
-
-        func jpegData(compressionQuality: CGFloat) -> Data? {
-            guard let cgImage else { return nil }
-            let data = NSMutableData()
-            guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil)
-            else { return nil }
-            var properties: [CFString: Any] = [
-                kCGImageDestinationLossyCompressionQuality: compressionQuality,
-            ]
-            if let orientation { properties[kCGImagePropertyOrientation] = orientation }
-            CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary)
-            return CGImageDestinationFinalize(destination) ? data as Data : nil
-        }
+/// Decode upright pixels once, so bitmap rendering and JPEG encoding agree on both Apple platforms.
+struct SdkImage {
+    let cgImage: CGImage?
+    var size: CGSize {
+        CGSize(width: cgImage?.width ?? 0, height: cgImage?.height ?? 0)
     }
-#else
-    import UIKit
 
-    typealias SdkImage = UIImage
-#endif
+    init?(data: Data) {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? Int,
+              let height = properties[kCGImagePropertyPixelHeight] as? Int,
+              let image = CGImageSourceCreateThumbnailAtIndex(source, 0, [
+                  kCGImageSourceCreateThumbnailFromImageAlways: true,
+                  kCGImageSourceCreateThumbnailWithTransform: true,
+                  kCGImageSourceThumbnailMaxPixelSize: max(width, height),
+              ] as CFDictionary)
+        else { return nil }
+        cgImage = image
+    }
+
+    func jpegData(compressionQuality: CGFloat) -> Data? {
+        guard let cgImage else { return nil }
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil)
+        else { return nil }
+        CGImageDestinationAddImage(destination, cgImage, [
+            kCGImageDestinationLossyCompressionQuality: compressionQuality,
+            kCGImagePropertyOrientation: 1,
+        ] as CFDictionary)
+        return CGImageDestinationFinalize(destination) ? data as Data : nil
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/SdkImage.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/SdkImage.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+#if os(macOS)
+    import ImageIO
+    import UniformTypeIdentifiers
+
+    /// Image decoding and JPEG encoding without a UI framework dependency on macOS.
+    struct SdkImage {
+        let cgImage: CGImage?
+        private let orientation: Int?
+        var size: CGSize {
+            CGSize(width: cgImage?.width ?? 0, height: cgImage?.height ?? 0)
+        }
+
+        init?(data: Data) {
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+                  let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+            else { return nil }
+            cgImage = image
+            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+            orientation = properties?[kCGImagePropertyOrientation] as? Int
+        }
+
+        func jpegData(compressionQuality: CGFloat) -> Data? {
+            guard let cgImage else { return nil }
+            let data = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil)
+            else { return nil }
+            var properties: [CFString: Any] = [
+                kCGImageDestinationLossyCompressionQuality: compressionQuality,
+            ]
+            if let orientation { properties[kCGImagePropertyOrientation] = orientation }
+            CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary)
+            return CGImageDestinationFinalize(destination) ? data as Data : nil
+        }
+    }
+#else
+    import UIKit
+
+    typealias SdkImage = UIImage
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Tests/MacAudioDevicesTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/MacAudioDevicesTests.swift
@@ -1,0 +1,32 @@
+#if os(macOS)
+    import CoreAudio
+    @testable import MentraBluetoothSDK
+    import XCTest
+
+    final class MacAudioDevicesTests: XCTestCase {
+        private let devices = [
+            MacAudioDevice(id: 1, name: "Internal", transport: kAudioDeviceTransportTypeBuiltIn, hasInput: true),
+            MacAudioDevice(id: 2, name: "Headset A", transport: kAudioDeviceTransportTypeBluetooth, hasInput: true),
+            MacAudioDevice(id: 3, name: "Headset B", transport: kAudioDeviceTransportTypeBluetoothLE, hasInput: true),
+            MacAudioDevice(id: 4, name: "Speakers", transport: kAudioDeviceTransportTypeBluetooth, hasInput: false),
+        ]
+
+        func testBluetoothUsesSelectedInputRegardlessOfEnumerationOrder() {
+            for mode in [MicTypes.BLUETOOTH, MicTypes.BLUETOOTH_CLASSIC] {
+                for inputs in [devices, devices.reversed()] {
+                    XCTAssertEqual(MacAudioDevice.input(for: mode, devices: inputs, defaultInput: 3), 3)
+                    XCTAssertEqual(MacAudioDevice.input(for: mode, devices: inputs, defaultInput: 2), 2)
+                    XCTAssertNil(MacAudioDevice.input(for: mode, devices: inputs, defaultInput: 1))
+                    XCTAssertNil(MacAudioDevice.input(for: mode, devices: inputs, defaultInput: 4))
+                    XCTAssertNil(MacAudioDevice.input(for: mode, devices: inputs, defaultInput: nil))
+                }
+            }
+        }
+
+        func testInternalModeNeverFallsBackToBluetooth() {
+            XCTAssertEqual(MacAudioDevice.input(for: MicTypes.PHONE_INTERNAL, devices: devices, defaultInput: 3), 1)
+            XCTAssertNil(MacAudioDevice.input(for: MicTypes.PHONE_INTERNAL, devices: Array(devices.dropFirst()), defaultInput: 3))
+            XCTAssertNil(MacAudioDevice.input(for: "invalid", devices: devices, defaultInput: 1))
+        }
+    }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Tests/SdkImageTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/SdkImageTests.swift
@@ -1,0 +1,36 @@
+#if os(macOS)
+    import CoreGraphics
+    import ImageIO
+    @testable import MentraBluetoothSDK
+    import UniformTypeIdentifiers
+    import XCTest
+
+    final class SdkImageTests: XCTestCase {
+        func testInvalidImageIsRejected() {
+            XCTAssertNil(SdkImage(data: Data("not an image".utf8)))
+        }
+
+        func testImageConvertsToJpegWithoutLosingDimensionsOrOrientation() throws {
+            let context = try XCTUnwrap(CGContext(data: nil, width: 8, height: 4, bitsPerComponent: 8,
+                                                  bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
+                                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+            context.setFillColor(CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+            context.fill(CGRect(x: 0, y: 0, width: 8, height: 4))
+            let image = try XCTUnwrap(context.makeImage())
+            let data = NSMutableData()
+            let destination = try XCTUnwrap(CGImageDestinationCreateWithData(data, UTType.tiff.identifier as CFString, 1, nil))
+            CGImageDestinationAddImage(destination, image, [kCGImagePropertyOrientation: 6] as CFDictionary)
+            XCTAssertTrue(CGImageDestinationFinalize(destination))
+
+            let decoded = try XCTUnwrap(SdkImage(data: data as Data))
+            XCTAssertEqual(decoded.size, CGSize(width: 8, height: 4))
+            let jpeg = try XCTUnwrap(decoded.jpegData(compressionQuality: 0.8))
+            let source = try XCTUnwrap(CGImageSourceCreateWithData(jpeg as CFData, nil))
+            XCTAssertEqual(CGImageSourceGetType(source), UTType.jpeg.identifier as CFString)
+            let properties = try XCTUnwrap(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+            XCTAssertEqual(properties[kCGImagePropertyPixelWidth] as? Int, 8)
+            XCTAssertEqual(properties[kCGImagePropertyPixelHeight] as? Int, 4)
+            XCTAssertEqual(properties[kCGImagePropertyOrientation] as? Int, 6)
+        }
+    }
+#endif

--- a/mobile/modules/bluetooth-sdk/ios/Tests/SdkImageTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/SdkImageTests.swift
@@ -1,36 +1,53 @@
-#if os(macOS)
-    import CoreGraphics
-    import ImageIO
-    @testable import MentraBluetoothSDK
-    import UniformTypeIdentifiers
-    import XCTest
+import CoreGraphics
+import ImageIO
+@testable import MentraBluetoothSDK
+import UniformTypeIdentifiers
+import XCTest
 
-    final class SdkImageTests: XCTestCase {
-        func testInvalidImageIsRejected() {
-            XCTAssertNil(SdkImage(data: Data("not an image".utf8)))
-        }
+final class SdkImageTests: XCTestCase {
+    func testInvalidImageIsRejected() {
+        XCTAssertNil(SdkImage(data: Data("not an image".utf8)))
+    }
 
-        func testImageConvertsToJpegWithoutLosingDimensionsOrOrientation() throws {
-            let context = try XCTUnwrap(CGContext(data: nil, width: 8, height: 4, bitsPerComponent: 8,
-                                                  bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
-                                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
-            context.setFillColor(CGColor(red: 0, green: 1, blue: 0, alpha: 1))
-            context.fill(CGRect(x: 0, y: 0, width: 8, height: 4))
-            let image = try XCTUnwrap(context.makeImage())
+    func testAllExifOrientationsProduceUprightPixelsAndJpegs() throws {
+        // Six asymmetric tiles distinguish rotations from reflections.
+        let pixels: [UInt8] = [10, 50, 90, 130, 170, 210]
+        let raster = (0 ..< 32).flatMap { y in (0 ..< 48).map { x in pixels[(y / 16) * 3 + x / 16] } }
+        let provider = try XCTUnwrap(CGDataProvider(data: Data(raster) as CFData))
+        let image = try XCTUnwrap(CGImage(width: 48, height: 32, bitsPerComponent: 8, bitsPerPixel: 8,
+                                          bytesPerRow: 48, space: CGColorSpaceCreateDeviceGray(), bitmapInfo: [],
+                                          provider: provider, decode: nil, shouldInterpolate: false, intent: .defaultIntent))
+        let expected: [[UInt8]] = [
+            [10, 50, 90, 130, 170, 210], [90, 50, 10, 210, 170, 130],
+            [210, 170, 130, 90, 50, 10], [130, 170, 210, 10, 50, 90],
+            [10, 130, 50, 170, 90, 210], [130, 10, 170, 50, 210, 90],
+            [210, 90, 170, 50, 130, 10], [90, 210, 50, 170, 10, 130],
+        ]
+        for orientation in 1 ... 8 {
             let data = NSMutableData()
             let destination = try XCTUnwrap(CGImageDestinationCreateWithData(data, UTType.tiff.identifier as CFString, 1, nil))
-            CGImageDestinationAddImage(destination, image, [kCGImagePropertyOrientation: 6] as CFDictionary)
+            CGImageDestinationAddImage(destination, image, [kCGImagePropertyOrientation: orientation] as CFDictionary)
             XCTAssertTrue(CGImageDestinationFinalize(destination))
 
             let decoded = try XCTUnwrap(SdkImage(data: data as Data))
-            XCTAssertEqual(decoded.size, CGSize(width: 8, height: 4))
-            let jpeg = try XCTUnwrap(decoded.jpegData(compressionQuality: 0.8))
+            let width = orientation < 5 ? 48 : 32
+            let height = orientation < 5 ? 32 : 48
+            XCTAssertEqual(decoded.size, CGSize(width: width, height: height))
+            let context = try XCTUnwrap(CGContext(data: nil, width: width, height: height, bitsPerComponent: 8,
+                                                  bytesPerRow: width, space: CGColorSpaceCreateDeviceGray(), bitmapInfo: 0))
+            try context.draw(XCTUnwrap(decoded.cgImage), in: CGRect(x: 0, y: 0, width: width, height: height))
+            let bytes = try XCTUnwrap(context.data).assumingMemoryBound(to: UInt8.self)
+            let actual = stride(from: 8, to: height, by: 16).flatMap { y in
+                stride(from: 8, to: width, by: 16).map { x in bytes[y * context.bytesPerRow + x] }
+            }
+            XCTAssertEqual(actual, expected[orientation - 1], "EXIF \(orientation)")
+
+            let jpeg = try XCTUnwrap(decoded.jpegData(compressionQuality: 1))
             let source = try XCTUnwrap(CGImageSourceCreateWithData(jpeg as CFData, nil))
-            XCTAssertEqual(CGImageSourceGetType(source), UTType.jpeg.identifier as CFString)
             let properties = try XCTUnwrap(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
-            XCTAssertEqual(properties[kCGImagePropertyPixelWidth] as? Int, 8)
-            XCTAssertEqual(properties[kCGImagePropertyPixelHeight] as? Int, 4)
-            XCTAssertEqual(properties[kCGImagePropertyOrientation] as? Int, 6)
+            XCTAssertEqual(CGImageSourceGetType(source), UTType.jpeg.identifier as CFString)
+            XCTAssertEqual(properties[kCGImagePropertyOrientation] as? Int ?? 1, 1)
+            XCTAssertEqual(try XCTUnwrap(SdkImage(data: jpeg)).size, decoded.size)
         }
     }
-#endif
+}

--- a/scripts/export-bluetooth-sdk-ios-spm.sh
+++ b/scripts/export-bluetooth-sdk-ios-spm.sh
@@ -6,12 +6,12 @@ usage() {
 Usage:
   scripts/export-bluetooth-sdk-ios-spm.sh [target-dir] [--verify]
 
-Exports the SwiftPM-ready iOS Bluetooth SDK from the MentraOS monorepo into a
+Exports the SwiftPM-ready iOS and macOS Bluetooth SDK from the MentraOS monorepo into a
 standalone package repository. The target defaults to ../mentra-bluetooth-sdk-ios.
 
 Options:
   --target DIR   Export into DIR.
-  --verify       Run SwiftPM describe and a generic iOS xcodebuild after export.
+  --verify       Build the exported package for native macOS and generic iOS.
   -h, --help     Show this help.
 EOF
 }
@@ -97,7 +97,8 @@ import PackageDescription
 let package = Package(
   name: "MentraBluetoothSDK",
   platforms: [
-    .iOS("15.1")
+    .iOS("15.1"),
+    .macOS(.v13)
   ],
   products: [
     .library(
@@ -138,9 +139,9 @@ DerivedData/
 EOF
 
 cat > "$target_root/README.md" <<'EOF'
-# Mentra Bluetooth SDK for iOS
+# Mentra Bluetooth SDK for iOS and macOS
 
-Native Swift package for building iOS apps that connect directly to Mentra smart glasses over Bluetooth.
+Native Swift package for building iOS, iPadOS, and macOS apps that connect directly to Mentra smart glasses over Bluetooth. Native macOS apps can use AppKit or SwiftUI on Apple silicon and Intel Macs.
 
 ## Installation
 
@@ -168,8 +169,9 @@ For `Package.swift` consumers:
 ## Requirements
 
 - iOS 15.1 or newer
+- macOS 13 or newer for native Mac apps
 - Xcode 15 or newer
-- A physical iPhone for Bluetooth testing
+- A physical iPhone, iPad, or Mac for Bluetooth testing
 
 ## Usage
 
@@ -219,7 +221,7 @@ If your app uses microphone features, also add:
 <string>This app uses the microphone when you enable audio features.</string>
 ```
 
-To keep the BLE link alive while the app is backgrounded, enable Core Bluetooth background mode:
+On iOS, to keep the BLE link alive while the app is backgrounded, enable Core Bluetooth background mode:
 
 ```xml
 <key>UIBackgroundModes</key>
@@ -230,7 +232,9 @@ To keep the BLE link alive while the app is backgrounded, enable Core Bluetooth 
 
 ## Scope
 
-This Swift package contains the core iOS Bluetooth SDK. It intentionally excludes optional MentraOS-internal code paths for local STT, offline TTS, Nex/SwiftProtobuf, Vuzix/Ultralite, and tar.bz2 extraction.
+Sandboxed macOS apps need the `com.apple.security.device.bluetooth` entitlement. Enable `com.apple.security.network.client` for uploads/OTA and `com.apple.security.device.audio-input` when capturing the Mac microphone. macOS does not use `UIBackgroundModes` or `AVAudioSession`; audio follows the Mac's selected output. ANCS notification relay is iOS-only.
+
+This Swift package contains the core Apple-platform Bluetooth SDK. It intentionally excludes optional MentraOS-internal code paths for local STT, offline TTS, Nex/SwiftProtobuf, Vuzix/Ultralite, and tar.bz2 extraction.
 EOF
 perl -0pi -e "s/__SDK_VERSION__/${sdk_version}/g" "$target_root/README.md"
 
@@ -278,6 +282,7 @@ if [[ "$verify" -eq 1 ]]; then
   (
     cd "$target_root"
     xcrun swift package describe >/dev/null
+    xcrun swift build >/dev/null
     xcodebuild \
       -scheme MentraBluetoothSDK \
       -destination 'generic/platform=iOS' \

--- a/scripts/export-bluetooth-sdk-ios-spm.sh
+++ b/scripts/export-bluetooth-sdk-ios-spm.sh
@@ -221,6 +221,13 @@ If your app uses microphone features, also add:
 <string>This app uses the microphone when you enable audio features.</string>
 ```
 
+For local photo receivers, LAN webhooks, or local OTA servers, also add:
+
+```xml
+<key>NSLocalNetworkUsageDescription</key>
+<string>This app accesses photo and OTA servers on your local network.</string>
+```
+
 On iOS, to keep the BLE link alive while the app is backgrounded, enable Core Bluetooth background mode:
 
 ```xml


### PR DESCRIPTION
## Why

The iOS example already runs on compatible Apple silicon Macs through TestFlight, but that does not make the SDK buildable by an AppKit, native SwiftUI/macOS, or `react-native-macos` host. The Apple sources and package metadata still assumed UIKit and AVAudioSession.

This adds a native macOS target while retaining one implementation of the Bluetooth transport, commands, photo upload, OTA, status, and event contracts. This is a feature PR against **dev**, not staging.

## Implementation

- Declare macOS 13 alongside iOS 15.1 in the local Swift package and exported public SwiftPM package. Keep the existing public repository URL and product name.
- Scope UIKit lifecycle/background logic and ANCS authorization to iOS. Native macOS does not request iOS ANCS authorization.
- Add CoreAudio device discovery and a Mac AVAudioEngine microphone adapter producing the same 16 kHz PCM. Device selection affects the SDK's own input engine, not the system-wide output. Permission remains host-owned. Queued microphone data/configuration events are accepted only for their original active engine.
- Use a small ImageIO-backed image implementation on macOS; retain UIImage on iOS. JPEG conversion preserves dimensions and EXIF orientation.
- Handle Mac playback-device reconfiguration by rejecting invalidated PCM operations, rather than waiting indefinitely for scheduled-buffer callbacks.
- Add a macOS CocoaPods source/dependency scope for the existing Expo Modules bridge. Do not pull iOS-only STT/TTS, Vuzix, or Nex dependencies into the Mac target. The phone pod's existing dependency set remains in its iOS scope.
- Document AppKit/SwiftUI integration, react-native-macos setup, sandbox entitlements, source overrides, and platform differences. Distinguish native macOS from iOS-on-Mac.
- Add a path-filtered Apple SDK PR check for native Swift tests and exported macOS/iOS builds, and register it with the dev CI gate. Release export verification now builds both Apple platforms.

## Verified Locally

- Native arm64 macOS Swift package: **11 tests passed**, including image rejection and JPEG orientation/dimension preservation.
- Native x86_64 macOS Swift package: build passed. This is compile verification, not an Intel hardware test.
- Generic iOS Swift package: build passed.
- Public SwiftPM export with `--verify`: both macOS and iOS builds passed.
- AppKit example against the local Swift package: built, launched as an ad-hoc signed sandboxed app, and discovered real Mentra Live glasses.
- React Native macOS 0.81.9 + Expo SDK 54 host against the local SDK: CocoaPods/native build, JavaScript bundle, SDK React hook rendering, and real BLE discovery passed.
- Workflow actionlint and scoped formatting checks passed.

## Boundaries

No firmware was flashed or updated during verification. Native-Mac photo transfer, a complete OTA/reconnect sequence, microphone recording/device changes, and Intel runtime still need hardware qualification. Existing Swift 6 migration warnings remain; the package continues using its existing Swift 5 language mode.

macOS has no AVAudioSession audio-focus contract: explicit own-app playback is tracked, but other apps' playback is not automatically detected. Bluetooth output selection and joining the glasses hotspot remain host/system responsibilities. The Android-only scoped-network adapter stays unavailable on Mac. This does not claim native macOS support for all Mentra Engine dependencies or arbitrary Expo modules.

Native Mac support must reach a coordinated SDK publication before a clean consumer can use a released dependency without the documented source override. The companion [Starter Kit PR #135](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/135) adds focused native Mac examples; it does not publish a new Mac TestFlight artifact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared connection, audio, and Mentra Live BLE paths with substantial platform branching; regressions on iOS are possible if guards are wrong, though scope is additive and new macOS unit tests plus CI builds reduce exposure.
> 
> **Overview**
> Adds **native macOS 13+** as a first-class target for the shared `MentraBluetoothSDK` Swift package and `@mentra/bluetooth-sdk` CocoaPods/Expo bridge, alongside existing iOS support.
> 
> Apple sources are split with `#if os(macOS)` so iOS-only behavior stays on iPhone: **AVAudioSession** pairing/monitoring, background mic rules, **ANCS** connect options, local STT/TTS/Nex/Vuzix paths, and related Expo module APIs. macOS gets **CoreAudio** device discovery, route observation, and a **Mac `PhoneMic`** adapter (16 kHz PCM via `AVAudioEngine`), plus **ImageIO `SdkImage`** for cross-platform bitmap/photo handling. PCM playback on Mac fails pending streams when the output device changes instead of hanging on iOS-style session interruptions.
> 
> **Packaging & CI:** `Package.swift`, podspec, and `export-bluetooth-sdk-ios-spm.sh` declare macOS and verify **macOS + generic iOS** builds. A path-filtered **`Bluetooth SDK Apple Platforms`** workflow runs `swift test` and export verification; it is registered in **`ci-gate`**. Docs add **`bluetooth-sdk/macos`** and update overview/quickstart to cover AppKit, SwiftUI, and `react-native-macos` (permissions, sandbox, platform limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773543389aec74fba94572b1be265647af93080b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->