### PR TITLE
Update live BES firmware to 26.9.4.1

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.9.4.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.4.0.bin",
-    "sha256": "17c0b8e784cc02ca65f4b2b111f40434ceb774fa86aff71bfc5a648341a49941"
+    "version": "26.9.4.1",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.4.1.bin",
+    "sha256": "793993cbec5cbaa6049efe9e91f84ffaeddfc83b27251bfa33411ede1e7c2fc5"
   }
 }


### PR DESCRIPTION
## Summary

Update `firmware_live.json` from BES 26.9.4.0 to 26.9.4.1, as published in [the authoritative CDN manifest](https://firmwarecdn.mentraglass.com/latest.json). Update the version, binary URL, and SHA-256 only; preserve all seven MTK patches.

## Verification

- Downloaded the published binary and verified its size (1,144,541 bytes) and SHA-256 against `latest.json`.
- SHA-256: `793993cbec5cbaa6049efe9e91f84ffaeddfc83b27251bfa33411ede1e7c2fc5`.
- JSON parsing, exact CDN field match, unchanged non-BES content, single-file diff, and `git diff --check` passed.
- Manifest-only change; no hardware OTA test performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest field update with no application logic changes; incorrect URL or hash would fail verification rather than silently installing bad firmware.
> 
> **Overview**
> Updates the live OTA manifest **`bes_firmware`** block from **26.9.4.0** to **26.9.4.1**, pointing devices at the new CDN binary and its SHA-256. All seven **`mtk_patches`** entries are unchanged.
> 
> This is a metadata-only change in `firmware_live.json`; clients that consume this manifest will download and verify the new BES image on the next applicable OTA check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a80178f3a17fc6ff548889a5c0d13fc9a10e6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->