### PR TITLE
Merge staging into dev after docs-default correction

### DIFF
--- a/.github/scripts/render-coordinated-docs.mjs
+++ b/.github/scripts/render-coordinated-docs.mjs
@@ -115,7 +115,7 @@ export function renderCoordinatedDocs({
   for (const name of [
     "release-version",
     "release-artifacts-url",
-    "example-app-version",
+    "example-app-download-label",
     "example-app-url",
     "example-app-ios-url",
   ]) {
@@ -129,7 +129,8 @@ export function renderCoordinatedDocs({
     `https://github.com/${repository}/releases/tag/${releasePlan.artifactContainerTag}`
   if (releasePlan.releaseIdentity.includes("-")) {
     const reactNative = validateStarterKitResult(releasePlan, starterKitResult)
-    config.variables["example-app-version"] = releasePlan.releaseIdentity
+    config.variables["example-app-download-label"] =
+      `Download the React Native example APK for SDK ${releasePlan.releaseIdentity}`
     config.variables["example-app-url"] = reactNative.url
     config.variables["example-app-ios-url"] = validateExampleTestflightResult(
       releasePlan,

--- a/.github/scripts/render-coordinated-docs.test.mjs
+++ b/.github/scripts/render-coordinated-docs.test.mjs
@@ -18,8 +18,8 @@ function fixture() {
       variables: {
         "release-version": "3.1.0",
         "release-artifacts-url": "https://example.com/stable",
-        "example-app-version": "0.1.21-beta.5",
-        "example-app-url": "https://example.com/example.apk",
+        "example-app-download-label": "Browse React Native example APK releases",
+        "example-app-url": "https://github.com/Mentra/Starter/releases",
         "example-app-ios-url": "https://testflight.apple.com/join/source",
       },
     }),
@@ -28,7 +28,7 @@ function fixture() {
     path.join(source, "page.mdx"),
     [
       "Release {{release-version}}",
-      "[Android]({{example-app-url}})",
+      "[{{example-app-download-label}}]({{example-app-url}})",
       "[iPhone]({{example-app-ios-url}})",
       "[Artifacts]({{release-artifacts-url}})",
     ].join("\n"),
@@ -92,20 +92,63 @@ test("renders exact coordinated release variables without changing source", (con
     rendered.variables["release-artifacts-url"],
     "https://github.com/Mentra/MentraOS/releases/tag/mentra-builds-v3.1.0",
   )
-  assert.equal(rendered.variables["example-app-version"], "3.1.0-beta.57")
+  assert.equal(
+    rendered.variables["example-app-download-label"],
+    "Download the React Native example APK for SDK 3.1.0-beta.57",
+  )
   assert.equal(rendered.variables["example-app-url"], starterKitResult.artifacts[0].url)
   assert.equal(rendered.variables["example-app-ios-url"], exampleTestflightResult.distribution.installUrl)
   assert.equal(original.variables["release-version"], "3.1.0")
+  assert.equal(original.variables["example-app-download-label"], "Browse React Native example APK releases")
+  assert.equal(original.variables["example-app-url"], "https://github.com/Mentra/Starter/releases")
   assert.equal(
     readFileSync(path.join(output, "page.mdx"), "utf8"),
     [
       "Release {{release-version}}",
-      `[Android](${starterKitResult.artifacts[0].url})`,
+      `[{{example-app-download-label}}](${starterKitResult.artifacts[0].url})`,
       `[iPhone](${exampleTestflightResult.distribution.installUrl})`,
       "[Artifacts](https://github.com/Mentra/MentraOS/releases/tag/mentra-builds-v3.1.0)",
     ].join("\n"),
   )
   assert.match(readFileSync(path.join(source, "page.mdx"), "utf8"), /\{\{example-app-url\}\}/)
+})
+
+test("source-only and stable docs use honest version-neutral example links", (context) => {
+  const {root, source, output} = fixture()
+  context.after(() => rmSync(root, {recursive: true, force: true}))
+  const docsRoot = fileURLToPath(new URL("../../mintlify-docs/", import.meta.url))
+  const sourceConfig = readFileSync(path.join(docsRoot, "docs.json"), "utf8")
+  const {variables} = JSON.parse(sourceConfig)
+  writeFileSync(path.join(source, "docs.json"), sourceConfig)
+
+  assert.equal(variables["example-app-download-label"], "Browse React Native example APK releases")
+  assert.equal(variables["example-app-url"], "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases")
+  assert.equal(variables["example-app-version"], undefined)
+
+  for (const file of ["software-update.mdx", "quickstart.mdx"]) {
+    const content = readFileSync(path.join(docsRoot, "bluetooth-sdk", file), "utf8")
+    assert.doesNotMatch(content, /\{\{example-app-version\}\}|This is the exact Android build/)
+    writeFileSync(path.join(source, file), content)
+  }
+
+  renderCoordinatedDocs({
+    sourceDir: source,
+    outputDir: output,
+    releasePlan: {
+      releaseIdentity: variables["release-version"],
+      releaseSetId: `mentra-${variables["release-version"]}`,
+      artifactContainerTag: `mentra-v${variables["release-version"]}`,
+    },
+    repository: "Mentra-Community/MentraOS",
+  })
+
+  const rendered = JSON.parse(readFileSync(path.join(output, "docs.json"), "utf8"))
+  assert.deepEqual(rendered.variables, variables)
+  assert.match(
+    readFileSync(path.join(output, "software-update.mdx"), "utf8"),
+    /\[\{\{example-app-download-label\}\}\]\(https:\/\/github\.com\/Mentra-Community\/Mentra-Bluetooth-SDK-Starter-Kit\/releases\)/,
+  )
+  assert.equal(readFileSync(path.join(source, "docs.json"), "utf8"), sourceConfig)
 })
 
 test("rejects unresolved URL variables", (context) => {

--- a/mintlify-docs/bluetooth-sdk/quickstart.mdx
+++ b/mintlify-docs/bluetooth-sdk/quickstart.mdx
@@ -30,8 +30,8 @@ The examples include the OTA flow required to install the Mentra Live glasses
 software that matches their Bluetooth SDK version. The React Native example
 owns a forkable `src/ota/` presentation layer over Mentra Engine's tested
 controller, so you can change its cosmetics without reimplementing OTA
-sequencing. For `{{release-version}}` integration instructions and the
-separately published `{{example-app-version}}` prebuilt example, see [Update
+sequencing. For `{{release-version}}` integration instructions and available
+prebuilt example apps, see [Update
 Mentra Live](/bluetooth-sdk/software-update).
 
 ## 2. Run an Example App

--- a/mintlify-docs/bluetooth-sdk/software-update.mdx
+++ b/mintlify-docs/bluetooth-sdk/software-update.mdx
@@ -33,7 +33,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. Build an example app with SDK `{{release-version}}` to install the matching glasses software.
 
-Prebuilt Starter Kit apps are validated against SDK `{{example-app-version}}`.
+Each prebuilt Starter Kit app uses the SDK version identified by its release.
 Choose the installation for your device:
 
 ### iOS: iPhone
@@ -55,10 +55,9 @@ iPhone and iPad app.
 
 ### Android: Phone Or Tablet
 
-[Download the React Native example APK for SDK `{{example-app-version}}`]({{example-app-url}}).
-This is the exact Android build produced by the coordinated release.
+[{{example-app-download-label}}]({{example-app-url}}).
 
-For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
+For another SDK version, open the [Starter Kit releases page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases). Coordinated APKs are grouped by base version; select `mentra-example-react-native-<version>.apk` for the exact SDK version you need.
 
 ### Complete The Android Installation
 

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -5,7 +5,7 @@
   "variables": {
     "release-version": "3.1.0",
     "release-artifacts-url": "https://github.com/Mentra-Community/MentraOS/releases/tag/mentra-v3.1.0",
-    "example-app-version": "VERSION",
+    "example-app-download-label": "Browse React Native example APK releases",
     "example-app-url": "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases",
     "example-app-ios-url": "https://appstoreconnect.apple.com/teams/52733bd2-726b-4742-b1e2-1cfc0174c696/apps/6792839366/testflight/groups/1b1daeae-9175-4020-9c1b-52fd6b14cc49"
   },

--- a/notes/coordinated-release-docs-and-example-apps-design.md
+++ b/notes/coordinated-release-docs-and-example-apps-design.md
@@ -422,8 +422,8 @@ The checked-in Mintlify config retains these structured variables:
 
 - `release-version`;
 - `release-artifacts-url`;
-- `example-app-version`; and
-- `example-app-url`; and
+- `example-app-download-label`;
+- `example-app-url`;
 - `example-app-ios-url`.
 
 For dev and beta, the renderer receives both the immutable Mentra release plan
@@ -431,7 +431,7 @@ and the validated Starter Kit result. It sets:
 
 - `release-version` to the exact coordinated identity;
 - `release-artifacts-url` to the coordinated Mentra release container;
-- `example-app-version` to that same exact identity; and
+- `example-app-download-label` to download copy naming that exact SDK identity;
 - `example-app-url` to the published React Native APK URL from the Starter Kit
   result, never to a constructed or guessed URL; and
 - `example-app-ios-url` to the verified App Store Connect group URL for dev or
@@ -483,7 +483,12 @@ release set.
 ### Production docs
 
 Production remains a Mintlify Git deployment from `main`. The checked-in
-variables use the stable family base and stable URLs. Before production starts,
+variables use the stable family base and stable URLs. Example-app copy is
+version-neutral and the Android link is labelled as browsing the releases
+index. Only the dev/beta renderer promises a direct APK for an exact SDK
+identity, using the validated Starter Kit result. Source-only and stable docs
+must not expose placeholder versions or claim that the releases index is a
+direct APK download. Before production starts,
 an operator promotes the exact Starter Kit merge commit recorded by the selected
 completed beta from Starter Kit `staging` to `main`, then promotes the exact
 MentraOS beta source from MentraOS `staging` to `main`. Both selected sources

--- a/notes/coordinated-release-system-proposal.md
+++ b/notes/coordinated-release-system-proposal.md
@@ -709,10 +709,12 @@ published site online, fails the docs job, and makes Slack report the otherwise
 finalized release as incomplete. It does not rewrite or roll back an immutable
 release manifest.
 
-Starter Kit example applications keep separate `example-app-version` and
-`example-app-url` variables until the Starter Kit joins the coordinated release
-pipeline. Coordinated docs must not construct a nonexistent example download
-from the MentraOS release identity. Production remains a Mintlify deployment
+Starter Kit example applications use `example-app-download-label` and
+`example-app-url` variables. Source-only docs link to the releases index with
+version-neutral copy. The dev/beta renderer supplies a label naming the exact
+SDK version and the APK URL from the validated Starter Kit result; it must not
+construct an example download from the MentraOS release identity.
+Production remains a Mintlify deployment
 from `main`; changing that external branch setting from `staging` to `main` is
 an operator action, not part of the dev/beta Pages workflow.
 


### PR DESCRIPTION
## Summary
Back-merge staging after #3933. This is an actual merge of staging commit 9ca238f8e2198b9640b6f0fb75d1c70aeb32a116, not an independent copy or cherry-pick of the fix. Both staging parents and dev ancestry are preserved.

## Conflict resolution
The only conflict was mintlify-docs/docs.json: keep the dev 3.2.0 release-version and artifact-container defaults, while accepting the new version-neutral example-app-download-label from staging. All other changes merged automatically. Staging remains on 3.1.0.

## Verification
145 release-script tests pass, including all 6 docs-renderer tests. git diff --check passes. The current staging tip is an ancestor of this branch. No OTA UI or runtime changes; both apps retain the tested changelog scrollbar and overflow hint.

Requested by Philippe after merging #3933 into staging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-script variable wiring only; no app runtime or OTA behavior changes.
> 
> **Overview**
> **Replaces `example-app-version` with `example-app-download-label`** so Mintlify docs can describe Android example downloads without implying a specific APK on stable/source builds.
> 
> For **checked-in / production** docs, `docs.json` now uses version-neutral copy (`Browse React Native example APK releases`) and points `example-app-url` at the Starter Kit **releases** index. **Quickstart** and **software-update** no longer reference a pinned example version or claim the link is the exact coordinated APK.
> 
> For **dev/beta coordinated rendering**, `render-coordinated-docs.mjs` still injects the validated Starter Kit APK URL, but sets the link text to *Download the React Native example APK for SDK {identity}* instead of reusing a version variable in the body. Tests add coverage that stable identities leave variables unchanged and that MDX does not retain old placeholders.
> 
> Design notes are updated to match the split: only the renderer promises a direct APK for an exact SDK identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b735de8de9a547da1121b07fa559f5a72b584d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->