### PR TITLE
Merge staging into dev: OTA changelog layout fix

### DIFF
--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-raw-text -- BodyText and PercentText are local Text wrappers. */
-import React, {useMemo, useState} from "react"
+import React, {useMemo} from "react"
 import {
   ActivityIndicator,
   Pressable,
@@ -99,7 +99,6 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:updateLater": "Later",
   "ota:updateComplete": "Update complete",
   "ota:whatsNew": "What's new",
-  "ota:scrollForMore": "Scroll for more",
   "ota:upToDate": "Up To Date",
   "ota:devBuild": "Development Build",
   "ota:devBuildNoOta":
@@ -323,12 +322,7 @@ function OtaFlowContent({
             {translate("ota:updatedToVersion", {version: state.releaseTransition.toVersion})}
           </BodyText>
         ) : null}
-        <ChangelogList
-          changelogs={state.changelogs}
-          colors={colors}
-          scrollHint={translate("ota:scrollForMore")}
-          title={translate("ota:whatsNew")}
-        />
+        <ChangelogList changelogs={state.changelogs} colors={colors} title={translate("ota:whatsNew")} />
       </FlowPage>
     )
   }
@@ -462,12 +456,7 @@ function OtaFlowContent({
             {translate("ota:updatedToVersion", {version: state.releaseTransition.toVersion})}
           </BodyText>
         ) : null}
-        <ChangelogList
-          changelogs={state.changelogs}
-          colors={colors}
-          scrollHint={translate("ota:scrollForMore")}
-          title={translate("ota:whatsNew")}
-        />
+        <ChangelogList changelogs={state.changelogs} colors={colors} title={translate("ota:whatsNew")} />
       </FlowPage>
     )
   }
@@ -523,11 +512,15 @@ type FlowPageProps = {
 function FlowPage({actions, children, colors, contentAlignment = "center", icon, title}: FlowPageProps) {
   return (
     <View style={styles.page} testID="mentra-live-ota-flow">
-      <View style={[styles.centerContent, contentAlignment === "top" && styles.topContent]}>
+      <ScrollView
+        contentContainerStyle={[styles.centerContent, contentAlignment === "top" && styles.topContent]}
+        nestedScrollEnabled
+        style={styles.contentScroll}
+        testID="ota-page-scroll">
         <FlowIcon colors={colors} name={icon} />
         <Text style={[styles.title, {color: colors.foreground}]}>{title}</Text>
         {children}
-      </View>
+      </ScrollView>
       {actions ? <View style={styles.actions}>{actions}</View> : <View style={styles.actionSpacer} />}
     </View>
   )
@@ -632,21 +625,13 @@ function ChangelogMarkdown({colors, markdown}: {colors: MentraLiveOtaFlowTheme; 
 export function ChangelogList({
   changelogs,
   colors,
-  scrollHint,
   title,
 }: {
   changelogs: MentraLiveOtaController["state"]["changelogs"]
   colors: MentraLiveOtaFlowTheme
-  scrollHint: string
   title: string
 }) {
-  const [contentHeight, setContentHeight] = useState(0)
-  const [viewportHeight, setViewportHeight] = useState(0)
-  const [isAtEnd, setIsAtEnd] = useState(false)
-
   if (changelogs.length === 0) return null
-
-  const showScrollHint = viewportHeight > 0 && contentHeight > viewportHeight + 1 && !isAtEnd
 
   return (
     <View style={[styles.changelogCard, {borderColor: colors.border}]} testID="ota-changelog-card">
@@ -654,17 +639,7 @@ export function ChangelogList({
       <ScrollView
         contentContainerStyle={styles.changelogContent}
         nestedScrollEnabled
-        onContentSizeChange={(_width, height) => {
-          setContentHeight(height)
-          setIsAtEnd(false)
-        }}
-        onLayout={({nativeEvent}) => setViewportHeight(nativeEvent.layout.height)}
-        onScroll={({nativeEvent}) => {
-          const distanceFromEnd =
-            nativeEvent.contentSize.height - (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height)
-          setIsAtEnd(distanceFromEnd <= 8)
-        }}
-        scrollEventThrottle={16}
+        persistentScrollbar
         showsVerticalScrollIndicator
         style={styles.changelogList}
         testID="ota-changelog-scroll">
@@ -683,13 +658,6 @@ export function ChangelogList({
           </View>
         ))}
       </ScrollView>
-      <View style={styles.changelogScrollHintSlot}>
-        {showScrollHint ? (
-          <Text style={[styles.changelogScrollHint, {color: colors.textDim}]} testID="ota-changelog-scroll-hint">
-            {scrollHint} ↓
-          </Text>
-        ) : null}
-      </View>
     </View>
   )
 }
@@ -753,7 +721,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
   page: {flex: 1, paddingBottom: 24, paddingHorizontal: 24},
-  centerContent: {alignItems: "center", flex: 1, gap: 16, justifyContent: "center"},
+  contentScroll: {flex: 1},
+  centerContent: {alignItems: "center", flexGrow: 1, gap: 16, justifyContent: "center"},
   topContent: {justifyContent: "flex-start", paddingBottom: 16, paddingTop: 12},
   actionSpacer: {height: 48},
   actions: {gap: 12},
@@ -766,21 +735,21 @@ const styles = StyleSheet.create({
   changelogCard: {
     borderRadius: 16,
     borderWidth: 1,
-    flex: 1,
+    flexGrow: 1,
     gap: 12,
     maxWidth: 420,
+    minHeight: 200,
     padding: 16,
     width: "100%",
   },
   changelogTitle: {fontSize: 16, fontWeight: "700"},
-  changelogList: {flex: 1, width: "100%"},
+  // Bound the notes themselves so the card can grow for its title, but not for all of the Markdown.
+  changelogList: {flexGrow: 1, height: 120, width: "100%"},
   changelogContent: {gap: 20, paddingBottom: 4},
   changelogEntry: {gap: 8},
   changelogEntryDivider: {borderTopWidth: StyleSheet.hairlineWidth, paddingTop: 20},
   changelogVersion: {fontSize: 14, fontWeight: "600"},
   changelogMarkdownContent: {gap: 10},
-  changelogScrollHintSlot: {alignItems: "center", height: 18, justifyContent: "center"},
-  changelogScrollHint: {fontSize: 12, fontWeight: "500", lineHeight: 16},
   button: {
     alignItems: "center",
     borderRadius: 50,

--- a/mobile/src/app/ota/__tests__/changelog-presentation.test.tsx
+++ b/mobile/src/app/ota/__tests__/changelog-presentation.test.tsx
@@ -1,6 +1,11 @@
-import {act, render} from "@testing-library/react-native"
+import {fireEvent, render, within} from "@testing-library/react-native"
 
-import {ChangelogList, type MentraLiveOtaFlowTheme} from "@/../modules/engine/src/react/MentraLiveOtaFlow"
+import {
+  ChangelogList,
+  MentraLiveOtaFlow,
+  type MentraLiveOtaFlowTheme,
+} from "@/../modules/engine/src/react/MentraLiveOtaFlow"
+import * as otaHook from "@/../modules/engine/src/react/useMentraLiveOta"
 
 const colors: MentraLiveOtaFlowTheme = {
   background: "#FFFFFF",
@@ -34,14 +39,13 @@ Use \`safe mode\`.`,
           },
         ]}
         colors={colors}
-        scrollHint="Scroll for more"
         title="What's new"
       />,
     )
 
     expect(getByTestId("ota-changelog-card")).toBeDefined()
-    expect(getByTestId("ota-changelog-card")).toHaveStyle({flex: 1})
-    expect(getByTestId("ota-changelog-scroll")).toHaveStyle({flex: 1})
+    expect(getByTestId("ota-changelog-card")).toHaveStyle({flexGrow: 1, minHeight: 200})
+    expect(getByTestId("ota-changelog-scroll")).toHaveStyle({flexGrow: 1, height: 120})
     expect(getByTestId("ota-changelog-markdown")).toBeDefined()
     expect(getByText("What's new")).toBeDefined()
     expect(getByText("Highlights")).toBeDefined()
@@ -55,21 +59,69 @@ Use \`safe mode\`.`,
     expect(queryByText("**overview**")).toBeNull()
 
     const scrollView = getByTestId("ota-changelog-scroll")
-    act(() => {
-      scrollView.props.onLayout({nativeEvent: {layout: {height: 200}}})
-      scrollView.props.onContentSizeChange(320, 400)
-    })
-    expect(getByTestId("ota-changelog-scroll-hint")).toHaveTextContent("Scroll for more ↓")
-
-    act(() => {
-      scrollView.props.onScroll({
-        nativeEvent: {
-          contentOffset: {y: 200},
-          contentSize: {height: 400},
-          layoutMeasurement: {height: 200},
-        },
-      })
-    })
+    expect(scrollView.props.showsVerticalScrollIndicator).toBe(true)
+    expect(scrollView.props.persistentScrollbar).toBe(true)
+    expect(scrollView.props.nestedScrollEnabled).toBe(true)
+    expect(scrollView.props.onScroll).toBeUndefined()
     expect(queryByTestId("ota-changelog-scroll-hint")).toBeNull()
+  })
+
+  it.each(["complete", "up_to_date"] as const)("keeps %s content scrollable with Done outside it", (screen) => {
+    const finish = jest.fn()
+    const hook = jest.spyOn(otaHook, "useMentraLiveOta").mockReturnValue({
+      finish,
+      check: jest.fn(),
+      retryCheck: jest.fn(),
+      install: jest.fn(),
+      retryInstall: jest.fn(),
+      discard: jest.fn(),
+      openWifiSetup: jest.fn(),
+      state: {
+        screen,
+        connected: true,
+        batteryLevel: 100,
+        transport: null,
+        updateRequired: false,
+        versionChange: false,
+        versionChangeConverged: false,
+        versionChangePhase: null,
+        wifiConnected: true,
+        wifiStatusKnown: true,
+        hotspotSupported: true,
+        hotspotPhase: "idle",
+        hotspotArtifactPercent: null,
+        phase: null,
+        step: null,
+        currentStep: null,
+        totalSteps: null,
+        progress: null,
+        installingApkOnly: false,
+        firmwareRestarting: false,
+        error: null,
+        canInstall: false,
+        canRetry: false,
+        canFinish: true,
+        canDismiss: true,
+        canDiscard: false,
+        canOpenWifiSetup: false,
+        continueDisabled: false,
+        completedUpdate: true,
+        changelogs: [{version: "3.1.0", markdown: "Release notes.\n\n".repeat(100)}],
+        releaseTransition: {fromVersion: "3.0.0", toVersion: "3.1.0-beta.128"},
+      },
+    })
+
+    try {
+      const {getByTestId} = render(<MentraLiveOtaFlow onFinished={finish} onOpenWifiSetup={jest.fn()} />)
+      const page = getByTestId("ota-page-scroll")
+      expect(page).toHaveStyle({flex: 1})
+      expect(page.props.contentContainerStyle).toEqual(expect.arrayContaining([expect.objectContaining({flexGrow: 1})]))
+      expect(within(page).getByTestId("ota-changelog-scroll")).toBeDefined()
+      expect(within(page).queryByTestId("button-Done")).toBeNull()
+      fireEvent.press(getByTestId("button-Done"))
+      expect(finish).toHaveBeenCalledTimes(1)
+    } finally {
+      hook.mockRestore()
+    }
   })
 })

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -465,7 +465,6 @@ const en = {
     updateComplete: "Update Complete",
     updateCompleteMessage: "Your glasses have been updated successfully.",
     whatsNew: "What's new",
-    scrollForMore: "Scroll for more",
     updateFailed: "Update Failed",
     updateFailedMessage: "The update could not be completed. You can try again later from Settings.",
     glassesDisconnected: "Glasses Disconnected",


### PR DESCRIPTION
Back-merge staging after #3938. This is an ordinary staging-to-dev merge, not a second implementation or cherry-pick.

The merge-tree check is conflict-free. Relative to current dev, the result contains only the three files from #3938: shared OTA layout, focused presentation tests, and removal of the unused hint translation. Dev keeps its 3.2.0 release family; staging remains on 3.1.0.

The staging fix passed mobile TypeScript, all 80 focused OTA tests, 12 Yoga layout cases and 22 browser layout/scroll interactions. Exact-head staging mobile quality and Android CI passed, and both AI reviews found no issues; iOS was still running when Philippe authorized the merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only OTA presentation and layout changes with updated tests; no OTA install logic or networking changes.
> 
> **Overview**
> Fixes OTA **complete** and **up to date** screens where long release notes could trap content or hide actions by restructuring scroll behavior.
> 
> **`FlowPage`** now wraps icon, title, and body in a page-level `ScrollView` (`ota-page-scroll`) with `nestedScrollEnabled`, while **Done/Continue** stays fixed below the scroll area so primary actions remain reachable.
> 
> **`ChangelogList`** drops the dynamic “Scroll for more ↓” hint and its layout/scroll tracking state. Notes scroll inside a bounded area (`height: 120`, card `minHeight: 200`, `flexGrow` instead of `flex: 1`) with a visible, **persistent** vertical scrollbar. The unused **`ota:scrollForMore`** string is removed from embedded OTA copy and **`mobile/src/i18n/en.ts`**.
> 
> Tests cover the new changelog styles/scroll props and assert **complete** / **up_to_date** flows keep changelog scrolling inside the page scroll with **Done** outside it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ec44bcb2f112f8ac0aadc31e2ce8e10b357282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->