### PR TITLE
Fix coordinated release consumer build configuration

### DIFF
--- a/.github/workflows/reusable-coordinated-engine-consumer.yml
+++ b/.github/workflows/reusable-coordinated-engine-consumer.yml
@@ -97,7 +97,15 @@ jobs:
     if: inputs.dry_run != true
     runs-on: macos-15
     timeout-minutes: 60
+    env:
+      # Expo SDK 55 requires Xcode 26; macos-15 defaults to Xcode 16.4.
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     steps:
+      - name: Verify the Expo iOS toolchain
+        run: |
+          xcodebuild -version
+          xcrun swift --version
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_commit }}
@@ -151,12 +159,9 @@ jobs:
         working-directory: ${{ runner.temp }}/engine-consumer/ios
         run: |
           set -euo pipefail
-          workspace=$(find . -maxdepth 1 -name '*.xcworkspace' -print -quit)
-          test -n "$workspace"
-          scheme=$(xcodebuild -list -json -workspace "$workspace" | jq -er '.workspace.schemes[0]')
           xcodebuild \
-            -workspace "$workspace" \
-            -scheme "$scheme" \
+            -workspace ExampleOEMApp.xcworkspace \
+            -scheme ExampleOEMApp \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             CODE_SIGNING_ALLOWED=NO \

--- a/mobile/modules/acs-meeting/README.md
+++ b/mobile/modules/acs-meeting/README.md
@@ -4,6 +4,14 @@ Phone-native Azure Communication Services client that puts a MentraOS wearer int
 Microsoft Teams meeting as a guest. The glasses provide the camera and the microphone;
 the phone does all the WebRTC and ACS work.
 
+## Host setup
+
+Add `"@mentra/acs-meeting"` to the host's Expo `plugins` list, including when
+this module is installed through `@mentra/engine`, then run Expo prebuild for
+the target platform. The plugin enables Android core library desugaring and
+builds `AzureCommunicationCommon` as the framework required by ACS on iOS.
+These requirements apply even when the host does not use Crust or Mapbox.
+
 The phone is a **relay, not a capture device**. It subscribes to whatever the glasses
 already published to Cloudflare, decodes it, and re-publishes it into ACS. No frame
 crosses the JavaScript bridge. Production never generates pixels on the phone.

--- a/mobile/modules/acs-meeting/app.plugin.js
+++ b/mobile/modules/acs-meeting/app.plugin.js
@@ -1,5 +1,9 @@
-const {withPodfile} = require("expo/config-plugins")
-const {mergeContents} = require("@expo/config-plugins/build/utils/generateCode")
+const {withAppBuildGradle, withPodfile} = require("expo/config-plugins")
+const {
+  createGeneratedHeaderComment,
+  mergeContents,
+  removeGeneratedContents,
+} = require("@expo/config-plugins/build/utils/generateCode")
 
 // Calling is a vendored dynamic framework: its umbrella header and LC_LOAD_DYLIB
 // both require Common.framework. Expo otherwise builds Common as a static library.
@@ -16,6 +20,31 @@ const commonFramework = `  installer.pod_targets.each do |pod|
   end`
 
 module.exports = function withAcsMeeting(config) {
+  config = withAppBuildGradle(config, (config) => {
+    if (config.modResults.language !== "groovy") {
+      throw new Error("@mentra/acs-meeting requires a Groovy app/build.gradle")
+    }
+    // A library cannot enable desugaring for its consuming app. Keep this
+    // requirement with ACS, including hosts that do not use the Crust plugin.
+    const tag = "acs-core-library-desugaring"
+    const contents = removeGeneratedContents(config.modResults.contents, tag) ?? config.modResults.contents
+    const desugaring = `android {
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
+}
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+}`
+    config.modResults.contents = [
+      contents.trimEnd(),
+      createGeneratedHeaderComment(desugaring, tag, "//"),
+      desugaring,
+      `// @generated end ${tag}`,
+      "",
+    ].join("\n")
+    return config
+  })
   return withPodfile(config, (config) => {
     let contents = config.modResults.contents
     const hook = /^\s*pre_install do \|installer\|\s*$/m

--- a/mobile/scripts/acs-android-plugin.test.mjs
+++ b/mobile/scripts/acs-android-plugin.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import {createRequire} from "node:module"
+import test from "node:test"
+
+const require = createRequire(import.meta.url)
+const withAcsMeeting = require("../modules/acs-meeting/app.plugin.js")
+
+async function applyPlugin(contents, language = "groovy") {
+  const config = withAcsMeeting({name: "Test", slug: "test"})
+  const result = await config.mods.android.appBuildGradle({
+    ...config,
+    modRequest: {platform: "android", modName: "appBuildGradle"},
+    modResults: {contents, language},
+  })
+  return result.modResults.contents
+}
+
+test("ACS configures a host without Crust and preserves its Gradle settings", async () => {
+  const original = `plugins { id 'com.android.application' }
+android {
+  namespace 'com.example.host'
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+    coreLibraryDesugaringEnabled false
+  }
+}
+dependencies { implementation 'com.example:unrelated:1.0.0' }
+`
+  const generated = await applyPlugin(original)
+  assert.ok(generated.startsWith(original))
+  assert.match(generated.slice(original.length), /coreLibraryDesugaringEnabled true/)
+  assert.match(generated, /coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'/)
+  assert.equal(await applyPlugin(generated), generated)
+})
+
+test("ACS refreshes its generated block while preserving another plugin's desugaring", async () => {
+  const original = `android { compileOptions { coreLibraryDesugaringEnabled true } }
+dependencies { coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4' }
+`
+  const generated = await applyPlugin(original)
+  const stale = generated.replace(/2\.1\.4(?='\n})/, "2.0.0")
+  const refreshed = await applyPlugin(stale)
+  assert.equal(refreshed, generated)
+  assert.equal(refreshed.match(/@generated begin acs-core-library-desugaring/g).length, 1)
+})
+
+test("ACS reports unsupported Gradle syntax instead of generating an invalid build", async () => {
+  await assert.rejects(applyPlugin("plugins {}", "kotlin"), /requires a Groovy app\/build.gradle/)
+})


### PR DESCRIPTION
The dev.136 coordinated release cannot finish because the public Engine iOS check compiles Expo SDK 55 with the macos-15 default Xcode 16.4, while the Starter Kit Android host omits ACS's required core library desugaring.

Pin the Engine consumer job to Xcode 26.2 and build the generated ExampleOEMApp workspace and scheme explicitly. The previous first-scheme selection built the AcsMeeting pod instead of the app. Extend the existing ACS config plugin to configure Android desugaring as well as the existing iOS framework setup, so hosts can apply ACS's requirements without enabling Crust/Mapbox.

[Starter Kit #145](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/145) must merge first; it applies this plugin from the installed Engine dependency and preserves older Engine releases without ACS. The next coordinated release then picks up both changes.

Validation:
- 87 mobile tooling tests and 18 coordinated workflow/external-consumer tests passed.
- An isolated AGP 8.12.0 / Gradle 9.0.0 host reproduced the same checkDebugAarMetadata desugaring failure before applying the plugin and passed afterward.
- Fresh OEM Android and iOS Expo prebuilds passed; xcodebuild -list confirmed ExampleOEMApp as the app scheme.
- actionlint, formatting, and git diff --check passed.

The full public Engine iOS compile and coordinated publication still require the next release run. No release was dispatched or republished during validation.

Failure evidence: [Engine iOS](https://github.com/Mentra-Community/MentraOS/actions/runs/33938134317/job/101233909959), [Starter Kit Android](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/33939475557/job/101233929398).
