### PR TITLE
Default loudness gate to off and reset saved settings

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkDefaults.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkDefaults.kt
@@ -3,5 +3,5 @@ package com.mentra.bluetoothsdk
 /** Defaults for the public Bluetooth SDK surface. */
 object BluetoothSdkDefaults {
     const val VOICE_ACTIVITY_DETECTION_ENABLED = false
-    const val LOUDNESS_GATE_ENABLED = true
+    const val LOUDNESS_GATE_ENABLED = false
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
@@ -9,7 +9,7 @@ enum BluetoothSdkDefaults {
     }
 
     static let voiceActivityDetectionEnabled = false
-    static let loudnessGateEnabled = true
+    static let loudnessGateEnabled = false
     private static let infoSdkVersionKey = "MentraBluetoothSdkVersion"
     private static let swiftPackageSdkVersion = "__MENTRA_BLUETOOTH_SDK_VERSION__"
     private static let swiftPackageSdkVersionPlaceholder = "__MENTRA" + "_BLUETOOTH_SDK_VERSION__"

--- a/mobile/modules/engine/src/stores/__tests__/settings.loudnessGate.test.ts
+++ b/mobile/modules/engine/src/stores/__tests__/settings.loudnessGate.test.ts
@@ -10,8 +10,8 @@ let failGateSave = false
 let logSpy: ReturnType<typeof spyOn>
 
 mock.module("react-native-localize", () => ({getTimeZone: () => "UTC"}))
-mock.module("./glasses", () => ({useGlassesStore: {getState: () => ({deviceModel: "Mentra Live"})}}))
-mock.module("../utils/storage", () => ({
+mock.module("../glasses", () => ({useGlassesStore: {getState: () => ({deviceModel: "Mentra Live"})}}))
+mock.module("../../utils/storage", () => ({
   storage: {
     load: (key: string) => (saved.has(key) ? Res.ok(saved.get(key)) : Res.error(new Error("Missing value"))),
     loadSubKeys: () => Res.ok({}),
@@ -24,8 +24,8 @@ mock.module("../utils/storage", () => ({
 }))
 
 function restartSettings() {
-  delete require.cache[require.resolve("./settings")]
-  return require("./settings") as typeof import("./settings")
+  delete require.cache[require.resolve("../settings")]
+  return require("../settings") as typeof import("../settings")
 }
 
 describe("loudness gate settings migration", () => {

--- a/mobile/modules/engine/src/stores/settings.loudnessGate.test.ts
+++ b/mobile/modules/engine/src/stores/settings.loudnessGate.test.ts
@@ -1,0 +1,77 @@
+/// <reference types="bun-types" />
+
+import {afterEach, beforeEach, describe, expect, mock, spyOn, test} from "bun:test"
+import {result as Res} from "typesafe-ts"
+
+const GATE_KEY = "loudness_gate_enabled"
+const MIGRATION_KEY = "migration:loudness_gate_default_off_v1"
+const saved = new Map<string, unknown>()
+let failGateSave = false
+let logSpy: ReturnType<typeof spyOn>
+
+mock.module("react-native-localize", () => ({getTimeZone: () => "UTC"}))
+mock.module("./glasses", () => ({useGlassesStore: {getState: () => ({deviceModel: "Mentra Live"})}}))
+mock.module("../utils/storage", () => ({
+  storage: {
+    load: (key: string) => (saved.has(key) ? Res.ok(saved.get(key)) : Res.error(new Error("Missing value"))),
+    loadSubKeys: () => Res.ok({}),
+    save: (key: string, value: unknown) => {
+      if (key === GATE_KEY && failGateSave) return Res.error(new Error("Write failed"))
+      saved.set(key, value)
+      return Res.ok(undefined)
+    },
+  },
+}))
+
+function restartSettings() {
+  delete require.cache[require.resolve("./settings")]
+  return require("./settings") as typeof import("./settings")
+}
+
+describe("loudness gate settings migration", () => {
+  beforeEach(() => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {})
+    Object.assign(globalThis, {__DEV__: false})
+    saved.clear()
+    failGateSave = false
+  })
+
+  afterEach(() => logSpy.mockRestore())
+
+  test("fresh installs default off and send off to Mentra Live", async () => {
+    const {SETTINGS, useSettingsStore} = restartSettings()
+    expect(SETTINGS[GATE_KEY].defaultValue()).toBe(false)
+    const result = await useSettingsStore.getState().loadAllSettings()
+    expect(result.is_error()).toBe(false)
+    expect(useSettingsStore.getState().getBluetoothSettings()[GATE_KEY]).toBe(false)
+    expect(saved.get(GATE_KEY)).toBe(false)
+    expect(saved.get(MIGRATION_KEY)).toBe(true)
+  })
+
+  test("resets a saved true once, then preserves a later opt-in across restart", async () => {
+    saved.set(GATE_KEY, true)
+    const {useSettingsStore} = restartSettings()
+    await useSettingsStore.getState().loadAllSettings()
+    expect(useSettingsStore.getState().getSetting(GATE_KEY)).toBe(false)
+    expect(saved.get(GATE_KEY)).toBe(false)
+
+    await useSettingsStore.getState().setSetting(GATE_KEY, true)
+    const restartedStore = restartSettings().useSettingsStore
+    await restartedStore.getState().loadAllSettings()
+    expect(restartedStore.getState().getBluetoothSettings()[GATE_KEY]).toBe(true)
+    expect(saved.get(GATE_KEY)).toBe(true)
+  })
+
+  test("retries on the next launch if persisting the reset failed", async () => {
+    saved.set(GATE_KEY, true)
+    failGateSave = true
+    await restartSettings().useSettingsStore.getState().loadAllSettings()
+    expect(saved.get(MIGRATION_KEY)).toBeUndefined()
+    expect(saved.get(GATE_KEY)).toBe(true)
+
+    failGateSave = false
+    await restartSettings().useSettingsStore.getState().loadAllSettings()
+    expect(saved.get(GATE_KEY)).toBe(false)
+    expect(saved.get(MIGRATION_KEY)).toBe(true)
+  })
+})

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -410,10 +410,10 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: true,
     persist: true,
   },
-  // Mentra Live center-mic loudness / "Barrier" gate (cs_swit type 10). Default on.
+  // Mentra Live center-mic loudness / "Barrier" gate (cs_swit type 10). Opt-in.
   loudness_gate_enabled: {
     key: "loudness_gate_enabled",
-    defaultValue: () => true,
+    defaultValue: () => false,
     writable: true,
     saveOnServer: true,
     persist: true,
@@ -1045,6 +1045,18 @@ export const useSettingsStore = create<SettingsState>()(
           // repeated attempt per launch until a write succeeds.
           if (allCleared) {
             storage.save(BUILD_ENV_KEY, buildEnv)
+          }
+        }
+
+        // Reset existing installs once; later user/app opt-ins remain available.
+        const LOUDNESS_GATE_MIGRATION_KEY = "migration:loudness_gate_default_off_v1"
+        const loudnessGateMigrationDone = storage.load<boolean>(LOUDNESS_GATE_MIGRATION_KEY)
+        if (loudnessGateMigrationDone.is_error() || !loudnessGateMigrationDone.value) {
+          const result = await get().setSetting(SETTINGS.loudness_gate_enabled.key, false)
+          if (result.is_error()) {
+            console.log("SETTINGS: loudness gate migration failed:", result.error)
+          } else {
+            storage.save(LOUDNESS_GATE_MIGRATION_KEY, true)
           }
         }
 

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -1052,7 +1052,10 @@ export const useSettingsStore = create<SettingsState>()(
         const LOUDNESS_GATE_MIGRATION_KEY = "migration:loudness_gate_default_off_v1"
         const loudnessGateMigrationDone = storage.load<boolean>(LOUDNESS_GATE_MIGRATION_KEY)
         if (loudnessGateMigrationDone.is_error() || !loudnessGateMigrationDone.value) {
-          const result = await get().setSetting(SETTINGS.loudness_gate_enabled.key, false)
+          // updateServer: true, matching the android_blur / camera_fov migrations. The flag is
+          // inert until the Cloud V2 settings sync lands, but this setting is saveOnServer, so
+          // the intent recorded here is the one that should carry over.
+          const result = await get().setSetting(SETTINGS.loudness_gate_enabled.key, false, true)
           if (result.is_error()) {
             console.log("SETTINGS: loudness gate migration failed:", result.error)
           } else {


### PR DESCRIPTION
The loudness gate currently defaults on, suppressing audio below the center-mic RMS threshold. That breaks apps such as recorder, translation, captions, and Mentra Notes when they need to capture other speakers or quieter audio. This gate is an optional bonus intended to pick up only the wearer; apps should enable it when that behavior is useful.

Default the gate to false in the Mentra App and Android/iOS Bluetooth SDKs. Reset persisted settings to false once on startup, while preserving subsequent user or app opt-ins. Retry the migration on the next launch if saving the reset fails.

Validation:
- Incremental ARM64 release APK build passed: 71 tasks executed, 1,744 up-to-date. Confirmed the APK bundle includes the migration.
- 28 tests passed: settings migration (3), MicStateCoordinator (16), DeviceStoreHydration (9).
- `git diff --check` passed. New test passes Prettier; settings.ts has an unrelated pre-existing formatting difference.
- Installed the release APK on the connected Samsung phone; Cayden confirmed the change was tested and works.
- iOS build was not run on Linux.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default microphone gating behavior for existing installs via migration and SDK defaults, which affects Bluetooth-synced audio to glasses but is scoped to an opt-in feature with explicit retry and user override paths.
> 
> **Overview**
> **Loudness gate is now opt-in** instead of on by default across the Mentra app and Android/iOS Bluetooth SDK defaults (`loudness_gate_enabled` / `LOUDNESS_GATE_ENABLED` → **false**), so continuous mic capture works better for recorder, translation, captions, and similar apps unless something explicitly enables the wearer-focused gate.
> 
> On app startup, **`loadAllSettings`** runs a one-time migration (`migration:loudness_gate_default_off_v1`) that sets `loudness_gate_enabled` to **false** (including server-update intent via `setSetting(..., true)`), marks the migration only after a successful write, and **retries on later launches** if persistence fails. Users can still turn the gate back on afterward.
> 
> Adds **`settings.loudnessGate.test.ts`** covering fresh installs, resetting a previously saved `true`, and failed-write retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b352643894b1972d655c8dbd12f7e59ac3e25623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->