### PR TITLE
Fix release docs rendering before staging publication

### DIFF
--- a/.github/scripts/render-coordinated-docs.mjs
+++ b/.github/scripts/render-coordinated-docs.mjs
@@ -5,21 +5,20 @@ import {pathToFileURL} from "node:url"
 
 const RELEASE_IDENTITY_PATTERN = /^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/
 
-function renderUrlVariables(directory, variables) {
+function renderVariables(directory, variables) {
   for (const entry of readdirSync(directory, {withFileTypes: true})) {
     const entryPath = path.join(directory, entry.name)
     if (entry.isDirectory()) {
-      renderUrlVariables(entryPath, variables)
+      renderVariables(entryPath, variables)
       continue
     }
     if (!entry.isFile() || !entry.name.endsWith(".mdx")) continue
 
     const source = readFileSync(entryPath, "utf8")
     const rendered = Object.entries(variables)
-      .filter(([name]) => name.endsWith("-url"))
       .reduce((content, [name, value]) => content.replaceAll(`{{${name}}}`, value), source)
-    if (/\{\{[A-Za-z0-9_-]+-url\}\}/.test(rendered)) {
-      throw new Error(`Unresolved URL variable in ${entryPath}`)
+    if (/\{\{[A-Za-z0-9_-]+\}\}/.test(rendered)) {
+      throw new Error(`Unresolved documentation variable in ${entryPath}`)
     }
     if (rendered !== source) writeFileSync(entryPath, rendered)
   }
@@ -139,7 +138,7 @@ export function renderCoordinatedDocs({
     )
   }
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
-  renderUrlVariables(output, config.variables)
+  renderVariables(output, config.variables)
 
   return {releaseIdentity: releasePlan.releaseIdentity, outputDir: output}
 }

--- a/.github/scripts/render-coordinated-docs.test.mjs
+++ b/.github/scripts/render-coordinated-docs.test.mjs
@@ -104,8 +104,8 @@ test("renders exact coordinated release variables without changing source", (con
   assert.equal(
     readFileSync(path.join(output, "page.mdx"), "utf8"),
     [
-      "Release {{release-version}}",
-      `[{{example-app-download-label}}](${starterKitResult.artifacts[0].url})`,
+      "Release 3.1.0-beta.57",
+      `[Download the React Native example APK for SDK 3.1.0-beta.57](${starterKitResult.artifacts[0].url})`,
       `[iPhone](${exampleTestflightResult.distribution.installUrl})`,
       "[Artifacts](https://github.com/Mentra/MentraOS/releases/tag/mentra-builds-v3.1.0)",
     ].join("\n"),
@@ -146,12 +146,12 @@ test("source-only and stable docs use honest version-neutral example links", (co
   assert.deepEqual(rendered.variables, variables)
   assert.match(
     readFileSync(path.join(output, "software-update.mdx"), "utf8"),
-    /\[\{\{example-app-download-label\}\}\]\(https:\/\/github\.com\/Mentra-Community\/Mentra-Bluetooth-SDK-Starter-Kit\/releases\)/,
+    /\[Browse React Native example APK releases\]\(https:\/\/github\.com\/Mentra-Community\/Mentra-Bluetooth-SDK-Starter-Kit\/releases\)/,
   )
   assert.equal(readFileSync(path.join(source, "docs.json"), "utf8"), sourceConfig)
 })
 
-test("rejects unresolved URL variables", (context) => {
+test("rejects unresolved documentation variables", (context) => {
   const {root, source, output} = fixture()
   context.after(() => rmSync(root, {recursive: true, force: true}))
   writeFileSync(path.join(source, "page.mdx"), "[Unknown]({{unknown-url}})")
@@ -168,7 +168,7 @@ test("rejects unresolved URL variables", (context) => {
         },
         repository: "Mentra/MentraOS",
       }),
-    /Unresolved URL variable/,
+    /Unresolved documentation variable/,
   )
 })
 

--- a/.github/scripts/verify-coordinated-docs.mjs
+++ b/.github/scripts/verify-coordinated-docs.mjs
@@ -1,0 +1,26 @@
+import {readFileSync} from "node:fs"
+import path from "node:path"
+import {pathToFileURL} from "node:url"
+
+export function verifyCoordinatedDocs(html, {releaseIdentity, apkUrl, iosUrl}) {
+  for (const [label, value] of Object.entries({releaseIdentity, apkUrl, iosUrl})) {
+    if (!value) throw new Error(`Missing expected ${label}`)
+  }
+  if (html.includes("A parsing error occurred")) throw new Error("Mintlify exported a parsing-error page")
+  if (/\{\{[a-z0-9_-]+\}\}|%7b%7b[a-z0-9_-]+%7d%7d/i.test(html)) {
+    throw new Error("Unresolved documentation variable")
+  }
+  if (!html.includes(releaseIdentity)) throw new Error(`Page is missing release ${releaseIdentity}`)
+  for (const url of [apkUrl, iosUrl]) {
+    const escaped = url.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
+    if (!html.includes(`href="${escaped}"`)) throw new Error(`Page is missing install link ${url}`)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  verifyCoordinatedDocs(readFileSync(process.argv[2], "utf8"), {
+    releaseIdentity: process.env.RELEASE_IDENTITY,
+    apkUrl: process.env.EXAMPLE_APK_URL,
+    iosUrl: process.env.EXAMPLE_IOS_URL,
+  })
+}

--- a/.github/scripts/verify-coordinated-docs.test.mjs
+++ b/.github/scripts/verify-coordinated-docs.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {verifyCoordinatedDocs} from "./verify-coordinated-docs.mjs"
+
+const expected = {releaseIdentity: "3.1.0-beta.138", apkUrl: "https://example.com/app.apk", iosUrl: "https://testflight.apple.com/join/example"}
+const page = `<p>${expected.releaseIdentity}</p><a href="${expected.apkUrl}">Android</a><a href="${expected.iosUrl}">iOS</a>`
+
+test("requires release identity and both usable install links on the page", () => {
+  verifyCoordinatedDocs(page, expected)
+  assert.throws(() => verifyCoordinatedDocs(page.replace(expected.releaseIdentity, "3.1.0-beta.137"), expected), /missing release/)
+  assert.throws(() => verifyCoordinatedDocs(page.replace(`href="${expected.apkUrl}"`, ""), expected), /missing install link/)
+  assert.throws(() => verifyCoordinatedDocs(page.replace(`href="${expected.iosUrl}"`, ""), expected), /missing install link/)
+})
+
+test("rejects parse-error pages even when navigation embeds the release and URLs", () => {
+  assert.throws(() => verifyCoordinatedDocs(`${page}🚧 A parsing error occurred.`, expected), /parsing-error page/)
+  for (const variable of ["{{example-app-download-label}}", "%7B%7Bexample-app-url%7D%7D"]) {
+    assert.throws(() => verifyCoordinatedDocs(`${page}${variable}`, expected), /Unresolved/)
+  }
+})

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -956,6 +956,11 @@ jobs:
           fi
           node .github/scripts/verify-coordinated-docs.mjs \
             "$export_dir/bluetooth-sdk/software-update/index.html"
+          # Mintlify's static export does not emit docs.json redirects.
+          cat >> "$export_dir/_redirects" <<'REDIRECTS'
+          /mentra-live/software-update /bluetooth-sdk/software-update/ 301
+          /mentra-live/software-update/ /bluetooth-sdk/software-update/ 301
+          REDIRECTS
 
       - name: Deploy to Cloudflare Pages
         env:

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -938,6 +938,8 @@ jobs:
       - name: Prepare and verify the Cloudflare Pages artifact
         env:
           RELEASE_IDENTITY: ${{ needs.plan.outputs.release_identity }}
+          EXAMPLE_APK_URL: ${{ needs.starter-kit.outputs.react_native_apk_url }}
+          EXAMPLE_IOS_URL: ${{ needs.example-testflight.outputs.install_url }}
         run: |
           set -euo pipefail
           export_dir="$RUNNER_TEMP/mentraos-docs"
@@ -948,13 +950,12 @@ jobs:
           /*
             X-Robots-Tag: noindex
           HEADERS
-          grep -R --fixed-strings --quiet "$RELEASE_IDENTITY" "$export_dir/bluetooth-sdk"
           if grep -R --extended-regexp --ignore-case --quiet '\{\{[a-z0-9_-]+\}\}|%7b%7b[a-z0-9_-]+%7d%7d' "$export_dir/bluetooth-sdk"; then
             echo "Mintlify export contains an unresolved documentation variable." >&2
             exit 1
           fi
-          grep -R --fixed-strings --quiet "${{ needs.starter-kit.outputs.react_native_apk_url }}" "$export_dir/bluetooth-sdk"
-          grep -R --fixed-strings --quiet "${{ needs.example-testflight.outputs.install_url }}" "$export_dir/bluetooth-sdk"
+          node .github/scripts/verify-coordinated-docs.mjs \
+            "$export_dir/bluetooth-sdk/software-update/index.html"
 
       - name: Deploy to Cloudflare Pages
         env:


### PR DESCRIPTION
Fix documentation publication in coordinated staging run [34000694894](https://github.com/Mentra-Community/MentraOS/actions/runs/34000694894).

Mintlify interpreted the unresolved download-label variable as an MDX expression and exported a parsing-error page. The directory-wide artifact checks found release metadata elsewhere, so deployment succeeded and only the custom-domain check caught the missing install links.

Render all configured variables before parsing, then require the actual software-update page to contain the release identity and both install links before deployment. Reject parsing-error pages explicitly. Include the legacy software-update redirect because Mintlify's static export does not emit docs.json redirects.

Validation: 144 release tests passed; actionlint and diff checks passed. The shared fix passed a complete 57-page Mintlify export and page-level validation; its parser reproduced the original error before the fix, and the new artifact check rejects the actual failed staging HTML. Live publication remains to be verified after merge; no release jobs were rerun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release documentation rendering and pre-deploy validation in CI; no runtime app, auth, or data-path impact.
> 
> **Overview**
> **Fixes coordinated release docs** by substituting **every** `docs.json` placeholder into MDX before Mintlify export, not only `*-url` keys—so labels like `{{example-app-download-label}}` cannot be left for MDX to treat as expressions and export a parsing-error page.
> 
> Adds **`verify-coordinated-docs`** to assert `bluetooth-sdk/software-update/index.html` contains the release identity, both Android/iOS `href`s, no unresolved `{{…}}` (including URL-encoded), and no Mintlify parse-error copy. The coordinated-release workflow uses that check instead of repo-wide greps, passes APK/TestFlight URLs via env, and appends **legacy** `/mentra-live/software-update` → `/bluetooth-sdk/software-update/` redirects because static export omits `docs.json` redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40786f0d65a0e840facb80fa6a7358f4d1916c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->