### PR TITLE
Rebind the notification listener after OEM process kills

### DIFF
--- a/mobile/modules/crust/android/build.gradle
+++ b/mobile/modules/crust/android/build.gradle
@@ -144,3 +144,9 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
 }
+
+// Notification lifecycle tests run against Android APIs without a device.
+dependencies {
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.11.1'
+}

--- a/mobile/modules/crust/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/crust/android/src/main/AndroidManifest.xml
@@ -15,6 +15,10 @@
       <intent-filter>
         <action android:name="android.service.notification.NotificationListenerService" />
       </intent-filter>
+      <!-- Android 15+ ignores NotificationListenerService.requestRebind() unless
+           autobind is opted out. Some OEMs (RedMagic/ZTE) already skip autobind
+           after process death, so an approved listener stays detached. -->
+      <meta-data android:name="android.service.notification.default_autobind_listenerservice" android:value="false" />
       <meta-data android:name="android.service.notification.default_filter_types" android:value="conversations|alerting" />
       <meta-data android:name="android.service.notification.disabled_filter_types" android:value="ongoing|silent" />
     </service>

--- a/mobile/modules/crust/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/crust/android/src/main/AndroidManifest.xml
@@ -15,9 +15,8 @@
       <intent-filter>
         <action android:name="android.service.notification.NotificationListenerService" />
       </intent-filter>
-      <!-- Android 15+ ignores NotificationListenerService.requestRebind() unless
-           autobind is opted out. Some OEMs (RedMagic/ZTE) already skip autobind
-           after process death, so an approved listener stays detached. -->
+      <!-- Use on-demand binding (Android 14+) so startup and permission-grant
+           recovery can explicitly request a bind after applying listener config. -->
       <meta-data android:name="android.service.notification.default_autobind_listenerservice" android:value="false" />
       <meta-data android:name="android.service.notification.default_filter_types" android:value="conversations|alerting" />
       <meta-data android:name="android.service.notification.disabled_filter_types" android:value="ongoing|silent" />

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
@@ -24,6 +24,7 @@ class NotificationListener private constructor(private val context: Context) {
     private const val PREF_NOTIFICATIONS_BLOCKLIST = "notifications_blocklist"
 
     @Volatile private var instance: NotificationListener? = null
+    @Volatile private var reboundThisProcess = false
 
     fun getInstance(context: Context): NotificationListener {
       return instance
@@ -54,15 +55,26 @@ class NotificationListener private constructor(private val context: Context) {
       val componentChanged = updateComponentState(applicationContext, enabled = listenerEnabled)
 
       // Keep the isolated process's own SharedPreferences cache and live
-      // singleton in sync. A rebind is only needed when enabling the component;
-      // ordinary blocklist updates must not restart a healthy listener.
+      // singleton in sync. Rebind once per process so OEM/Android 15 holes
+      // cannot leave an approved listener detached. Later blocklist updates
+      // must not restart a healthy listener.
+      val shouldRebind = shouldRun && (componentChanged || !reboundThisProcess)
+      if (shouldRun) {
+        reboundThisProcess = true
+      }
       if (permissionGranted) {
         NotificationProcessBridge.sendConfig(
           applicationContext,
           listenerEnabled,
           blocklistSet,
-          requestRebind = shouldRun && componentChanged,
+          requestRebind = shouldRebind,
         )
+      }
+
+      // requestRebind is a static NMS call. Do it from this process too so a
+      // dead or slow :notif receiver cannot leave an approved listener unbound.
+      if (shouldRebind) {
+        requestListenerRebind(applicationContext)
       }
 
       if (!shouldRun) {
@@ -97,6 +109,9 @@ class NotificationListener private constructor(private val context: Context) {
           // The :notif receiver persists the config before requesting rebind.
           requestRebind = shouldRun,
         )
+      }
+      if (shouldRun) {
+        requestListenerRebind(applicationContext)
       }
       return permissionGranted
     }

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
@@ -24,7 +24,7 @@ class NotificationListener private constructor(private val context: Context) {
     private const val PREF_NOTIFICATIONS_BLOCKLIST = "notifications_blocklist"
 
     @Volatile private var instance: NotificationListener? = null
-    @Volatile private var reboundThisProcess = false
+    private var rebindRequestedThisProcess = false
 
     fun getInstance(context: Context): NotificationListener {
       return instance
@@ -41,6 +41,7 @@ class NotificationListener private constructor(private val context: Context) {
      * The component stays enabled so Android can show it in notification-access
      * Settings, but its service process only starts after access is granted.
      */
+    @Synchronized
     fun setNotificationConfig(
       context: Context,
       listenerEnabled: Boolean,
@@ -50,37 +51,12 @@ class NotificationListener private constructor(private val context: Context) {
       val blocklistSet = blocklist.toSet()
       persistConfig(applicationContext, listenerEnabled, blocklistSet)
 
-      val permissionGranted = hasNotificationListenerPermission(applicationContext)
-      val shouldRun = listenerEnabled && permissionGranted
-      val componentChanged = updateComponentState(applicationContext, enabled = listenerEnabled)
-
-      // Keep the isolated process's own SharedPreferences cache and live
-      // singleton in sync. Rebind once per process so OEM/Android 15 holes
-      // cannot leave an approved listener detached. Later blocklist updates
-      // must not restart a healthy listener.
-      val shouldRebind = shouldRun && (componentChanged || !reboundThisProcess)
-      if (shouldRun) {
-        reboundThisProcess = true
-      }
-      if (permissionGranted) {
-        NotificationProcessBridge.sendConfig(
-          applicationContext,
-          listenerEnabled,
-          blocklistSet,
-          requestRebind = shouldRebind,
-        )
-      }
-
-      // requestRebind is a static NMS call. Do it from this process too so a
-      // dead or slow :notif receiver cannot leave an approved listener unbound.
-      if (shouldRebind) {
-        requestListenerRebind(applicationContext)
-      }
-
-      if (!shouldRun) {
-        Log.d(TAG, "Notification listener prerequisites not met; service will not start")
-        return
-      }
+      reconcileNotificationConfig(
+        applicationContext,
+        listenerEnabled,
+        blocklistSet,
+        hasNotificationListenerPermission(applicationContext),
+      )
     }
 
     /**
@@ -90,6 +66,7 @@ class NotificationListener private constructor(private val context: Context) {
      * newly granted listener starts immediately. Without permission the service
      * is not rebound and the isolated process is never started.
      */
+    @Synchronized
     fun refreshComponentForPermission(context: Context): Boolean {
       val applicationContext = context.applicationContext
       val permissionGranted = hasNotificationListenerPermission(applicationContext)
@@ -98,22 +75,41 @@ class NotificationListener private constructor(private val context: Context) {
       val blocklist =
         preferences.getStringSet(PREF_NOTIFICATIONS_BLOCKLIST, emptySet())?.toSet() ?: emptySet()
 
+      reconcileNotificationConfig(
+        applicationContext,
+        listenerEnabled,
+        blocklist,
+        permissionGranted,
+        forceRebind = true,
+      )
+      return permissionGranted
+    }
+
+    /** Both app entrypoints use one rebind decision; the receiver owns the request. */
+    private fun reconcileNotificationConfig(
+      context: Context,
+      listenerEnabled: Boolean,
+      blocklist: Set<String>,
+      permissionGranted: Boolean,
+      forceRebind: Boolean = false,
+    ) {
       val shouldRun = listenerEnabled && permissionGranted
-      updateComponentState(applicationContext, enabled = listenerEnabled)
+      val componentChanged = updateComponentState(context, enabled = listenerEnabled)
+      val shouldRebind = shouldRun && (forceRebind || componentChanged || !rebindRequestedThisProcess)
       if (permissionGranted) {
+        // The explicit broadcast starts :notif if needed. Its receiver applies
+        // the config before requesting the bind, avoiding duplicate requests
+        // and a listener that starts with a stale per-process preferences cache.
         NotificationProcessBridge.sendConfig(
-          applicationContext,
+          context,
           listenerEnabled,
           blocklist,
-          // This method is reserved for the confirmed permission-grant path.
-          // The :notif receiver persists the config before requesting rebind.
-          requestRebind = shouldRun,
+          requestRebind = shouldRebind,
         )
       }
-      if (shouldRun) {
-        requestListenerRebind(applicationContext)
-      }
-      return permissionGranted
+      // A permission-grant refresh also satisfies startup recovery. Ordinary
+      // blocklist updates therefore do not request another bind afterward.
+      rebindRequestedThisProcess = shouldRun
     }
 
     fun openNotificationListenerSettings(context: Context) {

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
@@ -24,7 +24,6 @@ class NotificationListener private constructor(private val context: Context) {
     private const val PREF_NOTIFICATIONS_BLOCKLIST = "notifications_blocklist"
 
     @Volatile private var instance: NotificationListener? = null
-    private var rebindRequestedThisProcess = false
 
     fun getInstance(context: Context): NotificationListener {
       return instance
@@ -95,7 +94,7 @@ class NotificationListener private constructor(private val context: Context) {
     ) {
       val shouldRun = listenerEnabled && permissionGranted
       val componentChanged = updateComponentState(context, enabled = listenerEnabled)
-      val shouldRebind = shouldRun && (forceRebind || componentChanged || !rebindRequestedThisProcess)
+      val shouldRebind = shouldRun && (forceRebind || componentChanged)
       if (permissionGranted) {
         // The explicit broadcast starts :notif if needed. Its receiver applies
         // the config before requesting the bind, avoiding duplicate requests
@@ -107,9 +106,6 @@ class NotificationListener private constructor(private val context: Context) {
           requestRebind = shouldRebind,
         )
       }
-      // A permission-grant refresh also satisfies startup recovery. Ordinary
-      // blocklist updates therefore do not request another bind afterward.
-      rebindRequestedThisProcess = shouldRun
     }
 
     fun openNotificationListenerSettings(context: Context) {
@@ -168,10 +164,11 @@ class NotificationListener private constructor(private val context: Context) {
       }
     }
 
-    internal fun requestListenerRebind(context: Context) {
+    internal fun requestListenerRebind(context: Context): Boolean {
       val component = ComponentName(context, NotificationListenerServiceImpl::class.java)
-      runCatching { NotificationListenerService.requestRebind(component) }
+      return runCatching { NotificationListenerService.requestRebind(component) }
         .onFailure { Log.w(TAG, "Could not request notification-listener rebind", it) }
+        .isSuccess
     }
 
     internal fun applyConfigToExisting(

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationProcessBridge.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationProcessBridge.kt
@@ -205,6 +205,12 @@ internal data class NotificationConfigUpdate(
 
 /** Persists and applies config inside the isolated notification process. */
 class NotificationConfigReceiver : BroadcastReceiver() {
+  companion object {
+    // Owned by :notif, so process death resets recovery independently of the
+    // main app. BroadcastReceiver instances themselves are short-lived.
+    private var rebindRequestedThisProcess = false
+  }
+
   override fun onReceive(context: Context, intent: Intent) {
     if (!NotificationProcessBridge.isConfigAction(context, intent)) return
     val config = NotificationProcessBridge.readConfig(intent)
@@ -215,8 +221,12 @@ class NotificationConfigReceiver : BroadcastReceiver() {
     NotificationListener.persistConfig(context, config.listenerEnabled, config.blocklist)
     NotificationListener.applyConfigToExisting(config.listenerEnabled, config.blocklist)
 
-    if (config.listenerEnabled && config.requestRebind) {
-      NotificationListener.requestListenerRebind(context)
+    if (!config.listenerEnabled || !NotificationListener.hasNotificationListenerPermission(context)) {
+      rebindRequestedThisProcess = false
+      return
+    }
+    if (config.requestRebind || !rebindRequestedThisProcess) {
+      rebindRequestedThisProcess = NotificationListener.requestListenerRebind(context)
     }
   }
 }

--- a/mobile/modules/crust/android/src/test/java/com/mentra/crust/services/NotificationListenerConfigTest.kt
+++ b/mobile/modules/crust/android/src/test/java/com/mentra/crust/services/NotificationListenerConfigTest.kt
@@ -2,6 +2,7 @@ package com.mentra.crust.services
 
 import android.app.Application
 import android.content.ComponentName
+import android.content.Intent
 import android.provider.Settings
 import android.service.notification.NotificationListenerService
 import org.junit.Assert.assertEquals
@@ -27,7 +28,12 @@ class NotificationListenerConfigTest {
     context = RuntimeEnvironment.getApplication()
     grantPermission(false)
     NotificationListener.setNotificationConfig(context, false, emptyList())
+    NotificationConfigReceiver().onReceive(
+      context,
+      Intent(context.packageName + ".crust.NOTIFICATION_CONFIG"),
+    )
     RebindRecorder.requests.clear()
+    RebindRecorder.failRequest = false
   }
 
   @Test
@@ -40,13 +46,42 @@ class NotificationListenerConfigTest {
     )
     NotificationListener.setNotificationConfig(context, true, emptyList())
     assertTrue(RebindRecorder.requests.isEmpty())
-    deliverLatestConfig(expectedRebind = true)
+    deliverLatestConfig(expectedRebind = false)
     assertEquals(1, RebindRecorder.requests.size)
 
     NotificationListener.setNotificationConfig(context, true, listOf("blocked.app"))
     deliverLatestConfig(expectedRebind = false)
     assertEquals(1, RebindRecorder.requests.size)
     assertEquals(setOf("blocked.app"), preferences().getStringSet("notifications_blocklist", emptySet()))
+  }
+
+  @Test
+  fun freshNotificationProcessRecoversOnConfigOnlyBroadcast() {
+    grantPermission(true)
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    // The app has already requested startup recovery, but the receiver starts
+    // fresh in :notif. This is also the state after only :notif was killed.
+    NotificationListener.setNotificationConfig(context, true, listOf("blocked.app"))
+    deliverLatestConfig(expectedRebind = false)
+    assertEquals(1, RebindRecorder.requests.size)
+
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    deliverLatestConfig(expectedRebind = false)
+    assertEquals(1, RebindRecorder.requests.size)
+  }
+
+  @Test
+  fun failedRequestCanRetryOnNextConfigWithoutRestartingProcess() {
+    grantPermission(true)
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    RebindRecorder.failRequest = true
+    deliverLatestConfig(expectedRebind = true)
+    assertTrue(RebindRecorder.requests.isEmpty())
+
+    RebindRecorder.failRequest = false
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    deliverLatestConfig(expectedRebind = false)
+    assertEquals(1, RebindRecorder.requests.size)
   }
 
   @Test
@@ -128,10 +163,12 @@ class NotificationListenerConfigTest {
 class RebindRecorder {
   companion object {
     val requests = mutableListOf<ComponentName>()
+    var failRequest = false
 
     @JvmStatic
     @Implementation
     fun requestRebind(component: ComponentName) {
+      if (failRequest) throw IllegalStateException("Binder unavailable")
       // Receiver must have applied config before binding the service.
       val context = RuntimeEnvironment.getApplication() as Application
       val prefs = context.getSharedPreferences("mentra_crust_notification_prefs", 0)

--- a/mobile/modules/crust/android/src/test/java/com/mentra/crust/services/NotificationListenerConfigTest.kt
+++ b/mobile/modules/crust/android/src/test/java/com/mentra/crust/services/NotificationListenerConfigTest.kt
@@ -1,0 +1,142 @@
+package com.mentra.crust.services
+
+import android.app.Application
+import android.content.ComponentName
+import android.provider.Settings
+import android.service.notification.NotificationListenerService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE, shadows = [RebindRecorder::class])
+class NotificationListenerConfigTest {
+  private lateinit var context: Application
+
+  @Before
+  fun reset() {
+    context = RuntimeEnvironment.getApplication()
+    grantPermission(false)
+    NotificationListener.setNotificationConfig(context, false, emptyList())
+    RebindRecorder.requests.clear()
+  }
+
+  @Test
+  fun startupRebindsOnlyThroughReceiverAndConfigUpdatesDoNotRebind() {
+    grantPermission(true)
+    context.packageManager.setComponentEnabledSetting(
+      component(),
+      android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+      android.content.pm.PackageManager.DONT_KILL_APP,
+    )
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    assertTrue(RebindRecorder.requests.isEmpty())
+    deliverLatestConfig(expectedRebind = true)
+    assertEquals(1, RebindRecorder.requests.size)
+
+    NotificationListener.setNotificationConfig(context, true, listOf("blocked.app"))
+    deliverLatestConfig(expectedRebind = false)
+    assertEquals(1, RebindRecorder.requests.size)
+    assertEquals(setOf("blocked.app"), preferences().getStringSet("notifications_blocklist", emptySet()))
+  }
+
+  @Test
+  fun permissionGrantCountsAsStartupRecovery() {
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    assertTrue(shadowOf(context).broadcastIntents.isEmpty())
+    grantPermission(true)
+    assertTrue(NotificationListener.refreshComponentForPermission(context))
+    assertTrue(RebindRecorder.requests.isEmpty())
+    deliverLatestConfig(expectedRebind = true)
+
+    NotificationListener.setNotificationConfig(context, true, listOf("blocked.app"))
+    deliverLatestConfig(expectedRebind = false)
+    assertEquals(1, RebindRecorder.requests.size)
+  }
+
+  @Test
+  fun deniedPermissionNeverStartsNotificationProcess() {
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    assertFalse(NotificationListener.refreshComponentForPermission(context))
+    assertTrue(shadowOf(context).broadcastIntents.isEmpty())
+    assertTrue(RebindRecorder.requests.isEmpty())
+    assertEquals(
+      android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+      context.packageManager.getComponentEnabledSetting(component()),
+    )
+  }
+
+  @Test
+  fun disablingAndReenablingAllowsAnotherBind() {
+    grantPermission(true)
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    deliverLatestConfig(expectedRebind = true)
+    NotificationListener.setNotificationConfig(context, false, emptyList())
+    deliverLatestConfig(expectedRebind = false)
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    deliverLatestConfig(expectedRebind = true)
+    assertEquals(2, RebindRecorder.requests.size)
+  }
+
+  @Test
+  fun confirmedRegrantCanRecoverAgainInSameProcess() {
+    grantPermission(true)
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    deliverLatestConfig(expectedRebind = true)
+    // Access can be revoked and granted in Settings without a config update.
+    NotificationListener.refreshComponentForPermission(context)
+    deliverLatestConfig(expectedRebind = true)
+    NotificationListener.setNotificationConfig(context, true, emptyList())
+    deliverLatestConfig(expectedRebind = false)
+    assertEquals(2, RebindRecorder.requests.size)
+  }
+
+  private fun grantPermission(granted: Boolean) {
+    Settings.Secure.putString(
+      context.contentResolver,
+      "enabled_notification_listeners",
+      if (granted) component().flattenToString() else "",
+    )
+  }
+
+  private fun component() = ComponentName(context, NotificationListenerServiceImpl::class.java)
+
+  private fun preferences() = context.getSharedPreferences("mentra_crust_notification_prefs", 0)
+
+  private fun deliverLatestConfig(expectedRebind: Boolean) {
+    val intent = shadowOf(context).broadcastIntents.last()
+    val config = NotificationProcessBridge.readConfig(intent)
+    assertEquals(expectedRebind, config.requestRebind)
+    // Model :notif's independent preference cache rather than relying on the
+    // value just written by the app process.
+    preferences().edit().clear().commit()
+    NotificationConfigReceiver().onReceive(context, intent)
+    assertEquals(config.listenerEnabled, preferences().getBoolean("notification_listener_enabled", false))
+  }
+}
+
+@Implements(NotificationListenerService::class)
+class RebindRecorder {
+  companion object {
+    val requests = mutableListOf<ComponentName>()
+
+    @JvmStatic
+    @Implementation
+    fun requestRebind(component: ComponentName) {
+      // Receiver must have applied config before binding the service.
+      val context = RuntimeEnvironment.getApplication() as Application
+      val prefs = context.getSharedPreferences("mentra_crust_notification_prefs", 0)
+      assertTrue(prefs.getBoolean("notification_listener_enabled", false))
+      requests.add(component)
+    }
+  }
+}


### PR DESCRIPTION
Recover an approved notification listener on config synchronization or a confirmed notification-access grant. The manifest selects on-demand binding, and the explicit `:notif` config receiver applies the latest config before requesting a bind.

The receiver owns the one-time recovery state. If only `:notif` dies while the main app survives, the next config broadcast requests a bind in the fresh notification process even when the app sends a config-only update. Healthy blocklist updates do not request another bind. Component enabling and confirmed permission grants explicitly request recovery; disabled/denied state clears the receiver flag. A failed bind request remains eligible on the next config sync. No duplicate app-process bind request or retry timer is needed.

Validation: compiled the Crust Android module and passed seven Robolectric lifecycle tests through the generated Expo Android project (`:mentra-crust:testDebugUnitTest --tests com.mentra.crust.services.NotificationListenerConfigTest`). The process-recovery regression failed on the preceding commit and passes with the receiver-owned state. Other tests cover already-enabled startup, permission grant/denial, config-only updates, disable/re-enable, repeated permission-grant recovery, and a failed bind request.

Physical-device validation of the final revision remains outstanding, particularly force-stop/relaunch recovery on RedMagic/ZTE and normal delivery on stock Android. The original author reported recovery on a RedMagic 11 Pro with the initial implementation; that does not verify this revision.
