### PR TITLE
Support minimum and initial WHIP video bitrates

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/config/WhipStreamConfig.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/config/WhipStreamConfig.java
@@ -27,6 +27,8 @@ public class WhipStreamConfig {
   private int videoHeight = DEFAULT_VIDEO_HEIGHT;
   private int videoFps = DEFAULT_VIDEO_FPS;
   private int videoBitrate = DEFAULT_VIDEO_BITRATE;
+  private Integer videoMinBitrateBps;
+  private Integer videoInitialBitrateBps;
   private volatile double statusVideoFps = Double.NaN;
 
   private boolean echoCancellation = DEFAULT_ECHO_CANCELLATION;
@@ -61,6 +63,12 @@ public class WhipStreamConfig {
       config.videoHeight = normalizeDimension(height, 240, 1080);
       config.videoBitrate = clamp(config.videoBitrate, 100000, 10000000);
       config.videoFps = clamp(config.videoFps, MIN_VIDEO_FPS, MAX_VIDEO_FPS);
+      int requestedInitial = videoJson.optInt("initialBitrateBps", 0);
+      if (requestedInitial > 0) config.videoInitialBitrateBps = requestedInitial;
+      int requestedMinimum = videoJson.optInt("minBitrateBps", 0);
+      if (requestedMinimum > 0) {
+        config.videoMinBitrateBps = Math.min(requestedMinimum, config.videoBitrate);
+      }
     }
 
     if (audioJson != null) {
@@ -157,6 +165,14 @@ public class WhipStreamConfig {
   public int getVideoHeight() { return videoHeight; }
   public int getVideoFps() { return videoFps; }
   public int getVideoBitrate() { return videoBitrate; }
+
+  /** Optional caller-supplied WHIP startup bitrate, bounded when applied. */
+  public Integer getVideoInitialBitrateBps() { return videoInitialBitrateBps; }
+
+  /** Optional WHIP video bitrate floor, bounded by the current maximum. */
+  public Integer getVideoMinBitrateBps() {
+    return videoMinBitrateBps == null ? null : Math.min(videoMinBitrateBps, videoBitrate);
+  }
   public boolean isEchoCancellation() { return echoCancellation; }
   public boolean isNoiseSuppression() { return noiseSuppression; }
   public boolean isCaptureAudio() { return captureAudio; }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicy.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicy.java
@@ -11,8 +11,26 @@ final class WhipBitratePolicy {
         return Math.min(maximumBitrateBps, AsgConstants.WHIP_INITIAL_VIDEO_BITRATE_BPS);
     }
 
-    static boolean applyTo(PeerConnection peerConnection, int maximumBitrateBps) {
-        return peerConnection.setBitrate(
-                null, initialBitrateBps(maximumBitrateBps), maximumBitrateBps);
+    static Integer minimumBitrateBps(Integer requestedMinimum, int maximumBitrateBps) {
+        return requestedMinimum != null && requestedMinimum > 0
+                ? Math.min(maximumBitrateBps, requestedMinimum)
+                : null;
+    }
+
+    static int initialBitrateBps(Integer requestedInitial, Integer requestedMinimum, int maximumBitrateBps) {
+        Integer minimum = minimumBitrateBps(requestedMinimum, maximumBitrateBps);
+        int initial = requestedInitial != null && requestedInitial > 0
+                ? requestedInitial : initialBitrateBps(maximumBitrateBps);
+        return Math.min(maximumBitrateBps, Math.max(initial, minimum == null ? 0 : minimum));
+    }
+
+    static boolean applyTo(PeerConnection peerConnection, Integer requestedMinimum, int maximumBitrateBps) {
+        return applyTo(peerConnection, requestedMinimum, null, maximumBitrateBps);
+    }
+
+    static boolean applyTo(PeerConnection peerConnection, Integer requestedMinimum,
+            Integer requestedInitial, int maximumBitrateBps) {
+        return peerConnection.setBitrate(minimumBitrateBps(requestedMinimum, maximumBitrateBps),
+                initialBitrateBps(requestedInitial, requestedMinimum, maximumBitrateBps), maximumBitrateBps);
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -701,7 +701,10 @@ public class WhipStreamingService extends Service {
    */
   private void applyBitrateConstraints() {
     int maximumBitrateBps = mStreamConfig.getVideoBitrate();
-    int initialBitrateBps = WhipBitratePolicy.initialBitrateBps(maximumBitrateBps);
+    int initialBitrateBps = WhipBitratePolicy.initialBitrateBps(
+        mStreamConfig.getVideoInitialBitrateBps(), mStreamConfig.getVideoMinBitrateBps(), maximumBitrateBps);
+    Integer minimumBitrateBps = WhipBitratePolicy.minimumBitrateBps(
+        mStreamConfig.getVideoMinBitrateBps(), maximumBitrateBps);
 
     for (RtpSender sender : mPeerConnection.getSenders()) {
       if (sender.track() == null) continue;
@@ -713,6 +716,7 @@ public class WhipStreamingService extends Service {
       params.degradationPreference = RtpParameters.DegradationPreference.MAINTAIN_FRAMERATE;
 
       for (RtpParameters.Encoding encoding : params.encodings) {
+        encoding.minBitrateBps = minimumBitrateBps;
         encoding.maxBitrateBps = maximumBitrateBps;
       }
 
@@ -720,11 +724,14 @@ public class WhipStreamingService extends Service {
     }
 
     boolean bitratePreferencesApplied =
-        WhipBitratePolicy.applyTo(mPeerConnection, maximumBitrateBps);
+        WhipBitratePolicy.applyTo(mPeerConnection, mStreamConfig.getVideoMinBitrateBps(),
+            mStreamConfig.getVideoInitialBitrateBps(), maximumBitrateBps);
     if (!bitratePreferencesApplied) {
-      Log.w(TAG, "Failed to apply WHIP initial/max bitrate preferences");
+      Log.w(TAG, "Failed to apply WHIP min/initial/max bitrate preferences");
     }
-    Log.i(TAG, "Applied video bitrate constraints: start=" + (initialBitrateBps / 1000)
+    Log.i(TAG, "Applied video bitrate constraints: min="
+        + (minimumBitrateBps == null ? "unset" : minimumBitrateBps / 1000)
+        + " kbps, start=" + (initialBitrateBps / 1000)
         + " kbps, max=" + (maximumBitrateBps / 1000)
         + " kbps, degradation=MAINTAIN_FRAMERATE");
   }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/streaming/config/WhipStreamConfigTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/streaming/config/WhipStreamConfigTest.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.streaming.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.json.JSONException;
@@ -144,4 +145,24 @@ public class WhipStreamConfigTest {
         WhipStreamConfig on = WhipStreamConfig.fromJson(null, enabled);
         assertTrue(on.isCaptureAudio());
     }
+    @Test
+    public void optionalBitrates_preserveDefaultsAndParseOverrides() throws JSONException {
+        WhipStreamConfig defaults = WhipStreamConfig.fromJson(null, null);
+        assertNull(defaults.getVideoMinBitrateBps());
+        assertNull(defaults.getVideoInitialBitrateBps());
+        JSONObject video = new JSONObject()
+                .put("bitrate", 500_000)
+                .put("minBitrateBps", 300_000)
+                .put("initialBitrateBps", 400_000);
+        WhipStreamConfig config = WhipStreamConfig.fromJson(video, null);
+        assertEquals(Integer.valueOf(300_000), config.getVideoMinBitrateBps());
+        assertEquals(Integer.valueOf(400_000), config.getVideoInitialBitrateBps());
+        config.setVideoBitrate(200_000);
+        assertEquals(Integer.valueOf(200_000), config.getVideoMinBitrateBps());
+        video.put("minBitrateBps", -1).put("initialBitrateBps", 0);
+        config = WhipStreamConfig.fromJson(video, null);
+        assertNull(config.getVideoMinBitrateBps());
+        assertNull(config.getVideoInitialBitrateBps());
+    }
+
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicyTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/streaming/services/WhipBitratePolicyTest.java
@@ -1,6 +1,7 @@
 package com.mentra.asg_client.io.streaming.services;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -26,8 +27,47 @@ public class WhipBitratePolicyTest {
         PeerConnection peerConnection = mock(PeerConnection.class);
         when(peerConnection.setBitrate(null, 1_500_000, 2_500_000)).thenReturn(true);
 
-        assertTrue(WhipBitratePolicy.applyTo(peerConnection, 2_500_000));
+        assertTrue(WhipBitratePolicy.applyTo(peerConnection, null, 2_500_000));
 
         verify(peerConnection).setBitrate(null, 1_500_000, 2_500_000);
     }
+
+    @Test
+    public void applyTo_setsRequestedMinimum() {
+        PeerConnection peerConnection = mock(PeerConnection.class);
+        when(peerConnection.setBitrate(1_300_000, 1_500_000, 1_500_000)).thenReturn(true);
+
+        assertTrue(WhipBitratePolicy.applyTo(peerConnection, 1_300_000, 1_500_000));
+
+        verify(peerConnection).setBitrate(1_300_000, 1_500_000, 1_500_000);
+    }
+
+    @Test
+    public void minimumBitrateBps_respectsLowerMaximum() {
+        assertEquals(Integer.valueOf(1_000_000), WhipBitratePolicy.minimumBitrateBps(1_300_000, 1_000_000));
+    }
+
+    @Test
+    public void minimumBitrateBps_omittedOrNonpositiveMeansUnset() {
+        assertNull(WhipBitratePolicy.minimumBitrateBps(null, 1_500_000));
+        assertNull(WhipBitratePolicy.minimumBitrateBps(0, 2_500_000));
+    }
+    @Test
+    public void initialBitrateBps_clampsToBothBoundsAndPreservesDefault() {
+        assertEquals(1_500_000, WhipBitratePolicy.initialBitrateBps(null, null, 2_500_000));
+        assertEquals(500_000, WhipBitratePolicy.initialBitrateBps(null, null, 500_000));
+        assertEquals(400_000, WhipBitratePolicy.initialBitrateBps(400_000, 300_000, 500_000));
+        assertEquals(300_000, WhipBitratePolicy.initialBitrateBps(100_000, 300_000, 500_000));
+        assertEquals(500_000, WhipBitratePolicy.initialBitrateBps(900_000, 300_000, 500_000));
+        assertEquals(1_500_000, WhipBitratePolicy.initialBitrateBps(0, null, 2_500_000));
+    }
+
+    @Test
+    public void applyTo_passesAllThreeRequestedBitrates() {
+        PeerConnection peerConnection = mock(PeerConnection.class);
+        when(peerConnection.setBitrate(300_000, 400_000, 500_000)).thenReturn(true);
+        assertTrue(WhipBitratePolicy.applyTo(peerConnection, 300_000, 400_000, 500_000));
+        verify(peerConnection).setBitrate(300_000, 400_000, 500_000);
+    }
+
 }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
@@ -5,12 +5,16 @@ data class StreamVideoConfig @JvmOverloads constructor(
     val height: Int? = null,
     val bitrate: Int? = null,
     val fps: Int? = null,
+    val minBitrateBps: Int? = null,
+    val initialBitrateBps: Int? = null,
 ) {
     fun toMap(): Map<String, Any> =
         listOfNotNull(
             width?.let { "width" to it },
             height?.let { "height" to it },
             bitrate?.let { "bitrate" to it },
+            minBitrateBps?.let { "minBitrateBps" to it },
+            initialBitrateBps?.let { "initialBitrateBps" to it },
             // ASG stream parsers shipped with the BLE key named "frameRate".
             fps?.let { "frameRate" to it },
         ).toMap()
@@ -24,6 +28,8 @@ data class StreamVideoConfig @JvmOverloads constructor(
                 height = numberValue(values, "height"),
                 bitrate = numberValue(values, "bitrate"),
                 fps = numberValue(values, "fps"),
+                minBitrateBps = numberValue(values, "minBitrateBps"),
+                initialBitrateBps = numberValue(values, "initialBitrateBps"),
             )
         }
     }

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/StreamRequestCaptureAudioTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/StreamRequestCaptureAudioTest.kt
@@ -5,6 +5,18 @@ import org.junit.Test
 
 class StreamRequestCaptureAudioTest {
   @Test
+  fun videoBitrateOptionsSurviveBridgeAndWireSerialization() {
+    val video = StreamVideoConfig.fromMap(mapOf(
+      "minBitrateBps" to 300_000,
+      "initialBitrateBps" to 400_000,
+      "bitrate" to 500_000,
+    ))!!
+    assertThat(video.toMap()).containsEntry("minBitrateBps", 300_000)
+      .containsEntry("initialBitrateBps", 400_000).containsEntry("bitrate", 500_000)
+    assertThat(StreamVideoConfig().toMap()).doesNotContainKeys("minBitrateBps", "initialBitrateBps")
+  }
+
+  @Test
   fun toMapOmitsCaptureAudioWhenTrue() {
     val map = StreamRequest(streamUrl = "https://example.com/whip", captureAudio = true).toMap()
     assertThat(map).doesNotContainKey("captureAudio")

--- a/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
@@ -4,17 +4,23 @@ public struct StreamVideoConfig {
     public let width: Int?
     public let height: Int?
     public let bitrate: Int?
+    public let minBitrateBps: Int?
+    public let initialBitrateBps: Int?
     public let fps: Int?
 
     public init(
         width: Int? = nil,
         height: Int? = nil,
         bitrate: Int? = nil,
-        fps: Int? = nil
+        fps: Int? = nil,
+        minBitrateBps: Int? = nil,
+        initialBitrateBps: Int? = nil
     ) {
         self.width = width
         self.height = height
         self.bitrate = bitrate
+        self.minBitrateBps = minBitrateBps
+        self.initialBitrateBps = initialBitrateBps
         self.fps = fps
     }
 
@@ -23,6 +29,8 @@ public struct StreamVideoConfig {
         if let width { values["width"] = width }
         if let height { values["height"] = height }
         if let bitrate { values["bitrate"] = bitrate }
+        if let minBitrateBps { values["minBitrateBps"] = minBitrateBps }
+        if let initialBitrateBps { values["initialBitrateBps"] = initialBitrateBps }
         // ASG stream parsers shipped with the BLE key named "frameRate".
         if let fps { values["frameRate"] = fps }
         return values
@@ -34,7 +42,9 @@ public struct StreamVideoConfig {
             width: intValue(values["width"]),
             height: intValue(values["height"]),
             bitrate: intValue(values["bitrate"]),
-            fps: intValue(values["fps"])
+            fps: intValue(values["fps"]),
+            minBitrateBps: intValue(values["minBitrateBps"]),
+            initialBitrateBps: intValue(values["initialBitrateBps"])
         )
     }
 }

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -620,6 +620,10 @@ export type StreamVideoConfig = {
   width?: number
   height?: number
   bitrate?: number
+  /** WHIP minimum target in bps; omitted leaves it unset. Clamped to the maximum. */
+  minBitrateBps?: number
+  /** WHIP startup bitrate in bps, clamped to the requested bounds. */
+  initialBitrateBps?: number
   fps?: number
 }
 

--- a/mobile/modules/engine/src/runtime/__tests__/streamConfig.test.ts
+++ b/mobile/modules/engine/src/runtime/__tests__/streamConfig.test.ts
@@ -10,6 +10,17 @@ import {
 } from "../streamConfig"
 
 describe("stream config normalizers", () => {
+  test("preserves optional bitrate controls and rejects nonfinite values", () => {
+    expect(normalizeStreamVideoConfig({minBitrateBps: 300_000, initialBitrateBps: 400_000})).toEqual({
+      minBitrateBps: 300_000,
+      initialBitrateBps: 400_000,
+    })
+    expect(normalizeStreamVideoConfig({minBitrateBps: NaN, initialBitrateBps: Infinity})).toBeUndefined()
+    expect(normalizeStreamVideoConfig({minBitrateBps: -1, initialBitrateBps: 400_000.9})).toEqual({
+      minBitrateBps: 0,
+      initialBitrateBps: 400_000,
+    })
+  })
   test("preserves local miniapp video fps", () => {
     expect(
       normalizeStreamVideoConfig({

--- a/mobile/modules/engine/src/runtime/config.ts
+++ b/mobile/modules/engine/src/runtime/config.ts
@@ -101,6 +101,10 @@ export interface StreamVideoConfig {
   width?: number
   height?: number
   bitrate?: number
+  /** WHIP minimum target in bps; omitted leaves it unset. Clamped to the maximum. */
+  minBitrateBps?: number
+  /** WHIP startup bitrate in bps, clamped to the requested bounds. */
+  initialBitrateBps?: number
   fps?: number
 }
 

--- a/mobile/modules/engine/src/runtime/streamConfig.ts
+++ b/mobile/modules/engine/src/runtime/streamConfig.ts
@@ -12,11 +12,15 @@ export const normalizeStreamVideoConfig = (value: unknown): StreamVideoConfig | 
   const width = finiteNumber(value.width)
   const height = finiteNumber(value.height)
   const bitrate = finiteNumber(value.bitrate)
+  const minBitrateBps = finiteNumber(value.minBitrateBps)
+  const initialBitrateBps = finiteNumber(value.initialBitrateBps)
   const frameRate = finiteNumber(value.frameRate)
   const fps = frameRate ?? finiteNumber(value.fps)
   if (width !== undefined) config.width = width
   if (height !== undefined) config.height = height
   if (bitrate !== undefined) config.bitrate = bitrate
+  if (minBitrateBps !== undefined) config.minBitrateBps = Math.max(0, Math.trunc(minBitrateBps))
+  if (initialBitrateBps !== undefined) config.initialBitrateBps = Math.max(0, Math.trunc(initialBitrateBps))
   if (fps !== undefined) config.fps = fps
   return Object.keys(config).length > 0 ? config : undefined
 }

--- a/mobile/modules/miniapp/src/modules/stream.ts
+++ b/mobile/modules/miniapp/src/modules/stream.ts
@@ -15,6 +15,10 @@ export interface StreamVideoConfig {
   width?: number
   height?: number
   bitrate?: number
+  /** WHIP minimum target in bps; omitted leaves it unset. Clamped to the maximum. */
+  minBitrateBps?: number
+  /** WHIP startup bitrate in bps, clamped to the requested bounds. */
+  initialBitrateBps?: number
   fps?: number
 }
 


### PR DESCRIPTION
Miniapps can currently cap WHIP video bitrate but cannot request a minimum target or startup bitrate. Add optional `minBitrateBps` and `initialBitrateBps` through the Miniapp SDK, engine, Android/iOS Bluetooth SDK, and ASG WHIP sender.

ASG clamps the minimum to the maximum and the startup bitrate to those bounds. Omitting both fields preserves the existing behavior: no explicit minimum and a startup target of min(1.5 Mbps, maximum). These are WebRTC bitrate preferences, not a guarantee of minimum measured payload throughput.

The companion Mentra Call PR requests a 1 Mbps minimum target and 1.5 Mbps startup target, and gives ACS twice the glasses' maximum bitrate for encoding headroom. The new controls require updated phone and ASG builds; older clients can continue omitting them.

Validation: focused ASG config/policy JVM tests and Bluetooth SDK Android release unit tests passed (Gradle builds successful); engine stream normalization tests passed (6 tests). Earlier device experiments exercised the controls. The final cleaned source has not been reflashed; iOS was not built on this Linux host. Temporary audio-disable, telemetry, watcher, and loudness-gate experiments are excluded.

Companion PR: https://github.com/Mentra-Community/Mentra-Call/pull/27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live WHIP encoder bitrate preferences on the glasses and adds a cross-stack streaming API; behavior is backward compatible when fields are omitted but mis-tuned values could affect call quality or thermals.
> 
> **Overview**
> Adds optional **`minBitrateBps`** and **`initialBitrateBps`** on stream video config so callers can steer WHIP/WebRTC encoder floors and startup targets in addition to the existing max **`bitrate`**.
> 
> The fields are wired end-to-end: miniapp SDK and engine types/normalizers, Bluetooth SDK Android/iOS serialization over BLE, and ASG **`WhipStreamConfig`** JSON parsing. On the glasses, **`WhipBitratePolicy`** clamps min/initial to the configured maximum (and lifts initial to at least min when set); **`WhipStreamingService`** applies them via **`PeerConnection.setBitrate`** and **`RtpParameters.Encoding.minBitrateBps`**. Omitting both preserves prior behavior (no explicit minimum; startup still capped at min(1.5 Mbps, max)).
> 
> Unit tests cover config parsing, policy clamping, bridge **`toMap`**, and engine normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c543b1a2544501cdacae5501c290c2f6a19ecd64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->