### PR TITLE
Expose head-up dashboard content through Bluetooth SDK

### DIFF
--- a/mintlify-docs/bluetooth-sdk/api-reference.mdx
+++ b/mintlify-docs/bluetooth-sdk/api-reference.mdx
@@ -365,6 +365,7 @@ These are the supported React Native app developer entrypoints:
 | Status and subscriptions | `useMentraBluetooth`, `useBluetoothScan`, and `useBluetoothEvent` for React components; `addListener` is available as the lower-level non-React subscription API |
 | Default device | `getDefaultDevice`, `setDefaultDevice`, `clearDefaultDevice` |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `cancelConnectionAttempt`, `disconnect`, `forget` |
+| Display | `displayText`, `clearDisplay`, `setDashboardContent`, `showDashboard`, `setDashboardPosition`, `setHeadUpAngle`, `setScreenDisabled` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
 | Camera and gallery | `requestPhoto`, `warmUpCamera`, `stopCameraWarmUp`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults` (deprecated), `setVideoRecordingDefaults`, `setMaxVideoRecordingDuration`, `setCameraFov`, `setCameraFovOverride`, `releaseCameraFovOverride`, `startVideoRecording`, `stopVideoRecording`, `queryVideoRecordingStatus` |
 | Streaming | `startStream`, `stopStream` |
@@ -379,6 +380,7 @@ Important defaults:
 
 - `scan(model, options)` reports progressive results through `options.onResults`, resolves with the final matching `Device[]`, and times out after 15 seconds unless `options.timeoutMs` is set.
 - `connect` and `connectDefault` default `saveAsDefault` and `cancelExistingConnectionAttempt` to `true`.
+- `setDashboardContent(content)` keeps the standard time, date, battery, and connection status header. It stores content for the current SDK session and renders it immediately only when the contextual dashboard is visible; otherwise it appears on the next head-up. Pass the exact empty string to restore the status-only dashboard.
 - `setMicState(enabled)` defaults to glasses microphone on, transcript events off, and LC3 events off. Microphone audio events are continuous while capture is enabled. Use `setVoiceActivityDetectionEnabled(...)` for glasses-side Voice Activity Detection and `setLoudnessGateEnabled(...)` for Mentra Live's center-microphone loudness gate ("Barrier"). With VAD disabled and Barrier enabled, quiet input is represented as silence while audio frames continue. The standalone public Bluetooth SDK defaults are VAD disabled and Barrier enabled, and both settings are reapplied after reconnect. The Mentra App manages separate persisted OS-level microphone preferences. `voice_activity_detection_status` reports whether VAD is enabled, and `speaking_status` reports speaking/not-speaking when supported. Microphone audio events include the latest `voiceActivityDetectionEnabled` value.
 - `requestPhoto({authToken, ...})` omits the `Authorization` header when `authToken` is `null` or empty.
 - `requestPhoto(...)` and `warmUpCamera(...)` generate unique request IDs when `requestId` is omitted or blank. Pass an explicit `requestId` only when your app needs to know it before the response, for example to poll a predictable upload-status URL.
@@ -391,6 +393,47 @@ Important defaults:
 - `startStream` optional `video` and `audio` configs are omitted unless supplied, so the connected glasses use their model defaults. Stream video input fields are `width`, `height`, `bitrate`, and `fps`; stream status reports the resolved effective frame rate as `resolvedConfig.video.fps`. The SDK sends stream keep-alives automatically and reports timeout/error state through `stream_status`.
 - Photo capture, video recording, and streaming always enable the camera light as a privacy indicator.
 - The SDK sends `set_system_time` once shortly after each glasses connection becomes ready, after the initial command burst has drained. The guard resets on disconnect, so reconnecting synchronizes again. There is no periodic clock correction during a long-lived connection; compare `requestVersionInfo().systemTimeMs` with the phone clock if your app needs to monitor later skew.
+
+## Head-Up Dashboard Content
+
+Use `setDashboardContent` to place persistent, glanceable text below the standard
+dashboard status header. The SDK keeps the raw status placeholders and expands
+them every time the dashboard renders, so time, date, battery, and connection
+remain current. The call does not force the dashboard open. If the contextual
+dashboard is hidden, the content appears on the next head-up.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.setDashboardContent('Next meeting at 2 PM');
+await BluetoothSdk.setDashboardContent('');
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.setDashboardContent("Next meeting at 2 PM")
+sdk.setDashboardContent("")
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+await sdk.setDashboardContent("Next meeting at 2 PM")
+await sdk.setDashboardContent("")
+```
+
+  </Tab>
+</Tabs>
+
+Only the exact empty string resets the custom content; whitespace and newlines
+are otherwise preserved. Dashboard content lasts for the current SDK process.
+Persist it in the host app and reapply it after launch when it must survive an
+app restart. Gate this API by display capability because Mentra Live does not
+have a display.
 
 ## Promise Results And Errors
 
@@ -443,6 +486,7 @@ Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGaller
 | Area | Commands |
 | --- | --- |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `disconnect`, `forget` |
+| Display | `displayText`, `clearDisplay`, `setDashboardContent`, `showDashboard`, dashboard position, and head-up angle |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
 | Camera | `requestPhoto`, gallery mode, photo capture defaults, video recording defaults, camera field of view |
 | Streaming | `startStream`, `stopStream` |

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -329,6 +329,38 @@ const ledAck = await BluetoothSdk.rgbLedControl(
 console.log(ledAck.state)
 ```
 
+## Dashboard Content
+
+`setDashboardContent(content)` keeps the standard `$TIME12$ $DATE$ $GBATT$
+$CONNECTION_STATUS$` status header and places non-empty content below it after a
+blank line. Pass the exact empty string to reset the dashboard to the status
+header only. The template is held in memory for the SDK process/session, and its
+status placeholders are refreshed each time the dashboard renders. Calling this
+method does not open the dashboard; it updates an active contextual dashboard
+immediately or appears on the next head-up. Repeating the same content is a
+no-op.
+
+React Native / Expo:
+
+```ts
+await BluetoothSdk.setDashboardContent('Next meeting at 2 PM')
+await BluetoothSdk.setDashboardContent('')
+```
+
+Kotlin:
+
+```kotlin
+sdk.setDashboardContent("Next meeting at 2 PM")
+sdk.setDashboardContent("")
+```
+
+Swift (iOS and macOS):
+
+```swift
+await sdk.setDashboardContent("Next meeting at 2 PM")
+await sdk.setDashboardContent("")
+```
+
 Settings commands that return `SettingsAckSuccessEvent` reject when the ASG reports an error ack. The SDK updates its local settings store only after that ASG ack resolves successfully, so observed SDK state reflects the acknowledged glasses state rather than a queued request. Raw `settings_ack` listener events still use `SettingsAckEvent` because they can include both success and failure statuses. `rgbLedControl(...)` resolves from a successful ASG `rgb_led_control_response` and rejects when the ASG reports `state: "error"`; raw `settings_ack` and `rgb_led_control_response` events remain available through listeners.
 
 WiFi, hotspot, and version-info commands resolve from the ASG response path, not local dispatch:

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -499,6 +499,10 @@ class BluetoothSdkModule : Module() {
 
         SdkAsyncFunction("clearDisplay") { -> sdk?.clearDisplay() }
 
+        SdkAsyncFunction("setDashboardContent") { content: String ->
+            sdk?.setDashboardContent(content)
+        }
+
         // MARK: - Connection Commands
 
         SdkAsyncFunction("connectDefault") { -> sdk?.connectDefault() }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -664,7 +664,7 @@ class DeviceManager {
                 " ",
                 " ",
                 "text_wall",
-                "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$",
+                DashboardContentFormatter.template(""),
                 null,
                 null
             )
@@ -676,7 +676,7 @@ class DeviceManager {
                 " ",
                 " ",
                 "text_wall",
-                "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$",
+                DashboardContentFormatter.template(""),
                 null,
                 null
             )
@@ -722,6 +722,8 @@ class DeviceManager {
     // native re-dispatch coherent (dashboard exit re-applies a complete scene,
     // not whatever element happened to arrive last).
     private val sceneStates = arrayOfNulls<SceneFrame>(2)
+    private var dashboardSceneCleanupPending = false
+    private val pendingDashboardSceneElementIds = linkedSetOf<String>()
     // MARK: - End Unique
 
     // MARK: - Voice Data Handling
@@ -1019,6 +1021,8 @@ class DeviceManager {
             Bridge.log("MAN: DeviceManager.sendCurrentState(): sgc not ready")
             return
         }
+
+        clearPendingDashboardSceneElements(currentStateIndex)
 
         // Cancel any pending clear display work item
         // sendStateWorkItem?.let { mainHandler.removeCallbacks(it) }
@@ -1519,6 +1523,45 @@ class DeviceManager {
         sgc?.clearDisplay()
     }
 
+    internal fun setDashboardContent(content: String) {
+        val nextState =
+            ViewState(
+                " ",
+                " ",
+                " ",
+                "text_wall",
+                DashboardContentFormatter.template(content),
+                null,
+                null,
+            )
+        val previousScene = sceneStates[1]
+        if (previousScene == null && viewStates[1] == nextState) {
+            return
+        }
+
+        previousScene?.let { frame ->
+            dashboardSceneCleanupPending = true
+            pendingDashboardSceneElementIds.addAll(frame.elements.map { it.id })
+        }
+        sceneStates[1] = null
+        viewStates[1] = nextState
+
+        if (headUp && contextualDashboard) {
+            sendCurrentState()
+        }
+    }
+
+    private fun clearPendingDashboardSceneElements(stateIndex: Int) {
+        if (stateIndex != 1 || !dashboardSceneCleanupPending) return
+
+        dashboardSceneCleanupPending = false
+        val elementIds = pendingDashboardSceneElementIds.toList()
+        pendingDashboardSceneElementIds.clear()
+        if (elementIds.isNotEmpty()) {
+            sgc?.clearSceneElements(elementIds)
+        }
+    }
+
     fun displayEvent(event: Map<String, Any>) {
         val view = event["view"] as? String
         if (view == null) {
@@ -1549,7 +1592,9 @@ class DeviceManager {
         // wipes everything anyway.
         sceneStates[stateIndex]?.let { prevFrame ->
             sceneStates[stateIndex] = null
-            if (layoutType != "clear_view") {
+            if (stateIndex == 1 && dashboardSceneCleanupPending) {
+                pendingDashboardSceneElementIds.addAll(prevFrame.elements.map { it.id })
+            } else if (layoutType != "clear_view") {
                 sgc?.clearSceneElements(prevFrame.elements.map { it.id })
             }
         }
@@ -1614,7 +1659,13 @@ class DeviceManager {
             // clearDisplay is the per-device "wipe what's there" (blank-in-place
             // on G2 — no page rebuild).
             val prevLegacyType = viewStates[stateIndex].layoutType
-            if (prevLegacyType.isNotEmpty() && prevLegacyType != "clear_view" && prevLegacyType != "scene") {
+            val cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending
+            if (
+                !cleanupDeferred &&
+                    prevLegacyType.isNotEmpty() &&
+                    prevLegacyType != "clear_view" &&
+                    prevLegacyType != "scene"
+            ) {
                 sgc?.clearDisplay()
             }
         } else if (prevFrame.appId != frame.appId) {
@@ -1624,7 +1675,11 @@ class DeviceManager {
             // them), then paint the new frame from scratch. In practice the
             // boot message interposes between apps, so this isn't visible as a
             // blank.
-            sgc?.clearSceneElements(prevFrame.elements.map { it.id })
+            if (stateIndex == 1 && dashboardSceneCleanupPending) {
+                pendingDashboardSceneElementIds.addAll(prevFrame.elements.map { it.id })
+            } else {
+                sgc?.clearSceneElements(prevFrame.elements.map { it.id })
+            }
             frame = frame.copy(replay = true, elements = frame.elements.map { it.copy(change = "created") })
         }
 
@@ -1637,18 +1692,19 @@ class DeviceManager {
 
         val hUp = headUp && contextualDashboard
         if ((stateIndex == 0 && !hUp) || (stateIndex == 1 && hUp)) {
-            dispatchSceneFrame(frame)
+            dispatchSceneFrame(stateIndex, frame)
         }
     }
 
     /** Guarded scene dispatch — mirrors sendCurrentState's send conditions. */
-    private fun dispatchSceneFrame(frame: SceneFrame) {
+    private fun dispatchSceneFrame(stateIndex: Int, frame: SceneFrame) {
         if (screenDisabled) return
         if (sgc?.type?.contains(DeviceTypes.SIMULATED) == true) return
         if (sgc?.fullyBooted != true) {
             Bridge.log("MAN: dispatchSceneFrame(): sgc not ready")
             return
         }
+        clearPendingDashboardSceneElements(stateIndex)
         sgc?.applySceneFrame(frame)
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -497,6 +497,11 @@ class MentraBluetoothSdk private constructor(
         deviceManager.clearDisplay()
     }
 
+    /** Sets session-only content shown below the standard dashboard status header. */
+    fun setDashboardContent(content: String) {
+        deviceManager.setDashboardContent(content)
+    }
+
     fun showDashboard() {
         deviceManager.showDashboard()
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/requests/DisplayRequests.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/requests/DisplayRequests.kt
@@ -1,5 +1,12 @@
 package com.mentra.bluetoothsdk
 
+internal object DashboardContentFormatter {
+    const val STATUS_HEADER = "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$"
+
+    fun template(content: String): String =
+        if (content.isEmpty()) STATUS_HEADER else "$STATUS_HEADER\n\n$content"
+}
+
 data class DisplayTextRequest(
     val text: String,
     val x: Int = 0,

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/DashboardContentFormatterTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/DashboardContentFormatterTest.kt
@@ -1,0 +1,22 @@
+package com.mentra.bluetoothsdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DashboardContentFormatterTest {
+    @Test
+    fun emptyContentReturnsStatusHeaderOnly() {
+        assertEquals(
+            "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$",
+            DashboardContentFormatter.template(""),
+        )
+    }
+
+    @Test
+    fun nonEmptyContentIsAppendedExactlyAfterBlankLine() {
+        assertEquals(
+            "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$\n\n  Next meeting\nRoom 2  ",
+            DashboardContentFormatter.template("  Next meeting\nRoom 2  "),
+        )
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -135,6 +135,11 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
             try? await sdk.displayText(text, x: x ?? 0, y: y ?? 0, size: size ?? 24)
         }
 
+        AsyncFunction("setDashboardContent") { (content: String) in
+            let sdk = await MainActor.run { self.bluetoothSdk() }
+            await sdk.setDashboardContent(content)
+        }
+
         // MARK: - Connection Commands
 
         AsyncFunction("connectDefault") {
@@ -935,6 +940,5 @@ private extension ConnectOptions {
         )
     }
 }
-
 
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -358,6 +358,9 @@ struct ViewState {
     private var dashboardSceneCleanupPending = false
     private var dashboardSceneCleanupTask: Task<Void, Never>?
     private var pendingDashboardSceneElementIds = Set<String>()
+    private var dashboardSceneCleanupDeferred: Bool {
+        dashboardSceneCleanupPending || dashboardSceneCleanupTask != nil
+    }
 
     override init() {
         Bridge.log("MAN: init()")
@@ -1277,7 +1280,8 @@ struct ViewState {
         // wipes everything anyway.
         if let prevFrame = sceneStates[stateIndex] {
             sceneStates[stateIndex] = nil
-            if stateIndex == 1, dashboardSceneCleanupPending {
+            if stateIndex == 1, dashboardSceneCleanupDeferred {
+                dashboardSceneCleanupPending = true
                 pendingDashboardSceneElementIds.formUnion(prevFrame.elements.map(\.id))
             } else if layoutType != "clear_view" {
                 let ids = prevFrame.elements.map(\.id)
@@ -1372,7 +1376,7 @@ struct ViewState {
             // clearDisplay is the per-device "wipe what's there" (blank-in-place
             // on G2 - no page rebuild).
             let prevLegacyType = viewStates[stateIndex].layoutType
-            let cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending
+            let cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupDeferred
             if !cleanupDeferred,
                !prevLegacyType.isEmpty,
                prevLegacyType != "clear_view",
@@ -1386,7 +1390,8 @@ struct ViewState {
             // glasses. Sweep the old app's elements (SGC registries still map
             // them), then paint the new frame from scratch. The boot message
             // interposes between apps in practice, so this isn't visible.
-            if stateIndex == 1, dashboardSceneCleanupPending {
+            if stateIndex == 1, dashboardSceneCleanupDeferred {
+                dashboardSceneCleanupPending = true
                 pendingDashboardSceneElementIds.formUnion(prevFrame.elements.map(\.id))
             } else {
                 let ids = prevFrame.elements.map(\.id)

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -356,6 +356,7 @@ struct ViewState {
     // native re-dispatch coherent (dashboard exit re-applies a complete scene).
     var sceneStates: [SceneFrame?] = [nil, nil]
     private var dashboardSceneCleanupPending = false
+    private var dashboardSceneCleanupTask: Task<Void, Never>?
     private var pendingDashboardSceneElementIds = Set<String>()
 
     override init() {
@@ -764,80 +765,76 @@ struct ViewState {
         }
     }
 
-    func sendCurrentState() {
-        if screenDisabled {
-            return
-        }
+    @discardableResult
+    func sendCurrentState() -> Task<Void, Never> {
+        Task { await renderCurrentState() }
+    }
 
-        Task {
-            let currentStateIndex = headUp && self.contextualDashboard ? 1 : 0
-            let currentViewState = self.viewStates[currentStateIndex]
+    private func renderCurrentState() async {
+        guard !screenDisabled, sgc?.fullyBooted == true,
+              sgc?.type.contains(DeviceTypes.SIMULATED) == false else { return }
 
-            if sgc?.type.contains(DeviceTypes.SIMULATED) ?? true {
-                // dont send the event to glasses that aren't there:
+        await clearPendingDashboardSceneElements(for: headUp && contextualDashboard ? 1 : 0)
+
+        // Cleanup can suspend. Select the visible slot and its contents only
+        // after it finishes, including any head movement or display update.
+        guard !screenDisabled, sgc?.fullyBooted == true,
+              sgc?.type.contains(DeviceTypes.SIMULATED) == false else { return }
+        let currentStateIndex = headUp && contextualDashboard ? 1 : 0
+        let currentViewState = viewStates[currentStateIndex]
+
+        // cancel any pending clear display work item:
+        sendStateWorkItem?.cancel()
+
+        let layoutType = currentViewState.layoutType
+        switch layoutType {
+        case "text_wall":
+            let text = parsePlaceholders(currentViewState.text)
+            await sgc?.sendTextWall(text)
+        case "double_text_wall":
+            let topText = parsePlaceholders(currentViewState.topText)
+            let bottomText = parsePlaceholders(currentViewState.bottomText)
+            await sgc?.sendDoubleTextWall(topText, bottomText)
+        case "reference_card":
+            let title = parsePlaceholders(currentViewState.title)
+            let text = parsePlaceholders(currentViewState.text)
+            await sgc?.sendTextWall(title + "\n\n" + text)
+        case "bitmap_view":
+            // Bridge.log("MAN: Processing bitmap_view layout")
+            guard let data = currentViewState.data else {
+                Bridge.log("MAN: ERROR: bitmap_view missing data field")
                 return
             }
-
-            var fullyBooted = sgc?.fullyBooted ?? false
-            if !fullyBooted {
-                return
+            // Bridge.log("MAN: Processing bitmap_view with base64 data, length: \(data.count)")
+            await sgc?.displayBitmap(
+                base64ImageData: data,
+                x: currentViewState.bmpX,
+                y: currentViewState.bmpY,
+                width: currentViewState.bmpWidth,
+                height: currentViewState.bmpHeight
+            )
+        case "positioned_text":
+            let text = parsePlaceholders(currentViewState.text)
+            Bridge.log(
+                "MAN: positioned_text -> text='\(text)' rect=\(currentViewState.bmpX ?? 0),\(currentViewState.bmpY ?? 0) \(currentViewState.bmpWidth ?? 576)x\(currentViewState.bmpHeight ?? 288)"
+            )
+            await sgc?.sendPositionedText(
+                text,
+                x: currentViewState.bmpX ?? 0,
+                y: currentViewState.bmpY ?? 0,
+                width: currentViewState.bmpWidth ?? 576,
+                height: currentViewState.bmpHeight ?? 288,
+                borderWidth: currentViewState.borderWidth ?? 0,
+                borderRadius: currentViewState.borderRadius ?? 0
+            )
+        case "scene":
+            if let frame = sceneStates[currentStateIndex] {
+                await sgc?.applySceneFrame(frame)
             }
-
-            await clearPendingDashboardSceneElements(for: currentStateIndex)
-
-            // cancel any pending clear display work item:
-            sendStateWorkItem?.cancel()
-
-            let layoutType = currentViewState.layoutType
-            switch layoutType {
-            case "text_wall":
-                let text = parsePlaceholders(currentViewState.text)
-                await sgc?.sendTextWall(text)
-            case "double_text_wall":
-                let topText = parsePlaceholders(currentViewState.topText)
-                let bottomText = parsePlaceholders(currentViewState.bottomText)
-                await sgc?.sendDoubleTextWall(topText, bottomText)
-            case "reference_card":
-                let title = parsePlaceholders(currentViewState.title)
-                let text = parsePlaceholders(currentViewState.text)
-                await sgc?.sendTextWall(title + "\n\n" + text)
-            case "bitmap_view":
-                // Bridge.log("MAN: Processing bitmap_view layout")
-                guard let data = currentViewState.data else {
-                    Bridge.log("MAN: ERROR: bitmap_view missing data field")
-                    return
-                }
-                // Bridge.log("MAN: Processing bitmap_view with base64 data, length: \(data.count)")
-                await sgc?.displayBitmap(
-                    base64ImageData: data,
-                    x: currentViewState.bmpX,
-                    y: currentViewState.bmpY,
-                    width: currentViewState.bmpWidth,
-                    height: currentViewState.bmpHeight
-                )
-            case "positioned_text":
-                let text = parsePlaceholders(currentViewState.text)
-                Bridge.log(
-                    "MAN: positioned_text -> text='\(text)' rect=\(currentViewState.bmpX ?? 0),\(currentViewState.bmpY ?? 0) \(currentViewState.bmpWidth ?? 576)x\(currentViewState.bmpHeight ?? 288)"
-                )
-                await sgc?.sendPositionedText(
-                    text,
-                    x: currentViewState.bmpX ?? 0,
-                    y: currentViewState.bmpY ?? 0,
-                    width: currentViewState.bmpWidth ?? 576,
-                    height: currentViewState.bmpHeight ?? 288,
-                    borderWidth: currentViewState.borderWidth ?? 0,
-                    borderRadius: currentViewState.borderRadius ?? 0
-                )
-            case "scene":
-                if let frame = self.sceneStates[currentStateIndex] {
-                    await sgc?.applySceneFrame(frame)
-                }
-            case "clear_view":
-                sgc?.clearDisplay()
-            default:
-                Bridge.log("UNHANDLED LAYOUT_TYPE \(layoutType)")
-            }
+        case "clear_view":
+            sgc?.clearDisplay()
+        default:
+            Bridge.log("UNHANDLED LAYOUT_TYPE \(layoutType)")
         }
     }
 
@@ -1218,19 +1215,30 @@ struct ViewState {
         viewStates[1] = nextState
 
         if headUp && contextualDashboard {
-            sendCurrentState()
+            await renderCurrentState()
         }
     }
 
     private func clearPendingDashboardSceneElements(for stateIndex: Int) async {
+        // Share cleanup until it has fully finished; consuming the pending IDs
+        // must not let a second renderer paint while the first is still clearing.
+        if let cleanup = dashboardSceneCleanupTask {
+            await cleanup.value
+            return
+        }
         guard stateIndex == 1, dashboardSceneCleanupPending else { return }
 
-        dashboardSceneCleanupPending = false
-        let elementIds = Array(pendingDashboardSceneElementIds)
-        pendingDashboardSceneElementIds.removeAll()
-        if !elementIds.isEmpty {
-            await sgc?.clearSceneElements(elementIds)
+        let cleanup = Task<Void, Never> {
+            while self.dashboardSceneCleanupPending {
+                self.dashboardSceneCleanupPending = false
+                let elementIds = Array(self.pendingDashboardSceneElementIds)
+                self.pendingDashboardSceneElementIds.removeAll()
+                await self.sgc?.clearSceneElements(elementIds)
+            }
+            self.dashboardSceneCleanupTask = nil
         }
+        dashboardSceneCleanupTask = cleanup
+        await cleanup.value
     }
 
     func displayEvent(_ event: [String: Any]) {
@@ -1414,8 +1422,13 @@ struct ViewState {
         }
         Task { [weak self] in
             guard let self else { return }
-            await self.clearPendingDashboardSceneElements(for: stateIndex)
-            await self.sgc?.applySceneFrame(frame)
+            if dashboardSceneCleanupTask != nil ||
+                (stateIndex == 1 && dashboardSceneCleanupPending)
+            {
+                await renderCurrentState()
+            } else {
+                await sgc?.applySceneFrame(frame)
+            }
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -337,7 +337,7 @@ struct ViewState {
         ),
         ViewState(
             topText: " ", bottomText: " ", title: " ", layoutType: "text_wall",
-            text: "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$"
+            text: DashboardContentFormatter.template(for: "")
         ),
         ViewState(
             topText: " ", bottomText: " ", title: " ", layoutType: "text_wall", text: "",
@@ -345,7 +345,7 @@ struct ViewState {
         ),
         ViewState(
             topText: " ", bottomText: " ", title: " ", layoutType: "text_wall",
-            text: "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$", data: nil,
+            text: DashboardContentFormatter.template(for: ""), data: nil,
             animationData: nil
         ),
     ]
@@ -355,6 +355,8 @@ struct ViewState {
     // sentinel so sendCurrentState routes here. Holding the WHOLE frame keeps
     // native re-dispatch coherent (dashboard exit re-applies a complete scene).
     var sceneStates: [SceneFrame?] = [nil, nil]
+    private var dashboardSceneCleanupPending = false
+    private var pendingDashboardSceneElementIds = Set<String>()
 
     override init() {
         Bridge.log("MAN: init()")
@@ -768,15 +770,8 @@ struct ViewState {
         }
 
         Task {
-            var currentViewState: ViewState!
-            if headUp {
-                currentViewState = self.viewStates[1]
-            } else {
-                currentViewState = self.viewStates[0]
-            }
-            if headUp && !self.contextualDashboard {
-                currentViewState = self.viewStates[0]
-            }
+            let currentStateIndex = headUp && self.contextualDashboard ? 1 : 0
+            let currentViewState = self.viewStates[currentStateIndex]
 
             if sgc?.type.contains(DeviceTypes.SIMULATED) ?? true {
                 // dont send the event to glasses that aren't there:
@@ -787,6 +782,8 @@ struct ViewState {
             if !fullyBooted {
                 return
             }
+
+            await clearPendingDashboardSceneElements(for: currentStateIndex)
 
             // cancel any pending clear display work item:
             sendStateWorkItem?.cancel()
@@ -833,8 +830,7 @@ struct ViewState {
                     borderRadius: currentViewState.borderRadius ?? 0
                 )
             case "scene":
-                let sceneIndex = (headUp && self.contextualDashboard) ? 1 : 0
-                if let frame = self.sceneStates[sceneIndex] {
+                if let frame = self.sceneStates[currentStateIndex] {
                     await sgc?.applySceneFrame(frame)
                 }
             case "clear_view":
@@ -1196,6 +1192,47 @@ struct ViewState {
         Task { await sgc?.sendTextWall(text) }
     }
 
+    func setDashboardContent(_ content: String) async {
+        let nextState = ViewState(
+            topText: " ", bottomText: " ", title: " ", layoutType: "text_wall",
+            text: DashboardContentFormatter.template(for: content), data: nil, animationData: nil
+        )
+        let previousScene = sceneStates[1]
+        let currentState = viewStates[1]
+        if previousScene == nil,
+           currentState.layoutType == nextState.layoutType,
+           currentState.text == nextState.text,
+           currentState.topText == nextState.topText,
+           currentState.bottomText == nextState.bottomText,
+           currentState.title == nextState.title,
+           currentState.data == nextState.data
+        {
+            return
+        }
+
+        if let previousScene {
+            dashboardSceneCleanupPending = true
+            pendingDashboardSceneElementIds.formUnion(previousScene.elements.map(\.id))
+        }
+        sceneStates[1] = nil
+        viewStates[1] = nextState
+
+        if headUp && contextualDashboard {
+            sendCurrentState()
+        }
+    }
+
+    private func clearPendingDashboardSceneElements(for stateIndex: Int) async {
+        guard stateIndex == 1, dashboardSceneCleanupPending else { return }
+
+        dashboardSceneCleanupPending = false
+        let elementIds = Array(pendingDashboardSceneElementIds)
+        pendingDashboardSceneElementIds.removeAll()
+        if !elementIds.isEmpty {
+            await sgc?.clearSceneElements(elementIds)
+        }
+    }
+
     func displayEvent(_ event: [String: Any]) {
         guard let view = event["view"] as? String else {
             Bridge.log("MAN: invalid view")
@@ -1232,7 +1269,9 @@ struct ViewState {
         // wipes everything anyway.
         if let prevFrame = sceneStates[stateIndex] {
             sceneStates[stateIndex] = nil
-            if layoutType != "clear_view" {
+            if stateIndex == 1, dashboardSceneCleanupPending {
+                pendingDashboardSceneElementIds.formUnion(prevFrame.elements.map(\.id))
+            } else if layoutType != "clear_view" {
                 let ids = prevFrame.elements.map(\.id)
                 Task { [weak self] in
                     await self?.sgc?.clearSceneElements(ids)
@@ -1325,7 +1364,12 @@ struct ViewState {
             // clearDisplay is the per-device "wipe what's there" (blank-in-place
             // on G2 - no page rebuild).
             let prevLegacyType = viewStates[stateIndex].layoutType
-            if !prevLegacyType.isEmpty, prevLegacyType != "clear_view", prevLegacyType != "scene" {
+            let cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending
+            if !cleanupDeferred,
+               !prevLegacyType.isEmpty,
+               prevLegacyType != "clear_view",
+               prevLegacyType != "scene"
+            {
                 sgc?.clearDisplay()
             }
         } else if let prevFrame, prevFrame.appId != frame.appId {
@@ -1334,9 +1378,13 @@ struct ViewState {
             // glasses. Sweep the old app's elements (SGC registries still map
             // them), then paint the new frame from scratch. The boot message
             // interposes between apps in practice, so this isn't visible.
-            let ids = prevFrame.elements.map(\.id)
-            Task { [weak self] in
-                await self?.sgc?.clearSceneElements(ids)
+            if stateIndex == 1, dashboardSceneCleanupPending {
+                pendingDashboardSceneElementIds.formUnion(prevFrame.elements.map(\.id))
+            } else {
+                let ids = prevFrame.elements.map(\.id)
+                Task { [weak self] in
+                    await self?.sgc?.clearSceneElements(ids)
+                }
             }
             frame = frame.asReplay()
         }
@@ -1352,12 +1400,12 @@ struct ViewState {
 
         let hUp = headUp && contextualDashboard
         if (stateIndex == 0 && !hUp) || (stateIndex == 1 && hUp) {
-            dispatchSceneFrame(frame)
+            dispatchSceneFrame(frame, stateIndex: stateIndex)
         }
     }
 
     /// Guarded scene dispatch - mirrors sendCurrentState's send conditions.
-    private func dispatchSceneFrame(_ frame: SceneFrame) {
+    private func dispatchSceneFrame(_ frame: SceneFrame, stateIndex: Int) {
         if screenDisabled { return }
         if sgc?.type.contains(DeviceTypes.SIMULATED) ?? true { return }
         guard sgc?.fullyBooted == true else {
@@ -1365,7 +1413,9 @@ struct ViewState {
             return
         }
         Task { [weak self] in
-            await self?.sgc?.applySceneFrame(frame)
+            guard let self else { return }
+            await self.clearPendingDashboardSceneElements(for: stateIndex)
+            await self.sgc?.applySceneFrame(frame)
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -472,6 +472,11 @@ public final class MentraBluetoothSDK {
         DeviceManager.shared.sgc?.clearDisplay()
     }
 
+    /// Sets session-only content shown below the standard dashboard status header.
+    public func setDashboardContent(_ content: String) async {
+        await DeviceManager.shared.setDashboardContent(content)
+    }
+
     public func showDashboard() {
         DeviceManager.shared.showDashboard()
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/requests/DisplayRequests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/requests/DisplayRequests.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+enum DashboardContentFormatter {
+    static let statusHeader = "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$"
+
+    static func template(for content: String) -> String {
+        content.isEmpty ? statusHeader : statusHeader + "\n\n" + content
+    }
+}
+
 public struct DisplayTextRequest {
     public let text: String
     public let x: Int

--- a/mobile/modules/bluetooth-sdk/ios/Tests/DashboardContentFormatterTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/DashboardContentFormatterTests.swift
@@ -1,0 +1,18 @@
+@testable import MentraBluetoothSDK
+import XCTest
+
+final class DashboardContentFormatterTests: XCTestCase {
+    func testEmptyContentReturnsStatusHeaderOnly() {
+        XCTAssertEqual(
+            DashboardContentFormatter.template(for: ""),
+            "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$"
+        )
+    }
+
+    func testNonEmptyContentIsAppendedExactlyAfterBlankLine() {
+        XCTAssertEqual(
+            DashboardContentFormatter.template(for: "  Next meeting\nRoom 2  "),
+            "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$\n\n  Next meeting\nRoom 2  "
+        )
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Tests/DashboardRenderingTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/DashboardRenderingTests.swift
@@ -1,0 +1,163 @@
+@testable import MentraBluetoothSDK
+import XCTest
+
+@MainActor
+final class DashboardRenderingTests: XCTestCase {
+    private func setupDashboard() -> (DeviceManager, PausedDisplay) {
+        let manager = DeviceManager()
+        let display = PausedDisplay()
+        manager.sgc = display
+        DeviceStore.shared.apply("glasses", "fullyBooted", true)
+        DeviceStore.shared.apply("glasses", "headUp", true)
+        DeviceStore.shared.apply("bluetooth", "contextual_dashboard", true)
+        DeviceStore.shared.apply("bluetooth", "screen_disabled", false)
+        manager.sceneStates[1] = SceneFrame(appId: "test", epoch: 1, replay: false, elements: [SceneElement(id: "old", type: "text", x: 0, y: 0, w: 100, h: 30, text: "old", data: nil, border: 0, radius: 0, change: "created", contentHash: "old")], removed: [])
+        return (manager, display)
+    }
+
+    func testSetterWaitsForCleanupAndLatestContentWins() async {
+        let (manager, display) = setupDashboard()
+        var firstReturned = false
+        let first = Task {
+            await manager.setDashboardContent("old")
+            firstReturned = true
+        }
+        await fulfillment(of: [display.cleanupStarted], timeout: 2)
+        XCTAssertFalse(firstReturned)
+        XCTAssertTrue(display.texts.isEmpty)
+
+        let secondStarted = XCTestExpectation(description: "second setter started")
+        let second = Task {
+            secondStarted.fulfill()
+            await manager.setDashboardContent("new")
+        }
+        await fulfillment(of: [secondStarted], timeout: 2)
+        display.finishCleanup()
+        await first.value
+        await second.value
+        XCTAssertFalse(display.texts.isEmpty)
+        XCTAssertTrue(display.texts.allSatisfy { $0.hasSuffix("new") })
+        XCTAssertEqual(display.cleanupCount, 1)
+    }
+
+    func testHeadDownDuringCleanupRendersMainView() async {
+        let (manager, display) = setupDashboard()
+        manager.viewStates[0].text = "main view"
+        let update = Task { await manager.setDashboardContent("dashboard") }
+        await fulfillment(of: [display.cleanupStarted], timeout: 2)
+        DeviceStore.shared.apply("glasses", "headUp", false)
+        display.finishCleanup()
+        await update.value
+        XCTAssertEqual(display.texts, ["main view"])
+    }
+
+    func testSceneArrivingDuringCleanupReplacesText() async {
+        let (manager, display) = setupDashboard()
+        let update = Task { await manager.setDashboardContent("old") }
+        await fulfillment(of: [display.cleanupStarted], timeout: 2)
+        manager.displayEvent([
+            "view": "dashboard",
+            "scene": ["appId": "new-scene", "sceneEpoch": 2, "elements": [[String: Any]]()],
+        ])
+        display.finishCleanup()
+        await update.value
+        await manager.sendCurrentState().value
+        XCTAssertTrue(display.texts.isEmpty)
+        XCTAssertFalse(display.scenes.isEmpty)
+        XCTAssertTrue(display.scenes.allSatisfy { $0.appId == "new-scene" })
+    }
+}
+
+@MainActor
+private final class PausedDisplay: SGCManager {
+    var type = "Test display"
+    let hasMic = false
+    let cleanupStarted = XCTestExpectation(description: "cleanup suspended")
+    var cleanupCount = 0
+    var texts: [String] = []
+    var scenes: [SceneFrame] = []
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func clearSceneElements(_: [String]) async {
+        cleanupCount += 1
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            cleanupStarted.fulfill()
+        }
+    }
+
+    func finishCleanup() {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func sendTextWall(_ text: String) async {
+        texts.append(text)
+    }
+
+    func applySceneFrame(_ frame: SceneFrame) async {
+        scenes.append(frame)
+    }
+
+    func clearDisplay() {}
+
+    // Unused device capabilities for the display test double.
+    func setMicEnabled(_: Bool) {}
+    func sortMicRanking(list: [String]) -> [String] {
+        list
+    }
+
+    func sendJson(_: [String: Any], wakeUp _: Bool, requireAck _: Bool) {}
+    func requestPhoto(_: PhotoRequest) {}
+    func startStream(_: [String: Any]) {}
+    func stopStream() {}
+    func sendStreamKeepAlive(_: [String: Any]) {}
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {}
+    func stopVideoRecording(requestId _: String) {}
+    func sendButtonPhotoSettings() {}
+    func sendButtonVideoRecordingSettings() {}
+    func sendCameraFovSetting() {}
+    func sendButtonMaxRecordingTime() {}
+    func setBrightness(_: Int, autoMode _: Bool) {}
+    func sendText(_: String) async {}
+    func sendDoubleTextWall(_: String, _: String) async {}
+    func displayBitmap(base64ImageData _: String, x _: Int32?, y _: Int32?, width _: Int32?, height _: Int32?) async -> Bool {
+        false
+    }
+
+    func showDashboard() {}
+    func setDashboardPosition(_: Int, _: Int) {}
+    func setHeadUpAngle(_: Int) {}
+    func getBatteryStatus() {}
+    func setSilentMode(_: Bool) {}
+    func exit() {}
+    func sendShutdown() {}
+    func sendReboot() {}
+    func sendRgbLedControl(requestId _: String, packageName _: String?, action _: String, color _: String?, onDurationMs _: Int, offDurationMs _: Int, count _: Int) {}
+    func disconnect() {}
+    func forget() {}
+    func findCompatibleDevices() {}
+    func stopScan() {}
+    func connectById(_: String) {}
+    func getConnectedBluetoothName() -> String? {
+        nil
+    }
+
+    func cleanup() {}
+    func ping() {}
+    func dbg1() {}
+    func dbg2() {}
+    func connectController() {}
+    func disconnectController() {}
+    func requestWifiScan(scanId _: String?) {}
+    func sendWifiCredentials(_: String, _: String) {}
+    func forgetWifiNetwork(_: String) {}
+    func sendHotspotState(_: Bool) {}
+    func sendUserEmailToGlasses(_: String) {}
+    func sendOtaStart(otaVersionUrl _: String?) {}
+    func sendOtaQueryStatus() {}
+    func queryGalleryStatus() {}
+    func sendGalleryMode() {}
+    func requestVersionInfo() {}
+    func sendIncidentId(_: String, apiBaseUrl _: String?) {}
+}

--- a/mobile/modules/bluetooth-sdk/ios/Tests/DashboardRenderingTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/DashboardRenderingTests.swift
@@ -59,6 +59,8 @@ final class DashboardRenderingTests: XCTestCase {
             "view": "dashboard",
             "scene": ["appId": "new-scene", "sceneEpoch": 2, "elements": [[String: Any]]()],
         ])
+        XCTAssertEqual(display.clearDisplayCount, 0)
+        XCTAssertTrue(display.scenes.isEmpty)
         display.finishCleanup()
         await update.value
         await manager.sendCurrentState().value
@@ -74,6 +76,7 @@ private final class PausedDisplay: SGCManager {
     let hasMic = false
     let cleanupStarted = XCTestExpectation(description: "cleanup suspended")
     var cleanupCount = 0
+    var clearDisplayCount = 0
     var texts: [String] = []
     var scenes: [SceneFrame] = []
     private var continuation: CheckedContinuation<Void, Never>?
@@ -99,7 +102,9 @@ private final class PausedDisplay: SGCManager {
         scenes.append(frame)
     }
 
-    func clearDisplay() {}
+    func clearDisplay() {
+        clearDisplayCount += 1
+    }
 
     // Unused device capabilities for the display test double.
     func setMicEnabled(_: Bool) {}

--- a/mobile/modules/bluetooth-sdk/scripts/public-dashboard-content-api.test.mjs
+++ b/mobile/modules/bluetooth-sdk/scripts/public-dashboard-content-api.test.mjs
@@ -70,5 +70,5 @@ test("keeps displayEvent internal and defers dashboard scene cleanup until rende
     /private func dispatchSceneFrame[\s\S]*?await (?:self\.)?renderCurrentState\(\)/,
   )
   assert.match(androidManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending/)
-  assert.match(appleManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending/)
+  assert.match(appleManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupDeferred/)
 })

--- a/mobile/modules/bluetooth-sdk/scripts/public-dashboard-content-api.test.mjs
+++ b/mobile/modules/bluetooth-sdk/scripts/public-dashboard-content-api.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict"
+import {readFileSync} from "node:fs"
+import path from "node:path"
+import test from "node:test"
+import {fileURLToPath} from "node:url"
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const readPackageFile = (relativePath) => readFileSync(path.join(packageRoot, relativePath), "utf8")
+
+test("publishes setDashboardContent on React Native and native SDK surfaces", () => {
+  const publicTypes = readPackageFile("src/BluetoothSdk.types.ts")
+  const publicRoot = readPackageFile("src/index.ts")
+  const privateModule = readPackageFile("src/_private/BluetoothSdkModule.ts")
+  const androidModule = readPackageFile("android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt")
+  const androidSdk = readPackageFile("android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt")
+  const appleModule = readPackageFile("ios/BluetoothSdkModule.swift")
+  const appleSdk = readPackageFile("ios/Source/MentraBluetoothSDK.swift")
+
+  assert.match(publicTypes, /setDashboardContent\(content: string\): Promise<void>/)
+  assert.match(publicRoot, /setDashboardContent: bindPublicMethod\("setDashboardContent"\)/)
+  assert.match(privateModule, /setDashboardContent\(content: string\): Promise<void>/)
+  assert.match(androidModule, /SdkAsyncFunction\("setDashboardContent"\)/)
+  assert.match(androidSdk, /fun setDashboardContent\(content: String\)/)
+  assert.match(appleModule, /AsyncFunction\("setDashboardContent"\)/)
+  assert.match(appleSdk, /public func setDashboardContent\(_ content: String\) async/)
+})
+
+test("keeps displayEvent internal and defers dashboard scene cleanup until rendering", () => {
+  const publicTypes = readPackageFile("src/BluetoothSdk.types.ts")
+  const publicRoot = readPackageFile("src/index.ts")
+  const androidSdk = readPackageFile("android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt")
+  const androidManager = readPackageFile("android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt")
+  const appleSdk = readPackageFile("ios/Source/MentraBluetoothSDK.swift")
+  const appleManager = readPackageFile("ios/Source/DeviceManager.swift")
+
+  assert.doesNotMatch(publicTypes, /\bdisplayEvent\(/)
+  assert.doesNotMatch(publicRoot, /\bdisplayEvent\b/)
+  assert.match(androidSdk, /internal fun displayEvent\(/)
+  assert.doesNotMatch(androidSdk, /public fun displayEvent\(/)
+  assert.match(appleSdk, /\n    func displayEvent\(/)
+  assert.doesNotMatch(appleSdk, /public func displayEvent\(/)
+
+  const androidSetter = androidManager.slice(
+    androidManager.indexOf("internal fun setDashboardContent"),
+    androidManager.indexOf("private fun clearPendingDashboardSceneElements"),
+  )
+  const appleSetter = appleManager.slice(
+    appleManager.indexOf("func setDashboardContent"),
+    appleManager.indexOf("private func clearPendingDashboardSceneElements"),
+  )
+  assert.match(androidSetter, /if \(headUp && contextualDashboard\)/)
+  assert.match(appleSetter, /if headUp && contextualDashboard/)
+  assert.match(androidSetter, /pendingDashboardSceneElementIds\.addAll/)
+  assert.match(appleSetter, /pendingDashboardSceneElementIds\.formUnion/)
+  assert.match(androidSetter, /dashboardSceneCleanupPending = true/)
+  assert.match(appleSetter, /dashboardSceneCleanupPending = true/)
+  assert.doesNotMatch(androidSetter, /clearSceneElements/)
+  assert.doesNotMatch(appleSetter, /clearSceneElements/)
+  assert.doesNotMatch(androidSetter, /showDashboard/)
+  assert.doesNotMatch(appleSetter, /showDashboard/)
+
+  assert.match(androidManager, /clearPendingDashboardSceneElements\(currentStateIndex\)/)
+  assert.match(appleManager, /clearPendingDashboardSceneElements\(for: currentStateIndex\)/)
+  assert.match(
+    androidManager,
+    /private fun dispatchSceneFrame[\s\S]*?clearPendingDashboardSceneElements\(stateIndex\)/,
+  )
+  assert.match(
+    appleManager,
+    /private func dispatchSceneFrame[\s\S]*?clearPendingDashboardSceneElements\(for: stateIndex\)/,
+  )
+  assert.match(androidManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending/)
+  assert.match(appleManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending/)
+})

--- a/mobile/modules/bluetooth-sdk/scripts/public-dashboard-content-api.test.mjs
+++ b/mobile/modules/bluetooth-sdk/scripts/public-dashboard-content-api.test.mjs
@@ -37,7 +37,7 @@ test("keeps displayEvent internal and defers dashboard scene cleanup until rende
   assert.doesNotMatch(publicRoot, /\bdisplayEvent\b/)
   assert.match(androidSdk, /internal fun displayEvent\(/)
   assert.doesNotMatch(androidSdk, /public fun displayEvent\(/)
-  assert.match(appleSdk, /\n    func displayEvent\(/)
+  assert.match(appleSdk, /\n\s+func displayEvent\(/)
   assert.doesNotMatch(appleSdk, /public func displayEvent\(/)
 
   const androidSetter = androidManager.slice(
@@ -60,14 +60,14 @@ test("keeps displayEvent internal and defers dashboard scene cleanup until rende
   assert.doesNotMatch(appleSetter, /showDashboard/)
 
   assert.match(androidManager, /clearPendingDashboardSceneElements\(currentStateIndex\)/)
-  assert.match(appleManager, /clearPendingDashboardSceneElements\(for: currentStateIndex\)/)
+  assert.match(appleManager, /await clearPendingDashboardSceneElements\(for:/)
   assert.match(
     androidManager,
     /private fun dispatchSceneFrame[\s\S]*?clearPendingDashboardSceneElements\(stateIndex\)/,
   )
   assert.match(
     appleManager,
-    /private func dispatchSceneFrame[\s\S]*?clearPendingDashboardSceneElements\(for: stateIndex\)/,
+    /private func dispatchSceneFrame[\s\S]*?await (?:self\.)?renderCurrentState\(\)/,
   )
   assert.match(androidManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending/)
   assert.match(appleManager, /cleanupDeferred = stateIndex == 1 && dashboardSceneCleanupPending/)

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -1103,6 +1103,8 @@ export interface BluetoothSdkPublicModule {
 
   displayText(text: string, x?: number, y?: number, size?: number): Promise<void>
   clearDisplay(): Promise<void>
+  /** Set session-only content below the dashboard status header. Pass an empty string to reset it. */
+  setDashboardContent(content: string): Promise<void>
   showDashboard(): Promise<void>
   setDashboardPosition(height: number, depth: number): Promise<void>
   setHeadUpAngle(angleDegrees: number): Promise<void>

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -77,6 +77,7 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   displayEvent(params: Record<string, unknown>): Promise<void>
   displayText(text: string, x?: number, y?: number, size?: number): Promise<void>
   clearDisplay(): Promise<void>
+  setDashboardContent(content: string): Promise<void>
 
   // Connection Commands
   requestStatus(): Promise<void>

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -105,6 +105,7 @@ export const BluetoothSdk: BluetoothSdkPublicModule = Object.freeze({
   forget: bindPublicMethod("forget"),
   displayText: bindPublicMethod("displayText"),
   clearDisplay: bindPublicMethod("clearDisplay"),
+  setDashboardContent: bindPublicMethod("setDashboardContent"),
   showDashboard: bindPublicMethod("showDashboard"),
   setDashboardPosition: bindPublicMethod("setDashboardPosition"),
   setHeadUpAngle: bindPublicMethod("setHeadUpAngle"),


### PR DESCRIPTION
## Summary

- add `setDashboardContent(content)` to the React Native, Android, and Apple public SDK surfaces
- retain the standard time, date, battery, and connection header while placing app content below it
- keep content session-scoped, update the visible contextual dashboard immediately, and defer scene cleanup until the dashboard can render
- document persistence and display-capability expectations
- add Swift, Kotlin, and cross-surface contract coverage

## Validation

- `swift test` (15 tests)
- `node --test scripts/*.test.mjs` (6 tests)
- `tsc --noEmit -p tsconfig.json`
- generic iOS Simulator `xcodebuild` against the generated standalone Swift package mirror

Android/JUnit compilation was not available in the sparse local checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches display routing and scene/legacy handoff on both platforms; wrong cleanup timing could leave stale UI on glasses, but changes are scoped to the dashboard slot with contract tests.
> 
> **Overview**
> Adds **`setDashboardContent(content)`** on React Native, Android, and iOS so apps can show session-scoped text under the standard dashboard status header (time, date, battery, connection). Empty string resets to header-only; the call does not force the dashboard open and refreshes immediately only when the contextual dashboard is visible.
> 
> Native **`DeviceManager`** builds templates via **`DashboardContentFormatter`**, replaces dashboard legacy/scene state, and **defers clearing old scene elements** until the next dashboard render to avoid flicker when switching from scenes to text-wall content. Docs add a **Display** API row and a **Head-Up Dashboard Content** section; tests cover formatting and cross-surface export/behavior contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df029f74cdc75951bfeaef3b338dc403906288d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `setDashboardContent(content)` to the React Native, Android, and iOS public SDKs so host apps can render persistent content below the standard dashboard status header. Previously the dashboard was status-only; now apps can set session-scoped text that updates an active contextual dashboard immediately or appears on the next head-up.

**New Features**
- Status placeholders re-expand on every render, so time, date, battery, and connection stay current.
- Content is session-scoped; host apps must persist and reapply it after launch.
- Passing the exact empty string resets the status-only dashboard; other whitespace and newlines pass through unchanged.
- The call never opens the dashboard on its own and is a no-op when content is unchanged.
- Dashboard wipes and scene-element cleanup are deferred until the next dashboard render, so new content never paints over stale scene UI.
- Works on display-capable devices only; Mentra Live has no display.

<sup>Written for commit a455c2ab9dbf51be07653e7b0ebb9c6d06f59dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

