### PR TITLE
Fix coordinated release stalls and external upload failures

### DIFF
--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -519,13 +519,27 @@ jobs:
         env:
           RESULT_NAME: ${{ steps.request.outputs.result_name }}
           RESULT_URL: ${{ steps.request.outputs.result_url }}
+          RUN_URL: ${{ steps.request.outputs.run_url }}
+          GH_TOKEN: ${{ steps.starter-kit-request-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p starter-kit-result
           for _ in {1..630}; do
-            if curl --fail --silent --show-error --location "$RESULT_URL" \
+            if curl --fail --silent --show-error --location --connect-timeout 10 --max-time 30 "$RESULT_URL" \
               --output "starter-kit-result/$RESULT_NAME" 2>/dev/null; then
               exit 0
+            fi
+            if [[ -n "$RUN_URL" ]]; then
+              # A transient API failure must not be mistaken for a failed build.
+              run_state=$(gh run view "${RUN_URL##*/}" --repo Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit \
+                --json status,conclusion 2>/dev/null || true)
+              if [[ "$(jq -r '.status // empty' <<< "${run_state:-null}")" == "completed" ]]; then
+                conclusion=$(jq -r '.conclusion // "unknown"' <<< "$run_state")
+                if [[ "$conclusion" != "success" ]]; then
+                  echo "Starter Kit run concluded $conclusion: $RUN_URL" >&2
+                  exit 1
+                fi
+              fi
             fi
             sleep 10
           done

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -520,7 +520,10 @@ jobs:
           RESULT_NAME: ${{ steps.request.outputs.result_name }}
           RESULT_URL: ${{ steps.request.outputs.result_url }}
           RUN_URL: ${{ steps.request.outputs.run_url }}
-          GH_TOKEN: ${{ steps.starter-kit-request-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          # Public run metadata needs no cross-repository permissions. The job
+          # token remains valid through this wait; the request App token expires
+          # after one hour, before the full 105-minute wait can finish.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           mkdir -p starter-kit-result
@@ -531,8 +534,8 @@ jobs:
             fi
             if [[ -n "$RUN_URL" ]]; then
               # A transient API failure must not be mistaken for a failed build.
-              run_state=$(gh run view "${RUN_URL##*/}" --repo Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit \
-                --json status,conclusion 2>/dev/null || true)
+              run_state=$(gh api "repos/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/${RUN_URL##*/}" \
+                --jq '{status,conclusion}' 2>/dev/null || true)
               if [[ "$(jq -r '.status // empty' <<< "${run_state:-null}")" == "completed" ]]; then
                 conclusion=$(jq -r '.conclusion // "unknown"' <<< "$run_state")
                 if [[ "$conclusion" != "success" ]]; then

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -354,7 +354,12 @@ jobs:
           MENTRA_COORDINATED_OUTPUT_DIR: ${{ github.workspace }}/mobile-release/android
           MENTRA_COORDINATED_RELEASE_IDENTITY: ${{ needs.prepare.outputs.release_identity }}
           RNMAPBOX_MAPS_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
-          SENTRY_ALLOW_FAILURE: "false"
+          # A Sentry outage must not fail a release build. sentry-cli still
+          # logs the failure loudly, and debug files can be uploaded after
+          # the fact; losing a coordinated release to someone else's 503 is
+          # the more expensive outcome. Seen 2026-09-08: an archive failed
+          # on "sentry reported an error: unknown error (http status: 503)".
+          SENTRY_ALLOW_FAILURE: "true"
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run release:android
 
@@ -691,7 +696,12 @@ jobs:
         env:
           MENTRA_COORDINATED_OUTPUT_DIR: ${{ github.workspace }}/mobile-release/ios
           MENTRA_COORDINATED_RELEASE_IDENTITY: ${{ needs.prepare.outputs.release_identity }}
-          SENTRY_ALLOW_FAILURE: "false"
+          # A Sentry outage must not fail a release build. sentry-cli still
+          # logs the failure loudly, and debug files can be uploaded after
+          # the fact; losing a coordinated release to someone else's 503 is
+          # the more expensive outcome. Seen 2026-09-08: an archive failed
+          # on "sentry reported an error: unknown error (http status: 503)".
+          SENTRY_ALLOW_FAILURE: "true"
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           MENTRA_TESTFLIGHT_INTERNAL_ONLY: ${{ inputs.compatibility_lab }}
         run: |

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -253,7 +253,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           APK_ASSET: ${{ steps.names.outputs.apk_asset }}
         run: |
-          gh release download "$ASG_RELEASE_TAG" --pattern "$APK_ASSET" --dir coordinated-ota-work
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            rm -f "coordinated-ota-work/$APK_ASSET"
+            if timeout 120s gh release download "$ASG_RELEASE_TAG" --pattern "$APK_ASSET" --dir coordinated-ota-work; then
+              break
+            fi
+            if [[ "$attempt" == 3 ]]; then
+              rm -f "coordinated-ota-work/$APK_ASSET"
+              echo "ASG download failed after three attempts (120 seconds each)." >&2
+              exit 1
+            fi
+            sleep 5
+          done
           mv "coordinated-ota-work/$APK_ASSET" coordinated-ota-work/asg.apk
 
       - name: Setup Java for ASG build and APK verification

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -59,12 +59,18 @@ env:
 jobs:
   ota:
     name: Select ASG and publish immutable OTA bundle
-    runs-on: [self-hosted, macOS, ARM64]
+    # Ubuntu, matching the standalone ASG build, which already produces this
+    # same production-signed APK there. The signed APK is ~105 MB and the
+    # release API takes it as a single POST with no resumable or block upload,
+    # so publishing it needs an uplink that can finish 105 MB inside GitHub's
+    # ~120s window. The self-hosted Macs share a residential connection that
+    # cannot, and the build itself needs nothing local: inject-signing supplies
+    # the keystore from secrets.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 90
     env:
-      # Keep coordinated builds isolated from persistent-runner Gradle state.
-      # A build failure remains a real failure instead of triggering a machine-
-      # wide cache deletion and an indiscriminate retry.
+      # Keep the Gradle home inside the workspace so a failed build stays a
+      # real failure instead of poisoning a cache shared with other jobs.
       GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-coordinated-asg
     outputs:
       manifest_url: ${{ steps.names.outputs.manifest_url }}
@@ -74,13 +80,32 @@ jobs:
       asg_apk_name: ${{ steps.names.outputs.apk_asset }}
       asg_apk_url: ${{ steps.names.outputs.apk_url }}
     steps:
-      - name: Clean persistent-runner build outputs
-        run: rm -rf asg_client/app/build asg_client/.gradle asg_client/StreamPackLite coordinated-ota-work "$GRADLE_USER_HOME"
-
       - name: Checkout exact source
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Init StreamPackLite submodule
+        # asg_client/settings.gradle builds :core, :extension-rtmp and
+        # :extension-srt out of this submodule, so the APK cannot compile
+        # without it. The persistent Mac runners kept it across jobs; an
+        # ephemeral runner has to fetch it. Path-scoped on purpose: .gitmodules
+        # also carries a dangling mcu_client/peripheral_uart_next/nrf5340 entry
+        # with an unfetchable relative self-URL, and a blanket recursive init
+        # would break if its gitlink ever lands.
+        run: git submodule update --init asg_client/StreamPackLite
+
+      - name: Free up disk space
+        # Ubuntu runners ship ~14GB free and a full ASG release build (NDK +
+        # Gradle + StreamPackLite) can exhaust it. Drop unused preinstalled
+        # toolchains; keep the Android SDK. Mirrors the standalone ASG build.
+        run: |
+          echo "Before:"; df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/share/powershell /usr/local/share/chromium \
+            /opt/hostedtoolcache/CodeQL /usr/local/lib/node_modules 2>/dev/null || true
+          sudo docker image prune --all --force 2>/dev/null || true
+          echo "After:"; df -h / | tail -1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -259,6 +284,20 @@ jobs:
           asg-key-password: ${{ secrets.ASG_KEY_PASSWORD }}
           asg-key-alias: ${{ secrets.ASG_KEY_ALIAS }}
 
+      - name: Write the ASG backend configuration
+        if: steps.existing-asg.outputs.exists != 'true'
+        working-directory: asg_client
+        # app/build.gradle bakes MENTRAOS_HOST/PORT/SECURE into BuildConfig from
+        # asg_client/.env, which is gitignored, and falls back to "" per field
+        # when the file is missing. ServerConfigUtil only rejects null, so an
+        # absent .env silently yields a "http://:" upload URL instead of failing
+        # the build. Write it explicitly so the released APK never depends on
+        # leftover state in a runner's workspace.
+        run: |
+          set -euo pipefail
+          cp .env.example .env
+          grep -q '^MENTRAOS_HOST=..*' .env
+
       - name: Build signed ASG APK once
         if: steps.existing-asg.outputs.exists != 'true'
         run: >-
@@ -277,8 +316,10 @@ jobs:
           EXPECTED_VERSION_NAME: ${{ steps.asg-identity.outputs.version_name }}
         run: |
           set -euo pipefail
-          apksigner=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -perm +111 | LC_ALL=C sort | tail -1)
-          aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm +111 | LC_ALL=C sort | tail -1)
+          # -perm -111 (all three execute bits) is understood by both GNU and
+          # BSD find; the BSD-only "+111" spelling is an error on GNU findutils.
+          apksigner=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -perm -111 | LC_ALL=C sort | tail -1)
+          aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm -111 | LC_ALL=C sort | tail -1)
           test -n "$apksigner"
           test -n "$aapt"
           $apksigner verify --print-certs coordinated-ota-work/asg.apk > coordinated-ota-work/apksigner-output.txt


### PR DESCRIPTION
Fix staging coordinated release stalls and carry the existing ASG runner and Sentry outage fixes into staging. ASG builds use the same Ubuntu runner and explicit backend configuration as dev. Reused APK downloads get three 120-second attempts with partial-file cleanup, and the coordinator stops waiting when its exact Starter Kit run fails. Sentry upload outages remain visible without failing the mobile build.

Validation: actionlint passes for the three changed workflows with existing Blacksmith runner labels allowed; 11 release-family tests pass. Six shell scenarios pass for first-attempt download, retry success, retry exhaustion and cleanup, existing result, failed companion, and transient GitHub API errors. The copied ASG runner change already passed the dev OTA job; full staging release validation is pending.

This hotfix targets staging. After staging validation, merge staging into dev to carry the shared fixes forward. No dev-to-staging merge or promotion is included.
