### PR TITLE
Add pinned upgrade-only MTK full OTA fallback

### DIFF
--- a/.github/scripts/build-bluetooth-sdk-ota-bundle.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-bundle.mjs
@@ -60,7 +60,10 @@ function collectArtifactReferences(manifest) {
   if (manifest.mtk_full_ota) {
     const entry = manifest.mtk_full_ota;
     if (typeof entry.url !== 'string' || !entry.url) throw new Error('MTK full OTA is missing a URL.');
-    references.push({entry, key: 'url', label: 'MTK full OTA', sha256: requireSha256(entry, 'MTK full OTA')});
+    if (!Number.isSafeInteger(entry.size) || entry.size <= 0 || entry.size > 1024 * 1024 * 1024) {
+      throw new Error('MTK full OTA must declare a positive integer size no larger than 1 GiB.');
+    }
+    references.push({entry, key: 'url', label: 'MTK full OTA', sha256: requireSha256(entry, 'MTK full OTA'), size: entry.size});
   }
 
   const bes = manifest.bes_firmware;
@@ -97,21 +100,26 @@ export async function buildPortableOtaBundle({manifest, outputDirectory, localAr
   const bundledByHash = new Map();
   for (const reference of references) {
     const source = reference.entry[reference.key];
-    let fileName = bundledByHash.get(reference.sha256);
-    if (!fileName) {
+    let bundled = bundledByHash.get(reference.sha256);
+    if (!bundled) {
       const data = await readSource(source, localArtifacts);
       const actualSha256 = sha256(data);
       if (actualSha256 !== reference.sha256) {
         throw new Error(`${reference.label} hash mismatch: expected ${reference.sha256}, got ${actualSha256}.`);
       }
-      fileName = `${reference.sha256}${artifactExtension(source)}`;
+      const fileName = `${reference.sha256}${artifactExtension(source)}`;
       const destination = join(artifactsDirectory, fileName);
       writeFileSync(destination, data);
       utimesSync(destination, FIXED_MTIME, FIXED_MTIME);
-      bundledByHash.set(reference.sha256, fileName);
+      bundled = {fileName, size: data.length};
+      bundledByHash.set(reference.sha256, bundled);
+    }
+    // Validate every reference, including artifacts deduplicated by hash.
+    if (reference.size !== undefined && reference.size !== bundled.size) {
+      throw new Error(`${reference.label} size mismatch: expected ${reference.size}, got ${bundled.size}.`);
     }
 
-    const relativePath = `artifacts/${fileName}`;
+    const relativePath = `artifacts/${bundled.fileName}`;
     reference.entry[reference.key] = relativePath;
     if (reference.key === 'url' && typeof reference.entry.firmwareUrl === 'string') {
       reference.entry.firmwareUrl = relativePath;
@@ -153,7 +161,7 @@ export async function buildPortableOtaBundle({manifest, outputDirectory, localAr
 
   const sums = [...bundledByHash.entries()]
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([hash, fileName]) => `${hash}  artifacts/${fileName}`)
+    .map(([hash, artifact]) => `${hash}  artifacts/${artifact.fileName}`)
     .join('\n');
   const sumsPath = join(outputDirectory, 'SHA256SUMS');
   writeFileSync(sumsPath, `${sums}\n`);

--- a/.github/scripts/build-bluetooth-sdk-ota-bundle.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-bundle.mjs
@@ -59,6 +59,11 @@ function collectArtifactReferences(manifest) {
   });
   if (manifest.mtk_full_ota) {
     const entry = manifest.mtk_full_ota;
+    if (typeof entry.end_firmware !== 'string' ||
+        !/^[0-9]{8}(\.[0-9]{1,9})?$/.test(entry.end_firmware.trim().split('_').at(-1)) ||
+        Object.hasOwn(entry, 'start_firmware')) {
+      throw new Error('MTK full OTA must declare a valid string end_firmware and no start_firmware.');
+    }
     if (typeof entry.url !== 'string' || !entry.url) throw new Error('MTK full OTA is missing a URL.');
     if (!Number.isSafeInteger(entry.size) || entry.size <= 0 || entry.size > 1024 * 1024 * 1024) {
       throw new Error('MTK full OTA must declare a positive integer size no larger than 1 GiB.');

--- a/.github/scripts/build-bluetooth-sdk-ota-bundle.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-bundle.mjs
@@ -57,6 +57,11 @@ function collectArtifactReferences(manifest) {
     }
     references.push({entry, key, label: `MTK patch ${index}`, sha256: requireSha256(entry, `MTK patch ${index}`)});
   });
+  if (manifest.mtk_full_ota) {
+    const entry = manifest.mtk_full_ota;
+    if (typeof entry.url !== 'string' || !entry.url) throw new Error('MTK full OTA is missing a URL.');
+    references.push({entry, key: 'url', label: 'MTK full OTA', sha256: requireSha256(entry, 'MTK full OTA')});
+  }
 
   const bes = manifest.bes_firmware;
   const besKey = typeof bes?.url === 'string' && bes.url.length > 0 ? 'url' : 'firmwareUrl';

--- a/.github/scripts/build-bluetooth-sdk-ota-bundle.test.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-bundle.test.mjs
@@ -110,7 +110,7 @@ test('rejects a hash mismatch independently for every OTA component', async (t) 
           'com.mentra.asg_client': {apkUrl: sources.asg, sha256: hash(expected.asg)},
         },
         mtk_patches: [{url: sources.mtk, sha256: hash(expected.mtk)}],
-        mtk_full_ota: {url: sources.full, sha256: hash(expected.full)},
+        mtk_full_ota: {url: sources.full, sha256: hash(expected.full), size: expected.full.length},
         bes_firmware: {url: sources.bes, sha256: hash(expected.bes)},
       };
 
@@ -131,6 +131,25 @@ test('rejects a non-HTTP final manifest URL', () => {
     () => configureOtaManifest({apps: {}}, 'file:///tmp/version.json'),
     /must use HTTP\(S\)/,
   );
+});
+
+test('validates full size even when bytes were already bundled under the same hash', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'mentra-ota-size-'));
+  const source = 'https://cdn.example.com/shared.zip';
+  const file = join(root, 'shared.zip');
+  writeFileSync(file, 'data');
+  const artifact = {url: source, sha256: hash('data')};
+  for (const size of [undefined, 0, -1, 1.5, '4', 1073741825, 3]) {
+    const manifest = {
+      apps: {'com.mentra.asg_client': {apkUrl: source, sha256: artifact.sha256}},
+      mtk_patches: [artifact], bes_firmware: artifact,
+      mtk_full_ota: {...artifact, size},
+    };
+    await assert.rejects(buildPortableOtaBundle({
+      manifest, outputDirectory: join(root, 'bundle'), localArtifacts: {[source]: file},
+    }), /MTK full OTA.*(?:size|GiB)/);
+    assert.equal(existsSync(join(root, 'bundle', 'version.template.json')), false);
+  }
 });
 
 test('rejects a final URL that does not match the generated manifest filename', () => {

--- a/.github/scripts/build-bluetooth-sdk-ota-bundle.test.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-bundle.test.mjs
@@ -18,6 +18,7 @@ test('builds a portable template and configures a backward-compatible absolute m
     'https://cdn.example.com/asg.apk': 'asg',
     'https://cdn.example.com/mtk.zip': 'mtk',
     'https://cdn.example.com/bes.bin': 'bes',
+    'https://cdn.example.com/full.zip': 'full',
   };
   const localArtifacts = {};
   for (const [source, contents] of Object.entries(sources)) {
@@ -48,17 +49,19 @@ test('builds a portable template and configures a backward-compatible absolute m
       url: 'https://cdn.example.com/bes.bin',
       sha256: hash('bes'),
     },
+    mtk_full_ota: {end_firmware: '20260908.0', url: 'https://cdn.example.com/full.zip', sha256: hash('full'), size: 4},
   };
 
   const result = await buildPortableOtaBundle({manifest, outputDirectory, localArtifacts});
 
-  assert.equal(result.artifactCount, 3);
+  assert.equal(result.artifactCount, 4);
   const portable = JSON.parse(readFileSync(join(outputDirectory, 'version.template.json'), 'utf8'));
   assert.equal(
     portable.apps['com.mentra.asg_client'].apkUrl,
     `artifacts/${hash('asg')}.apk`,
   );
   assert.equal(portable.mtk_patches[0].url, `artifacts/${hash('mtk')}.zip`);
+  assert.equal(portable.mtk_full_ota.url, `artifacts/${hash('full')}.zip`);
   assert.equal(portable.bes_firmware.url, `artifacts/${hash('bes')}.bin`);
   assert.match(readFileSync(join(outputDirectory, 'SHA256SUMS'), 'utf8'), new RegExp(hash('asg')));
   assert.equal(existsSync(join(outputDirectory, 'version.json')), false);
@@ -69,6 +72,7 @@ test('builds a portable template and configures a backward-compatible absolute m
   });
   assert.equal(configured.status, 0, configured.stderr);
   const configuredManifest = JSON.parse(readFileSync(join(outputDirectory, 'version.json'), 'utf8'));
+  assert.equal(configuredManifest.mtk_full_ota.url, `https://updates.example.com/mentra/v1/artifacts/${hash('full')}.zip`);
   assert.equal(
     configuredManifest.apps['com.mentra.asg_client'].apkUrl,
     `https://updates.example.com/mentra/v1/artifacts/${hash('asg')}.apk`,
@@ -84,16 +88,17 @@ test('builds a portable template and configures a backward-compatible absolute m
 });
 
 test('rejects a hash mismatch independently for every OTA component', async (t) => {
-  const labels = {asg: 'ASG APK', mtk: 'MTK patch 0', bes: 'BES firmware'};
+  const labels = {asg: 'ASG APK', mtk: 'MTK patch 0', full: 'MTK full OTA', bes: 'BES firmware'};
   for (const mismatchedKind of Object.keys(labels)) {
     await t.test(mismatchedKind, async () => {
       const root = mkdtempSync(join(tmpdir(), `mentra-ota-bundle-bad-${mismatchedKind}-`));
       const sources = {
         asg: 'https://cdn.example.com/asg.apk',
         mtk: 'https://cdn.example.com/mtk.zip',
+        full: 'https://cdn.example.com/full.zip',
         bes: 'https://cdn.example.com/bes.bin',
       };
-      const expected = {asg: 'expected-asg', mtk: 'expected-mtk', bes: 'expected-bes'};
+      const expected = {asg: 'expected-asg', mtk: 'expected-mtk', full: 'expected-full', bes: 'expected-bes'};
       const localArtifacts = {};
       for (const kind of Object.keys(sources)) {
         const path = join(root, `${kind}.bin`);
@@ -105,6 +110,7 @@ test('rejects a hash mismatch independently for every OTA component', async (t) 
           'com.mentra.asg_client': {apkUrl: sources.asg, sha256: hash(expected.asg)},
         },
         mtk_patches: [{url: sources.mtk, sha256: hash(expected.mtk)}],
+        mtk_full_ota: {url: sources.full, sha256: hash(expected.full)},
         bes_firmware: {url: sources.bes, sha256: hash(expected.bes)},
       };
 

--- a/.github/scripts/build-bluetooth-sdk-ota-bundle.test.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-bundle.test.mjs
@@ -110,7 +110,7 @@ test('rejects a hash mismatch independently for every OTA component', async (t) 
           'com.mentra.asg_client': {apkUrl: sources.asg, sha256: hash(expected.asg)},
         },
         mtk_patches: [{url: sources.mtk, sha256: hash(expected.mtk)}],
-        mtk_full_ota: {url: sources.full, sha256: hash(expected.full), size: expected.full.length},
+        mtk_full_ota: {end_firmware: '20260908.0', url: sources.full, sha256: hash(expected.full), size: expected.full.length},
         bes_firmware: {url: sources.bes, sha256: hash(expected.bes)},
       };
 
@@ -143,12 +143,27 @@ test('validates full size even when bytes were already bundled under the same ha
     const manifest = {
       apps: {'com.mentra.asg_client': {apkUrl: source, sha256: artifact.sha256}},
       mtk_patches: [artifact], bes_firmware: artifact,
-      mtk_full_ota: {...artifact, size},
+      mtk_full_ota: {...artifact, end_firmware: '20260908.0', size},
     };
     await assert.rejects(buildPortableOtaBundle({
       manifest, outputDirectory: join(root, 'bundle'), localArtifacts: {[source]: file},
     }), /MTK full OTA.*(?:size|GiB)/);
     assert.equal(existsSync(join(root, 'bundle', 'version.template.json')), false);
+  }
+});
+
+test('rejects malformed full target and any start_firmware key before fetching', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'mentra-full-schema-'));
+  const artifact = {url: 'https://cdn.invalid/full.zip', sha256: hash('data'), size: 4};
+  for (const fields of [{}, {end_firmware: 20260908}, {end_firmware: 'unknown'},
+    {end_firmware: '20260908.0', start_firmware: null},
+    {end_firmware: '20260908.0', start_firmware: '20260709'}]) {
+    await assert.rejects(buildPortableOtaBundle({
+      manifest: {
+        apps: {'com.mentra.asg_client': {apkUrl: artifact.url, sha256: artifact.sha256}},
+        mtk_patches: [artifact], bes_firmware: artifact, mtk_full_ota: {...artifact, ...fields},
+      }, outputDirectory: join(root, 'bundle'),
+    }), /end_firmware and no start_firmware/);
   }
 });
 

--- a/.github/scripts/build-bluetooth-sdk-ota-manifest.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-manifest.mjs
@@ -54,6 +54,7 @@ const manifest = {
     },
   },
   mtk_patches: firmware.mtk_patches,
+  ...(firmware.mtk_full_ota ? {mtk_full_ota: firmware.mtk_full_ota} : {}),
   bes_firmware: firmware.bes_firmware,
 };
 

--- a/.github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs
@@ -15,6 +15,7 @@ function runManifestBuild(releaseVersion) {
     firmwarePath,
     JSON.stringify({
       mtk_patches: [{start_firmware: 'A', end_firmware: 'B', url: 'https://example.com/mtk.zip'}],
+      mtk_full_ota: {end_firmware: '20260908.0', url: 'https://example.com/full.zip', sha256: 'b'.repeat(64), size: 640341205},
       bes_firmware: {version: '1.0.0', url: 'https://example.com/bes.bin'},
     }),
   );
@@ -41,6 +42,14 @@ test('writes the coordinated release version independently of the ASG version', 
   const manifest = JSON.parse(readFileSync(outputPath, 'utf8'));
   assert.equal(manifest.releaseVersion, '3.1.0-beta.3');
   assert.equal(manifest.apps['com.mentra.asg_client'].versionName, 'asg.40');
+  assert.equal(manifest.mtk_full_ota.end_firmware, '20260908.0');
+  assert.equal(manifest.mtk_full_ota.size, 640341205);
+  const inputsPath = path.join(path.dirname(outputPath), 'inputs.json');
+  const collected = spawnSync(process.execPath, [
+    path.resolve('.github/scripts/collect-ota-release-inputs.mjs'), outputPath, inputsPath,
+  ], {encoding: 'utf8'});
+  assert.equal(collected.status, 0, collected.stderr);
+  assert.deepEqual(JSON.parse(readFileSync(inputsPath, 'utf8')).mtkFullOta, manifest.mtk_full_ota);
 });
 
 test('rejects a value outside the coordinated release identity format', () => {

--- a/.github/scripts/collect-ota-release-inputs.mjs
+++ b/.github/scripts/collect-ota-release-inputs.mjs
@@ -20,6 +20,7 @@ const result = {
     sha256: createHash("sha256").update(bytes).digest("hex"),
   },
   mtkPatches: manifest.mtk_patches,
+  ...(manifest.mtk_full_ota ? {mtkFullOta: manifest.mtk_full_ota} : {}),
   besFirmware: manifest.bes_firmware,
 }
 

--- a/.github/scripts/configure-bluetooth-sdk-ota-manifest.mjs
+++ b/.github/scripts/configure-bluetooth-sdk-ota-manifest.mjs
@@ -53,6 +53,9 @@ export function configureOtaManifest(manifest, finalManifestUrl) {
     resolveField(patch, 'url', manifestUrl);
     resolveField(patch, 'firmwareUrl', manifestUrl);
   }
+  if (configured.mtk_full_ota) {
+    resolveField(configured.mtk_full_ota, 'url', manifestUrl);
+  }
   if (configured.bes_firmware) {
     resolveField(configured.bes_firmware, 'url', manifestUrl);
     resolveField(configured.bes_firmware, 'firmwareUrl', manifestUrl);

--- a/.github/scripts/coordinated-ota-records.mjs
+++ b/.github/scripts/coordinated-ota-records.mjs
@@ -148,6 +148,9 @@ export function createOtaReleaseResult({
   if (canonicalJson(manifest.mtk_patches) !== canonicalJson(releasePlan.otaInputs.mtkPatches)) {
     throw new Error("OTA manifest MTK inputs differ from the release plan")
   }
+  if (canonicalJson(manifest.mtk_full_ota ?? null) !== canonicalJson(releasePlan.otaInputs.mtkFullOta ?? null)) {
+    throw new Error("OTA manifest MTK full OTA differs from the release plan")
+  }
   if (canonicalJson(manifest.bes_firmware) !== canonicalJson(releasePlan.otaInputs.besFirmware)) {
     throw new Error("OTA manifest BES input differs from the release plan")
   }

--- a/.github/scripts/coordinated-ota-records.test.mjs
+++ b/.github/scripts/coordinated-ota-records.test.mjs
@@ -35,6 +35,7 @@ const releasePlan = {
   otaInputs: {
     firmwareManifest: {path: "asg_client/ota_manifests/firmware_live.json", sha256: "d".repeat(64)},
     mtkPatches: [{start_firmware: "20260709", end_firmware: "20260730", url: "https://example.com/mtk.zip"}],
+    mtkFullOta: {end_firmware: "20260730", url: "https://example.com/full.zip", sha256: "f".repeat(64), size: 640341205},
     besFirmware: {version: "26.8.1", url: "https://example.com/bes.bin"},
   },
 }
@@ -71,6 +72,7 @@ function fixture() {
           },
         },
         mtk_patches: releasePlan.otaInputs.mtkPatches,
+        mtk_full_ota: releasePlan.otaInputs.mtkFullOta,
         bes_firmware: releasePlan.otaInputs.besFirmware,
       },
       null,
@@ -258,10 +260,11 @@ test("compares promoted firmware semantically instead of by object key order", (
   )
 })
 
-test("rejects a manifest whose promoted firmware differs from release intent", () => {
+for (const field of ["bes_firmware", "mtk_full_ota"]) {
+test(`rejects a manifest whose ${field} differs from release intent`, () => {
   const fixtureData = fixture()
   const manifest = JSON.parse(readFileSync(fixtureData.manifestPath, "utf8"))
-  manifest.bes_firmware.version = "unexpected"
+  manifest[field].url = "https://example.com/unexpected"
   writeFileSync(fixtureData.manifestPath, JSON.stringify(manifest))
 
   assert.throws(
@@ -288,6 +291,7 @@ test("rejects a manifest whose promoted firmware differs from release intent", (
           runAttempt: 1,
         },
       }),
-    /BES input differs/,
+    /(?:BES input|MTK full OTA) differs/,
   )
 })
+}

--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -15,6 +15,10 @@ on:
         description: Optional Android versionCode for an installable test build
         required: false
         type: number
+      ota_manifest_url:
+        description: Optional OTA manifest URL embedded in the test app
+        required: false
+        type: string
 
 # Cancel a branch's in-flight build when a newer commit is pushed to it.
 # Scoped per-ref so branches never cancel each other; keeps the runner
@@ -39,6 +43,7 @@ jobs:
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
       MENTRAOS_PINNED_BUILD_NUMBER: ${{ inputs.build_number || '' }}
+      EXPO_PUBLIC_ASG_OTA_VERSION_URL: ${{ inputs.ota_manifest_url || '' }}
       # Compile-check APKs are phone sideloads. Full ABI belongs on the
       # coordinated release workflow, not on this compile-check workflow.
       ORG_GRADLE_PROJECT_reactNativeArchitectures: arm64-v8a
@@ -56,6 +61,11 @@ jobs:
               echo "::error::build_number must be an integer from 1 to 2100000000, got '$MENTRAOS_PINNED_BUILD_NUMBER'"
               exit 1
             fi
+          fi
+          if [[ -n "$EXPO_PUBLIC_ASG_OTA_VERSION_URL" ]] \
+            && ! [[ "$EXPO_PUBLIC_ASG_OTA_VERSION_URL" =~ ^https?://[^[:space:]\#]+$ ]]; then
+            echo "::error::ota_manifest_url must be an HTTP(S) URL without whitespace or a fragment"
+            exit 1
           fi
 
       - name: Update PR comment - Build started
@@ -165,6 +175,7 @@ jobs:
         run: |
           # Create .env from example (Expo reads from mobile/.env, not android/.env)
           cp .env.example .env
+          printf '\nEXPO_PUBLIC_ASG_OTA_VERSION_URL=%s\n' "$EXPO_PUBLIC_ASG_OTA_VERSION_URL" >> .env
           # Pin which cloud this binary talks to (OS-1875).
           #
           # main is production-configured; dev, PRs and feature branches use dev
@@ -351,6 +362,20 @@ jobs:
             echo "Both build attempts failed"
             exit 1
           fi
+
+      - name: Verify embedded OTA manifest pin
+        if: inputs.ota_manifest_url != ''
+        run: |
+          python3 - <<'PY'
+          import os
+          import zipfile
+          with zipfile.ZipFile("mobile/android/app/build/outputs/apk/release/app-release.apk") as apk:
+              bundle = apk.read("assets/index.android.bundle")
+          expected = os.environ["EXPO_PUBLIC_ASG_OTA_VERSION_URL"].encode()
+          if expected not in bundle:
+              raise SystemExit("Requested OTA manifest URL is missing from the compiled app bundle")
+          print("Verified requested OTA manifest URL in compiled app bundle")
+          PY
 
       - name: Verify release signature (not debug)
         run: |

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -43,6 +43,9 @@ public class AsgConstants {
     /** Protocol version for phone-served OTA artifacts over the Mentra Live hotspot. */
     public static final int HOTSPOT_OTA_VERSION = 1;
 
+    /** Bounded MTK ZIP download size, including full system OTAs (~611 MiB today). */
+    public static final long MTK_OTA_MAX_DOWNLOAD_BYTES = 1024L * 1024 * 1024;
+
     /** Canonical camera crop defaults shared with the phone and Bluetooth SDK. */
     public static final int CAMERA_FOV_DEFAULT = 118;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -45,6 +45,8 @@ public class AsgConstants {
 
     /** Bounded MTK ZIP download size, including full system OTAs (~611 MiB today). */
     public static final long MTK_OTA_MAX_DOWNLOAD_BYTES = 1024L * 1024 * 1024;
+    /** Non-retryable until the user frees storage on the glasses. */
+    public static final String OTA_INSUFFICIENT_STORAGE = "insufficient_storage";
 
     /** Canonical camera crop defaults shared with the phone and Bluetooth SDK. */
     public static final int CAMERA_FOV_DEFAULT = 118;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -140,6 +140,7 @@ public class OtaHelper {
     // Progress throttling - send every 2s OR every 5% change
     private long lastProgressSentTime = 0;
     private int lastProgressSentPercent = 0;
+    private volatile long downloadBytes = 0;
     private static final long PROGRESS_MIN_INTERVAL_MS = 2000; // 2 seconds
     private static final int PROGRESS_MIN_CHANGE_PERCENT = 5;   // 5%
     // Current update stage for progress reporting
@@ -2376,7 +2377,7 @@ public class OtaHelper {
 
     private JSONObject buildBesInstallStartStatus() {
         updateSessionFromProgress("install", 0, "STARTED", null);
-        lastProgressSentTime = System.currentTimeMillis();
+        lastProgressSentTime = android.os.SystemClock.elapsedRealtime();
         lastProgressSentPercent = 0;
         lastOtaPhoneStage = "install";
         lastOtaPhoneProgress = 0;
@@ -2540,15 +2541,9 @@ public class OtaHelper {
                 Log.i(TAG, "MTK firmware update initiated - system will handle in background");
             }, 1000); // 1 second delay
 
-            // 10-minute timeout: if no broadcast arrives, clear isMtkOtaInProgress
-            final long MTK_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
-            mtkHandler.postDelayed(() -> {
-                if (isMtkOtaInProgress) {
-                    Log.e(TAG, "MTK install timeout after " + (MTK_INSTALL_TIMEOUT_MS / 60000) + " min — no broadcast received, clearing flag");
-                    isMtkOtaInProgress = false;
-                    sendMtkInstallProgressToPhone("FAILED", 0, "MTK install timed out — no response from system");
-                }
-            }, MTK_INSTALL_TIMEOUT_MS);
+            // Only a terminal system-updater result releases install ownership. The phone
+            // detects stalled progress, but elapsed time does not mean update_engine stopped.
+            // In particular, a retry must not replace the ZIP while it is still being read.
 
             return true;
         } catch (Exception e) {
@@ -2569,7 +2564,7 @@ public class OtaHelper {
      * @param context Application context
      * @return true if downloaded and verified successfully
      */
-    private boolean downloadMtkFirmware(String firmwareUrl, JSONObject firmwareInfo, Context context) {
+    boolean downloadMtkFirmware(String firmwareUrl, JSONObject firmwareInfo, Context context) {
         try {
             boolean success = downloadMtkFirmwareInternal(firmwareUrl, firmwareInfo, context);
             if (success) {
@@ -2653,6 +2648,8 @@ public class OtaHelper {
 
         currentUpdateType = "mtk";
 
+        final long progressSize = expectedSize > 0 ? expectedSize : fileSize;
+        sendProgressToPhone("download", 0, 0, progressSize, "STARTED", null);
         try {
             while ((len = in.read(buffer)) > 0) {
                 total += len;
@@ -2664,7 +2661,8 @@ public class OtaHelper {
                 }
                 out.write(buffer, 0, len);
 
-                int progress = fileSize > 0 ? (int) (total * 100 / fileSize) : 0;
+                int progress = progressSize > 0 ? (int) (total * 100 / progressSize) : 0;
+                sendProgressToPhone("download", progress, total, progressSize, "PROGRESS", null);
                 if (progress >= lastProgress + 10 || progress == 100) {
                     Log.d(TAG, "MTK firmware download progress: " + progress + "%");
                     EventBus.getDefault().post(new DownloadProgressEvent(
@@ -2693,6 +2691,7 @@ public class OtaHelper {
         boolean verified = verifyMtkFirmwareChecksum(firmwareFile.getAbsolutePath(), firmwareInfo);
         if (verified) {
             Log.i(TAG, "MTK firmware file verified successfully");
+            sendProgressToPhone("download", 100, total, progressSize, "FINISHED", null);
             return true;
         } else {
             firmwareFile.delete();
@@ -2781,13 +2780,14 @@ public class OtaHelper {
     private void sendProgressToPhone(String stage, int progress, long bytesDownloaded,
                                      long totalBytes, String status, String errorMessage) {
 
+        downloadBytes = "download".equals(stage) ? bytesDownloaded : 0;
         updateSessionFromProgress(stage, progress, status, errorMessage);
 
         if (phoneConnectionProvider == null || !isPhoneConnected()) {
             return;
         }
 
-        long now = System.currentTimeMillis();
+        long now = android.os.SystemClock.elapsedRealtime();
         boolean shouldSend = false;
 
         // Always send STARTED, FINISHED, FAILED immediately
@@ -2975,6 +2975,10 @@ public class OtaHelper {
             // Phone bridge (MentraLive.java) reads all fields from the top level of the JSON
             // object, so we add "type" directly to sessionState rather than nesting it under "data".
             sessionState.put("type", "ota_status");
+            if ("download".equals(sessionState.optString("phase"))
+                    && currentUpdateType.equals(sessionState.optString("step_type"))) {
+                sessionState.put("bytes_downloaded", downloadBytes);
+            }
             if ("failed".equals(sessionState.optString("status"))) {
                 sessionState.put("glasses_time_ms", System.currentTimeMillis());
             }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -46,14 +46,13 @@ import java.util.stream.Collectors;
 
 import com.mentra.asg_client.io.ota.session.OtaSessionManager;
 import com.mentra.asg_client.io.ota.utils.DowngradeGate;
+import com.mentra.asg_client.io.ota.utils.MtkOtaSelector;
 import com.mentra.asg_client.io.ota.utils.FirmwareDownloadException;
 import com.mentra.asg_client.io.ota.utils.OtaConstants;
 import com.mentra.asg_client.service.system.core.SystemControllerFactory;
 import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.service.utils.SysProp;
 import com.mentra.asg_client.utils.WakeLockManager;
-
-import org.json.JSONArray;
 
 public class OtaHelper {
 
@@ -386,9 +385,9 @@ public class OtaHelper {
                     break;
                 }
             }
-            if (!wasMtkUpdatedThisSession() && !isMtkOtaInProgress() && rootJson.has("mtk_patches")) {
+            if (!wasMtkUpdatedThisSession() && !isMtkOtaInProgress()) {
                 String currentMtk = SysProp.getProperty(context, "ro.custom.ota.version");
-                JSONObject mtkPatch = findMatchingMtkPatch(rootJson.getJSONArray("mtk_patches"), currentMtk);
+                JSONObject mtkPatch = MtkOtaSelector.select(rootJson, currentMtk);
                 if (mtkPatch != null) steps.add("mtk");
             }
             if (rootJson.has("bes_firmware")) {
@@ -884,10 +883,10 @@ public class OtaHelper {
                 } else if (isMtkOtaInProgress()) {
                     Log.i(TAG, "📱 MTK update currently in progress - skipping MTK check");
                     mtkPatch = null;
-                } else if (rootJson.has("mtk_patches")) {
+                } else {
                     String currentMtkVersion = SysProp.getProperty(context, "ro.custom.ota.version");
                     Log.d(TAG, "Current MTK version: " + currentMtkVersion);
-                    mtkPatch = findMatchingMtkPatch(rootJson.getJSONArray("mtk_patches"), currentMtkVersion);
+                    mtkPatch = MtkOtaSelector.select(rootJson, currentMtkVersion);
                     if (mtkPatch != null) {
                         Log.i(TAG, "MTK patch found for current version: " + currentMtkVersion);
                     }
@@ -1144,9 +1143,9 @@ public class OtaHelper {
 
     private boolean hasApplicableFirmwareUpdate(JSONObject rootJson, Context context) {
         try {
-            if (!wasMtkUpdatedThisSession() && !isMtkOtaInProgress() && rootJson.has("mtk_patches")) {
+            if (!wasMtkUpdatedThisSession() && !isMtkOtaInProgress()) {
                 String currentMtkVersion = SysProp.getProperty(context, "ro.custom.ota.version");
-                if (findMatchingMtkPatch(rootJson.getJSONArray("mtk_patches"), currentMtkVersion) != null) {
+                if (MtkOtaSelector.select(rootJson, currentMtkVersion) != null) {
                     return true;
                 }
             }
@@ -2034,57 +2033,6 @@ public class OtaHelper {
 
     // ========== BES Firmware Update Methods ==========
     /**
-     * Find MTK firmware patch matching the current version.
-     * MTK requires sequential updates - must find patch starting from current version.
-     * @param patches Array of patch objects with start_firmware, end_firmware, url
-     * @param currentVersion Current MTK firmware version as reported by
-     *     {@code ro.custom.ota.version}, e.g. "MentraLive_20260820.1"; both sides are
-     *     normalized before comparison, so a bare "20260820.1" would also match
-     * @return Matching patch object, or null if no match or version unknown
-     */
-    private JSONObject findMatchingMtkPatch(JSONArray patches, String currentVersion) {
-        if (currentVersion == null || currentVersion.isEmpty()) {
-            Log.w(TAG, "Cannot match MTK patch - current version unknown");
-            return null;
-        }
-        String normalizedCurrentVersion = normalizeMtkFirmwareVersion(currentVersion);
-
-        try {
-            for (int i = 0; i < patches.length(); i++) {
-                JSONObject patch = patches.getJSONObject(i);
-                String startFirmware = patch.getString("start_firmware");
-                if (normalizeMtkFirmwareVersion(startFirmware).equals(normalizedCurrentVersion)) {
-                    Log.i(TAG, "Found matching MTK patch: " + startFirmware + " -> " + patch.getString("end_firmware"));
-                    return patch;
-                }
-            }
-        } catch (JSONException e) {
-            Log.e(TAG, "Error parsing MTK patches", e);
-            return null;
-        }
-
-        Log.i(TAG, "No MTK patch available for current version: " + currentVersion);
-        return null;
-    }
-
-    /**
-     * Reduce an MTK version string to its version suffix so manifest entries and the device
-     * property match regardless of any "MentraLive_"-style prefix. Both normally carry the
-     * prefix; this is defensive so a bare suffix on either side still matches.
-     */
-    private String normalizeMtkFirmwareVersion(String version) {
-        if (version == null) {
-            return "";
-        }
-        String trimmed = version.trim();
-        int separator = trimmed.lastIndexOf('_');
-        if (separator >= 0 && separator + 1 < trimmed.length()) {
-            return trimmed.substring(separator + 1);
-        }
-        return trimmed;
-    }
-
-    /**
      * Check if BES firmware update is available.
      * BES does not require sequential updates - can install any newer version directly.
      * If current version is unknown, assume update is needed.
@@ -2121,7 +2069,7 @@ public class OtaHelper {
      * Compare two version strings.
      * Supports dotted formats like "17.26.1.14" (BES) or bare dates like "20241130".
      * MTK patch matching does not use this - it uses normalized exact equality in
-     * {@link #findMatchingMtkPatch}.
+     * {@link MtkOtaSelector}.
      * @param version1 First version string
      * @param version2 Second version string
      * @return positive if version1 > version2, negative if version1 < version2, 0 if equal
@@ -2508,13 +2456,11 @@ public class OtaHelper {
                 return false;
             }
 
-            // Detect if this is a patch object (from findMatchingMtkPatch) or legacy firmware info
-            // Patch objects have start_firmware/end_firmware fields and are already version-matched
-            boolean isPatchObject = firmwareInfo.has("start_firmware");
+            // Both delta and full entries were selected before reaching the common installer.
+            boolean isSelectedMtkUpdate = firmwareInfo.has("end_firmware");
 
-            if (isPatchObject) {
-                // Patch object - version matching already done by findMatchingMtkPatch()
-                String startFirmware = firmwareInfo.optString("start_firmware", "unknown");
+            if (isSelectedMtkUpdate) {
+                String startFirmware = firmwareInfo.optString("start_firmware", "full OTA");
                 String endFirmware = firmwareInfo.optString("end_firmware", "unknown");
                 Log.i(TAG, "MTK patch update: " + startFirmware + " -> " + endFirmware);
             } else {
@@ -2674,18 +2620,25 @@ public class OtaHelper {
         conn.setReadTimeout(OtaConstants.READ_TIMEOUT_MS);
         conn.connect();
 
-        // 100 MiB hard cap. Server-advertised content-length is checked first; the
+        // Bounded full-OTA-capable limit. Content-length is checked first; the
         // streaming loop also enforces the cap so a missing/lying header
         // (Content-Length: -1) cannot drain disk.
-        final long maxBytes = 100L * 1024 * 1024;
-        long fileSize = conn.getContentLength();
+        final long maxBytes = AsgConstants.MTK_OTA_MAX_DOWNLOAD_BYTES;
+        long fileSize = conn.getContentLengthLong();
+        long expectedSize = firmwareInfo.optLong("size", 0);
 
-        if (fileSize > maxBytes) {
+        // Keep room for both the ZIP and extracted payload. Legacy deltas may lack size.
+        long requiredSize = expectedSize > 0 ? expectedSize : Math.max(fileSize, 0);
+        if (fileSize > maxBytes || requiredSize > maxBytes) {
             conn.disconnect();
             throw new FirmwareDownloadException(
                 FirmwareDownloadException.CODE_FILE_TOO_LARGE,
                 "MTK firmware file too large: " + fileSize + " bytes (max " + maxBytes + ")"
             );
+        }
+        if (requiredSize > 0 && asgDir.getUsableSpace() < requiredSize * 2) {
+            conn.disconnect();
+            throw new IOException("Insufficient space for MTK ZIP and payload: " + requiredSize);
         }
 
         InputStream in = conn.getInputStream();
@@ -2730,6 +2683,12 @@ public class OtaHelper {
         }
 
         Log.i(TAG, "MTK firmware downloaded to: " + firmwareFile.getAbsolutePath());
+
+        if (expectedSize > 0 && total != expectedSize) {
+            firmwareFile.delete();
+            throw new FirmwareDownloadException(
+                FirmwareDownloadException.CODE_VERIFY_FAILED, "MTK firmware size does not match manifest");
+        }
 
         boolean verified = verifyMtkFirmwareChecksum(firmwareFile.getAbsolutePath(), firmwareInfo);
         if (verified) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -522,6 +522,7 @@ public class OtaHelper {
             // Reset progress tracking
             lastProgressSentTime = 0;
             lastProgressSentPercent = 0;
+            downloadBytes = 0;
 
             Log.i(
                     TAG,
@@ -2376,7 +2377,7 @@ public class OtaHelper {
     }
 
     private JSONObject buildBesInstallStartStatus() {
-        updateSessionFromProgress("install", 0, "STARTED", null);
+        updateSessionFromProgress("install", 0, 0, "STARTED", null);
         lastProgressSentTime = android.os.SystemClock.elapsedRealtime();
         lastProgressSentPercent = 0;
         lastOtaPhoneStage = "install";
@@ -2618,22 +2619,13 @@ public class OtaHelper {
         // Bounded full-OTA-capable limit. Content-length is checked first; the
         // streaming loop also enforces the cap so a missing/lying header
         // (Content-Length: -1) cannot drain disk.
-        final long maxBytes = AsgConstants.MTK_OTA_MAX_DOWNLOAD_BYTES;
         long fileSize = conn.getContentLengthLong();
         long expectedSize = firmwareInfo.optLong("size", 0);
-
-        // Keep room for both the ZIP and extracted payload. Legacy deltas may lack size.
-        long requiredSize = expectedSize > 0 ? expectedSize : Math.max(fileSize, 0);
-        if (fileSize > maxBytes || requiredSize > maxBytes) {
+        try {
+            validateMtkResponse(expectedSize, fileSize, asgDir.getUsableSpace());
+        } catch (FirmwareDownloadException e) {
             conn.disconnect();
-            throw new FirmwareDownloadException(
-                FirmwareDownloadException.CODE_FILE_TOO_LARGE,
-                "MTK firmware file too large: " + fileSize + " bytes (max " + maxBytes + ")"
-            );
-        }
-        if (requiredSize > 0 && asgDir.getUsableSpace() < requiredSize * 2) {
-            conn.disconnect();
-            throw new IOException("Insufficient space for MTK ZIP and payload: " + requiredSize);
+            throw e;
         }
 
         InputStream in = conn.getInputStream();
@@ -2653,12 +2645,7 @@ public class OtaHelper {
         try {
             while ((len = in.read(buffer)) > 0) {
                 total += len;
-                if (total > maxBytes) {
-                    throw new FirmwareDownloadException(
-                        FirmwareDownloadException.CODE_FILE_TOO_LARGE,
-                        "MTK firmware exceeded " + maxBytes + " bytes during streaming (Content-Length=" + fileSize + ")"
-                    );
-                }
+                validateMtkReceivedBytes(expectedSize, total);
                 out.write(buffer, 0, len);
 
                 int progress = progressSize > 0 ? (int) (total * 100 / progressSize) : 0;
@@ -2699,6 +2686,30 @@ public class OtaHelper {
                 FirmwareDownloadException.CODE_VERIFY_FAILED,
                 "MTK firmware sha256 verification failed"
             );
+        }
+    }
+
+    static void validateMtkResponse(long expected, long advertised, long freeBytes) throws FirmwareDownloadException {
+        if (expected > 0 && advertised >= 0 && expected != advertised) {
+            throw new FirmwareDownloadException(FirmwareDownloadException.CODE_VERIFY_FAILED,
+                    "MTK response length does not match manifest");
+        }
+        long required = expected > 0 ? expected : Math.max(advertised, 0);
+        validateMtkReceivedBytes(0, required);
+        if (required > 0 && freeBytes < required * 2) {
+            throw new FirmwareDownloadException(AsgConstants.OTA_INSUFFICIENT_STORAGE,
+                    "Insufficient space for MTK ZIP and payload");
+        }
+    }
+
+    static void validateMtkReceivedBytes(long expected, long received) throws FirmwareDownloadException {
+        if (expected > 0 && received > expected) {
+            throw new FirmwareDownloadException(FirmwareDownloadException.CODE_VERIFY_FAILED,
+                    "MTK firmware exceeds manifest size");
+        }
+        if (received > AsgConstants.MTK_OTA_MAX_DOWNLOAD_BYTES) {
+            throw new FirmwareDownloadException(FirmwareDownloadException.CODE_FILE_TOO_LARGE,
+                    "MTK firmware exceeds maximum size");
         }
     }
 
@@ -2781,7 +2792,7 @@ public class OtaHelper {
                                      long totalBytes, String status, String errorMessage) {
 
         downloadBytes = "download".equals(stage) ? bytesDownloaded : 0;
-        updateSessionFromProgress(stage, progress, status, errorMessage);
+        updateSessionFromProgress(stage, progress, bytesDownloaded, status, errorMessage);
 
         if (phoneConnectionProvider == null || !isPhoneConnected()) {
             return;
@@ -2818,7 +2829,7 @@ public class OtaHelper {
         sendOtaStatus();
     }
 
-    private void updateSessionFromProgress(String stage, int progress, String status, String errorMessage) {
+    private void updateSessionFromProgress(String stage, int progress, long bytesDownloaded, String status, String errorMessage) {
         if (sessionManager == null || sessionManager.getSessionState() == null) return;
 
         int stepIndex = findStepIndex(currentUpdateType);
@@ -2849,6 +2860,9 @@ public class OtaHelper {
             }
         } else if ("FAILED".equals(status)) {
             sessionManager.setFailed(errorMessage != null ? errorMessage : "Update failed");
+        }
+        if ("download".equals(stage) && !"FAILED".equals(status)) {
+            sessionManager.updateDownloadProgress(progress, bytesDownloaded);
         }
     }
 
@@ -2975,10 +2989,6 @@ public class OtaHelper {
             // Phone bridge (MentraLive.java) reads all fields from the top level of the JSON
             // object, so we add "type" directly to sessionState rather than nesting it under "data".
             sessionState.put("type", "ota_status");
-            if ("download".equals(sessionState.optString("phase"))
-                    && currentUpdateType.equals(sessionState.optString("step_type"))) {
-                sessionState.put("bytes_downloaded", downloadBytes);
-            }
             if ("failed".equals(sessionState.optString("status"))) {
                 sessionState.put("glasses_time_ms", System.currentTimeMillis());
             }
@@ -3036,6 +3046,7 @@ public class OtaHelper {
             o.put("current_step", 1);
             o.put("step_type", currentUpdateType != null ? currentUpdateType : "apk");
             o.put("phase", lastOtaPhoneStage != null ? lastOtaPhoneStage : "download");
+            if ("download".equals(o.optString("phase"))) o.put("bytes_downloaded", downloadBytes);
             o.put("step_percent", lastOtaPhoneProgress);
             o.put("overall_percent", lastOtaPhoneProgress);
             String ev = lastOtaPhoneEventStatus;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/session/OtaSessionManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/session/OtaSessionManager.java
@@ -37,6 +37,8 @@ public class OtaSessionManager {
     private int mCurrentStepIndex;
     private String mCurrentPhase;
     private int mStepPercent;
+    // Live transfer state, deliberately not restored from disk after a process restart.
+    private long mDownloadBytes;
     private String mStatus;
     private String mErrorMessage;
     private String mVersionJsonUrl;
@@ -82,6 +84,7 @@ public class OtaSessionManager {
         mCurrentStepIndex = 0;
         mCurrentPhase = "download";
         mStepPercent = 0;
+        mDownloadBytes = 0;
         mStatus = "in_progress";
         mErrorMessage = null;
         mVersionJsonUrl = versionJsonUrl;
@@ -168,6 +171,7 @@ public class OtaSessionManager {
             state.put("st", getStepType(mCurrentStepIndex));
             state.put("sq", mStepSequence != null ? mStepSequence : new JSONArray());
             state.put("phase", mCurrentPhase);
+            if ("download".equals(mCurrentPhase)) state.put("bytes_downloaded", mDownloadBytes);
             state.put("sp", mStepPercent);
             state.put("op", computeOverallPercent());
             state.put("status", mStatus);
@@ -185,9 +189,17 @@ public class OtaSessionManager {
         mCurrentStepIndex = stepIndex;
         mCurrentPhase = phase;
         mStepPercent = 0;
+        mDownloadBytes = 0;
         mLastPersistedPercent = 0;
         mLastActivityAtElapsed = SystemClock.elapsedRealtime();
         persist();
+    }
+
+    /** Update live download evidence owned by the current session step. */
+    public synchronized void updateDownloadProgress(int stepPercent, long bytesDownloaded) {
+        if (!"download".equals(mCurrentPhase) || "complete".equals(mStatus) || "failed".equals(mStatus)) return;
+        mDownloadBytes = Math.max(0, bytesDownloaded);
+        updateProgress(stepPercent);
     }
 
     public synchronized void updateProgress(int stepPercent) {
@@ -333,6 +345,7 @@ public class OtaSessionManager {
     }
 
     public synchronized void clear() {
+        mDownloadBytes = 0;
         mSessionId = null;
         mTotalSteps = 0;
         mStepSequence = new JSONArray();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelector.java
@@ -22,7 +22,8 @@ public final class MtkOtaSelector {
             }
         }
         JSONObject full = manifest.optJSONObject("mtk_full_ota");
-        if (full == null || !isNewer(full.optString("end_firmware"), current)) return null;
+        if (full == null || !(full.opt("end_firmware") instanceof String)
+                || !isNewer((String) full.opt("end_firmware"), current)) return null;
         long size = full.optLong("size", 0);
         if (full.has("start_firmware")
                 || !(full.opt("size") instanceof Integer || full.opt("size") instanceof Long)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelector.java
@@ -1,0 +1,55 @@
+package com.mentra.asg_client.io.ota.utils;
+
+import com.mentra.asg_client.AsgConstants;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** One selection policy for MTK step planning, ordering, and installation. */
+public final class MtkOtaSelector {
+    private MtkOtaSelector() {}
+
+    /** Prefer an exact-base delta; a full OTA is eligible only for a known older version. */
+    public static JSONObject select(JSONObject manifest, String currentVersion) {
+        String current = normalize(currentVersion);
+        if (current.isEmpty()) return null;
+        JSONArray patches = manifest.optJSONArray("mtk_patches");
+        if (patches != null) {
+            for (int i = 0; i < patches.length(); i++) {
+                JSONObject patch = patches.optJSONObject(i);
+                if (patch != null && current.equals(normalize(patch.optString("start_firmware")))) {
+                    return patch;
+                }
+            }
+        }
+        JSONObject full = manifest.optJSONObject("mtk_full_ota");
+        if (full == null || !isNewer(full.optString("end_firmware"), current)) return null;
+        long size = full.optLong("size", 0);
+        if (full.has("start_firmware")
+                || !(full.opt("size") instanceof Integer || full.opt("size") instanceof Long)
+                || !full.optString("url").matches("https?://[^/\\s]+/.*")
+                || !full.optString("sha256").matches("[a-fA-F0-9]{64}")
+                || size <= 0 || size > AsgConstants.MTK_OTA_MAX_DOWNLOAD_BYTES) return null;
+        return full;
+    }
+
+    /** Compare date and numeric revision; legacy date-only versions have revision zero. */
+    public static boolean isNewer(String targetVersion, String currentVersion) {
+        String target = normalize(targetVersion);
+        String current = normalize(currentVersion);
+        if (!target.matches("[0-9]{8}(\\.[0-9]{1,9})?")
+                || !current.matches("[0-9]{8}(\\.[0-9]{1,9})?")) return false;
+        String[] targetParts = target.split("\\.");
+        String[] currentParts = current.split("\\.");
+        int dateComparison = targetParts[0].compareTo(currentParts[0]);
+        if (dateComparison != 0) return dateComparison > 0;
+        long targetRevision = targetParts.length == 2 ? Long.parseLong(targetParts[1]) : 0;
+        long currentRevision = currentParts.length == 2 ? Long.parseLong(currentParts[1]) : 0;
+        return targetRevision > currentRevision;
+    }
+
+    private static String normalize(String version) {
+        if (version == null) return "";
+        String trimmed = version.trim();
+        return trimmed.substring(trimmed.lastIndexOf('_') + 1);
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperMtkLifecycleTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperMtkLifecycleTest.java
@@ -13,6 +13,9 @@ import androidx.test.core.app.ApplicationProvider;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
 import com.mentra.asg_client.io.ota.receivers.MtkOtaReceiver;
 import com.mentra.asg_client.io.ota.utils.OtaConstants;
+import com.mentra.asg_client.io.ota.utils.FirmwareDownloadException;
+import com.mentra.asg_client.AsgConstants;
+import org.junit.Assert;
 import com.mentra.asg_client.service.system.core.SystemControllerFactory;
 import com.mentra.asg_client.service.system.interfaces.ISystemController;
 import java.lang.reflect.Method;
@@ -40,6 +43,7 @@ public class OtaHelperMtkLifecycleTest {
     }
 
     @After public void cleanup() {
+        if (helper != null) helper.getSessionManager().clear();
         if (helper != null) helper.cleanup();
         if (original != null) original.cleanup();
         OtaHelper.setMtkOtaInProgress(false);
@@ -85,5 +89,46 @@ public class OtaHelperMtkLifecycleTest {
         verify(phone, atLeast(3)).sendOtaStatus(status.capture());
         assertThat(status.getAllValues().stream().anyMatch(value -> value.optLong("bytes_downloaded") == 8192)).isTrue();
         assertThat(status.getValue().has("bytes_downloaded")).isFalse();
+    }
+
+    @Test public void activeSessionOwnsBytesAcrossQueriesStepsAndRetries() throws Exception {
+        createHelper();
+        helper.getSessionManager().createSession(new String[]{"apk", "mtk"}, "https://cdn/manifest.json");
+        Method report = OtaHelper.class.getDeclaredMethod("sendProgressToPhone", String.class, int.class,
+                long.class, long.class, String.class, String.class);
+        report.setAccessible(true);
+        report.invoke(helper, "download", 0, 8192L, 640341205L, "PROGRESS", null);
+        JSONObject snapshot = helper.getSessionManager().getSessionState();
+        assertThat(snapshot.getString("st")).isEqualTo("apk");
+        assertThat(snapshot.getLong("bytes_downloaded")).isEqualTo(8192);
+        Method phoneStatus = OtaHelper.class.getDeclaredMethod("buildOtaStatusForPhone");
+        phoneStatus.setAccessible(true);
+        assertThat(((JSONObject) phoneStatus.invoke(helper)).getLong("bytes_downloaded")).isEqualTo(8192);
+        helper.getSessionManager().advanceStep(1, "download");
+        assertThat(helper.getSessionManager().getSessionState().getLong("bytes_downloaded")).isZero();
+        helper.getSessionManager().updateDownloadProgress(1, 99999);
+        helper.getSessionManager().setFailed("test");
+        helper.getSessionManager().createSession(new String[]{"mtk"}, "https://cdn/manifest.json");
+        assertThat(helper.getSessionManager().getSessionState().getLong("bytes_downloaded")).isZero();
+        helper.getSessionManager().advanceStep(0, "install");
+        assertThat(helper.getSessionManager().getSessionState().has("bytes_downloaded")).isFalse();
+    }
+
+    @Test public void responseAndStreamBoundsFailBeforeOversizedWrites() throws Exception {
+        OtaHelper.validateMtkResponse(600, -1, 1200);
+        OtaHelper.validateMtkResponse(600, 600, 1200);
+        assertThat(Assert.assertThrows(FirmwareDownloadException.class,
+                () -> OtaHelper.validateMtkResponse(600, 700, 1200)).getErrorCode())
+                .isEqualTo(FirmwareDownloadException.CODE_VERIFY_FAILED);
+        assertThat(Assert.assertThrows(FirmwareDownloadException.class,
+                () -> OtaHelper.validateMtkResponse(600, 600, 1199)).getErrorCode())
+                .isEqualTo(AsgConstants.OTA_INSUFFICIENT_STORAGE);
+        OtaHelper.validateMtkReceivedBytes(600, 600);
+        assertThat(Assert.assertThrows(FirmwareDownloadException.class,
+                () -> OtaHelper.validateMtkReceivedBytes(600, 601)).getErrorCode())
+                .isEqualTo(FirmwareDownloadException.CODE_VERIFY_FAILED);
+        assertThat(Assert.assertThrows(FirmwareDownloadException.class,
+                () -> OtaHelper.validateMtkReceivedBytes(0, AsgConstants.MTK_OTA_MAX_DOWNLOAD_BYTES + 1)).getErrorCode())
+                .isEqualTo(FirmwareDownloadException.CODE_FILE_TOO_LARGE);
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperMtkLifecycleTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/helpers/OtaHelperMtkLifecycleTest.java
@@ -1,0 +1,89 @@
+package com.mentra.asg_client.io.ota.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Looper;
+import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.io.ota.interfaces.IBesOtaRegistry;
+import com.mentra.asg_client.io.ota.receivers.MtkOtaReceiver;
+import com.mentra.asg_client.io.ota.utils.OtaConstants;
+import com.mentra.asg_client.service.system.core.SystemControllerFactory;
+import com.mentra.asg_client.service.system.interfaces.ISystemController;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/** Regression tests for real transfer progress and system-updater ownership. */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class OtaHelperMtkLifecycleTest {
+    private OtaHelper original;
+    private OtaHelper helper;
+
+    private OtaHelper createHelper() {
+        original = new OtaHelper(ApplicationProvider.getApplicationContext(), mock(IBesOtaRegistry.class));
+        helper = spy(original);
+        return helper;
+    }
+
+    @After public void cleanup() {
+        if (helper != null) helper.cleanup();
+        if (original != null) original.cleanup();
+        OtaHelper.setMtkOtaInProgress(false);
+        OtaHelper.clearMtkSessionFlag();
+    }
+
+    @Test public void elapsedTimeCannotReleaseSystemInstallOrPermitReplacementDownload() throws Exception {
+        createHelper();
+        helper.setPhoneInitiatedOta(true);
+        doReturn(true).when(helper).downloadMtkFirmware(anyString(), any(), any());
+        ISystemController system = mock(ISystemController.class);
+        Context context = ApplicationProvider.getApplicationContext();
+        JSONObject firmware = new JSONObject().put("end_firmware", "20260908.0").put("url", "https://cdn/full.zip");
+        Method install = OtaHelper.class.getDeclaredMethod("checkAndUpdateMtkFirmware", JSONObject.class, Context.class);
+        install.setAccessible(true);
+        try (MockedStatic<SystemControllerFactory> factory = mockStatic(SystemControllerFactory.class)) {
+            factory.when(() -> SystemControllerFactory.get(any())).thenReturn(system);
+            assertThat(install.invoke(helper, firmware, context)).isEqualTo(true);
+            shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMinutes(11));
+            assertThat(OtaHelper.isMtkOtaInProgress()).isTrue();
+            assertThat(install.invoke(helper, firmware, context)).isEqualTo(false);
+            verify(helper, times(1)).downloadMtkFirmware(anyString(), any(), any());
+            verify(system, times(1)).installSystemOta(anyString());
+            new MtkOtaReceiver().onReceive(context, new Intent(OtaConstants.ACTION_MTK_UPDATE_RESULT)
+                    .putExtra("cmd", "success").putExtra("msg", "done"));
+            assertThat(OtaHelper.isMtkOtaInProgress()).isFalse();
+        }
+    }
+
+    @Test public void zeroPercentDownloadReportsRealBytesAndInstallDoesNotReuseThem() throws Exception {
+        createHelper();
+        OtaHelper.PhoneConnectionProvider phone = mock(OtaHelper.PhoneConnectionProvider.class);
+        when(phone.isPhoneConnected()).thenReturn(true);
+        helper.setPhoneConnectionProvider(phone);
+        Method report = OtaHelper.class.getDeclaredMethod("sendProgressToPhone", String.class, int.class,
+                long.class, long.class, String.class, String.class);
+        report.setAccessible(true);
+        report.invoke(helper, "download", 0, 0L, 640341205L, "STARTED", null);
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(3));
+        report.invoke(helper, "download", 0, 8192L, 640341205L, "PROGRESS", null);
+        report.invoke(helper, "install", 0, 0L, 0L, "STARTED", null);
+        ArgumentCaptor<JSONObject> status = ArgumentCaptor.forClass(JSONObject.class);
+        verify(phone, atLeast(3)).sendOtaStatus(status.capture());
+        assertThat(status.getAllValues().stream().anyMatch(value -> value.optLong("bytes_downloaded") == 8192)).isTrue();
+        assertThat(status.getValue().has("bytes_downloaded")).isFalse();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelectorTest.java
@@ -1,0 +1,43 @@
+package com.mentra.asg_client.io.ota.utils;
+
+import static org.junit.Assert.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class MtkOtaSelectorTest {
+    private JSONObject full() throws Exception {
+        return new JSONObject().put("end_firmware", "MentraLive_20260908.10")
+                .put("url", "https://cdn/full.zip").put("sha256", "a".repeat(64))
+                .put("size", 640341205);
+    }
+
+    @Test public void deltaWinsOtherwiseFullIsUpgradeOnly() throws Exception {
+        JSONObject full = full();
+        JSONObject delta = new JSONObject().put("start_firmware", "20260709")
+                .put("end_firmware", "20260908.10");
+        JSONObject manifest = new JSONObject().put("mtk_full_ota", full)
+                .put("mtk_patches", new JSONArray().put(delta));
+        assertSame(delta, MtkOtaSelector.select(manifest, "MentraLive_20260709"));
+        assertSame(full, MtkOtaSelector.select(manifest, "20260908.9"));
+        assertSame(full, MtkOtaSelector.select(manifest, "20260907.20"));
+        for (String current : new String[]{null, "", "unknown", "20260908.10", "20260908.11", "20260909"}) {
+            assertNull(MtkOtaSelector.select(manifest, current));
+        }
+        assertFalse(MtkOtaSelector.isNewer("20260908.0", "20260908"));
+    }
+
+    @Test public void fullOnlyAndMissingMetadataFailClosed() throws Exception {
+        JSONObject full = full();
+        JSONObject manifest = new JSONObject().put("mtk_full_ota", full);
+        assertSame(full, MtkOtaSelector.select(manifest, "20260709"));
+        for (String key : new String[]{"end_firmware", "url", "sha256", "size"}) {
+            JSONObject invalid = full();
+            invalid.remove(key);
+            assertNull(MtkOtaSelector.select(new JSONObject().put("mtk_full_ota", invalid), "20260709"));
+        }
+        full.put("size", 2L * 1024 * 1024 * 1024);
+        assertNull(MtkOtaSelector.select(manifest, "20260709"));
+        assertNull(MtkOtaSelector.select(new JSONObject(), "20260709"));
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/ota/utils/MtkOtaSelectorTest.java
@@ -28,6 +28,10 @@ public class MtkOtaSelectorTest {
     }
 
     @Test public void fullOnlyAndMissingMetadataFailClosed() throws Exception {
+        assertNull(MtkOtaSelector.select(new JSONObject().put("mtk_full_ota", full().put("end_firmware", 20260908)), "20260709"));
+        for (Object start : new Object[]{JSONObject.NULL, "20260709"}) {
+            assertNull(MtkOtaSelector.select(new JSONObject().put("mtk_full_ota", full().put("start_firmware", start)), "20260709"));
+        }
         JSONObject full = full();
         JSONObject manifest = new JSONObject().put("mtk_full_ota", full);
         assertSame(full, MtkOtaSelector.select(manifest, "20260709"));

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -162,6 +162,19 @@ must be refused.
 
 Update flows must preserve device recoverability, report progress where possible, and avoid interrupting active media operations without cleanup.
 
+MTK updates prefer an incremental patch whose start version matches the glasses.
+If no patch matches, a pinned `mtk_full_ota` can update a known older firmware
+directly. Full fallback requires a valid target version, URL, SHA-256, and size;
+unknown, equal, or newer installed versions do not qualify. A failed incremental
+does not silently switch to a full image. Both paths use the existing user-approved
+installation and Android compatibility checks; full OTAs do not enable rollback
+or request a userdata wipe. Release manifests pin the full artifact, including
+when the phone downloads and serves it over the glasses hotspot.
+Glasses reuse `asg/mtk_firmware.zip` rather than retaining one file per release.
+MTK downloads are capped at 1 GiB and reserve room for the ZIP plus payload
+before downloading when the artifact size is known. Historical development
+packages and post-install space reclamation are separate from this fallback.
+
 The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. At startup, `asg_client` retries discovery at 460800 before making one bounded probe at 1152000, then returns to 460800 if neither rate answers. The alternate probe does not depend on app-local cached state, so an APK reinstall can recover a BES that survived at the negotiated rate. Once traffic confirms a negotiated 1152000 link, BES keeps that baud across UART driver restarts and Android sleep; ordinary phone heartbeats and expected MTK sleep silence must not return one endpoint to 460800. If an older BES nevertheless falls back or reboots while ASG remains alive, several small unframed reads or an idle-link health probe cause `asg_client` to verify 1152000, probe 460800, and renegotiate the fast link after finding BES at the rendezvous rate. If neither rate answers, ASG remains at 460800 and retries the two-rate scan with capped exponential backoff so a later BES boot cannot leave the endpoints split indefinitely. Each scan is bounded and recovery is suppressed during BES OTA, file transfer, and active baud transitions. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.
 
 ### Diagnostics and reporting

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -174,6 +174,12 @@ Glasses reuse `asg/mtk_firmware.zip` rather than retaining one file per release.
 MTK downloads are capped at 1 GiB and reserve room for the ZIP plus payload
 before downloading when the artifact size is known. Historical development
 packages and post-install space reclamation are separate from this fallback.
+Download liveness uses actual received bytes, not just rounded percentages;
+repeated status replies do not count as transfer progress. A phone timeout does
+not release an active MTK system install: ASG retains ownership until the system
+updater reports a terminal result (or the process/device restarts), preventing a
+retry from replacing its staged ZIP. Release packaging checks declared full-OTA
+size against the same bytes whose SHA-256 is verified.
 
 The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. At startup, `asg_client` retries discovery at 460800 before making one bounded probe at 1152000, then returns to 460800 if neither rate answers. The alternate probe does not depend on app-local cached state, so an APK reinstall can recover a BES that survived at the negotiated rate. Once traffic confirms a negotiated 1152000 link, BES keeps that baud across UART driver restarts and Android sleep; ordinary phone heartbeats and expected MTK sleep silence must not return one endpoint to 460800. If an older BES nevertheless falls back or reboots while ASG remains alive, several small unframed reads or an idle-link health probe cause `asg_client` to verify 1152000, probe 460800, and renegotiate the fast link after finding BES at the rendezvous rate. If neither rate answers, ASG remains at 460800 and retries the two-rate scan with capped exponential backoff so a later BES boot cannot leave the endpoints split indefinitely. Each scan is bounded and recovery is suppressed during BES OTA, file transfer, and active baud transitions. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.
 

--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -57,8 +57,8 @@
     "size": 640341205
   },
   "bes_firmware": {
-    "version": "26.9.4.1",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.4.1.bin",
-    "sha256": "793993cbec5cbaa6049efe9e91f84ffaeddfc83b27251bfa33411ede1e7c2fc5"
+    "version": "26.9.7.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.7.0.bin",
+    "sha256": "f3e8874164dd1fee06eaaacb60dfdf5caaabfd771e4d7b15ae7bb0c08c121995"
   }
 }

--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -1,6 +1,13 @@
 {
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260709",
+      "end_firmware": "MentraLive_20260908.0",
+      "url": "https://mtkfirmware.mentraglass.com/mtk_ota_update_20260709_20260908.0.zip",
+      "sha256": "4bc84c93080686751a7ab0d177af7a9d549b1e443ce2572a67c105869581f804",
+      "size": 34578024
+    },
+    {
       "start_firmware": "MentraLive_20260113",
       "end_firmware": "MentraLive_20260709",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
@@ -43,6 +50,12 @@
       "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
     }
   ],
+  "mtk_full_ota": {
+    "end_firmware": "MentraLive_20260908.0",
+    "url": "https://mtkfirmware.mentraglass.com/mtk_ota_full_20260908.0.zip",
+    "sha256": "4b27d8fbb843b3cb55e3f03e6cea4e5400149a3ef1b963b6c6f3ba32466b6676",
+    "size": 640341205
+  },
   "bes_firmware": {
     "version": "26.9.4.1",
     "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.9.4.1.bin",

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -717,6 +717,7 @@ public class Bridge private constructor() {
                 status: String,
                 errorMessage: String? = null,
                 glassesTimeMs: Long? = null,
+                bytesDownloaded: Long? = null,
         ) {
             val eventBody = HashMap<String, Any>()
             eventBody["session_id"] = sessionId
@@ -727,6 +728,7 @@ public class Bridge private constructor() {
             eventBody["step_percent"] = stepPercent
             eventBody["overall_percent"] = overallPercent
             eventBody["status"] = status
+            bytesDownloaded?.let { eventBody["bytes_downloaded"] = it }
             errorMessage?.let { eventBody["error_message"] = it }
             if (glassesTimeMs != null && glassesTimeMs > 0) {
                 eventBody["glasses_time_ms"] = glassesTimeMs

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
@@ -158,7 +158,7 @@ internal object OtaManifestChecker {
             if (startFirmware.trim().substringAfterLast('_') == current) return true
         }
         val full = manifest.optJSONObject("mtk_full_ota") ?: return false
-        val target = full.optString("end_firmware", "").trim().substringAfterLast('_')
+        val target = (full.opt("end_firmware") as? String)?.trim()?.substringAfterLast('_') ?: return false
         val pattern = Regex("[0-9]{8}(\\.[0-9]{1,9})?")
         if (!pattern.matches(current) || !pattern.matches(target)) return false
         val currentParts = current.split('.').map { it.toLong() }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
@@ -3,7 +3,6 @@ package com.mentra.bluetoothsdk
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
-import org.json.JSONArray
 import org.json.JSONObject
 
 internal object OtaManifestDefaults {
@@ -80,11 +79,11 @@ internal object OtaManifestChecker {
         downgradeFloorVersionCode: Long = 0L,
     ): Boolean =
         hasApkUpdate(currentBuildNumber, manifest, downgradeFloorVersionCode) ||
-            hasMtkUpdate(manifest.optJSONArray("mtk_patches"), currentMtkVersion) ||
+            hasMtkUpdate(manifest, currentMtkVersion) ||
             hasBesUpdate(manifest.optJSONObject("bes_firmware"), currentBesVersion)
 
     fun hasMtkPatches(manifest: JSONObject): Boolean =
-        (manifest.optJSONArray("mtk_patches")?.length() ?: 0) > 0
+        (manifest.optJSONArray("mtk_patches")?.length() ?: 0) > 0 || manifest.optJSONObject("mtk_full_ota") != null
 
     fun hasBesFirmware(manifest: JSONObject): Boolean =
         manifest.optJSONObject("bes_firmware") != null
@@ -149,18 +148,28 @@ internal object OtaManifestChecker {
         return downgradeFloorVersionCode > 0 && serverVersion >= downgradeFloorVersionCode
     }
 
-    private fun hasMtkUpdate(patches: JSONArray?, currentVersion: String): Boolean {
-        if (patches == null || patches.length() == 0) return false
+    private fun hasMtkUpdate(manifest: JSONObject, currentVersion: String): Boolean {
         if (currentVersion.isBlank()) return false
-
-        for (index in 0 until patches.length()) {
-            val patch = patches.optJSONObject(index) ?: continue
+        val current = currentVersion.trim().substringAfterLast('_')
+        val patches = manifest.optJSONArray("mtk_patches")
+        for (index in 0 until (patches?.length() ?: 0)) {
+            val patch = patches?.optJSONObject(index) ?: continue
             val startFirmware = patch.optString("start_firmware", "")
-            if (startFirmware == currentVersion) return true
-            val serverDate = if (startFirmware.contains("_")) startFirmware.substringAfterLast("_") else startFirmware
-            if (serverDate == currentVersion) return true
+            if (startFirmware.trim().substringAfterLast('_') == current) return true
         }
-        return false
+        val full = manifest.optJSONObject("mtk_full_ota") ?: return false
+        val target = full.optString("end_firmware", "").trim().substringAfterLast('_')
+        val pattern = Regex("[0-9]{8}(\\.[0-9]{1,9})?")
+        if (!pattern.matches(current) || !pattern.matches(target)) return false
+        val currentParts = current.split('.').map { it.toLong() }
+        val targetParts = target.split('.').map { it.toLong() }
+        val newer = targetParts[0] > currentParts[0] ||
+            (targetParts[0] == currentParts[0] && targetParts.getOrElse(1) { 0 } > currentParts.getOrElse(1) { 0 })
+        return newer && !full.has("start_firmware") &&
+            Regex("https?://[^/\\s]+/.*").matches(full.optString("url", "")) &&
+            Regex("[a-fA-F0-9]{64}").matches(full.optString("sha256", "")) &&
+            (full.opt("size") is Int || full.opt("size") is Long) &&
+            full.optLong("size", 0) in 1..(1024L * 1024 * 1024)
     }
 
     private fun hasBesUpdate(besFirmware: JSONObject?, currentVersion: String): Boolean {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -4047,7 +4047,8 @@ class MentraLive : SGCManager() {
                         osOverallPercent,
                         osStatus,
                         osErrorMessage,
-                        if (glassesTimeMs > 0) glassesTimeMs else null
+                        if (glassesTimeMs > 0) glassesTimeMs else null,
+                        if (json.has("bytes_downloaded")) json.optLong("bytes_downloaded", 0) else null
                 )
             }
             "ota_progress" -> {

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/OtaManifestFullOtaTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/OtaManifestFullOtaTest.kt
@@ -1,0 +1,47 @@
+package com.mentra.bluetoothsdk
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class OtaManifestFullOtaTest {
+    private fun full(): JSONObject = JSONObject()
+        .put("end_firmware", "MentraLive_20260908.10")
+        .put("url", "https://cdn/full.zip").put("sha256", "a".repeat(64)).put("size", 640341205)
+
+    private fun hasUpdate(manifest: JSONObject, current: String): Boolean =
+        OtaManifestChecker.hasUpdate("38", current, "", manifest.put("versionCode", 38))
+
+    @Test fun fullIsUpgradeOnlyWithNumericRevisionComparison() {
+        val manifest = JSONObject().put("mtk_full_ota", full())
+        assertTrue(OtaManifestChecker.hasMtkPatches(manifest))
+        for (current in listOf("20260709", "MentraLive_20260908.9", "20260907.20")) {
+            assertTrue(current, hasUpdate(manifest, current))
+        }
+        for (current in listOf("", "unknown", "20260908.10", "20260908.11", "20260909")) {
+            assertFalse(current, hasUpdate(manifest, current))
+        }
+        manifest.put("mtk_full_ota", full().put("end_firmware", "20260908.0"))
+        assertFalse(hasUpdate(manifest, "20260908"))
+    }
+
+    @Test fun deltaRemainsAvailableAndFullNeedsMetadata() {
+        val delta = JSONObject().put("start_firmware", "20260709")
+        assertTrue(hasUpdate(JSONObject().put("mtk_patches", JSONArray().put(delta)), "MentraLive_20260709"))
+        assertFalse(hasUpdate(JSONObject(), "20260709"))
+        for (key in listOf("end_firmware", "url", "sha256", "size")) {
+            val invalid = full().apply { remove(key) }
+            assertFalse(key, hasUpdate(JSONObject().put("mtk_full_ota", invalid), "20260709"))
+        }
+        for (size in listOf(2147483648L, "640341205", 1.5)) {
+            assertFalse(hasUpdate(JSONObject().put("mtk_full_ota", full().put("size", size)), "20260709"))
+        }
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/OtaManifestFullOtaTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/OtaManifestFullOtaTest.kt
@@ -33,6 +33,10 @@ class OtaManifestFullOtaTest {
     }
 
     @Test fun deltaRemainsAvailableAndFullNeedsMetadata() {
+        assertFalse(hasUpdate(JSONObject().put("mtk_full_ota", full().put("end_firmware", 20260908)), "20260709"))
+        for (start in listOf(JSONObject.NULL, "20260709")) {
+            assertFalse(hasUpdate(JSONObject().put("mtk_full_ota", full().put("start_firmware", start)), "20260709"))
+        }
         val delta = JSONObject().put("start_firmware", "20260709")
         assertTrue(hasUpdate(JSONObject().put("mtk_patches", JSONArray().put(delta)), "MentraLive_20260709"))
         assertFalse(hasUpdate(JSONObject(), "20260709"))

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -566,7 +566,8 @@ class Bridge {
         overallPercent: Int,
         status: String,
         errorMessage: String?,
-        glassesTimeMs: Int64? = nil
+        glassesTimeMs: Int64? = nil,
+        bytesDownloaded: Int64? = nil
     ) {
         var eventBody: [String: Any] = [
             "session_id": sessionId,
@@ -583,6 +584,9 @@ class Bridge {
         }
         if let glassesTimeMs, glassesTimeMs > 0 {
             eventBody["glasses_time_ms"] = glassesTimeMs
+        }
+        if let bytesDownloaded {
+            eventBody["bytes_downloaded"] = bytesDownloaded
         }
         Bridge.sendTypedMessage("ota_status", body: eventBody)
     }
@@ -660,6 +664,5 @@ class Bridge {
         return payload
     }
 }
-
 
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
@@ -35,7 +35,7 @@ struct BesFirmware: Decodable {
 
 struct MtkFullOta: Decodable {
     let endFirmware: String?
-    let startFirmware: String?
+    let hasStartFirmware: Bool
     let url: String?
     let sha256: String?
     let size: Int64?
@@ -44,6 +44,15 @@ struct MtkFullOta: Decodable {
         case endFirmware = "end_firmware"
         case startFirmware = "start_firmware"
         case url, sha256, size
+    }
+
+    init(from decoder: Decoder) throws {
+        let fields = try decoder.container(keyedBy: CodingKeys.self)
+        hasStartFirmware = fields.contains(.startFirmware)
+        endFirmware = try fields.decodeIfPresent(String.self, forKey: .endFirmware)
+        url = try fields.decodeIfPresent(String.self, forKey: .url)
+        sha256 = try fields.decodeIfPresent(String.self, forKey: .sha256)
+        size = try fields.decodeIfPresent(Int64.self, forKey: .size)
     }
 }
 
@@ -198,7 +207,7 @@ enum OtaManifestChecker {
         let pattern = "^[0-9]{8}(\\.[0-9]{1,9})?$"
         guard current.range(of: pattern, options: .regularExpression) != nil,
               target.range(of: pattern, options: .regularExpression) != nil,
-              full.startFirmware == nil,
+              !full.hasStartFirmware,
               let url = full.url, url.range(of: "^https?://[^/\\s]+/.*$", options: .regularExpression) != nil,
               let hash = full.sha256, hash.range(of: "^[a-fA-F0-9]{64}$", options: .regularExpression) != nil,
               let size = full.size, size > 0, size <= 1024 * 1024 * 1024

--- a/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
@@ -33,15 +33,31 @@ struct BesFirmware: Decodable {
     let version: String?
 }
 
+struct MtkFullOta: Decodable {
+    let endFirmware: String?
+    let startFirmware: String?
+    let url: String?
+    let sha256: String?
+    let size: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case endFirmware = "end_firmware"
+        case startFirmware = "start_firmware"
+        case url, sha256, size
+    }
+}
+
 struct OtaManifest: Decodable {
     let apps: [String: OtaManifestApp]?
     let mtkPatches: [MtkPatch]?
+    let mtkFullOta: MtkFullOta?
     let besFirmware: BesFirmware?
     let versionCode: Int?
 
     enum CodingKeys: String, CodingKey {
         case apps
         case mtkPatches = "mtk_patches"
+        case mtkFullOta = "mtk_full_ota"
         case besFirmware = "bes_firmware"
         case versionCode
     }
@@ -101,12 +117,12 @@ enum OtaManifestChecker {
             manifest: manifest,
             downgradeFloorVersionCode: downgradeFloorVersionCode
         ) ||
-            hasMtkUpdate(patches: manifest.mtkPatches, currentVersion: currentMtkVersion) ||
+            hasMtkUpdate(patches: manifest.mtkPatches, full: manifest.mtkFullOta, currentVersion: currentMtkVersion) ||
             hasBesUpdate(besFirmware: manifest.besFirmware, currentVersion: currentBesVersion)
     }
 
     static func hasMtkPatches(_ manifest: OtaManifest) -> Bool {
-        !(manifest.mtkPatches?.isEmpty ?? true)
+        !(manifest.mtkPatches?.isEmpty ?? true) || manifest.mtkFullOta != nil
     }
 
     static func hasBesFirmware(_ manifest: OtaManifest) -> Bool {
@@ -170,19 +186,29 @@ enum OtaManifestChecker {
         return downgradeFloorVersionCode > 0 && serverVersion >= downgradeFloorVersionCode
     }
 
-    private static func hasMtkUpdate(patches: [MtkPatch]?, currentVersion: String) throws -> Bool {
-        guard let patches, !patches.isEmpty else { return false }
-        guard !currentVersion.isEmpty else { return false }
-
-        return patches.contains { patch in
-            if patch.startFirmware == currentVersion {
-                return true
-            }
-            let serverDate = patch.startFirmware.contains("_")
-                ? String(patch.startFirmware.split(separator: "_").last ?? "")
-                : patch.startFirmware
-            return serverDate == currentVersion
+    private static func hasMtkUpdate(patches: [MtkPatch]?, full: MtkFullOta?, currentVersion: String) -> Bool {
+        func normalize(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "_").last ?? ""
         }
+        let current = normalize(currentVersion)
+        guard !current.isEmpty else { return false }
+        if (patches ?? []).contains(where: { normalize($0.startFirmware) == current }) { return true }
+        guard let full, let endFirmware = full.endFirmware else { return false }
+        let target = normalize(endFirmware)
+        let pattern = "^[0-9]{8}(\\.[0-9]{1,9})?$"
+        guard current.range(of: pattern, options: .regularExpression) != nil,
+              target.range(of: pattern, options: .regularExpression) != nil,
+              full.startFirmware == nil,
+              let url = full.url, url.range(of: "^https?://[^/\\s]+/.*$", options: .regularExpression) != nil,
+              let hash = full.sha256, hash.range(of: "^[a-fA-F0-9]{64}$", options: .regularExpression) != nil,
+              let size = full.size, size > 0, size <= 1024 * 1024 * 1024
+        else { return false }
+        let currentParts = current.split(separator: ".").compactMap { Int64($0) }
+        let targetParts = target.split(separator: ".").compactMap { Int64($0) }
+        let currentRevision = currentParts.count == 2 ? currentParts[1] : 0
+        let targetRevision = targetParts.count == 2 ? targetParts[1] : 0
+        return targetParts[0] > currentParts[0] ||
+            (targetParts[0] == currentParts[0] && targetRevision > currentRevision)
     }
 
     private static func hasBesUpdate(besFirmware: BesFirmware?, currentVersion: String) throws -> Bool {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -3026,7 +3026,8 @@ class MentraLive: NSObject, SGCManager {
                 overallPercent: osOverallPercent,
                 status: osStatus,
                 errorMessage: osErrorMessage,
-                glassesTimeMs: glassesTimeMs > 0 ? glassesTimeMs : nil
+                glassesTimeMs: glassesTimeMs > 0 ? glassesTimeMs : nil,
+                bytesDownloaded: (json["bytes_downloaded"] as? NSNumber)?.int64Value
             )
 
         case "ota_progress":

--- a/mobile/modules/bluetooth-sdk/ios/Tests/OtaManifestTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/OtaManifestTests.swift
@@ -33,6 +33,14 @@ final class OtaManifestTests: XCTestCase {
     }
 
     func testDeltaRemainsAvailableAndFullNeedsMetadata() throws {
+        for start in [NSNull(), "20260709"] as [Any] {
+            var invalid = full
+            invalid["start_firmware"] = start
+            XCTAssertFalse(try hasUpdate(manifest(invalid), "20260709"))
+        }
+        var numericTarget = full
+        numericTarget["end_firmware"] = 20_260_908
+        XCTAssertThrowsError(try manifest(numericTarget))
         XCTAssertTrue(try hasUpdate(manifest(patches: [["start_firmware": "20260709"]]), "MentraLive_20260709"))
         XCTAssertFalse(try hasUpdate(manifest(), "20260709"))
         for key in ["end_firmware", "url", "sha256", "size"] {

--- a/mobile/modules/bluetooth-sdk/ios/Tests/OtaManifestTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/OtaManifestTests.swift
@@ -1,0 +1,47 @@
+@testable import MentraBluetoothSDK
+import XCTest
+
+final class OtaManifestTests: XCTestCase {
+    private func manifest(_ full: [String: Any]? = nil, patches: [[String: String]] = []) throws -> OtaManifest {
+        var json: [String: Any] = ["mtk_patches": patches, "versionCode": 38]
+        if let full { json["mtk_full_ota"] = full }
+        return try JSONDecoder().decode(OtaManifest.self, from: JSONSerialization.data(withJSONObject: json))
+    }
+
+    private var full: [String: Any] {
+        ["end_firmware": "MentraLive_20260908.10", "url": "https://cdn/full.zip",
+         "sha256": String(repeating: "a", count: 64), "size": 640_341_205]
+    }
+
+    private func hasUpdate(_ manifest: OtaManifest, _ current: String) throws -> Bool {
+        try OtaManifestChecker.hasUpdate(currentBuildNumber: "38", currentMtkVersion: current,
+                                         currentBesVersion: "", manifest: manifest)
+    }
+
+    func testFullIsUpgradeOnlyWithNumericRevisionComparison() throws {
+        let value = try manifest(full)
+        XCTAssertTrue(OtaManifestChecker.hasMtkPatches(value))
+        for current in ["20260709", "MentraLive_20260908.9", "20260907.20"] {
+            XCTAssertTrue(try hasUpdate(value, current), current)
+        }
+        for current in ["", "unknown", "20260908.10", "20260908.11", "20260909"] {
+            XCTAssertFalse(try hasUpdate(value, current), current)
+        }
+        var zero = full
+        zero["end_firmware"] = "20260908.0"
+        XCTAssertFalse(try hasUpdate(manifest(zero), "20260908"))
+    }
+
+    func testDeltaRemainsAvailableAndFullNeedsMetadata() throws {
+        XCTAssertTrue(try hasUpdate(manifest(patches: [["start_firmware": "20260709"]]), "MentraLive_20260709"))
+        XCTAssertFalse(try hasUpdate(manifest(), "20260709"))
+        for key in ["end_firmware", "url", "sha256", "size"] {
+            var invalid = full
+            invalid.removeValue(forKey: key)
+            XCTAssertFalse(try hasUpdate(manifest(invalid), "20260709"), key)
+        }
+        var invalid = full
+        invalid["size"] = 2_147_483_648 as Int64
+        XCTAssertFalse(try hasUpdate(manifest(invalid), "20260709"))
+    }
+}

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -884,6 +884,8 @@ export type OtaStatusEvent = {
   step_type: "apk" | "mtk" | "bes"
   phase: "download" | "install"
   step_percent: number
+  /** Real bytes received in the current download; absent on older glasses. */
+  bytes_downloaded?: number
   overall_percent: number
   status: "in_progress" | "step_complete" | "complete" | "failed" | "idle"
   error_message?: string
@@ -1283,6 +1285,8 @@ export interface OtaStatus {
   stepType: "apk" | "mtk" | "bes"
   phase: "download" | "install"
   stepPercent: number
+  /** Real bytes received in the current download; independent of rounded percent. */
+  bytesDownloaded?: number
   overallPercent: number
   status: "in_progress" | "step_complete" | "complete" | "failed" | "idle"
   error?: string

--- a/mobile/modules/engine/src/services/OtaArtifactDownloader.ts
+++ b/mobile/modules/engine/src/services/OtaArtifactDownloader.ts
@@ -89,9 +89,10 @@ export function planArtifacts(result: OtaCheckCurrentGlassesResult): OtaArtifact
   }
 
   if (result.updates.includes("mtk") && result.mtkPatch) {
-    const raw = (manifest.mtk_patches ?? []).find(
-      (patch) => firmwareUrl(patch) === firmwareUrl(result.mtkPatch!),
-    ) as unknown as Record<string, unknown> | undefined
+    const candidates = [...(manifest.mtk_patches ?? []), ...(manifest.mtk_full_ota ? [manifest.mtk_full_ota] : [])]
+    const raw = candidates.find((entry) => firmwareUrl(entry) === firmwareUrl(result.mtkPatch!)) as unknown as
+      | Record<string, unknown>
+      | undefined
     const url = firmwareUrl(raw) ?? firmwareUrl(result.mtkPatch)
     if (!url) {
       throw new OtaArtifactError("manifest_invalid", "Manifest has no URL for the pending MTK patch")
@@ -238,6 +239,9 @@ export function rewriteManifestForLocalServer(
 
   for (const patch of manifest.mtk_patches ?? []) {
     rewriteFirmwareEntry(patch as unknown as Record<string, unknown>, byUrl, localUrl)
+  }
+  if (manifest.mtk_full_ota) {
+    rewriteFirmwareEntry(manifest.mtk_full_ota as unknown as Record<string, unknown>, byUrl, localUrl)
   }
   if (manifest.bes_firmware) {
     rewriteFirmwareEntry(manifest.bes_firmware as unknown as Record<string, unknown>, byUrl, localUrl)

--- a/mobile/modules/engine/src/services/OtaErrorMapping.ts
+++ b/mobile/modules/engine/src/services/OtaErrorMapping.ts
@@ -28,6 +28,9 @@ export function shouldShowChangeWifiForOtaDownloadFailure(
   otaProgress: OtaProgress | null | undefined,
   localErrorMessage: string,
 ): boolean {
+  if (otaStatus?.error === "insufficient_storage" || otaProgress?.errorMessage === "insufficient_storage") {
+    return false
+  }
   if (otaStatus?.status === "failed" && otaStatus.phase === "download") {
     return true
   }
@@ -50,6 +53,8 @@ export function getOtaErrorMessage(error?: string): string {
       return "Secure connection failed — try a different WiFi network"
     case "download_failed":
       return "Download failed — check glasses WiFi connection"
+    case "insufficient_storage":
+      return "Not enough storage on your glasses — free up space before trying again"
     case "firmware_too_large":
       return "Firmware file is unexpectedly large — please contact support"
     case "firmware_verify_failed":

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -261,7 +261,7 @@ class OtaInstallCoordinator {
   // command as permission to start a second OTA transaction.
   private otaStartOwnership: OtaStartOwnership | null = null
   private hasFirstActivity = false
-  // Stuck-at-zero watchdog clears only on first NON-ZERO progress; "first activity"
+  // Stuck-at-zero watchdog clears only on real byte/percent progress; "first activity"
   // alone (e.g. ota_status with stepPercent=0) used to clear it too eagerly.
   private hasFirstNonZeroProgress = false
   private retryCount = 0
@@ -276,6 +276,8 @@ class OtaInstallCoordinator {
   private lastBuildNumber = ""
   private lastDisplayState: DisplayState | null = null
   private lastStallSig = ""
+  private downloadStepKey = ""
+  private downloadByteHighWater = 0
 
   // Reaction pass re-entrancy guard (mirrors React deferring a setState-during-
   // effects re-render until the current effect batch finished).
@@ -586,6 +588,8 @@ class OtaInstallCoordinator {
     this.lastBuildNumber = ""
     this.lastDisplayState = null
     this.lastStallSig = ""
+    this.downloadStepKey = ""
+    this.downloadByteHighWater = 0
     this.reactQueued = false
   }
 
@@ -596,6 +600,8 @@ class OtaInstallCoordinator {
       return false
     }
     this.otaStartOwnership = null
+    this.downloadStepKey = ""
+    this.downloadByteHighWater = 0
     this.hasFirstActivity = false
     this.hasFirstNonZeroProgress = false
     this.setApkCompletedViaBuildIncrease(false)
@@ -752,6 +758,18 @@ class OtaInstallCoordinator {
       versionChangeSession: this.versionChangeSession,
     })
     const stallSig = buildProgressStalenessSignature(otaStatus, otaProgress, displayState)
+    // Percent is a UI projection, not transfer liveness. Repeated status replies (including
+    // older replies without bytes) must not keep a stalled download alive.
+    const downloadKey =
+      otaStatus?.phase === "download" ? `${otaStatus.sessionId}|${otaStatus.currentStep}|${otaStatus.stepType}` : ""
+    if (downloadKey !== this.downloadStepKey) {
+      this.downloadStepKey = downloadKey
+      this.downloadByteHighWater = 0
+    }
+    const receivedBytes = otaStatus?.bytesDownloaded ?? 0
+    const downloadAdvanced =
+      downloadKey !== "" && Number.isSafeInteger(receivedBytes) && receivedBytes > this.downloadByteHighWater
+    if (downloadAdvanced) this.downloadByteHighWater = receivedBytes
     const stallDuration = progressTimeoutDurationMs(otaStatus, otaProgress, legacySession)
 
     const displayStateChanged = isMount || displayState !== this.lastDisplayState
@@ -962,7 +980,7 @@ class OtaInstallCoordinator {
       this.onFirstActivity()
     }
 
-    // The stuck-at-zero watchdog clears only on the FIRST real (>0%) progress.
+    // The stuck-at-zero watchdog clears only on real byte or percent progress.
     // Without this distinction, an ota_status reply with stepPercent=0 would
     // disable the watchdog before any download had actually started, hiding
     // wedged downloads from the user.
@@ -970,7 +988,7 @@ class OtaInstallCoordinator {
       const stepPct = otaStatus?.stepPercent ?? 0
       const overallPct = otaStatus?.overallPercent ?? 0
       const legacyPct = otaProgress?.progress ?? 0
-      if (stepPct > 0 || overallPct > 0 || legacyPct > 0) {
+      if (downloadAdvanced || stepPct > 0 || overallPct > 0 || legacyPct > 0) {
         this.onFirstNonZeroProgress()
       }
     }
@@ -979,7 +997,7 @@ class OtaInstallCoordinator {
     // Keyed on the staleness SIGNATURE string (not the object refs) so a store
     // update that doesn't change the signature keeps the same timer running
     // instead of forever re-extending the deadline.
-    if (stallSigChanged || displayStateChanged) {
+    if (stallSigChanged || displayStateChanged || downloadAdvanced) {
       if (this.isInVersionChangeDetour()) {
         // Recovery worker owns the transaction; there are no progress events to stall on.
         this.clearProgressTimeout()
@@ -1372,7 +1390,7 @@ class OtaInstallCoordinator {
   /**
    * "Glasses are talking to us" — suppresses retry if the native request later rejects.
    * Important: this does NOT clear the stuck-at-zero watchdog; that one fires
-   * on real progress > 0% (see {@link onFirstNonZeroProgress}).
+   * on real byte/percent progress (see {@link onFirstNonZeroProgress}).
    */
   private onFirstActivity(): void {
     if (this.hasFirstActivity) return
@@ -1385,10 +1403,8 @@ class OtaInstallCoordinator {
 
   /**
    * "Real download progress arrived" — clears the stuck-at-zero watchdog. We
-   * deliberately wait for non-zero progress before clearing this so that an
-   * ota_status reply with stepPercent: 0 (which is "first activity" but not
-   * "real progress") doesn't disable the only watchdog that catches a wedged
-   * download.
+   * require advancing bytes or non-zero percent, so an ordinary status reply
+   * cannot disable the watchdog that catches a wedged download.
    */
   private onFirstNonZeroProgress(): void {
     if (this.hasFirstNonZeroProgress) return

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -32,6 +32,16 @@ export interface MtkPatch {
   sha256?: string
 }
 
+export interface MtkFullOta {
+  start_firmware?: never
+  end_firmware: string
+  url: string
+  sha256: string
+  size: number
+}
+
+export type MtkUpdate = MtkPatch | MtkFullOta
+
 export interface BesFirmware {
   version: string
   url: string
@@ -44,6 +54,7 @@ export interface VersionJson {
     [packageName: string]: VersionInfo
   }
   mtk_patches?: MtkPatch[]
+  mtk_full_ota?: MtkFullOta
   bes_firmware?: BesFirmware
   versionCode?: number
   versionName?: string
@@ -58,7 +69,8 @@ export interface OtaCheckResult {
   updateAvailable: boolean
   latestVersionInfo: VersionInfo | null
   updates: string[]
-  mtkPatch: MtkPatch | null
+  /** Selected MTK artifact: exact-base incremental, otherwise a newer full OTA. */
+  mtkPatch: MtkUpdate | null
   besVersion: string | null
   /** True when the pending APK step installs an OLDER build than the glasses currently run. */
   isApkDowngrade: boolean
@@ -254,15 +266,43 @@ export function findMatchingMtkPatch(
 
   return (
     patches.find((patch) => {
-      if (patch.start_firmware === currentVersion) {
-        return true
-      }
-      const serverDate = patch.start_firmware.includes("_")
-        ? patch.start_firmware.split("_").pop()
-        : patch.start_firmware
-      return serverDate === currentVersion
+      return normalizeMtkVersion(patch.start_firmware) === normalizeMtkVersion(currentVersion)
     }) || null
   )
+}
+
+function normalizeMtkVersion(version: string): string {
+  return version.trim().split("_").pop() ?? ""
+}
+
+/** Full OTAs are not rollback packages. Unknown versions must not grant eligibility. */
+export function selectMtkUpdate(
+  manifest: VersionJson | undefined,
+  currentVersion: string | undefined,
+): MtkUpdate | null {
+  const patch = findMatchingMtkPatch(manifest?.mtk_patches, currentVersion)
+  if (patch) return patch
+  const full = manifest?.mtk_full_ota
+  if (!full || !currentVersion || typeof full.end_firmware !== "string") return null
+  const current = normalizeMtkVersion(currentVersion)
+  const target = normalizeMtkVersion(full.end_firmware)
+  const versionPattern = /^\d{8}(?:\.\d{1,9})?$/
+  if (!versionPattern.test(current) || !versionPattern.test(target)) return null
+  const [currentDate, currentRevision = 0] = current.split(".").map(Number)
+  const [targetDate, targetRevision = 0] = target.split(".").map(Number)
+  if (targetDate < currentDate || (targetDate === currentDate && targetRevision <= currentRevision)) return null
+  if (
+    full.start_firmware !== undefined ||
+    typeof full.url !== "string" ||
+    !/^https?:\/\/[^/\s]+\//.test(full.url) ||
+    typeof full.sha256 !== "string" ||
+    !/^[a-fA-F0-9]{64}$/.test(full.sha256) ||
+    !Number.isSafeInteger(full.size) ||
+    full.size <= 0 ||
+    full.size > 1024 * 1024 * 1024
+  )
+    return null
+  return full
 }
 
 export function checkBesUpdate(besFirmware: BesFirmware | undefined, currentVersion: string | undefined): boolean {
@@ -360,7 +400,7 @@ export async function checkForOtaUpdate(
       `OTA: APK update available: ${apkUpdateAvailable} (current: ${currentBuildNumber}, direction: ${apkDirection ?? "none"})`,
     )
 
-    const mtkPatch = findMatchingMtkPatch(versionJson?.mtk_patches, currentMtkVersion)
+    const mtkPatch = selectMtkUpdate(versionJson, currentMtkVersion)
     const mtkUpdateAvailable = mtkPatch !== null
     if (!currentMtkVersion && versionJson?.mtk_patches?.length) {
       console.log(`OTA: MTK current version unknown - skipping MTK patch check`)

--- a/mobile/modules/engine/src/services/__tests__/OtaArtifactDownloader.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/OtaArtifactDownloader.test.ts
@@ -112,6 +112,16 @@ function contentFor(url: string): string {
 }
 
 describe("planArtifacts", () => {
+  test("plans and rewrites the selected full OTA for hotspot serving", () => {
+    const full = {end_firmware: "20260908.0", url: MTK_URL, sha256: hashes.mtk, size: 640341205}
+    const body = JSON.stringify({mtk_patches: [], mtk_full_ota: full})
+    const plan = planArtifacts(checkResult({updates: ["mtk"], mtkPatch: full, manifestBody: body}))
+    expect(plan).toEqual([{kind: "mtk", url: MTK_URL, sha256: hashes.mtk}])
+    const rewritten = JSON.parse(
+      rewriteManifestForLocalServer(body, [{...plan[0], filePath: "/full.zip"}], "http://phone:8791"),
+    )
+    expect(rewritten.mtk_full_ota).toEqual({...full, url: `http://phone:8791/artifacts/${hashes.mtk}`})
+  })
   test("plans every pending artifact from the raw manifest", () => {
     const plan = planArtifacts(checkResult())
     expect(plan).toEqual([

--- a/mobile/modules/engine/src/services/otaLegacyMapping.ts
+++ b/mobile/modules/engine/src/services/otaLegacyMapping.ts
@@ -8,6 +8,7 @@ export type NormalizedOtaStatusEvent = {
   step_type: string
   phase: "download" | "install"
   step_percent: number
+  bytes_downloaded?: number
   overall_percent: number
   status: string
   error_message?: string
@@ -21,6 +22,7 @@ export function normalizeOtaStatusEvent(event: Record<string, unknown>): Normali
   const e = event as Record<string, any>
   const phase: "download" | "install" = e?.phase === "install" ? "install" : "download"
   const err = e?.error_message ?? e?.errorMessage
+  const bytes = e?.bytes_downloaded ?? e?.bytesDownloaded
   return {
     session_id: String(e?.session_id ?? e?.sessionId ?? ""),
     total_steps: Number(e?.total_steps ?? e?.totalSteps ?? 0),
@@ -28,6 +30,7 @@ export function normalizeOtaStatusEvent(event: Record<string, unknown>): Normali
     step_type: String(e?.step_type ?? e?.stepType ?? "apk"),
     phase,
     step_percent: Number(e?.step_percent ?? e?.stepPercent ?? 0),
+    bytes_downloaded: Number.isSafeInteger(bytes) && bytes >= 0 ? bytes : undefined,
     overall_percent: Number(e?.overall_percent ?? e?.overallPercent ?? 0),
     status: String(e?.status ?? "idle"),
     error_message: err == null || err === "" ? undefined : String(err),
@@ -42,6 +45,7 @@ export function otaStatusFromNormalized(n: NormalizedOtaStatusEvent): OtaStatus 
     stepType: n.step_type as OtaStatus["stepType"],
     phase: n.phase,
     stepPercent: n.step_percent,
+    bytesDownloaded: n.bytes_downloaded,
     overallPercent: n.overall_percent,
     status: n.status as OtaStatus["status"],
     error: n.error_message,
@@ -63,7 +67,7 @@ export function legacyOtaProgressFromOtaStatusEvent(
     stage: n.phase === "install" ? "install" : "download",
     status: st,
     progress: Math.round(raw),
-    bytesDownloaded: 0,
+    bytesDownloaded: n.bytes_downloaded ?? 0,
     totalBytes: 0,
     currentUpdate: n.step_type || "apk",
     errorMessage: n.error_message,

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -619,6 +619,24 @@ describe("OtaInstallCoordinator version-change detour retry gate", () => {
 })
 
 describe("OtaInstallCoordinator stuck-at-zero watchdog", () => {
+  it("uses advancing bytes at 0%, but repeated or missing byte counts cannot mask a stall", async () => {
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    const status = inProgressStatus({stepType: "mtk", stepPercent: 0, overallPercent: 0})
+    for (let bytes = 1; bytes <= 5; bytes++) {
+      useGlassesStore.getState().setOtaStatus({...status, bytesDownloaded: bytes * 8192})
+      await jest.advanceTimersByTimeAsync(60_000)
+      expect(otaInstallCoordinator.snapshot().errorMsg).toBe("")
+    }
+    // Ordinary queries need not carry bytes. Neither they nor a duplicate sample is progress.
+    useGlassesStore.getState().setOtaStatus(status)
+    await jest.advanceTimersByTimeAsync(30_000)
+    useGlassesStore.getState().setOtaStatus({...status, bytesDownloaded: 5 * 8192})
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(otaInstallCoordinator.snapshot().errorMsg).toBe(OtaProgressMessages.stalledOrStuck)
+  })
+
   it("fails after DOWNLOAD_STUCK_TIMEOUT_MS at 0%", async () => {
     setGlassesConnected()
     otaInstallCoordinator.attach()

--- a/mobile/src/__tests__/otaService.test.ts
+++ b/mobile/src/__tests__/otaService.test.ts
@@ -18,6 +18,15 @@ describe("OtaService projection", () => {
     stopOtaService()
   })
 
+  it("preserves real download bytes independently of rounded progress", () => {
+    emitBluetoothSdkEvent("ota_status", {
+      session_id: "s1", total_steps: 1, current_step: 1, step_type: "mtk",
+      phase: "download", step_percent: 0, overall_percent: 0,
+      bytes_downloaded: 8192, status: "in_progress",
+    })
+    expect(useGlassesStore.getState().otaStatus).toMatchObject({bytesDownloaded: 8192, stepPercent: 0})
+  })
+
   it("projects ota_status into the store and clears the available flag on completion", () => {
     useGlassesStore.getState().setOtaUpdateAvailable({
       available: true,

--- a/mobile/src/__tests__/otaUpdateCheckService.test.ts
+++ b/mobile/src/__tests__/otaUpdateCheckService.test.ts
@@ -1,8 +1,43 @@
-import {checkCurrentGlassesForUpdate} from "../../modules/engine/src/services/OtaUpdateCheckService"
+import {checkCurrentGlassesForUpdate, selectMtkUpdate} from "../../modules/engine/src/services/OtaUpdateCheckService"
 import {useGlassesStore} from "../../modules/engine/src/stores/glasses"
 import {SETTINGS} from "@mentra/engine"
 import {useSettingsStore} from "@mentra/engine-host-internal"
 import {bluetoothSdkMock, resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
+
+describe("MTK full fallback", () => {
+  const full = {
+    end_firmware: "MentraLive_20260908.10",
+    url: "https://cdn/full.zip",
+    sha256: "a".repeat(64),
+    size: 640341205,
+  }
+  const patch = {start_firmware: "20260709", end_firmware: "20260908.10", url: "https://cdn/delta.zip"}
+  const manifest = {mtk_patches: [patch], mtk_full_ota: full}
+
+  it("prefers the exact-base delta even when a full image exists", () => {
+    expect(selectMtkUpdate(manifest, "MentraLive_20260709")).toBe(patch)
+  })
+  it.each(["20260908.9", "MentraLive_20260907.20", "20260101"])("offers full to older %s", (current) => {
+    expect(selectMtkUpdate(manifest, current)).toBe(full)
+  })
+  it.each([undefined, "", "unknown", "20260908.10", "MentraLive_20260908.11", "20260909"])(
+    "does not offer full to %s",
+    (current) => {
+      expect(selectMtkUpdate(manifest, current)).toBeNull()
+    },
+  )
+  it("handles full-only, legacy-only, and date-only revision zero", () => {
+    expect(selectMtkUpdate({mtk_full_ota: full}, "20260709")).toBe(full)
+    expect(selectMtkUpdate({mtk_patches: [patch]}, "20260101")).toBeNull()
+    expect(selectMtkUpdate({mtk_full_ota: {...full, end_firmware: "20260908.0"}}, "20260908")).toBeNull()
+  })
+  it.each([{sha256: ""}, {size: 0}, {size: 2 ** 31}, {url: "file:///tmp/full.zip"}, {end_firmware: "unknown"}])(
+    "refuses malformed full metadata %j",
+    (invalid) => {
+      expect(selectMtkUpdate({mtk_full_ota: {...full, ...invalid}}, "20260101")).toBeNull()
+    },
+  )
+})
 
 describe("OtaUpdateCheckService", () => {
   const originalFetch = global.fetch
@@ -278,7 +313,9 @@ describe("OtaUpdateCheckService", () => {
         waitForMtkVersionMs: 0,
       })
 
-    global.fetch = jest.fn(() => Promise.resolve({ok: false, status: 404} as unknown as Response)) as unknown as typeof fetch
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ok: false, status: 404} as unknown as Response),
+    ) as unknown as typeof fetch
     let result = await check()
     expect(result.hasCheckCompleted).toBe(false)
     expect(result.checkFailureReason).toBe("pin_unavailable")
@@ -288,7 +325,9 @@ describe("OtaUpdateCheckService", () => {
     expect(result.hasCheckCompleted).toBe(false)
     expect(result.checkFailureReason).toBe("network")
 
-    global.fetch = jest.fn(() => Promise.resolve({ok: false, status: 503} as unknown as Response)) as unknown as typeof fetch
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ok: false, status: 503} as unknown as Response),
+    ) as unknown as typeof fetch
     result = await check()
     expect(result.checkFailureReason).toBe("network")
   })
@@ -369,7 +408,17 @@ describe("OtaUpdateCheckService", () => {
         floorVersionCode: 9,
       })
     const manifestWith = (extra: object) => ({
-      apps: {"com.mentra.asg_client": {versionCode: 9, versionName: "9", downloadUrl: "u", apkSize: 1, sha256: "s", releaseNotes: "", ...extra}},
+      apps: {
+        "com.mentra.asg_client": {
+          versionCode: 9,
+          versionName: "9",
+          downloadUrl: "u",
+          apkSize: 1,
+          sha256: "s",
+          releaseNotes: "",
+          ...extra,
+        },
+      },
     })
 
     // Glasses newer than the pin -> downgrade; absent isRequired -> skippable.
@@ -391,7 +440,19 @@ describe("OtaUpdateCheckService", () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({apps: {"com.mentra.asg_client": {versionCode: 999999, versionName: "n", downloadUrl: "u", apkSize: 1, sha256: "s", releaseNotes: ""}}}),
+        json: () =>
+          Promise.resolve({
+            apps: {
+              "com.mentra.asg_client": {
+                versionCode: 999999,
+                versionName: "n",
+                downloadUrl: "u",
+                apkSize: 1,
+                sha256: "s",
+                releaseNotes: "",
+              },
+            },
+          }),
       } as unknown as Response),
     ) as unknown as typeof fetch
     result = await check()

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -34,6 +34,10 @@ function baseOtaProgress(overrides: Partial<OtaProgress> = {}): OtaProgress {
 }
 
 describe("getOtaErrorMessage", () => {
+  it("reports insufficient storage without suggesting a WiFi change", () => {
+    expect(getOtaErrorMessage("insufficient_storage")).toContain("free up space")
+    expect(shouldShowChangeWifiForOtaDownloadFailure(baseOtaStatus({error: "insufficient_storage"}), null, "")).toBe(false)
+  })
   it("maps no_internet to WiFi message", () => {
     expect(getOtaErrorMessage("no_internet")).toBe("Glasses WiFi has no internet connection")
   })


### PR DESCRIPTION
## Summary

- Prefer an exact-base MTK incremental patch. If none matches, select the release-pinned full OTA only when its target is strictly newer than a known installed version.
- Apply the same selection policy in ASG, the Mentra App engine, and the Android/Swift Bluetooth SDK checks. Unknown, equal, and newer installed versions do not qualify for full fallback; failed deltas do not silently switch to full.
- Carry `mtk_full_ota` through coordinated release inputs, generated manifests, portable bundles, provenance checks, and phone hotspot URL rewriting. Pin the published `20260908.0` full OTA and the July 9 incremental to that target; retain the older incremental chain. BES is pinned to published `26.9.7.0` per latest.json.
- Raise the MTK streaming/download cap to 1 GiB, check free space for ZIP plus payload, and verify the manifest size as well as SHA-256. Reuse the existing `asg/mtk_firmware.zip` path, so updates do not accumulate version-named files.

## Scope boundaries

Review follow-up (`e9fdc51bf8`): validate full-OTA declared size against the verified bytes even on hash-deduplicated bundle references; report real download bytes through the existing throttled status path and both native bridges; remove the ASG absolute install timer so only a terminal system result releases install ownership. Phone progress-stall/global limits remain unchanged. Repeated status replies cannot masquerade as download progress.

Second review follow-up: make live download bytes session-owned and reset them across steps/retries; reject malformed full-OTA target types and any `start_firmware` key consistently; fail contradictory response lengths before downloading and cap writes at the declared size; report insufficient storage without suggesting a WiFi change. No new timers or cleanup behavior.

- No Android updater/payload-generation changes, downgrade bypass, userdata wipe, or mutable `latest.json` lookup at runtime.
- No post-install reclamation feature or cleanup of historical development files.
- No MTK downgrade, release publication, or merge performed. Authorized BES hardware verification is in progress; phone-driven and MTK upgrade qualification remain separate.

## Validation

- ASG Java compile and focused selector, ownership/progress, download-bound, and BES guard tests: passed (20 tests).
- Public-mode Android Bluetooth SDK AAR build and OTA manifest tests: passed (9 tests, including existing APK downgrade-policy coverage).
- Swift SDK build and focused OTA manifest tests: passed (2 tests on macOS).
- Mobile OTA coordinator, projection, chain, update-check/effect, and error mapping suites: 182 tests passed.
- Artifact planning/download/hotspot suite: 15 tests passed.
- Release manifest, bundle, and provenance suites: 21 tests passed, including full-artifact tampering, declared-size rejection, and strict target/start-field validation.
- Engine TypeScript type-check and `git diff --check`: passed.
- Published full ZIP was streamed and SHA-256 verified against the pinned `4b27d8fbb843b3cb55e3f03e6cea4e5400149a3ef1b963b6c6f3ba32466b6676`.

Hardware validation remains pending: test a known older version with no delta, an exact-delta base, an equal/newer version, insufficient free space, and the phone-hotspot transport. Verify rebooted target and unchanged userdata. Local tests and artifact integrity are not device-install proof.
