### PR TITLE
Merge staging npm publication recovery into dev

### DIFF
--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -76,7 +76,12 @@ export function publishWithRetry(
       publish()
       return "published"
     } catch (error) {
-      const landed = registryIntegrityOf(coordinate)
+      let landed = null
+      try {
+        landed = registryIntegrityOf(coordinate)
+      } catch (viewError) {
+        console.log(`npm view of ${coordinate} failed during publish recovery: ${viewError.message}`)
+      }
       if (landed !== null) {
         if (landed !== integrity) throw new Error(`${coordinate} already exists on npm with different bytes`)
         return "published"

--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -60,6 +60,35 @@ function parseArgs(args) {
   return values
 }
 
+// npm publish --provenance mints a Sigstore signing certificate from
+// fulcio.sigstore.dev, so a blip reaching that CA fails the publish and, with
+// it, the coordinated release: seen 2026-09-08 as
+// CA_CREATE_SIGNING_CERTIFICATE_ERROR / "read ECONNRESET". Retry, and treat a
+// version that turns up on the registry with the bytes we packed as published,
+// because a publish can also fail after the tarball has already landed.
+export function publishWithRetry(
+  coordinate,
+  integrity,
+  {attempts = 4, publish, registryIntegrityOf, sleep = () => execFileSync("sleep", ["15"])},
+) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      publish()
+      return "published"
+    } catch (error) {
+      const landed = registryIntegrityOf(coordinate)
+      if (landed !== null) {
+        if (landed !== integrity) throw new Error(`${coordinate} already exists on npm with different bytes`)
+        return "published"
+      }
+      if (attempt === attempts) throw error
+      console.log(`npm publish of ${coordinate} failed (attempt ${attempt}/${attempts}); retrying: ${error.message}`)
+      sleep()
+    }
+  }
+  throw new Error(`${coordinate} was not published`)
+}
+
 function run(command, args, options = {}) {
   console.log(`$ ${command} ${args.join(" ")}`)
   return execFileSync(command, args, {stdio: "inherit", ...options})
@@ -359,8 +388,11 @@ export function publishReleaseNpm({
       }
       status = "reused"
     } else if (!dryRun) {
-      run("npm", ["publish", tarball, "--tag", tag, "--access", "public", "--provenance"], {cwd: rootDir})
-      status = "published"
+      status = publishWithRetry(coordinate, integrity, {
+        publish: () =>
+          run("npm", ["publish", tarball, "--tag", tag, "--access", "public", "--provenance"], {cwd: rootDir}),
+        registryIntegrityOf: (spec) => parseViewValue(npmView(spec, "dist.integrity")),
+      })
     }
 
     let url = `https://registry.npmjs.org/${encodeURIComponent(name)}`

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -199,3 +199,51 @@ test("gives up after the last attempt and surfaces the publish error", () => {
   )
   assert.equal(calls, 3)
 })
+
+test("retries when the recovery registry read also fails", () => {
+  let publishes = 0
+  let reads = 0
+  let pauses = 0
+  const status = publishWithRetry("@mentra/engine@3.2.0-dev.157", "sha512-abc", {
+    publish: () => {
+      publishes += 1
+      throw new Error("publish connection reset")
+    },
+    registryIntegrityOf: () => {
+      reads += 1
+      if (reads === 1) throw new Error("registry unavailable")
+      return "sha512-abc"
+    },
+    sleep: () => {
+      pauses += 1
+    },
+  })
+  assert.equal(status, "published")
+  assert.equal(publishes, 2)
+  assert.equal(reads, 2)
+  assert.equal(pauses, 1)
+})
+
+test("keeps bounded attempts and the publish error when every recovery read fails", () => {
+  let publishes = 0
+  let pauses = 0
+  const publishError = new Error("publish connection reset")
+  assert.throws(
+    () => publishWithRetry("@mentra/engine@3.2.0-dev.157", "sha512-abc", {
+      attempts: 3,
+      publish: () => {
+        publishes += 1
+        throw publishError
+      },
+      registryIntegrityOf: () => {
+        throw new Error("registry unavailable")
+      },
+      sleep: () => {
+        pauses += 1
+      },
+    }),
+    (error) => error === publishError,
+  )
+  assert.equal(publishes, 3)
+  assert.equal(pauses, 2)
+})

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -11,6 +11,7 @@ import {
   npmMembersInOrder,
   npmReleaseTag,
   npmViewPublishedTarball,
+  publishWithRetry,
   releaseMetadataArgs,
   requireNpmProvenanceSource,
   requirePlanSourceCommit,
@@ -137,4 +138,64 @@ test("stamps SDK and Engine packages from the same immutable release metadata", 
       "b".repeat(64),
     ],
   )
+})
+
+test("retries a publish that fails before Sigstore issues a certificate", () => {
+  let calls = 0
+  const status = publishWithRetry("@mentra/engine@3.2.0-dev.157", "sha512-abc", {
+    publish: () => {
+      calls += 1
+      if (calls < 3) throw new Error("CA_CREATE_SIGNING_CERTIFICATE_ERROR: read ECONNRESET")
+    },
+    registryIntegrityOf: () => null,
+    sleep: () => {},
+  })
+  assert.equal(status, "published")
+  assert.equal(calls, 3)
+})
+
+test("accepts a publish that landed even though the command reported failure", () => {
+  let calls = 0
+  const status = publishWithRetry("@mentra/engine@3.2.0-dev.157", "sha512-abc", {
+    publish: () => {
+      calls += 1
+      throw new Error("write ECONNRESET")
+    },
+    registryIntegrityOf: () => "sha512-abc",
+    sleep: () => {},
+  })
+  assert.equal(status, "published")
+  assert.equal(calls, 1)
+})
+
+test("refuses a registry copy whose bytes differ from the packed tarball", () => {
+  assert.throws(
+    () =>
+      publishWithRetry("@mentra/engine@3.2.0-dev.157", "sha512-abc", {
+        publish: () => {
+          throw new Error("boom")
+        },
+        registryIntegrityOf: () => "sha512-different",
+        sleep: () => {},
+      }),
+    /already exists on npm with different bytes/,
+  )
+})
+
+test("gives up after the last attempt and surfaces the publish error", () => {
+  let calls = 0
+  assert.throws(
+    () =>
+      publishWithRetry("@mentra/engine@3.2.0-dev.157", "sha512-abc", {
+        attempts: 3,
+        publish: () => {
+          calls += 1
+          throw new Error("read ECONNRESET")
+        },
+        registryIntegrityOf: () => null,
+        sleep: () => {},
+      }),
+    /read ECONNRESET/,
+  )
+  assert.equal(calls, 3)
 })


### PR DESCRIPTION
Merge staging into dev to carry #3956's npm publication recovery fix forward. Dev already contains bounded publish retries; this merge keeps a failed recovery registry read inside that loop, preserving the attempt limit and original publish error while still rejecting mismatched registry bytes.

The merge conflicts were confined to the two npm publisher files. Those files now match the reviewed staging implementation; the effective dev change is the recovery catch and two regression tests. All 16 npm release tests and the diff check pass locally. CI is pending.
