### PR TITLE
Preserve queued coordinated release publications

### DIFF
--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -118,6 +118,7 @@ jobs:
     concurrency:
       group: mentra-ios-signing-runner
       cancel-in-progress: false
+      queue: max
     outputs:
       upload_artifact: ${{ steps.coordinates.outputs.upload_artifact }}
       upload_status: ${{ steps.app-store.outputs.exists == 'true' && 'reused' || 'published' }}

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -101,6 +101,7 @@ permissions:
 concurrency:
   group: coordinated-mobile-publication
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare:
@@ -536,6 +537,7 @@ jobs:
     concurrency:
       group: mentra-ios-signing-runner
       cancel-in-progress: false
+      queue: max
     env:
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -51,6 +51,7 @@ permissions:
 concurrency:
   group: coordinated-ota-publication
   cancel-in-progress: false
+  queue: max
 
 env:
   ASG_RELEASE_TAG: mentra-coordinated-asg

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -41,6 +41,7 @@ permissions:
 concurrency:
   group: coordinated-sdk-native-publication
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare:


### PR DESCRIPTION
A staging TestFlight retry was pending behind the dev main-app signing job when the dev example queued into the same concurrency group. GitHub's default single-pending queue cancelled staging even with `cancel-in-progress: false`.

Set `queue: max` on the shared mobile, native SDK, OTA, and iOS signing concurrency groups. Publications remain serialized, and pending releases can wait instead of replacing one another. The branch-level coordinator still coalesces same-branch pushes as before.

GitHub documents this supported queue mode: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

Validation: six mobile/example publication tests and diff checks pass. Local actionlint 1.7.12 predates `concurrency.queue`; lint passes with only that specific unknown-key diagnostic and the existing Blacksmith runner-label diagnostics excluded. Remote workflow validation and end-to-end release queue behavior will be checked after merge.
