### PR TITLE
Merge staging publication queue preservation into dev

### DIFF
--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -118,6 +118,7 @@ jobs:
     concurrency:
       group: mentra-ios-signing-runner
       cancel-in-progress: false
+      queue: max
     outputs:
       upload_artifact: ${{ steps.coordinates.outputs.upload_artifact }}
       upload_status: ${{ steps.app-store.outputs.exists == 'true' && 'reused' || 'published' }}

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -101,6 +101,7 @@ permissions:
 concurrency:
   group: coordinated-mobile-publication
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare:
@@ -536,6 +537,7 @@ jobs:
     concurrency:
       group: mentra-ios-signing-runner
       cancel-in-progress: false
+      queue: max
     env:
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -51,6 +51,7 @@ permissions:
 concurrency:
   group: coordinated-ota-publication
   cancel-in-progress: false
+  queue: max
 
 env:
   ASG_RELEASE_TAG: mentra-coordinated-asg

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -41,6 +41,7 @@ permissions:
 concurrency:
   group: coordinated-sdk-native-publication
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare:


### PR DESCRIPTION
Merge staging into dev to preserve pending coordinated publications from #3958. GitHub's default single-pending concurrency mode cancelled a staging example retry when a dev example joined the shared iOS signing queue.

The real staging merge adds `queue: max` to the shared mobile, native SDK, OTA, and iOS signing groups. Publication remains serialized; waiting releases no longer replace one another. The effective dev diff is five settings across four workflows.

Validation: six mobile/example publication tests and diff checks pass; staging PR CI and automated reviews passed. GitHub documents the queue option at https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency. Local actionlint 1.7.12 requires a narrow exclusion for this newer queue key and existing Blacksmith labels. Complete dev/staging runs will verify the updated queue behavior.

Review clarification: the automated claim that `concurrency.queue` is unsupported is contradicted by the current GitHub documentation linked above, which explicitly documents `queue: max`. Staging run https://github.com/Mentra-Community/MentraOS/actions/runs/34209759934 executes source `73f425bcb8eae8a8901bf0b07edd9c29c9d7c29c` with these settings; its OTA publication and SwiftPM publication have already succeeded. GitHub therefore accepts the updated reusable workflows. No workaround or removal of the supported queue key is needed.
