### PR TITLE
Build signed iOS releases on isolated hosted runners

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -204,7 +204,8 @@ test("mobile destinations use real TestFlight groups without changing the releas
   assert.match(example, /PlistBuddy -c 'Print :com\.apple\.developer\.networking\.HotspotConfiguration'/)
   assert.equal([...example.matchAll(/--app-id "\$EXAMPLE_APP_ID"/g)].length, 5)
   assert.match(example, /starterKit\.releaseCommit/)
-  assert.match(example, /runs-on: \[self-hosted, macOS, ARM64\]/)
+  assert.match(jobBlock(example, "ios"), /runs-on: macos-15/)
+  assert.match(jobBlock(example, "ios"), /DEVELOPER_DIR: \/Applications\/Xcode_26\.2\.app\/Contents\/Developer/)
   assert.match(example, /app-store-connect-build\.mjs upload/)
   assert.match(mobile, /app-store-connect-build\.mjs upload/)
   assert.match(example, /app-store-connect-build\.mjs assign/)
@@ -333,7 +334,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(example, /continue-on-error: true/)
   assert.doesNotMatch(example, /STARTER_KIT_APP_PRIVATE_KEY:/)
   assert.match(example, /permission-contents: read/)
-  assert.match(example, /^      group: mentra-ios-signing-runner$/m)
+  assert.doesNotMatch(example, /group: mentra-ios-signing-runner/)
   assert.match(
     example,
     /token: \$\{\{ steps\.starter-kit-app-token\.outputs\.token \|\| secrets\.STARTER_KIT_COORDINATOR_TOKEN/,

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -113,12 +113,11 @@ jobs:
   ios:
     name: Publish React Native example to TestFlight
     needs: preflight
-    runs-on: [self-hosted, macOS, ARM64]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+    # Each hosted job owns its signing state and artifact transfer.
+    runs-on: macos-15
     timeout-minutes: 90
-    concurrency:
-      group: mentra-ios-signing-runner
-      cancel-in-progress: false
-      queue: max
     outputs:
       upload_artifact: ${{ steps.coordinates.outputs.upload_artifact }}
       upload_status: ${{ steps.app-store.outputs.exists == 'true' && 'reused' || 'published' }}
@@ -234,14 +233,22 @@ jobs:
           token: ${{ steps.starter-kit-app-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
           path: starter-kit
 
-      - name: Add runner-managed tools to PATH
+      - uses: actions/setup-node@v4
         if: steps.app-store.outputs.exists != 'true'
-        run: |
-          {
-            echo "$HOME/.rbenv/shims"
-            echo "$HOME/.rbenv/bin"
-            echo "$HOME/.bun/bin"
-          } >> "$GITHUB_PATH"
+        with:
+          node-version: "20"
+
+      - name: Set up Ruby signing tools
+        if: steps.app-store.outputs.exists != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: mobile
+
+      - name: Install CocoaPods for the selected Ruby
+        if: steps.app-store.outputs.exists != 'true'
+        run: gem install cocoapods --version 1.16.2 --no-document
 
       - uses: oven-sh/setup-bun@v2
         if: steps.app-store.outputs.exists != 'true'
@@ -304,7 +311,6 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
         run: |
           set -euo pipefail
-          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
           previous_keychains="${RUNNER_TEMP}/mentra-example-previous-keychains-${GITHUB_RUN_ID}.txt"
           previous_default="${RUNNER_TEMP}/mentra-example-previous-default-keychain-${GITHUB_RUN_ID}.txt"
           security list-keychains -d user \
@@ -319,7 +325,6 @@ jobs:
           } >> "$GITHUB_ENV"
           MATCH_GIT_BASIC_AUTHORIZATION="$(printf '%s' "$RAW_MATCH_GIT_BASIC_AUTHORIZATION" | tr -d '\r\n')"
           export MATCH_GIT_BASIC_AUTHORIZATION
-          bundle install
           keychain="mentra-example-${GITHUB_RUN_ID}.keychain-db"
           password="$(openssl rand -hex 32)"
           security delete-keychain "$keychain" 2>/dev/null || true
@@ -535,7 +540,7 @@ jobs:
           # A failed response can leave an intermediate artifact behind.
           overwrite: true
 
-      - name: Clean persistent-runner credentials
+      - name: Clean signing credentials
         if: always()
         run: |
           if [[ -n "${MENTRA_CI_KEYCHAIN:-}" ]]; then

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -327,6 +327,7 @@ jobs:
           export MATCH_GIT_BASIC_AUTHORIZATION
           keychain="mentra-example-${GITHUB_RUN_ID}.keychain-db"
           password="$(openssl rand -hex 32)"
+          echo "::add-mask::$password"
           security delete-keychain "$keychain" 2>/dev/null || true
           security create-keychain -p "$password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"

--- a/.github/workflows/reusable-coordinated-example-testflight.yml
+++ b/.github/workflows/reusable-coordinated-example-testflight.yml
@@ -233,11 +233,6 @@ jobs:
           token: ${{ steps.starter-kit-app-token.outputs.token || secrets.STARTER_KIT_COORDINATOR_TOKEN || secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
           path: starter-kit
 
-      - uses: actions/setup-node@v4
-        if: steps.app-store.outputs.exists != 'true'
-        with:
-          node-version: "20"
-
       - name: Set up Ruby signing tools
         if: steps.app-store.outputs.exists != 'true'
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -532,13 +532,11 @@ jobs:
   ios:
     name: Build and distribute coordinated iOS app
     needs: prepare
-    runs-on: [self-hosted, macOS, ARM64]
+    # Each hosted job owns its signing state and artifact transfer.
+    runs-on: macos-15
     timeout-minutes: 90
-    concurrency:
-      group: mentra-ios-signing-runner
-      cancel-in-progress: false
-      queue: max
     env:
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
     outputs:
@@ -553,13 +551,17 @@ jobs:
           name: ${{ inputs.release_plan_artifact }}
           path: release-intent
 
-      - name: Add runner-managed tools to PATH
-        run: |
-          {
-            echo "$HOME/.rbenv/shims"
-            echo "$HOME/.rbenv/bin"
-            echo "$HOME/.bun/bin"
-          } >> "$GITHUB_PATH"
+      - name: Set up Ruby signing tools
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: mobile
+
+      - name: Install CocoaPods for the selected Ruby
+        if: inputs.dry_run == true || needs.prepare.outputs.ios_asset_exists != 'true'
+        run: gem install cocoapods --version 1.16.2 --no-document
 
       - uses: actions/setup-node@v4
         with:
@@ -645,7 +647,6 @@ jobs:
           RAW_MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: |
           set -euo pipefail
-          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
           previous_keychains="${RUNNER_TEMP}/mentra-previous-keychains-${GITHUB_RUN_ID}.txt"
           previous_default="${RUNNER_TEMP}/mentra-previous-default-keychain-${GITHUB_RUN_ID}.txt"
           security list-keychains -d user \
@@ -658,7 +659,6 @@ jobs:
           echo "MENTRA_PREVIOUS_DEFAULT_KEYCHAIN=$previous_default" >> "$GITHUB_ENV"
           MATCH_GIT_BASIC_AUTHORIZATION="$(printf '%s' "$RAW_MATCH_GIT_BASIC_AUTHORIZATION" | tr -d '\r\n')"
           export MATCH_GIT_BASIC_AUTHORIZATION
-          bundle install
           keychain="mentra-coordinated-${GITHUB_RUN_ID}.keychain-db"
           password="$(openssl rand -hex 32)"
           security delete-keychain "$keychain" 2>/dev/null || true
@@ -706,7 +706,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           MENTRA_TESTFLIGHT_INTERNAL_ONLY: ${{ inputs.compatibility_lab }}
         run: |
-          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
           security unlock-keychain -p "$MENTRA_CI_KEYCHAIN_PASSWORD" "$MENTRA_CI_KEYCHAIN"
           security set-keychain-settings "$MENTRA_CI_KEYCHAIN"
           if [[ "$MENTRA_TESTFLIGHT_INTERNAL_ONLY" == "true" ]]; then
@@ -780,7 +779,7 @@ jobs:
           # A failed response can leave an intermediate artifact behind.
           overwrite: true
 
-      - name: Clean persistent-runner credentials
+      - name: Clean signing credentials
         if: always()
         run: |
           if [[ -n "${MENTRA_CI_KEYCHAIN:-}" ]]; then

--- a/.github/workflows/reusable-coordinated-mobile.yml
+++ b/.github/workflows/reusable-coordinated-mobile.yml
@@ -661,6 +661,7 @@ jobs:
           export MATCH_GIT_BASIC_AUTHORIZATION
           keychain="mentra-coordinated-${GITHUB_RUN_ID}.keychain-db"
           password="$(openssl rand -hex 32)"
+          echo "::add-mask::$password"
           security delete-keychain "$keychain" 2>/dev/null || true
           security create-keychain -p "$password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
@@ -680,6 +681,7 @@ jobs:
           security list-keychains -d user -s "${keychains[@]}"
           security default-keychain -s "$keychain"
           bundle exec fastlane match appstore --readonly --keychain_name "$keychain" --keychain_password "$password"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$password" "$keychain"
           echo "MENTRA_CI_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
           echo "MENTRA_CI_KEYCHAIN_PASSWORD=$password" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
The signing runner could build valid IPAs but could not deliver them to artifact storage. In staging run 34215794395, all three upload attempts failed after transferring more than 100 MB: one `ECONNRESET` and two `write EPIPE` errors. Similar failures had already blocked two earlier releases.

Build and sign the Mentra App and React Native example on isolated `macos-15` runners. Select Xcode 26.2 explicitly, set up Ruby 3.3 with the locked Bundler dependencies, and install CocoaPods 1.16.2 for that Ruby. Explicitly grant noninteractive signing access to the fresh main-app keychain and mask the generated keychain passwords. Remove the machine-wide signing queue because the jobs now have separate keychains and workspaces. Keep the bounded upload retry and immutable publication flow.

Validation: all 19 coordinated workflow/mobile/example record tests passed; actionlint passed with only the existing Blacksmith labels and supported global concurrency queue key excluded for the older local linter; diff checks passed. The current release's signed main IPA archive and clean hosted iOS Engine/Starter Kit builds passed, but the full signed hosted build and transfer still need verification in the next coordinated run. The current GitHub macOS 15 image includes Xcode 26.2; the same explicit selection already passes in the clean Engine consumer job.

Shared fix targets staging first and will flow to dev through a real staging merge.
