### PR TITLE
Keep live docs verification authoritative when cache purge fails

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -371,7 +371,15 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(docs, /--example-testflight/)
   assert.match(docs, /Cache-Control: public, max-age=0, must-revalidate/)
   assert.match(docs, /X-Robots-Tag: noindex/)
-  assert.match(docs, /Purge release-sensitive documentation routes/)
+  const purge = docs.slice(
+    docs.indexOf("- name: Purge release-sensitive"),
+    docs.indexOf("- name: Verify the published custom domain"),
+  )
+  const verify = docs.slice(docs.indexOf("- name: Verify the published custom domain"))
+  assert.match(purge, /continue-on-error: true/)
+  assert.match(purge, /timeout-minutes: 1/)
+  assert.doesNotMatch(verify, /continue-on-error: true/)
+  assert.match(verify, /exit 1/)
   assert.match(docs, /CLOUDFLARE_ZONE_ID: \$\{\{ vars\.CLOUDFLARE_ZONE_ID \}\}/)
   assert.match(docs, /zones\/\$CLOUDFLARE_ZONE_ID\/purge_cache/)
   assert.match(docs, /\$DOCS_URL\/mentra-live\/software-update\//)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -1068,7 +1068,11 @@ jobs:
             --commit-message "Deploy MentraOS docs for $RELEASE_IDENTITY" \
             --commit-dirty=true
 
+      # Purging accelerates propagation; the required live-page check below
+      # determines whether the exact release is available to users.
       - name: Purge release-sensitive documentation routes
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}


### PR DESCRIPTION
Dev release 3.2.0-dev.167 deployed the correct documentation, then failed because the Pages token received HTTP 401 from the zone cache-purge endpoint. Both the canonical and legacy live install pages already contained the exact release and install links.

Allow the dev-only cache-purge helper to fail within one minute, then retain the mandatory live-page verification as the release gate. Publication still fails if either route has the wrong version or install links, unresolved variables, or a missing noindex header. This fixes the dev-only step introduced by 8f37577d0c; staging has no cache-purge step and its fully validated beta.166 release is unaffected.

Validation: 25 focused workflow/docs tests pass, actionlint passes with the existing queue-syntax exclusion, and git diff --check passes. The exact required live verification script passes against both dev.167 routes. Full coordinated dev execution will validate the workflow behavior after merge.
