### PR TITLE
Lock the Mentra Live OTA screen against back navigation

### DIFF
--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -22,6 +22,7 @@ import {useSettingsStore} from "../../../../modules/engine/src/stores/settings"
 const setSuperMode = (enabled: boolean) => useSettingsStore.getState().setSetting("super_mode", enabled, false)
 
 jest.mock("@/contexts/NavigationHistoryContext", () => ({
+  focusEffectLockScreen: jest.fn(),
   focusEffectPreventBack: jest.fn(),
   useNavigationHistory: () => ({replace: mockReplace}),
 }))

--- a/mobile/src/components/ota/MentraLiveOtaFlowHost.tsx
+++ b/mobile/src/components/ota/MentraLiveOtaFlowHost.tsx
@@ -3,7 +3,7 @@ import {MentraLiveOtaFlow, type MentraLiveOtaFlowPage} from "@mentra/engine/ota"
 import {useCallback, useEffect} from "react"
 
 import {useConnectionOverlayConfig} from "@/contexts/ConnectionOverlayContext"
-import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
+import {focusEffectLockScreen} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n/translate"
 import {useNavigationStore} from "@/stores/navigation"
@@ -18,7 +18,11 @@ export function MentraLiveOtaFlowHost({initialPage = "check"}: {initialPage?: Me
   const [onboardingOsCompleted] = useSetting(SETTINGS.onboarding_os_completed.key)
   const [superMode] = useSetting(SETTINGS.super_mode.key)
 
-  focusEffectPreventBack()
+  // Every page of this flow — download, install, "Restarting Mentra Live" —
+  // is one-way and renders no back affordance. Leaving mid-update strands the
+  // glasses half-installed with no route back to the progress UI, so lock the
+  // screen instead of merely asking the navigator not to go back.
+  focusEffectLockScreen()
   useEffect(() => clearConfig, [clearConfig])
 
   const handleFinished = useCallback(() => {

--- a/mobile/src/contexts/NavigationHistoryContext.tsx
+++ b/mobile/src/contexts/NavigationHistoryContext.tsx
@@ -83,6 +83,24 @@ export const focusEffectLockScreen = () => {
       return () => setGesture({gestureEnabled: undefined})
     }, [navigation]),
   )
+
+  // Backstop for a back action dispatched in JS rather than by the gesture.
+  // Only GO_BACK/POP are blocked: a locked screen still has to be able to leave
+  // through its own controls, and those go out as REPLACE/POP_TO_TOP/POP_TO
+  // (goBack() is never one of the exits). Blocking removal outright would
+  // strand the user on the screen for good.
+  useFocusEffect(
+    useCallback(
+      () =>
+        navigation.addListener("beforeRemove", (event: any) => {
+          const actionType = event?.data?.action?.type ?? ""
+          if (actionType === "GO_BACK" || actionType === "POP") {
+            event.preventDefault()
+          }
+        }),
+      [navigation],
+    ),
+  )
 }
 
 export function usePushUnder() {

--- a/mobile/src/contexts/NavigationHistoryContext.tsx
+++ b/mobile/src/contexts/NavigationHistoryContext.tsx
@@ -47,6 +47,44 @@ export const focusEffectPreventBack = (backFn?: (event?: PreventBackEvent) => vo
   )
 }
 
+// Stable identity so focusEffectPreventBack's focus effect (keyed on backFn)
+// runs once per focus instead of on every render of the locked screen.
+const noopBack = () => {}
+
+/**
+ * Hard-locks a one-way screen: no back gesture, no hardware back, no inherited
+ * back handler. Use it on screens that deliberately render no back affordance
+ * at all and that strand the user if they are left mid-flow (Mentra Live OTA).
+ *
+ * focusEffectPreventBack() on its own leaves two ways out:
+ *
+ *  - Android: `androidBackFn` is a single global slot that decPreventBack only
+ *    clears once the prevent-back count reaches zero. A screen we were pushed
+ *    on top of (any capsule host) is still holding that slot when it blurs, and
+ *    NavigationHost runs whatever is in it on hardware/gesture back — which
+ *    pops us off this screen. Claiming the slot with a no-op closes that path.
+ *  - iOS: the stack's `gestureEnabled` is a navigator-wide default of
+ *    `forceGestureEnabled || !preventBack`, so anything still holding
+ *    `forceGestureEnabled` (a miniapp host mid-teardown) re-enables the edge
+ *    swipe for every screen. A per-screen option beats the navigator default
+ *    and cannot be turned back on from elsewhere.
+ */
+export const focusEffectLockScreen = () => {
+  const navigation = useNavigation()
+
+  focusEffectPreventBack(noopBack)
+
+  useFocusEffect(
+    useCallback(() => {
+      // expo-router types useNavigation() against the generic navigator, which
+      // doesn't surface the native stack's gestureEnabled option.
+      const setGesture = navigation.setOptions as (options: {gestureEnabled?: boolean}) => void
+      setGesture({gestureEnabled: false})
+      return () => setGesture({gestureEnabled: undefined})
+    }, [navigation]),
+  )
+}
+
 export function usePushUnder() {
   const navigation = useNavigation()
 

--- a/mobile/src/contexts/__tests__/focusEffectLockScreen.test.tsx
+++ b/mobile/src/contexts/__tests__/focusEffectLockScreen.test.tsx
@@ -1,0 +1,82 @@
+import {render} from "@testing-library/react-native"
+import {useEffect} from "react"
+
+import {focusEffectLockScreen} from "@/contexts/NavigationHistoryContext"
+import {useNavigationStore} from "@/stores/navigation"
+
+const mockSetOptions = jest.fn()
+const mockNavigation = {
+  addListener: jest.fn(() => jest.fn()),
+  setOptions: mockSetOptions,
+}
+
+jest.mock("expo-router", () => ({
+  // React Navigation's useFocusEffect is a focus-scoped useEffect, and these
+  // screens render focused, so a plain effect reproduces both run and cleanup.
+  useFocusEffect: (effect: () => void | (() => void)) => {
+    const React = require("react")
+    React.useEffect(effect, [effect])
+  },
+  useNavigation: () => mockNavigation,
+  router: {
+    back: jest.fn(),
+    canGoBack: () => true,
+    dismissAll: jest.fn(),
+    dismissTo: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+  },
+}))
+
+function LockedScreen() {
+  focusEffectLockScreen()
+  return null
+}
+
+/** A screen that only asks the navigator not to go back, as most screens do. */
+function PreviousScreen({onBack}: {onBack: () => void}) {
+  const {incPreventBack, decPreventBack, setAndroidBackFn} = useNavigationStore.getState()
+  useEffect(() => {
+    incPreventBack()
+    setAndroidBackFn(onBack)
+    return () => decPreventBack()
+  }, [decPreventBack, incPreventBack, onBack, setAndroidBackFn])
+  return null
+}
+
+describe("focusEffectLockScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useNavigationStore.setState({androidBackFn: undefined, preventBack: false, preventBackCount: 0})
+  })
+
+  it("claims the Android back slot from the screen it was pushed on top of", () => {
+    // decPreventBack only clears androidBackFn once the count reaches zero, so
+    // the screen underneath still holds the slot when it blurs — NavigationHost
+    // would run its handler (minimize / goBack) and pop us off the OTA flow.
+    const previousScreenBack = jest.fn()
+    const previous = render(<PreviousScreen onBack={previousScreenBack} />)
+    const locked = render(<LockedScreen />)
+    previous.unmount()
+
+    const {androidBackFn, preventBack} = useNavigationStore.getState()
+    expect(preventBack).toBe(true)
+    androidBackFn?.()
+    expect(previousScreenBack).not.toHaveBeenCalled()
+
+    locked.unmount()
+    expect(useNavigationStore.getState().preventBack).toBe(false)
+  })
+
+  it("disables the back gesture on its own screen, not just navigator-wide", () => {
+    // The navigator's default is `forceGestureEnabled || !preventBack`, so a
+    // lingering forceGestureEnabled re-enables the iOS edge swipe everywhere.
+    // A per-screen option beats that default.
+    const locked = render(<LockedScreen />)
+    expect(mockSetOptions).toHaveBeenCalledWith({gestureEnabled: false})
+
+    mockSetOptions.mockClear()
+    locked.unmount()
+    expect(mockSetOptions).toHaveBeenCalledWith({gestureEnabled: undefined})
+  })
+})

--- a/mobile/src/contexts/__tests__/focusEffectLockScreen.test.tsx
+++ b/mobile/src/contexts/__tests__/focusEffectLockScreen.test.tsx
@@ -5,8 +5,12 @@ import {focusEffectLockScreen} from "@/contexts/NavigationHistoryContext"
 import {useNavigationStore} from "@/stores/navigation"
 
 const mockSetOptions = jest.fn()
+const mockBeforeRemoveListeners: Array<(event: unknown) => void> = []
 const mockNavigation = {
-  addListener: jest.fn(() => jest.fn()),
+  addListener: jest.fn((event: string, listener: (event: unknown) => void) => {
+    if (event === "beforeRemove") mockBeforeRemoveListeners.push(listener)
+    return jest.fn()
+  }),
   setOptions: mockSetOptions,
 }
 
@@ -44,16 +48,27 @@ function PreviousScreen({onBack}: {onBack: () => void}) {
   return null
 }
 
+/** Dispatch a removal at every registered beforeRemove listener, as the navigator does. */
+function dispatchRemoval(actionType: string) {
+  const preventDefault = jest.fn()
+  const event = {data: {action: {type: actionType}}, preventDefault}
+  for (const listener of mockBeforeRemoveListeners) listener(event)
+  return preventDefault
+}
+
 describe("focusEffectLockScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockBeforeRemoveListeners.length = 0
     useNavigationStore.setState({androidBackFn: undefined, preventBack: false, preventBackCount: 0})
   })
 
-  it("claims the Android back slot from the screen it was pushed on top of", () => {
-    // decPreventBack only clears androidBackFn once the count reaches zero, so
-    // the screen underneath still holds the slot when it blurs — NavigationHost
-    // would run its handler (minimize / goBack) and pop us off the OTA flow.
+  it("claims the shared back-handler slot from the screen it was pushed on top of", () => {
+    // The slot itself is platform-independent; NavigationHost is its Android
+    // consumer. decPreventBack only clears androidBackFn once the prevent-back
+    // count reaches zero, so the screen underneath still holds the slot when it
+    // blurs — NavigationHost would run its handler (minimize / goBack) and pop
+    // the user off the locked screen.
     const previousScreenBack = jest.fn()
     const previous = render(<PreviousScreen onBack={previousScreenBack} />)
     const locked = render(<LockedScreen />)
@@ -78,5 +93,21 @@ describe("focusEffectLockScreen", () => {
     mockSetOptions.mockClear()
     locked.unmount()
     expect(mockSetOptions).toHaveBeenCalledWith({gestureEnabled: undefined})
+  })
+
+  it("blocks a back action dispatched in JS", () => {
+    render(<LockedScreen />)
+    expect(dispatchRemoval("GO_BACK")).toHaveBeenCalled()
+    expect(dispatchRemoval("POP")).toHaveBeenCalled()
+  })
+
+  it("still lets the screen's own controls leave", () => {
+    // handleFinished leaves via replace() / clearHistoryAndGoHome(); blocking
+    // those would strand the user on the locked screen for good.
+    render(<LockedScreen />)
+    expect(dispatchRemoval("REPLACE")).not.toHaveBeenCalled()
+    expect(dispatchRemoval("POP_TO_TOP")).not.toHaveBeenCalled()
+    expect(dispatchRemoval("POP_TO")).not.toHaveBeenCalled()
+    expect(dispatchRemoval("NAVIGATE")).not.toHaveBeenCalled()
   })
 })

--- a/mobile/src/effects/NavigationHost.tsx
+++ b/mobile/src/effects/NavigationHost.tsx
@@ -18,16 +18,20 @@ export default function NavigationHost() {
     const sub = BackHandler.addEventListener("hardwareBackPress", () => {
       const {preventBack, androidBackFn, goBack, interceptor} = useNavigationStore.getState()
       // An offline-hosted miniapp (Settings, Store, …) registers a NavInterceptor
-      // and owns its own internal stack. Route hardware back straight through
-      // goBack() so it reaches interceptor.goBack() → the host's popOrExit: pop one
-      // sub-screen, and minimize to home only at the host's root. This bypasses
-      // the global androidBackFn slot, which the still-mounted root screen can
-      // clobber with its "minimize-to-home" handler on any re-render — the cause
-      // of Android back exiting the whole miniapp instead of going back one page.
-      if (interceptor) {
-        goBack()
+      // and owns its own internal stack. Hand hardware back to interceptor.goBack()
+      // → the host's popOrExit: pop one sub-screen, and minimize to home only at
+      // the host's root. This bypasses the global androidBackFn slot, which the
+      // still-mounted root screen can clobber with its "minimize-to-home" handler
+      // on any re-render — the cause of Android back exiting the whole miniapp
+      // instead of going back one page.
+      if (interceptor?.goBack()) {
         return true
       }
+      // A registered interceptor that DECLINES is a host standing down mid-exit
+      // (activeRef already false, still mounted for the fade-out). Falling
+      // through to the store's goBack() there would reach router.back() and pop
+      // whatever screen the push landed on — including a screen that locked
+      // itself. Let the normal guard below decide instead.
       if (!preventBack) {
         goBack()
         return true

--- a/mobile/src/effects/NavigationHost.tsx
+++ b/mobile/src/effects/NavigationHost.tsx
@@ -17,23 +17,26 @@ export default function NavigationHost() {
   useEffect(() => {
     const sub = BackHandler.addEventListener("hardwareBackPress", () => {
       const {preventBack, androidBackFn, goBack, interceptor} = useNavigationStore.getState()
-      // An offline-hosted miniapp (Settings, Store, …) registers a NavInterceptor
-      // and owns its own internal stack. Hand hardware back to interceptor.goBack()
-      // → the host's popOrExit: pop one sub-screen, and minimize to home only at
-      // the host's root. This bypasses the global androidBackFn slot, which the
-      // still-mounted root screen can clobber with its "minimize-to-home" handler
-      // on any re-render — the cause of Android back exiting the whole miniapp
-      // instead of going back one page.
-      if (interceptor?.goBack()) {
-        return true
-      }
-      // A registered interceptor that DECLINES is a host standing down mid-exit
-      // (activeRef already false, still mounted for the fade-out). Falling
-      // through to the store's goBack() there would reach router.back() and pop
-      // whatever screen the push landed on — including a screen that locked
-      // itself. Let the normal guard below decide instead.
+      // Nothing is guarding the focused screen, so goBack() decides: it
+      // dispatches the interceptor itself and otherwise pops the router.
       if (!preventBack) {
         goBack()
+        return true
+      }
+      // A guard is up. An offline-hosted miniapp (Settings, Store, …) registers a
+      // NavInterceptor and owns its own internal stack, so ask it first:
+      // interceptor.goBack() → the host's popOrExit: pop one sub-screen, and
+      // minimize to home only at the host's root. This bypasses the global
+      // androidBackFn slot, which the still-mounted root screen can clobber with
+      // its "minimize-to-home" handler on any re-render — the cause of Android
+      // back exiting the whole miniapp instead of going back one page.
+      //
+      // An interceptor that DECLINES is a host standing down mid-exit (activeRef
+      // already false, still mounted for the fade-out). Handing back to the
+      // store's goBack() there would reach router.back() and pop whatever screen
+      // the push landed on — including a screen that locked itself. Fall through
+      // to the guard instead. Either way the interceptor is dispatched once.
+      if (interceptor?.goBack()) {
         return true
       }
       androidBackFn?.()

--- a/mobile/src/effects/__tests__/NavigationHost.test.tsx
+++ b/mobile/src/effects/__tests__/NavigationHost.test.tsx
@@ -49,12 +49,13 @@ describe("NavigationHost hardware back", () => {
   afterEach(() => jest.restoreAllMocks())
 
   it("hands back to an interceptor that claims it", () => {
+    // A hosted miniapp holds preventBack for as long as it is mounted.
     const interceptorBack = jest.fn(() => true)
-    useNavigationStore.setState({interceptor: interceptorStub(interceptorBack)})
+    useNavigationStore.setState({interceptor: interceptorStub(interceptorBack), preventBack: true})
     render(<NavigationHost />)
 
     expect(pressHardwareBack()).toBe(true)
-    expect(interceptorBack).toHaveBeenCalled()
+    expect(interceptorBack).toHaveBeenCalledTimes(1)
     expect(mockRouter.back).not.toHaveBeenCalled()
   })
 
@@ -64,9 +65,10 @@ describe("NavigationHost hardware back", () => {
     // declines once it is standing down, and back used to fall through to
     // router.back() — popping the screen the push just landed on.
     const lockedScreenBack = jest.fn()
+    const interceptorBack = jest.fn(() => false)
     useNavigationStore.setState({
       androidBackFn: lockedScreenBack,
-      interceptor: interceptorStub(() => false),
+      interceptor: interceptorStub(interceptorBack),
       preventBack: true,
     })
     render(<NavigationHost />)
@@ -74,13 +76,17 @@ describe("NavigationHost hardware back", () => {
     expect(pressHardwareBack()).toBe(true)
     expect(mockRouter.back).not.toHaveBeenCalled()
     expect(lockedScreenBack).toHaveBeenCalled()
+    expect(interceptorBack).toHaveBeenCalledTimes(1)
   })
 
   it("still goes back normally when nothing is guarding the screen", () => {
-    useNavigationStore.setState({interceptor: interceptorStub(() => false)})
+    const interceptorBack = jest.fn(() => false)
+    useNavigationStore.setState({interceptor: interceptorStub(interceptorBack)})
     render(<NavigationHost />)
 
     expect(pressHardwareBack()).toBe(true)
     expect(mockRouter.back).toHaveBeenCalled()
+    // goBack() is the single dispatch site when no guard is up.
+    expect(interceptorBack).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/effects/__tests__/NavigationHost.test.tsx
+++ b/mobile/src/effects/__tests__/NavigationHost.test.tsx
@@ -1,0 +1,86 @@
+import {render} from "@testing-library/react-native"
+import {BackHandler} from "react-native"
+
+import NavigationHost from "@/effects/NavigationHost"
+import {useNavigationStore, type NavInterceptor} from "@/stores/navigation"
+
+const mockRouter = {
+  back: jest.fn(),
+  canGoBack: () => true,
+  dismissAll: jest.fn(),
+  dismissTo: jest.fn(),
+  push: jest.fn(),
+  replace: jest.fn(),
+}
+
+jest.mock("expo-router", () => ({
+  usePathname: () => "/ota/check-for-updates",
+  // Lazy: jest hoists this factory above the mockRouter declaration.
+  get router() {
+    return mockRouter
+  },
+}))
+
+function interceptorStub(goBack: () => boolean): NavInterceptor {
+  return {goBack, push: () => false, replace: () => false}
+}
+
+/** Press Android hardware back the way the OS does, and report whether it was consumed. */
+function pressHardwareBack(): boolean {
+  const addEventListener = BackHandler.addEventListener as jest.Mock
+  const handler = addEventListener.mock.calls.at(-1)?.[1] as () => boolean
+  return handler()
+}
+
+describe("NavigationHost hardware back", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(BackHandler, "addEventListener").mockReturnValue({remove: jest.fn()} as never)
+    useNavigationStore.setState({
+      androidBackFn: undefined,
+      history: ["/home", "/ota/check-for-updates"],
+      historyParams: [undefined, undefined],
+      interceptor: null,
+      preventBack: false,
+      preventBackCount: 0,
+    })
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it("hands back to an interceptor that claims it", () => {
+    const interceptorBack = jest.fn(() => true)
+    useNavigationStore.setState({interceptor: interceptorStub(interceptorBack)})
+    render(<NavigationHost />)
+
+    expect(pressHardwareBack()).toBe(true)
+    expect(interceptorBack).toHaveBeenCalled()
+    expect(mockRouter.back).not.toHaveBeenCalled()
+  })
+
+  it("does not let a declining interceptor bypass a locked screen", () => {
+    // An offline miniapp host stays mounted (and registered) through its
+    // ~260ms exit fade after pushing an external route. Its interceptor
+    // declines once it is standing down, and back used to fall through to
+    // router.back() — popping the screen the push just landed on.
+    const lockedScreenBack = jest.fn()
+    useNavigationStore.setState({
+      androidBackFn: lockedScreenBack,
+      interceptor: interceptorStub(() => false),
+      preventBack: true,
+    })
+    render(<NavigationHost />)
+
+    expect(pressHardwareBack()).toBe(true)
+    expect(mockRouter.back).not.toHaveBeenCalled()
+    expect(lockedScreenBack).toHaveBeenCalled()
+  })
+
+  it("still goes back normally when nothing is guarding the screen", () => {
+    useNavigationStore.setState({interceptor: interceptorStub(() => false)})
+    render(<NavigationHost />)
+
+    expect(pressHardwareBack()).toBe(true)
+    expect(mockRouter.back).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes [OS-1947](https://linear.app/mentralabs/issue/OS-1947/mentra-live-ota-back-gesture-exits-the-in-progress-update-screen).

## Problem

Cayden swiped back mid-OTA and left the update screen ([Slack](https://mentra-labs.slack.com/archives/C096YCLEBFW/p1788822194596509)):

> oh FUCK - accidentally swiped back and it left the update page...

I checked the ask first: **there is no back affordance on any OTA page.** `MentraLiveOtaFlow` renders its own header (spacer + Mentra mark, no back control), and the navigator runs `headerShown: false`. So per the issue, back should be impossible here — the flow's own buttons are the only exit.

`MentraLiveOtaFlowHost` already called `focusEffectPreventBack()`. That left four ways out:

1. **Android, inherited handler** — `androidBackFn` is a single global slot, and `decPreventBack` only clears it once the prevent-back count reaches **zero**. The OTA screen increments before the screen underneath blurs, so that screen's handler (e.g. a capsule host's minimize-then-`goBack`) stays registered. `NavigationHost` runs whatever is in the slot → the user gets popped off the flow. Same global-slot clobber already documented in `NavigationHost.tsx`.
2. **iOS, navigator-wide gesture** — `gestureEnabled` is a *navigator-wide* default of `forceGestureEnabled || !preventBack` (`AllProviders.tsx:191`). Anything still holding `forceGestureEnabled` (a miniapp host mid-teardown) re-enables the edge swipe for every screen regardless of `preventBack`.
3. **Android, interceptor bypass** (found by Codex in review) — `NavigationHost` checked `interceptor` *before* `preventBack`. `OfflineAppHost` sets `activeRef.current = false` and calls `clearForeground()` on an external push (Settings debug → `/ota/check-for-updates`) but stays mounted and registered through its exit fade, so `interceptor.goBack()` declines and the store's `goBack()` fell through to `router.back()` — popping the screen the push had just landed on.
4. **Either platform, JS-dispatched back** (raised by cubic) — no live caller today, but nothing stopped one.

## Change

New `focusEffectLockScreen()` in `NavigationHistoryContext`, used by `MentraLiveOtaFlowHost`:

- claims the shared back-handler slot with a stable no-op, so an inherited handler can't fire;
- disables the gesture through the **screen's own** options (`navigation.setOptions({gestureEnabled: false})`), which beats the navigator default and can't be re-enabled from elsewhere;
- backstops `beforeRemove`, preventDefaulting **only** `GO_BACK`/`POP` — the flow's own exits go out as REPLACE / POP_TO_TOP / POP_TO, and blocking removal outright would strand the user for good. Same convention as `pairing/scan.tsx` and `auth/workspace-signin.tsx`.

And in `NavigationHost`, back is handed to the interceptor only when it *claims* the press:

```ts
if (interceptor?.goBack()) return true
if (!preventBack) { goBack(); return true }
androidBackFn?.()
```

Behaviour is unchanged when the interceptor is active, and unchanged when it declines with no guard up. The generic single-slot `androidBackFn` design is otherwise untouched.

## Trade-off worth naming

This is deliberate per the issue ("users should probably not be able to leave this screen at all"): if the flow wedges, the only ways out are its own buttons (`Done` / `Retry` / dev+super skips) or backgrounding the app. The `failed` and `up_to_date` pages both surface an exit button, and `superMode` keeps its skip.

## Test evidence

- `src/contexts/__tests__/focusEffectLockScreen.test.tsx` — slot claim, per-screen gesture lock, JS back blocked, own-exit action types still allowed.
- `src/effects/__tests__/NavigationHost.test.tsx` — interceptor claims / interceptor declines over a locked screen / plain back.

Both new regressions were verified to fail against the old code before fixing (revert the no-op claim → `previousScreenBack` called once; revert the `NavigationHost` ordering → the declining-interceptor case fails).

```
npx jest src/app/ota src/contexts src/effects src/__tests__/app src/components
  Test Suites: 30 passed, 30 total
  Tests:       209 passed, 209 total

npx tsc --noEmit -p tsconfig.json   # clean
```

Not device-tested — needs a hardware pass on an actual Mentra Live OTA (Android gesture back + iOS edge swipe on download / install / "Restarting Mentra Live").