### PR TITLE
Fix OTA recovery after interrupted downloads

### DIFF
--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -140,8 +140,10 @@ function latestPercentForStuck(otaStatus: OtaStatus | null, otaProgress: OtaProg
  * reply that cancels the fallback.
  */
 function hasRecoveringOtaReply(otaStatus: OtaStatus | null, otaProgress: OtaProgress | null): boolean {
-  if (otaProgress) return true
-  return !!otaStatus && otaStatus.status !== "idle"
+  // OtaService projects status into legacy progress too: idle becomes STARTED.
+  // Neither that projection nor progress retained across reboot proves activity.
+  if (otaStatus) return otaStatus.status !== "idle"
+  return !!otaProgress
 }
 
 /** Read model the host progress screen renders from. */

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -504,6 +504,74 @@ describe("OtaInstallCoordinator ota_start request ownership", () => {
 })
 
 describe("OtaInstallCoordinator query-status arbitration with an existing session", () => {
+  it.each([false, true])(
+    "recovers an interrupted download after idle with mapped progress=%s",
+    async (mapIdleProgress) => {
+      setGlassesConnected()
+      otaInstallCoordinator.attach()
+      await flushNativeStartPromise()
+      emitLegacyOtaProgress({stage: "download", status: "PROGRESS", progress: 55, currentUpdate: "apk"})
+
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+      setGlassesConnected()
+      expect(bluetoothSdkMock.queryOtaStatus).toHaveBeenCalledTimes(1)
+
+      const idle = normalizeOtaStatusEvent({
+        session_id: "",
+        total_steps: 0,
+        current_step: 0,
+        step_type: "apk",
+        phase: "download",
+        status: "idle",
+        step_percent: 0,
+        overall_percent: 0,
+      })
+      useGlassesStore.getState().setOtaStatus(otaStatusFromNormalized(idle))
+      if (mapIdleProgress) {
+        useGlassesStore.getState().setOtaProgress(legacyOtaProgressFromOtaStatusEvent(idle))
+      }
+      expect(otaInstallCoordinator.snapshot().displayState).toBe("starting")
+      await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS)
+      expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+
+      emitLegacyOtaProgress({stage: "download", status: "PROGRESS", progress: 10, currentUpdate: "apk"})
+      await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS * 2)
+      expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(2)
+      expect(otaInstallCoordinator.snapshot().displayState).toBe("updating")
+    },
+  )
+
+  it("cancels idle recovery when fresh download activity arrives before the fallback", async () => {
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    await flushNativeStartPromise()
+    emitLegacyOtaProgress({stage: "download", status: "PROGRESS", progress: 55, currentUpdate: "apk"})
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+    useGlassesStore.getState().setOtaStatus(idleStatus())
+    emitLegacyOtaProgress({stage: "download", status: "PROGRESS", progress: 56, currentUpdate: "apk"})
+    await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS * 2)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps progress-only legacy replies able to cancel recovery", async () => {
+    setLegacyGlassesConnected()
+    otaInstallCoordinator.attach()
+    await flushNativeStartPromise()
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setLegacyGlassesConnected()
+    useGlassesStore.getState().setOtaProgress({
+      stage: "download",
+      status: "PROGRESS",
+      progress: 10,
+      currentUpdate: "apk",
+      bytesDownloaded: 10,
+      totalBytes: 100,
+    })
+    await jest.advanceTimersByTimeAsync(QUERY_REPLY_TIMEOUT_MS * 2)
+    expect(bluetoothSdkMock.startOtaUpdate).toHaveBeenCalledTimes(1)
+  })
+
   it("sends ota_query_status; an idle reply does NOT cancel the fallback, so ota_start fires after QUERY_REPLY_TIMEOUT_MS", async () => {
     setGlassesConnected()
     useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: 10, overallPercent: 10}))


### PR DESCRIPTION
## Problem and change

Powering off Mentra Live during an APK download can leave the phone at Reconnecting, then Starting update, then Update failed. In the observed beta.169 run, reconnect restored communication, but the glasses reported `idle` while the phone retained 55% download progress. The recovery helper counted that stale progress as a useful reply and canceled the existing query fallback. OtaService then projected idle into legacy `STARTED` progress, which also incorrectly counted as activity.

Give structured OTA status precedence over its legacy progress projection. An explicit idle reply keeps the existing bounded recovery fallback armed; non-idle status still cancels it, and progress-only legacy replies remain supported. No new timers or UI changes.

## Validation

- Reproduced the failure before the fix: both stale-progress and idle-projection regression cases failed because no recovery start was sent.
- 278 OTA tests passed across 13 suites, including four new cases covering stale progress, mapped idle progress, fresh activity before fallback, and progress-only legacy replies. Existing active-session, no-reply, retry ownership, and expected-restart tests pass.
- Prettier and git diff checks pass.
- Mobile typecheck has 10 existing Radio/Switch toggle diagnostics; unchanged base `4b429bc36e` produces byte-identical diagnostics. No new type errors.
- Device evidence before the fix (Pacific time): 16:10:17 reconnect; 16:10:23 idle reply and Starting state; glasses log says it is waiting for phone-initiated ota_start. User subsequently observed Update failed.
- Native builds and post-fix device validation remain pending: local disk has about 186 MB free. Retest by interrupting an APK download and verifying one recovery start, advancing progress, completion, and the installed version on a build containing this commit.
