### PR TITLE
Enable Mentra 3.0 downgrade floor in Engine and native SDKs

### DIFF
--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -155,6 +155,18 @@ Phone-pinned `asg_client` APK downgrades are supported when the target version c
 `51518114` (Mentra 3.0). Older targets predate the downgrade-safe media and recovery contract and
 must be refused.
 
+**Downgrade release invariant:** the MentraOS phone app and `asg_client` are kept aligned
+through coordinated releases. For supported releases, a higher installed ASG version from
+which the phone offers a downgrade already supports the downgrade/recovery contract and
+has the downgrade floor enabled. Phone-side availability checks therefore rely on this
+release invariant rather than a separate minimum-installed-version or capability gate.
+
+The shipped downgrade floor must never decrease. It may increase to retire older targets,
+but any increase must be coordinated across ASG, the recovery worker, Engine, and the Swift
+and Kotlin SDK defaults so the phone only offers targets accepted by the aligned glasses.
+The supported-source invariant must continue to hold when the floor increases. Explicit
+floor overrides used by tests do not change this release policy.
+
 Update flows must preserve device recoverability, report progress where possible, and avoid interrupting active media operations without cleanup.
 
 The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. At startup, `asg_client` retries discovery at 460800 before making one bounded probe at 1152000, then returns to 460800 if neither rate answers. The alternate probe does not depend on app-local cached state, so an APK reinstall can recover a BES that survived at the negotiated rate. Once traffic confirms a negotiated 1152000 link, BES keeps that baud across UART driver restarts and Android sleep; ordinary phone heartbeats and expected MTK sleep silence must not return one endpoint to 460800. If an older BES nevertheless falls back or reboots while ASG remains alive, several small unframed reads or an idle-link health probe cause `asg_client` to verify 1152000, probe 460800, and renegotiate the fast link after finding BES at the rendezvous rate. If neither rate answers, ASG remains at 460800 and retries the two-rate scan with capped exponential backoff so a later BES boot cannot leave the endpoints split indefinitely. Each scan is bounded and recovery is suppressed during BES OTA, file transfer, and active baud transitions. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
@@ -69,6 +69,9 @@ internal object OtaManifestChecker {
         currentBesVersion: String,
         manifest: JSONObject,
         // Mentra 3.0 is the oldest downgrade-safe target, matching Engine, ASG, and recovery.
+        // Coordinated releases guarantee higher supported ASG builds can downgrade; no source gate is needed.
+        // The shipped floor may increase, never decrease, and must stay aligned across all checkers.
+        // See asg_client/docs/mentra-live-spec.md#ota-and-updates.
         // An explicit non-positive override still disables downgrades.
         downgradeFloorVersionCode: Long = 51518114L,
     ): Boolean =

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/OtaManifest.kt
@@ -68,11 +68,9 @@ internal object OtaManifestChecker {
         currentMtkVersion: String,
         currentBesVersion: String,
         manifest: JSONObject,
-        // Downgrade floor: a non-positive value (the default) disables downgrades entirely,
-        // matching ASG's fail-closed DowngradeGate and the engine. OEM SDK consumers that do
-        // not set a floor therefore get upgrade-only behavior and are never told a downgrade is
-        // available that the glasses would refuse.
-        downgradeFloorVersionCode: Long = 0L,
+        // Mentra 3.0 is the oldest downgrade-safe target, matching Engine, ASG, and recovery.
+        // An explicit non-positive override still disables downgrades.
+        downgradeFloorVersionCode: Long = 51518114L,
     ): Boolean =
         hasApkUpdate(currentBuildNumber, manifest, downgradeFloorVersionCode) ||
             hasMtkUpdate(manifest.optJSONArray("mtk_patches"), currentMtkVersion) ||

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/OtaManifestDowngradeTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/OtaManifestDowngradeTest.kt
@@ -32,6 +32,14 @@ class OtaManifestDowngradeTest {
         )
 
     @Test
+    fun shippedFloorAllowsMentra30ButRejectsOlderTargets() {
+        for ((target, expected) in listOf(51518113L to false, 51518114L to true, 51518115L to true, 100000095L to false)) {
+            assertEquals(expected, OtaManifestChecker.hasUpdate("100000095", "", "", manifest(target)))
+        }
+        assertFalse(OtaManifestChecker.hasUpdate("100000095", "", "", manifest(51518114L), downgradeFloorVersionCode = 0L))
+    }
+
+    @Test
     fun upgradeIsAlwaysAnUpdate() {
         assertTrue(hasUpdate("49000000", manifest(49076573L)))
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
@@ -88,6 +88,9 @@ enum OtaManifestChecker {
         currentBesVersion: String,
         manifest: OtaManifest,
         // Mentra 3.0 is the oldest downgrade-safe target, matching Engine, ASG, and recovery.
+        // Coordinated releases guarantee higher supported ASG builds can downgrade; no source gate is needed.
+        // The shipped floor may increase, never decrease, and must stay aligned across all checkers.
+        // See asg_client/docs/mentra-live-spec.md#ota-and-updates.
         // An explicit non-positive override still disables downgrades.
         downgradeFloorVersionCode: Int = 51518114
     ) throws -> Bool {

--- a/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/OtaManifest.swift
@@ -87,11 +87,9 @@ enum OtaManifestChecker {
         currentMtkVersion: String,
         currentBesVersion: String,
         manifest: OtaManifest,
-        // Downgrade floor: a non-positive value (the default) disables downgrades entirely,
-        // matching ASG's fail-closed DowngradeGate and the engine. OEM SDK consumers that do not
-        // set a floor get upgrade-only behavior and are never told a downgrade is available that
-        // the glasses would refuse.
-        downgradeFloorVersionCode: Int = 0
+        // Mentra 3.0 is the oldest downgrade-safe target, matching Engine, ASG, and recovery.
+        // An explicit non-positive override still disables downgrades.
+        downgradeFloorVersionCode: Int = 51518114
     ) throws -> Bool {
         try hasApkUpdate(
             currentBuildNumber: currentBuildNumber,

--- a/mobile/modules/bluetooth-sdk/ios/Tests/OtaManifestDowngradeTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/OtaManifestDowngradeTests.swift
@@ -1,0 +1,20 @@
+@testable import MentraBluetoothSDK
+import XCTest
+
+final class OtaManifestDowngradeTests: XCTestCase {
+    func testShippedFloorAllowsMentra30ButRejectsOlderTargets() throws {
+        for (target, expected) in [(51_518_113, false), (51_518_114, true), (51_518_115, true), (100_000_095, false)] {
+            let manifest = OtaManifest(apps: ["com.mentra.asg_client": OtaManifestApp(versionCode: target)],
+                                       mtkPatches: nil, besFirmware: nil, versionCode: nil)
+            XCTAssertEqual(try OtaManifestChecker.hasUpdate(currentBuildNumber: "100000095",
+                                                            currentMtkVersion: "", currentBesVersion: "", manifest: manifest), expected)
+        }
+    }
+
+    func testExplicitDisabledFloorStillRejectsDowngrades() throws {
+        let manifest = OtaManifest(apps: ["com.mentra.asg_client": OtaManifestApp(versionCode: 51_518_114)],
+                                   mtkPatches: nil, besFirmware: nil, versionCode: nil)
+        XCTAssertFalse(try OtaManifestChecker.hasUpdate(currentBuildNumber: "100000095",
+                                                        currentMtkVersion: "", currentBesVersion: "", manifest: manifest, downgradeFloorVersionCode: 0))
+    }
+}

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -13,7 +13,8 @@ import {resolveOtaReleaseVersion} from "./otaReleaseVersion"
  * glasses reporting a bare "complete", which would otherwise present as false success. Keep this
  * in lockstep with the ASG/recovery constant at release time.
  */
-export const DOWNGRADE_FLOOR_VERSION_CODE = 0
+// Mentra 3.0: matches OtaConstants and RecoveryConstants on the glasses.
+export const DOWNGRADE_FLOOR_VERSION_CODE = 51518114
 
 export interface VersionInfo {
   versionCode: number

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -14,6 +14,9 @@ import {resolveOtaReleaseVersion} from "./otaReleaseVersion"
  * in lockstep with the ASG/recovery constant at release time.
  */
 // Mentra 3.0: matches OtaConstants and RecoveryConstants on the glasses.
+// Coordinated releases guarantee higher supported ASG builds can downgrade; no source gate is needed.
+// The shipped floor may increase, never decrease, and must stay aligned across all checkers.
+// See asg_client/docs/mentra-live-spec.md#ota-and-updates.
 export const DOWNGRADE_FLOOR_VERSION_CODE = 51518114
 
 export interface VersionInfo {

--- a/mobile/src/__tests__/otaUpdateCheckService.test.ts
+++ b/mobile/src/__tests__/otaUpdateCheckService.test.ts
@@ -132,7 +132,9 @@ describe("OtaUpdateCheckService", () => {
         waitForMtkVersionMs: 0,
       })
 
-    global.fetch = jest.fn(() => Promise.resolve({ok: false, status: 404} as unknown as Response)) as unknown as typeof fetch
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ok: false, status: 404} as unknown as Response),
+    ) as unknown as typeof fetch
     let result = await check()
     expect(result.hasCheckCompleted).toBe(false)
     expect(result.checkFailureReason).toBe("pin_unavailable")
@@ -142,7 +144,9 @@ describe("OtaUpdateCheckService", () => {
     expect(result.hasCheckCompleted).toBe(false)
     expect(result.checkFailureReason).toBe("network")
 
-    global.fetch = jest.fn(() => Promise.resolve({ok: false, status: 503} as unknown as Response)) as unknown as typeof fetch
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ok: false, status: 503} as unknown as Response),
+    ) as unknown as typeof fetch
     result = await check()
     expect(result.checkFailureReason).toBe("network")
   })
@@ -212,8 +216,34 @@ describe("OtaUpdateCheckService", () => {
     expect(useGlassesStore.getState().buildNumber).toBe("10")
   })
 
+  it.each([
+    [51518113, false],
+    [51518114, true],
+    [51518115, true],
+    [100000095, false],
+  ])("uses the shipped downgrade floor for target %i", async (versionCode, available) => {
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "100000095"})
+    global.fetch = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({apps: {"com.mentra.asg_client": {versionCode}}}),
+        }) as Response,
+    ) as unknown as typeof fetch
+
+    const result = await checkCurrentGlassesForUpdate({
+      refreshVersionInfo: false,
+      fixClockBeforeCheck: false,
+      waitForBesVersionMs: 0,
+      waitForMtkVersionMs: 0,
+    })
+    expect(result.updateAvailable).toBe(available)
+    expect(result.isApkDowngrade).toBe(available)
+    expect(useGlassesStore.getState().otaUpdateAvailable?.isDowngrade ?? false).toBe(available)
+  })
+
   it("downgrades default to skippable; explicit isRequired forces them", async () => {
-    // Enable downgrades with a floor at/below the pin (production ships floor 0 = disabled).
+    // Use a small test-only floor for this synthetic manifest.
     const check = () =>
       checkCurrentGlassesForUpdate({
         refreshVersionInfo: false,
@@ -223,7 +253,17 @@ describe("OtaUpdateCheckService", () => {
         floorVersionCode: 9,
       })
     const manifestWith = (extra: object) => ({
-      apps: {"com.mentra.asg_client": {versionCode: 9, versionName: "9", downloadUrl: "u", apkSize: 1, sha256: "s", releaseNotes: "", ...extra}},
+      apps: {
+        "com.mentra.asg_client": {
+          versionCode: 9,
+          versionName: "9",
+          downloadUrl: "u",
+          apkSize: 1,
+          sha256: "s",
+          releaseNotes: "",
+          ...extra,
+        },
+      },
     })
 
     // Glasses newer than the pin -> downgrade; absent isRequired -> skippable.
@@ -245,14 +285,26 @@ describe("OtaUpdateCheckService", () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({apps: {"com.mentra.asg_client": {versionCode: 999999, versionName: "n", downloadUrl: "u", apkSize: 1, sha256: "s", releaseNotes: ""}}}),
+        json: () =>
+          Promise.resolve({
+            apps: {
+              "com.mentra.asg_client": {
+                versionCode: 999999,
+                versionName: "n",
+                downloadUrl: "u",
+                apkSize: 1,
+                sha256: "s",
+                releaseNotes: "",
+              },
+            },
+          }),
       } as unknown as Response),
     ) as unknown as typeof fetch
     result = await check()
     expect(result.isApkDowngrade).toBe(false)
     expect(result.isRequired).toBe(true)
 
-    // Floor 0 (production default) disables downgrades entirely: the same lower pin is not offered.
+    // An explicit floor 0 disables downgrades entirely: the same lower pin is not offered.
     global.fetch = jest.fn(() =>
       Promise.resolve({ok: true, json: () => Promise.resolve(manifestWith({}))} as unknown as Response),
     ) as unknown as typeof fetch

--- a/mobile/src/effects/__tests__/OtaUpdateChecker.test.ts
+++ b/mobile/src/effects/__tests__/OtaUpdateChecker.test.ts
@@ -128,8 +128,8 @@ describe("checkVersionUpdateAvailable", () => {
     expect(checkVersionUpdateAvailable("100", newFormatJson)).toBe(false)
   })
 
-  it("does not flag a downgrade when the floor is disabled (production default 0)", () => {
-    // Floor 0 disables downgrades: a newer installed build than the exact pin is not offered.
+  it("does not flag a downgrade below the shipped floor", () => {
+    // Synthetic build 100 predates the oldest supported downgrade target.
     expect(checkVersionUpdateAvailable("200", newFormatJson)).toBe(false)
   })
 


### PR DESCRIPTION
## Problem and change

ASG and its recovery worker allow downgrades to Mentra 3.0 (ASG versionCode 51518114), but all three phone-side OTA checkers still defaulted to floor 0, disabling downgrade availability. The Mentra App/React Native example therefore never offered the version change, and native iOS/Android examples received false from checkForOtaUpdate, leaving Start OTA disabled.

Set Engine, Swift SDK, and Kotlin SDK defaults to 51518114. Keep exact-manifest-pin requirements, rejection below the floor, equal-version no-op, legacy-manifest upgrade-only behavior, and explicit floor-0 disabling. ASG/recovery already use this boundary and require no changes.

## Coordinated-release invariant

The phone app and ASG are kept aligned through coordinated releases. Any higher supported ASG build from which the phone offers a downgrade already supports the downgrade/recovery contract and has its floor enabled. A separate installed-build/capability gate is therefore unnecessary for the supported release path.

The shipped floor may increase but must never decrease. Increases must remain aligned across ASG, recovery, Engine, Swift, and Kotlin and preserve that source-build invariant. This contract is documented in `asg_client/docs/mentra-live-spec.md` and referenced beside all three phone-side defaults. The review's hypothetical higher ASG build without downgrade support is outside this release invariant; no capability gate is added.

## Validation

- Before the Engine fix, new default-policy tests failed for targets 51518114 and 51518115; both now pass.
- 278 OTA Jest tests across 13 suites pass, including end-to-end availability/store tests using the default floor and installed ASG version 100000095.
- Repository Android compile check passes: scripts/check-android-compile.sh bluetooth-sdk (public SDK AAR).
- Eight Kotlin checker tests pass in a standalone JVM harness using the real checker and test assertions with org.json (Robolectric annotations removed for this isolated policy run; release metadata/error dependencies supplied by harness).
- Two Swift XCTest cases pass in an isolated macOS Swift package using the real checker/error source and the new test file; only generated manifest metadata is supplied by the harness. Full iOS app compilation remains a CI check.
- Mobile typecheck has the same 10 existing Radio/Switch diagnostics as unchanged staging, with no new diagnostics. git diff --check passes.
- No hardware downgrade initiated; post-release physical validation remains pending.

## Release and testing

This accompanies Starter Kit PR https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/176 and OTA recovery PR https://github.com/Mentra-Community/MentraOS/pull/3967. Preserve the requested order: example presentation first, then MentraOS changes and coordinated package/TestFlight releases.

Existing App Store 3.0 and older example binaries retain their shipped disabled policy. Updated examples can test downgrade only when their selected exact manifest targets a lower ASG build at or above 51518114; using the current release pin may simply match the already-installed build. No example app source or manual package-pin change is needed for this shared policy fix.

