### PR TITLE
Fix release asset lookup buffer overflow

### DIFF
--- a/.github/scripts/publish-immutable-release-asset.mjs
+++ b/.github/scripts/publish-immutable-release-asset.mjs
@@ -29,6 +29,23 @@ export function releaseAssetUploadUrl(repository, releaseId, name) {
   return `https://uploads.github.com/repos/${repository}/releases/${releaseId}/assets?name=${encodeURIComponent(name)}`
 }
 
+export function findReleaseAsset(repository, releaseId, name, run = gh) {
+  // Filter inside gh so a growing release cannot overflow Node's output buffer.
+  // Keep all matching assets across pages so duplicate detection still fails closed.
+  const output = run(
+    [
+      "api",
+      "--paginate",
+      `repos/${repository}/releases/${releaseId}/assets?per_page=100`,
+      "--jq",
+      `.[] | select(.name == ${JSON.stringify(name)}) | {id, name} | tojson`,
+    ],
+    {encoding: "utf8"},
+  )
+  const assets = output.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+  return matchingAsset(assets, name)
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2))
   const file = path.resolve(args.file)
@@ -39,13 +56,7 @@ function main() {
     throw new Error("--file, --name, --release-id, and --repository are required")
   }
   if (path.basename(file) !== name) throw new Error("Immutable asset name must equal the source file basename")
-  const pages = JSON.parse(
-    gh(["api", "--paginate", "--slurp", `repos/${repository}/releases/${releaseId}/assets?per_page=100`], {
-      encoding: "utf8",
-    }),
-  )
-  const assets = pages.flat()
-  const existing = matchingAsset(assets, name)
+  const existing = findReleaseAsset(repository, releaseId, name)
   if (!existing) {
     gh(
       [

--- a/.github/scripts/publish-immutable-release-asset.test.mjs
+++ b/.github/scripts/publish-immutable-release-asset.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import {matchingAsset, releaseAssetUploadUrl} from "./publish-immutable-release-asset.mjs"
+import {findReleaseAsset, matchingAsset, releaseAssetUploadUrl} from "./publish-immutable-release-asset.mjs"
 
 test("selects one immutable release asset and rejects duplicates", () => {
   assert.equal(matchingAsset([{name: "one"}, {name: "two"}], "two").name, "two")
@@ -14,4 +14,30 @@ test("targets GitHub's release upload host without enterprise API routing", () =
     releaseAssetUploadUrl("Mentra-Community/MentraOS", "123", "Mentra 3.1.0 #1.apk"),
     "https://uploads.github.com/repos/Mentra-Community/MentraOS/releases/123/assets?name=Mentra%203.1.0%20%231.apk",
   )
+})
+
+test("filters all release asset pages inside gh and safely quotes the exact name", () => {
+  const name = 'Mentra "quoted" \\ build.apk'
+  const asset = {id: 123, name}
+  const result = findReleaseAsset("owner/repo", "456", name, (args, options) => {
+    assert.deepEqual(args, [
+      "api",
+      "--paginate",
+      "repos/owner/repo/releases/456/assets?per_page=100",
+      "--jq",
+      `.[] | select(.name == ${JSON.stringify(name)}) | {id, name} | tojson`,
+    ])
+    assert.equal(options.encoding, "utf8")
+    return JSON.stringify(asset)
+  })
+  assert.deepEqual(result, asset)
+})
+
+test("filtered lookups retain missing-asset and duplicate-asset behavior", () => {
+  assert.equal(findReleaseAsset("owner/repo", "1", "missing", () => ""), null)
+  assert.throws(
+    () => findReleaseAsset("owner/repo", "1", "one", () => '{"id":1,"name":"one"}\n{"id":2,"name":"one"}\n'),
+    /duplicate asset one/,
+  )
+  assert.throws(() => findReleaseAsset("owner/repo", "1", "one", () => "invalid JSON"), SyntaxError)
 })


### PR DESCRIPTION
The staging 3.1.0-beta.173 release built ASG successfully but failed to publish its immutable asset: the accumulated GitHub release asset metadata exceeded Node's default 1 MiB subprocess buffer (`spawnSync gh ENOBUFS`).

Filter each asset page inside `gh` and return only the exact name and ID. Continue traversing all pages and rejecting duplicate names; existing assets still require identical bytes before reuse.

Validation:
- All 213 coordinated release-tooling tests pass; release-family and generated changelog checks pass.
- Reproduced the original overflow with the live 1,049,169-byte asset listing, then verified the fixed lookup finds its last-page asset.
- A larger fixture passes with quoted/backslash filenames and rejects duplicate matches across pages.

Failed run: https://github.com/Mentra-Community/MentraOS/actions/runs/34300806798
