### PR TITLE
Wait for package publication before dispatching Starter Kit

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -237,7 +237,7 @@ test("coordinated docs publish only after finalization to the matching channel",
   const docs = jobBlock(coordinator, "docs")
   const notify = jobBlock(coordinator, "notify-slack")
 
-  assert.match(starterKit, /^    needs: \[plan, ota\]$/m)
+  assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native\]$/m)
   assert.match(engineConsumer, /^    needs: \[plan, npm\]$/m)
   assert.match(starterKit, /coordinated-example-release\.yml/)
   assert.match(coordinator, /Freeze the Starter Kit channel source/)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -341,7 +341,7 @@ jobs:
 
   starter-kit:
     name: Build coordinated Starter Kit examples
-    needs: [plan, ota]
+    needs: [plan, ota, npm, sdk-native]
     runs-on: ubuntu-latest
     timeout-minutes: 150
     outputs:


### PR DESCRIPTION
Dev release 3.2.0-dev.177 dispatched Starter Kit while npm publication was still running. Starter Kit exhausted its ten-minute prerequisite wait at 03:20:51 UTC; npm publication completed at 03:21:13 UTC, leaving the otherwise successful release blocked.

Make Starter Kit depend on npm and native SDK publication. Its existing bounded checks can then handle propagation after publication instead of racing the builds themselves. Update the workflow contract accordingly.

Validation: all 213 release-tooling tests, actionlint, release-family validation, and diff checks pass. Public npm and SwiftPM prerequisites for dev.177 were verified before retrying its failed jobs.

This shared fix originates on staging and will flow into dev through a staging merge.
