### PR TITLE
Gate Android releases and the app config on Bluetooth SDK analytics being enabled

### DIFF
--- a/mobile/scripts/app-config-analytics.test.mjs
+++ b/mobile/scripts/app-config-analytics.test.mjs
@@ -9,12 +9,28 @@ import test from "node:test"
 // `expo config`, the same path prebuild uses, so what is asserted is what ships.
 
 function bluetoothSdkPluginProps() {
-  const json = execFileSync("npx", ["expo", "config", "--json", "--type", "prebuild"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    env: {...process.env, EXPO_NO_TELEMETRY: "1", CI: "1"},
-    maxBuffer: 16 * 1024 * 1024,
-  })
+  let json
+  try {
+    json = execFileSync("npx", ["expo", "config", "--json", "--type", "prebuild"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        EXPO_NO_TELEMETRY: "1",
+        // app.config.ts refuses to build without a Mapbox token in CI. The token
+        // has nothing to do with this check, so supply the same placeholder
+        // .env.example ships when the environment has none.
+        EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN: process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN || "ci-dummy-not-a-real-token",
+      },
+      maxBuffer: 16 * 1024 * 1024,
+    })
+  } catch (error) {
+    throw new Error(
+      `expo config failed: ${String(error.stderr || error.message)
+        .trim()
+        .slice(0, 2000)}`,
+    )
+  }
   const config = JSON.parse(json)
   const entry = (config.plugins ?? []).find(
     (p) => Array.isArray(p) && String(p[0]).includes("modules/bluetooth-sdk/app.plugin"),

--- a/mobile/scripts/app-config-analytics.test.mjs
+++ b/mobile/scripts/app-config-analytics.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import {execFileSync} from "node:child_process"
+import test from "node:test"
+
+// Guards the regression that silently zeroed glasses WAU: from 2026-08-11 every
+// dev/beta build shipped with `analytics: false` on the Bluetooth SDK plugin.
+// The SDK's usage analytics are the source of truth for WAU, so the Mentra App
+// must always leave them enabled and declare its build lane. Resolved through
+// `expo config`, the same path prebuild uses, so what is asserted is what ships.
+
+function bluetoothSdkPluginProps() {
+  const json = execFileSync("npx", ["expo", "config", "--json", "--type", "prebuild"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    env: {...process.env, EXPO_NO_TELEMETRY: "1", CI: "1"},
+    maxBuffer: 16 * 1024 * 1024,
+  })
+  const config = JSON.parse(json)
+  const entry = (config.plugins ?? []).find(
+    (p) => Array.isArray(p) && String(p[0]).includes("modules/bluetooth-sdk/app.plugin"),
+  )
+  assert.ok(entry, "app.config.ts no longer registers ./modules/bluetooth-sdk/app.plugin.js")
+  return entry[1] ?? {}
+}
+
+test("the Mentra App never disables the Bluetooth SDK's usage analytics", () => {
+  const {analytics} = bluetoothSdkPluginProps()
+  assert.notEqual(analytics, false, "analytics: false would zero glasses WAU for every Mentra App install")
+  if (analytics && typeof analytics === "object") {
+    assert.notEqual(analytics.enabled, false)
+  }
+})
+
+test("the Mentra App declares its build lane so store installs are separable from dev and staging", () => {
+  const {analytics} = bluetoothSdkPluginProps()
+  assert.ok(analytics && typeof analytics === "object", "analytics must be configured as an object with an environment")
+  const expected = (process.env.EXPO_PUBLIC_BUILD_ENV || "dev").trim().toLowerCase()
+  assert.equal(analytics.environment, expected)
+  assert.match(analytics.environment, /^[a-z0-9][a-z0-9_-]{0,31}$/)
+})

--- a/mobile/scripts/release-android.mjs
+++ b/mobile/scripts/release-android.mjs
@@ -3,6 +3,7 @@
 import { setBuildEnv } from './set-build-env.mjs';
 import { withRetry, isSentryTransientError, writeSummary } from './release-utils.mjs';
 import { validateReleaseArchive } from './release-bundle-config.mjs';
+import { validateAndroidSdkAnalyticsMetadata } from './release-sdk-metadata.mjs';
 import { getBuildNumber } from './build-number.mjs';
 import { cp, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -114,7 +115,8 @@ console.log('APK built successfully');
 // a clean Metro cache, but this prevents a future release-script regression
 // from publishing an APK with missing runtime configuration.
 validateReleaseArchive(apkPath, 'Android');
-console.log('Verified Android release JS bundle configuration');
+validateAndroidSdkAnalyticsMetadata(apkPath);
+console.log('Verified Android release JS bundle configuration and Bluetooth SDK analytics metadata');
 
 // Coordinated release CI owns immutable artifact naming and distribution. Keep
 // the established build/sign/validation path, but return both store and

--- a/mobile/scripts/release-sdk-metadata.mjs
+++ b/mobile/scripts/release-sdk-metadata.mjs
@@ -70,22 +70,41 @@ export function validateIosSdkAnalyticsMetadata(ipaPath, env = process.env) {
 
 // ---- Android -----------------------------------------------------------------
 
-/** Parses `aapt2 dump xmltree` output into {metaDataName: value} for the application's meta-data entries. */
+/**
+ * Parses `aapt2 dump xmltree` output into {metaDataName: value} for the
+ * application's meta-data entries. aapt2 prints a value in one of these forms:
+ *   ="staging" (Raw: "staging")        string
+ *   =true / =false                     boolean (build-tools 36 prints it bare)
+ *   =(type 0x12)0xffffffff             boolean, older build-tools
+ *   =@0x7f... (Raw: "...")             resource reference with its raw text
+ * Anything else is kept verbatim so a validator can reject it instead of
+ * mistaking it for "unset".
+ */
 export function parseManifestMetaData(xmltree) {
   const meta = {}
   const lines = xmltree.split("\n")
+  const attr = /android:(name|value)\([^)]*\)=(.*)$/
+  const decode = (rest) => {
+    const trimmed = rest.trim()
+    const quoted = trimmed.match(/^"([^"]*)"/)
+    if (quoted) return quoted[1]
+    const typed = trimmed.match(/^\(type 0x12\)0x([0-9a-f]+)/i)
+    if (typed) return /^0+$/.test(typed[1]) ? "false" : "true"
+    const bare = trimmed.match(/^(true|false)\b/i)
+    if (bare) return bare[1].toLowerCase()
+    const raw = trimmed.match(/\(Raw: "([^"]*)"\)/)
+    if (raw) return raw[1]
+    return trimmed
+  }
   for (let i = 0; i < lines.length; i++) {
     if (!/E: meta-data/.test(lines[i])) continue
     let name
     let value
     for (let j = i + 1; j < lines.length && !/^\s*E: /.test(lines[j]); j++) {
-      const m = lines[j].match(
-        /android:(name|value)\([^)]*\)=(?:"([^"]*)"|\(type 0x12\)0x([0-9a-f]+)|\S+ \(Raw: "([^"]*)"\)|\S+)/,
-      )
+      const m = lines[j].match(attr)
       if (!m) continue
-      const raw = m[2] ?? m[4] ?? (m[3] !== undefined ? (m[3] === "0" ? "false" : "true") : undefined)
-      if (m[1] === "name") name = raw
-      else value = raw
+      if (m[1] === "name") name = decode(m[2])
+      else value = decode(m[2])
     }
     if (name) meta[name] = value ?? ""
   }
@@ -94,9 +113,13 @@ export function parseManifestMetaData(xmltree) {
 
 export function assertAndroidSdkAnalyticsMetadata(meta, expected, platform = "Android") {
   const problems = []
-  if (String(meta[META_ANALYTICS_DISABLED]).toLowerCase() === "true") {
+  if (META_ANALYTICS_DISABLED in meta && meta[META_ANALYTICS_DISABLED] !== "false") {
+    // Anything other than an explicit "false" fails: "true", an empty value, or a
+    // form this parser did not recognize must never read as "enabled".
     problems.push(
-      `${META_ANALYTICS_DISABLED}=true (Bluetooth SDK analytics must ship enabled; they are the glasses WAU source)`,
+      `${META_ANALYTICS_DISABLED}=${JSON.stringify(
+        meta[META_ANALYTICS_DISABLED],
+      )} (Bluetooth SDK analytics must ship enabled; they are the glasses WAU source)`,
     )
   }
   if (meta[META_ANALYTICS_ENVIRONMENT] !== expected.environment) {

--- a/mobile/scripts/release-sdk-metadata.mjs
+++ b/mobile/scripts/release-sdk-metadata.mjs
@@ -1,5 +1,7 @@
 import {execFileSync} from "node:child_process"
+import {existsSync, readdirSync} from "node:fs"
 import {createRequire} from "node:module"
+import path from "node:path"
 
 const require = createRequire(import.meta.url)
 
@@ -7,6 +9,9 @@ const require = createRequire(import.meta.url)
 export const INFO_SDK_VERSION = "MentraBluetoothSdkVersion"
 export const INFO_ANALYTICS_ENVIRONMENT = "MentraBluetoothSdkAnalyticsEnvironment"
 export const INFO_ANALYTICS_DISABLED = "MentraBluetoothSdkAnalyticsDisabled"
+// Keys the same plugin stamps into AndroidManifest.xml.
+export const META_ANALYTICS_ENVIRONMENT = "com.mentra.bluetoothsdk.analytics.environment"
+export const META_ANALYTICS_DISABLED = "com.mentra.bluetoothsdk.analytics.disabled"
 
 /**
  * What a Mentra App release archive must carry for the Bluetooth SDK's usage
@@ -61,4 +66,74 @@ export function readIpaInfoPlist(ipaPath) {
 
 export function validateIosSdkAnalyticsMetadata(ipaPath, env = process.env) {
   assertSdkAnalyticsMetadata(readIpaInfoPlist(ipaPath), expectedSdkAnalyticsMetadata(env), "iOS")
+}
+
+// ---- Android -----------------------------------------------------------------
+
+/** Parses `aapt2 dump xmltree` output into {metaDataName: value} for the application's meta-data entries. */
+export function parseManifestMetaData(xmltree) {
+  const meta = {}
+  const lines = xmltree.split("\n")
+  for (let i = 0; i < lines.length; i++) {
+    if (!/E: meta-data/.test(lines[i])) continue
+    let name
+    let value
+    for (let j = i + 1; j < lines.length && !/^\s*E: /.test(lines[j]); j++) {
+      const m = lines[j].match(
+        /android:(name|value)\([^)]*\)=(?:"([^"]*)"|\(type 0x12\)0x([0-9a-f]+)|\S+ \(Raw: "([^"]*)"\)|\S+)/,
+      )
+      if (!m) continue
+      const raw = m[2] ?? m[4] ?? (m[3] !== undefined ? (m[3] === "0" ? "false" : "true") : undefined)
+      if (m[1] === "name") name = raw
+      else value = raw
+    }
+    if (name) meta[name] = value ?? ""
+  }
+  return meta
+}
+
+export function assertAndroidSdkAnalyticsMetadata(meta, expected, platform = "Android") {
+  const problems = []
+  if (String(meta[META_ANALYTICS_DISABLED]).toLowerCase() === "true") {
+    problems.push(
+      `${META_ANALYTICS_DISABLED}=true (Bluetooth SDK analytics must ship enabled; they are the glasses WAU source)`,
+    )
+  }
+  if (meta[META_ANALYTICS_ENVIRONMENT] !== expected.environment) {
+    problems.push(
+      `${META_ANALYTICS_ENVIRONMENT}=${JSON.stringify(meta[META_ANALYTICS_ENVIRONMENT] ?? null)} (expected ${
+        expected.environment
+      })`,
+    )
+  }
+  if (problems.length > 0) {
+    throw new Error(`${platform} release manifest has wrong Bluetooth SDK analytics metadata: ${problems.join("; ")}`)
+  }
+}
+
+export function findAapt2(env = process.env) {
+  const home = env.ANDROID_HOME || env.ANDROID_SDK_ROOT || path.join(env.HOME || "", "Library/Android/sdk")
+  const buildTools = path.join(home, "build-tools")
+  if (!existsSync(buildTools)) return null
+  const versions = readdirSync(buildTools).sort((a, b) => a.localeCompare(b, undefined, {numeric: true}))
+  for (const v of versions.reverse()) {
+    const candidate = path.join(buildTools, v, "aapt2")
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+export function readApkManifestMetaData(apkPath, env = process.env) {
+  const aapt2 = findAapt2(env)
+  if (!aapt2)
+    throw new Error("aapt2 not found under ANDROID_HOME/build-tools; cannot verify the Android release manifest")
+  const xmltree = execFileSync(aapt2, ["dump", "xmltree", "--file", "AndroidManifest.xml", apkPath], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  return parseManifestMetaData(xmltree)
+}
+
+export function validateAndroidSdkAnalyticsMetadata(apkPath, env = process.env) {
+  assertAndroidSdkAnalyticsMetadata(readApkManifestMetaData(apkPath, env), expectedSdkAnalyticsMetadata(env), "Android")
 }

--- a/mobile/scripts/release-sdk-metadata.test.mjs
+++ b/mobile/scripts/release-sdk-metadata.test.mjs
@@ -6,11 +6,17 @@ import path from "node:path"
 import test from "node:test"
 
 import {
+  assertAndroidSdkAnalyticsMetadata,
   assertSdkAnalyticsMetadata,
   expectedSdkAnalyticsMetadata,
+  findAapt2,
   INFO_ANALYTICS_DISABLED,
   INFO_ANALYTICS_ENVIRONMENT,
   INFO_SDK_VERSION,
+  META_ANALYTICS_DISABLED,
+  META_ANALYTICS_ENVIRONMENT,
+  parseManifestMetaData,
+  readApkManifestMetaData,
   readIpaInfoPlist,
 } from "./release-sdk-metadata.mjs"
 
@@ -27,7 +33,10 @@ test("assertSdkAnalyticsMetadata accepts a correctly stamped Info.plist", () => 
   assert.doesNotThrow(() =>
     assertSdkAnalyticsMetadata({[INFO_SDK_VERSION]: "3.1.0", [INFO_ANALYTICS_ENVIRONMENT]: "staging"}, expected),
   )
-  assert.throws(() => assertSdkAnalyticsMetadata({[INFO_SDK_VERSION]: "3.1.0"}, expected), /MentraBluetoothSdkAnalyticsEnvironment=null/)
+  assert.throws(
+    () => assertSdkAnalyticsMetadata({[INFO_SDK_VERSION]: "3.1.0"}, expected),
+    /MentraBluetoothSdkAnalyticsEnvironment=null/,
+  )
 })
 
 test("assertSdkAnalyticsMetadata names every missing or wrong key", () => {
@@ -62,3 +71,68 @@ test("readIpaInfoPlist decodes the binary Info.plist inside an IPA", {skip: proc
   assert.equal(infoPlist[INFO_SDK_VERSION], "3.1.0")
   assert.doesNotThrow(() => assertSdkAnalyticsMetadata(infoPlist, expected))
 })
+
+const XMLTREE_SAMPLE = `N: android=http://schemas.android.com/apk/res/android
+  E: manifest (line=2)
+    E: application (line=10)
+      E: meta-data (line=20)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="com.mapbox.token" (Raw: "com.mapbox.token")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)="pk.abc" (Raw: "pk.abc")
+      E: meta-data (line=24)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="${META_ANALYTICS_ENVIRONMENT}" (Raw: "${META_ANALYTICS_ENVIRONMENT}")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)="staging" (Raw: "staging")
+      E: meta-data (line=28)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="${META_ANALYTICS_DISABLED}" (Raw: "${META_ANALYTICS_DISABLED}")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)="true" (Raw: "true")
+      E: service (line=40)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="com.mentra.bluetoothsdk.services.ForegroundService"
+`
+
+test("parseManifestMetaData reads meta-data name/value pairs out of aapt2 xmltree output", () => {
+  const meta = parseManifestMetaData(XMLTREE_SAMPLE)
+  assert.deepEqual(meta, {
+    "com.mapbox.token": "pk.abc",
+    [META_ANALYTICS_ENVIRONMENT]: "staging",
+    [META_ANALYTICS_DISABLED]: "true",
+  })
+})
+
+test("assertAndroidSdkAnalyticsMetadata rejects disabled analytics or a wrong lane, accepts a correct manifest", () => {
+  assert.throws(
+    () =>
+      assertAndroidSdkAnalyticsMetadata(parseManifestMetaData(XMLTREE_SAMPLE), {
+        sdkVersion: "3.1.0",
+        environment: "prod",
+      }),
+    (error) => {
+      assert.match(error.message, /analytics\.disabled=true/)
+      assert.match(error.message, /analytics\.environment="staging" \(expected prod\)/)
+      return true
+    },
+  )
+  assert.throws(
+    () => assertAndroidSdkAnalyticsMetadata({}, {sdkVersion: "3.1.0", environment: "prod"}),
+    /analytics\.environment=null/,
+  )
+  assert.doesNotThrow(() =>
+    assertAndroidSdkAnalyticsMetadata(
+      {[META_ANALYTICS_ENVIRONMENT]: "prod"},
+      {sdkVersion: "3.1.0", environment: "prod"},
+    ),
+  )
+  assert.doesNotThrow(() =>
+    assertAndroidSdkAnalyticsMetadata(
+      {[META_ANALYTICS_ENVIRONMENT]: "prod", [META_ANALYTICS_DISABLED]: "false"},
+      {sdkVersion: "3.1.0", environment: "prod"},
+    ),
+  )
+})
+
+test(
+  "readApkManifestMetaData reads a real APK when aapt2 is available",
+  {skip: !findAapt2() || !process.env.MENTRA_TEST_APK},
+  () => {
+    const meta = readApkManifestMetaData(process.env.MENTRA_TEST_APK)
+    assert.ok(META_ANALYTICS_ENVIRONMENT in meta, "the Mentra App manifest carries the analytics lane")
+  },
+)

--- a/mobile/scripts/release-sdk-metadata.test.mjs
+++ b/mobile/scripts/release-sdk-metadata.test.mjs
@@ -105,7 +105,7 @@ test("assertAndroidSdkAnalyticsMetadata rejects disabled analytics or a wrong la
         environment: "prod",
       }),
     (error) => {
-      assert.match(error.message, /analytics\.disabled=true/)
+      assert.match(error.message, /analytics\.disabled="true"/)
       assert.match(error.message, /analytics\.environment="staging" \(expected prod\)/)
       return true
     },
@@ -136,3 +136,45 @@ test(
     assert.ok(META_ANALYTICS_ENVIRONMENT in meta, "the Mentra App manifest carries the analytics lane")
   },
 )
+
+const BARE_BOOLEAN_SAMPLE = `N: android=http://schemas.android.com/apk/res/android
+  E: manifest (line=2)
+    E: application (line=10)
+      E: meta-data (line=24)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="${META_ANALYTICS_ENVIRONMENT}" (Raw: "${META_ANALYTICS_ENVIRONMENT}")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)="prod" (Raw: "prod")
+      E: meta-data (line=28)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="${META_ANALYTICS_DISABLED}" (Raw: "${META_ANALYTICS_DISABLED}")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)=true
+      E: meta-data (line=32)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="legacy.typed" (Raw: "legacy.typed")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)=(type 0x12)0xffffffff
+      E: meta-data (line=36)
+        A: http://schemas.android.com/apk/res/android:name(0x01010003)="legacy.typed.false" (Raw: "legacy.typed.false")
+        A: http://schemas.android.com/apk/res/android:value(0x01010024)=(type 0x12)0x0
+`
+
+test("a bare aapt2 boolean, the build-tools 36 form, is parsed and rejects disabled analytics even with a correct lane", () => {
+  const meta = parseManifestMetaData(BARE_BOOLEAN_SAMPLE)
+  assert.equal(meta[META_ANALYTICS_DISABLED], "true")
+  assert.equal(meta[META_ANALYTICS_ENVIRONMENT], "prod")
+  assert.equal(meta["legacy.typed"], "true")
+  assert.equal(meta["legacy.typed.false"], "false")
+  assert.throws(
+    () => assertAndroidSdkAnalyticsMetadata(meta, {sdkVersion: "3.1.0", environment: "prod"}),
+    /analytics\.disabled="true"/,
+  )
+})
+
+test("an unrecognized value on the disabled key fails rather than reading as enabled", () => {
+  for (const bad of ["", "@0x7f010000", "yes"]) {
+    assert.throws(
+      () =>
+        assertAndroidSdkAnalyticsMetadata(
+          {[META_ANALYTICS_ENVIRONMENT]: "prod", [META_ANALYTICS_DISABLED]: bad},
+          {sdkVersion: "3.1.0", environment: "prod"},
+        ),
+      /analytics\.disabled=/,
+    )
+  }
+})


### PR DESCRIPTION
## What could recur

From 2026-08-11 until #3973, `app.config.ts` passed `analytics: false` to the Bluetooth SDK plugin, so every dev/beta build shipped silent. #3973 added an iOS release gate (Info.plist must carry the SDK version and lane, and must not have analytics disabled). Android had no gate, and nothing checked the config at PR time.

## Guards after this PR

| When | What | Where |
|---|---|---|
| Every PR (mobile script tests) | `expo config --type prebuild` must show the SDK plugin with analytics enabled and a valid lane | `mobile/scripts/app-config-analytics.test.mjs` |
| iOS release | IPA Info.plist: SDK version present, lane matches `EXPO_PUBLIC_BUILD_ENV`, analytics not disabled | `release-ios.mjs` (from #3973) |
| Android release | APK manifest via aapt2: analytics not disabled, lane matches `EXPO_PUBLIC_BUILD_ENV` | `release-android.mjs` → `validateAndroidSdkAnalyticsMetadata` (new) |

## Review round (local Codex, Astra)

P1 found and fixed: build-tools 36 prints boolean meta-data bare (`=true`), which the first parser turned into an empty string the validator accepted. The parser now handles every aapt2 value form, and the validator fails on anything but an explicit `"false"` for the disabled key. Regression tests cover a bare `true` with a correct lane and unrecognized values.

## Verification

- `node --test mobile/scripts/app-config-analytics.test.mjs` → 2/2; with `analytics: false` temporarily reintroduced → 0/2 (the guard fires).
- `node --test mobile/scripts/release-sdk-metadata.test.mjs` → 9/9, including `readApkManifestMetaData` against last night's real CI APK (build 53407874), which carries `com.mentra.bluetoothsdk.analytics.environment=dev`.
- The Android gate needs `aapt2` under `ANDROID_HOME/build-tools`; the coordinated workflow already installs build-tools 36.0.0 and uses aapt/apksigner from there.

Not covered by any gate: a partner's app disabling analytics in its own config, which is their right. This is about our own builds.

