### PR TITLE
Wait longer for npm to expose large published tarballs

### DIFF
--- a/.github/scripts/publish-release-npm.mjs
+++ b/.github/scripts/publish-release-npm.mjs
@@ -125,14 +125,49 @@ export function isHttpsRegistryUrl(value) {
   return typeof value === "string" && value.startsWith("https://")
 }
 
+// npm processes a large publish asynchronously ("Your package is being
+// processed and may take a few minutes to become available"), and the
+// metadata read-back keeps returning nothing until that finishes. Seen
+// 2026-09-10 in the beta 3.1.0-beta.192 release: the 18.5 MB
+// @mentra/bluetooth-sdk tarball published fine but was still invisible after
+// the previous 10-minute bound, so the job failed and only a re-run recovered
+// it through the "reused" path. Wait at least 30 minutes, and longer for
+// bigger tarballs, before treating the missing metadata as a failure.
+export const NPM_READBACK_POLL_SECONDS = 5
+export const NPM_READBACK_MIN_WAIT_SECONDS = 30 * 60
+export const NPM_READBACK_SECONDS_PER_MEBIBYTE = 2 * 60
+
+export function npmReadbackWaitSeconds(tarballBytes = 0) {
+  const mebibytes = Math.ceil(Math.max(0, Number(tarballBytes) || 0) / (1024 * 1024))
+  return Math.max(NPM_READBACK_MIN_WAIT_SECONDS, mebibytes * NPM_READBACK_SECONDS_PER_MEBIBYTE)
+}
+
+export function npmReadbackAttempts(tarballBytes = 0) {
+  return Math.ceil(npmReadbackWaitSeconds(tarballBytes) / NPM_READBACK_POLL_SECONDS) + 1
+}
+
 export function npmViewPublishedTarball(
   spec,
-  {attempts = 120, view = npmView, sleep = () => execFileSync("sleep", ["5"])} = {},
+  {
+    tarballBytes = 0,
+    attempts = npmReadbackAttempts(tarballBytes),
+    view = npmView,
+    sleep = () => execFileSync("sleep", [String(NPM_READBACK_POLL_SECONDS)]),
+    log = console.log,
+  } = {},
 ) {
+  const progressEvery = Math.max(1, Math.round((5 * 60) / NPM_READBACK_POLL_SECONDS))
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const value = parseViewValue(view(spec, "dist.tarball"))
     if (isHttpsRegistryUrl(value)) return value
-    if (attempt < attempts) sleep()
+    if (attempt < attempts) {
+      sleep()
+      if (attempt % progressEvery === 0) {
+        const waited = attempt * NPM_READBACK_POLL_SECONDS
+        const bound = (attempts - 1) * NPM_READBACK_POLL_SECONDS
+        log(`npm has not exposed ${spec} yet; waited ${waited}s of up to ${bound}s`)
+      }
+    }
   }
   return null
 }
@@ -402,9 +437,11 @@ export function publishReleaseNpm({
 
     let url = `https://registry.npmjs.org/${encodeURIComponent(name)}`
     if (!dryRun) {
-      const registryUrl = npmViewPublishedTarball(coordinate)
+      const registryUrl = npmViewPublishedTarball(coordinate, {tarballBytes: bytes.length})
       if (!isHttpsRegistryUrl(registryUrl)) {
-        throw new Error(`${coordinate} was published but has no HTTPS registry tarball URL`)
+        throw new Error(
+          `${coordinate} was published but has no HTTPS registry tarball URL after ${npmReadbackWaitSeconds(bytes.length)}s`,
+        )
       }
       url = registryUrl
     }

--- a/.github/scripts/publish-release-npm.test.mjs
+++ b/.github/scripts/publish-release-npm.test.mjs
@@ -10,7 +10,10 @@ import {
   isHttpsRegistryUrl,
   npmMembersInOrder,
   npmReleaseTag,
+  npmReadbackAttempts,
+  npmReadbackWaitSeconds,
   npmViewPublishedTarball,
+  NPM_READBACK_POLL_SECONDS,
   publishWithRetry,
   releaseMetadataArgs,
   requireNpmProvenanceSource,
@@ -87,6 +90,56 @@ test("waits through empty npm metadata until the registry exposes the tarball", 
     "https://registry.npmjs.org/package/-/package-3.1.0.tgz",
   )
   assert.equal(sleeps, 2)
+})
+
+test("waits at least 30 minutes for npm to finish processing a publish", () => {
+  assert.equal(npmReadbackWaitSeconds(), 30 * 60)
+  assert.equal(npmReadbackWaitSeconds(1024), 30 * 60)
+  assert.equal(npmReadbackAttempts(), (30 * 60) / NPM_READBACK_POLL_SECONDS + 1)
+
+  let sleeps = 0
+  const progress = []
+  assert.equal(
+    npmViewPublishedTarball("package@3.1.0", {
+      view: () => "",
+      sleep: () => {
+        sleeps += 1
+      },
+      log: (line) => progress.push(line),
+    }),
+    null,
+  )
+  assert.equal(sleeps * NPM_READBACK_POLL_SECONDS, 30 * 60)
+  assert.equal(progress.length, 6)
+  assert.match(progress[0], /^npm has not exposed package@3\.1\.0 yet; waited 300s of up to 1800s$/)
+  assert.match(progress.at(-1), /waited 1800s of up to 1800s$/)
+})
+
+test("waits longer for larger tarballs before giving up on the read-back", () => {
+  const bluetoothSdkBytes = Math.round(18.5 * 1024 * 1024)
+  assert.equal(npmReadbackWaitSeconds(bluetoothSdkBytes), 19 * 2 * 60)
+  assert.ok(npmReadbackWaitSeconds(bluetoothSdkBytes) > npmReadbackWaitSeconds())
+  assert.ok(npmReadbackWaitSeconds(60 * 1024 * 1024) > npmReadbackWaitSeconds(bluetoothSdkBytes))
+
+  let sleeps = 0
+  let views = 0
+  assert.equal(
+    npmViewPublishedTarball("@mentra/bluetooth-sdk@3.1.0-beta.192", {
+      tarballBytes: bluetoothSdkBytes,
+      view: () => {
+        views += 1
+        return null
+      },
+      sleep: () => {
+        sleeps += 1
+      },
+      log: () => {},
+    }),
+    null,
+  )
+  assert.equal(views, sleeps + 1)
+  assert.equal(sleeps * NPM_READBACK_POLL_SECONDS, npmReadbackWaitSeconds(bluetoothSdkBytes))
+  assert.ok(sleeps * NPM_READBACK_POLL_SECONDS > 30 * 60)
 })
 
 test("requires the package checkout to match the immutable release plan", () => {

--- a/.github/workflows/reusable-coordinated-npm.yml
+++ b/.github/workflows/reusable-coordinated-npm.yml
@@ -41,7 +41,13 @@ jobs:
   publish:
     name: Publish exact npm family closure
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Every npm member reads its published metadata back before the next one
+    # publishes, and publish-release-npm.mjs waits at least 30 minutes (2
+    # minutes per MiB for large tarballs) for npm to finish processing each
+    # one. Budget the ~6 minutes of install/build/publish work, a slow
+    # Bluetooth SDK (~36 minutes), a full floor for Engine, and a few minutes
+    # for each small package, with margin.
+    timeout-minutes: 120
     steps:
       - name: Checkout exact package source
         uses: actions/checkout@v4


### PR DESCRIPTION
## Scope

`npmViewPublishedTarball` in `.github/scripts/publish-release-npm.mjs` polled `npm view <coordinate> dist.tarball` for at most 10 minutes (120 × 5 s) after `npm publish`. npm processes large publishes asynchronously, and the metadata read-back returns nothing until that finishes.

In the beta `3.1.0-beta.192` coordinated release ([run 34519543739](https://github.com/Mentra-Community/MentraOS/actions/runs/34519543739)) the 17.6 MiB `@mentra/bluetooth-sdk` tarball published successfully, npm printed "Your package is being processed and may take a few minutes to become available", and the 10-minute bound expired with `@mentra/bluetooth-sdk@3.1.0-beta.192 was published but has no HTTPS registry tarball URL`.

## Change

- The read-back bound is now at least 30 minutes and scales with tarball size (2 minutes per MiB, whichever is larger). The 17.6 MiB Bluetooth SDK tarball gets 36 minutes.
- `npmViewPublishedTarball` accepts `tarballBytes` and derives its attempt count from it. The explicit `attempts` override and the poll/sleep loop behaviour are unchanged.
- The publish call site passes the packed tarball's byte length, and the failure message states how long it waited.
- A progress line is logged every 5 minutes so a long wait is visible in the job log (logger injectable, silent in tests).
- `publishWithRetry` is untouched.
- The publish job in `.github/workflows/reusable-coordinated-npm.yml` now has a 120-minute timeout instead of 45. The seven npm members read back sequentially in one job, and in the failed run the SDK read-back only started 5.7 minutes in, so the old cap would have cancelled a slow-but-successful read-back before miniapp and Engine could publish. 120 minutes budgets the pre-work, a slow SDK, a full 30-minute floor for Engine, a few minutes per small package (crust and cloud-client each took ~3 minutes of processing in that run), and margin.

## Test evidence

Two tests added to `.github/scripts/publish-release-npm.test.mjs`: one asserts the 30-minute floor and progress-line cadence, one asserts the size-scaled bound using an 18.5 MiB fixture.

```
node --test .github/scripts/publish-release-npm.test.mjs   # 18 pass, 0 fail
node --test .github/scripts/*.test.mjs                    # 186 pass, 0 fail
```

Targets `staging` because the failure occurred in the beta channel release from that branch. The script is identical on `dev`, so this should be carried forward with the next staging → dev sync.
