### PR TITLE
Publish stable packages from the promoted beta after production promotion

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -403,8 +403,8 @@ SDK jobs as the coordinated beta on the production channel:
   `candidate-X.Y.Z`; `latest` is untouched. Publication uses provenance, so if
   npm trusted publishing is scoped per workflow file, register
   `production-release-packages.yml` for each package or keep `NPM_TOKEN` set.
-- Maven Central receives a `USER_MANAGED` Sonatype deployment. It is validated
-  but nothing is public until phase 2.
+- Maven Central receives a `USER_MANAGED` Sonatype deployment. The phase only
+  succeeds once Sonatype reports it validated; nothing is public until phase 2.
 - The SwiftPM export is committed and pushed to the mirror branch
   `release/X.Y.Z` of `mentra-bluetooth-sdk-ios`; no tag is created.
 
@@ -414,23 +414,24 @@ Phase 2 makes them public after `production-packages-release` approval:
 ./scripts/production-release.mjs packages --beta X.Y.Z-beta.N --phase release
 ```
 
-It moves npm `latest` to `X.Y.Z` for every member (refusing if `latest`
-already points at a newer version), retires the candidate dist-tag, requests
-the Sonatype publication and waits for `PUBLISHED`, and pushes the SwiftPM tag
-`X.Y.Z` at the staged commit after verifying it matches the archived export.
-Moving a dist-tag requires the `NPM_TOKEN` automation secret; trusted-publisher
-OIDC only covers `npm publish`.
+It first checks all three targets without changing anything: every npm
+member is published and its `latest` is not already newer, the Sonatype
+deployment is validated, and the staged SwiftPM commit is the one recorded in
+the archived export. Only then does it move npm `latest` to `X.Y.Z` for every
+member and retire the candidate dist-tag, request the Sonatype publication and
+wait for `PUBLISHED`, and push the SwiftPM tag `X.Y.Z`. Moving a dist-tag
+requires the `NPM_TOKEN` automation secret; trusted-publisher OIDC only covers
+`npm publish`.
 
 Both phases are idempotent: a rerun reuses versions, deployments, and mirror
 commits that already exist and refuses anything that exists with different
-bytes. Evidence is stored as content-addressed assets in the stable draft
-release `mentra-vX.Y.Z` (the same draft the rollout finalization stages the
-canonical records into). When a live promotion attempt for `X.Y.Z` exists and
-selected the same beta, the evidence is also appended to its chain as an
-additive `production-packages-publication` or `production-packages-release`
-record without changing its state. A promotion at the `finalizing` checkpoint,
-or one that is completed or aborted, keeps the evidence in the stable draft
-only. A live attempt that froze a different beta or source is a hard stop.
+bytes. Evidence is stored as content-addressed assets in the stable release
+`mentra-vX.Y.Z` (the same draft the rollout finalization stages the canonical
+records into; it is also accepted after that release has been published by
+hand). The promotion chain is never written by these phases, so they cannot
+race a Cloud or mobile transition. It is read once: a live attempt for `X.Y.Z`
+that froze a different beta or source is a hard stop, and an allocated attempt
+without a state record must be resumed or aborted first.
 
 Stop conditions specific to packages:
 

--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -65,6 +65,8 @@ Configure these GitHub environments:
 | `production-mobile-candidates` | Production-signed candidate uploads | Required reviewer; no public release       |
 | `production-store-submission`  | App review submission               | Required reviewer                          |
 | `production-store-release`     | Public release and rollout evidence | Required reviewer different from initiator |
+| `production-packages`          | Stage plain package versions        | Required reviewer                          |
+| `production-packages-release`  | npm latest, Maven Central, SwiftPM  | Required reviewer different from initiator |
 
 Required secrets are the existing Porter, App Store Connect, Google Play,
 Android upload-signing, Apple Match, Doppler, Mapbox, and Sentry credentials
@@ -113,6 +115,7 @@ git pull --ff-only origin main
 `status` is the source of truth for the current state and next action. Use
 `--json` for machine-readable output. Use `--attempt N` when inspecting an older
 attempt. Use `status --refresh` to dispatch the read-only store status workflow.
+Stable package publication is not part of `next`; see "Stable packages" below.
 
 Mutating commands require typing the release identity, or `--yes` in an already
 reviewed non-interactive procedure. The CLI never reads production credentials
@@ -370,6 +373,72 @@ window.
 After completion, inspect the two canonical assets and perform the final public
 availability checks. Publish the already-staged GitHub release manually; no
 workflow in this system publishes it automatically.
+
+## Stable packages - independent of the mobile path
+
+The plain `X.Y.Z` package versions (npm `latest`, the stable Maven Central
+coordinates, and the SwiftPM tag) are published by
+`production-release-packages.yml`. This is a separate step from the Cloud
+deployment and the Mentra App promotion. It is keyed on the promoted beta, not
+on a promotion state, so it can run at any point after `promote` has merged the
+beta source into `main`: before the promotion is prepared, while store review
+is pending, or after rollout. No mobile phase waits on it and it never
+transitions the promotion state machine.
+
+Both phases build from the exact `sourceCommit` recorded in the selected
+beta's `release-plan.json`, verified to be contained in `main`, and reuse the
+beta's frozen OTA manifest pin. The release identity is the beta's base
+version (`3.1.0-beta.192` publishes `3.1.0`).
+
+Phase 1 stages everything without moving any default pointer:
+
+```bash
+./scripts/production-release.mjs packages --beta X.Y.Z-beta.N --phase publish
+```
+
+After `production-packages` approval it runs the same reusable npm and native
+SDK jobs as the coordinated beta on the production channel:
+
+- npm publishes every family member at `X.Y.Z` under the dist-tag
+  `candidate-X.Y.Z`; `latest` is untouched. Publication uses provenance, so if
+  npm trusted publishing is scoped per workflow file, register
+  `production-release-packages.yml` for each package or keep `NPM_TOKEN` set.
+- Maven Central receives a `USER_MANAGED` Sonatype deployment. It is validated
+  but nothing is public until phase 2.
+- The SwiftPM export is committed and pushed to the mirror branch
+  `release/X.Y.Z` of `mentra-bluetooth-sdk-ios`; no tag is created.
+
+Phase 2 makes them public after `production-packages-release` approval:
+
+```bash
+./scripts/production-release.mjs packages --beta X.Y.Z-beta.N --phase release
+```
+
+It moves npm `latest` to `X.Y.Z` for every member (refusing if `latest`
+already points at a newer version), retires the candidate dist-tag, requests
+the Sonatype publication and waits for `PUBLISHED`, and pushes the SwiftPM tag
+`X.Y.Z` at the staged commit after verifying it matches the archived export.
+Moving a dist-tag requires the `NPM_TOKEN` automation secret; trusted-publisher
+OIDC only covers `npm publish`.
+
+Both phases are idempotent: a rerun reuses versions, deployments, and mirror
+commits that already exist and refuses anything that exists with different
+bytes. Evidence is stored as content-addressed assets in the stable draft
+release `mentra-vX.Y.Z` (the same draft the rollout finalization stages the
+canonical records into). When a live promotion attempt for `X.Y.Z` exists and
+selected the same beta, the evidence is also appended to its chain as an
+additive `production-packages-publication` or `production-packages-release`
+record without changing its state. A promotion at the `finalizing` checkpoint,
+or one that is completed or aborted, keeps the evidence in the stable draft
+only. A live attempt that froze a different beta or source is a hard stop.
+
+Stop conditions specific to packages:
+
+- Once phase 1 has published `X.Y.Z` on npm, that identity is spent. An aborted
+  promotion cannot be replaced by a different source under the same version;
+  bump the family base version on `dev` and cut a new beta.
+- Do not run phase 2 until the Cloud side of the release is at least deployed
+  or you have explicitly decided that the stable packages may lead it.
 
 ## Abort, retry, and incident handling
 

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -146,13 +146,28 @@ test("stable packages publish from the frozen beta source independently of the m
   assert.match(packages, /ref: \$\{\{ steps\.beta\.outputs\.source_commit \}\}/)
   assert.match(packages, /production-packages\.mjs plan \\\n\s+--root release-source/)
   assert.match(packages, /source_commit: \$\{\{ needs\.load\.outputs\.source_commit \}\}/)
-  // The promotion state machine is read, never transitioned; evidence is additive.
+  // The promotion state machine is read only, to refuse a conflicting frozen beta.
   assert.match(packages, /download-latest-attempt/)
-  assert.match(packages, /production-promotion-state\.mjs packages-link/)
-  assert.match(packages, /production-promotion-state\.mjs append/)
-  assert.doesNotMatch(packages, /production-promotion-state\.mjs transition/)
-  assert.doesNotMatch(packages, /attest-transition|--to [a-z-]+/)
+  assert.match(packages, /production-promotion-state\.mjs packages-guard/)
+  assert.doesNotMatch(packages, /production-promotion-state\.mjs (transition|append|attest-transition)/)
+  assert.doesNotMatch(packages, /publish-record|--to [a-z-]+/)
   assert.doesNotMatch(packages, /stores-approved|store-review-approved|production-store-release|production-cloud|reusable-coordinated-cloud-v2|reusable-coordinated-mobile/)
+  assert.match(packages, /group: production-release-packages\n/)
+  // Every target is checked before the first irreversible mutation.
+  const releaseJob = jobBlock(packages, "release")
+  const firstMutation = releaseJob.indexOf("Move npm latest to the staged plain versions")
+  for (const preflight of [
+    "Preflight npm without moving any dist-tag",
+    "Preflight the validated Sonatype deployment",
+    "Preflight the staged SwiftPM commit against its archived export",
+  ]) {
+    const index = releaseJob.indexOf(preflight)
+    assert.notEqual(index, -1, preflight)
+    assert.ok(index < firstMutation, `${preflight} must precede the npm latest flip`)
+  }
+  assert.match(releaseJob, /--dry-run true/)
+  assert.match(releaseJob, /git get-tar-commit-id/)
+  assert.doesNotMatch(releaseJob, /cmp /)
   // Staging and public release are separate protected approvals.
   assert.match(packages, /name: production-packages\n/)
   assert.match(packages, /name: production-packages-release\n/)
@@ -164,9 +179,16 @@ test("stable packages publish from the frozen beta source independently of the m
   // Both workflows must recognize the same stable draft container.
   assert.match(rollout, /body: "Canonical production release records\. Publish manually only after the completed promotion and final public-availability checks\."/)
   assert.match(packages, /production-packages\.mjs ensure-container/)
-  // The reusable native job stages production without publishing.
+  // The reusable native job stages production without publishing, using
+  // registry tooling from the workflow revision rather than the frozen source.
   assert.match(sdkNative, /publishing_type=USER_MANAGED/)
+  assert.match(sdkNative, /ref: \$\{\{ github\.sha \}\}\n\s+path: release-tooling/)
+  assert.match(sdkNative, /release-tooling\/\.github\/scripts\/sonatype-central-deployment\.mjs upload/)
+  assert.match(sdkNative, /release-tooling\/\.github\/scripts\/sonatype-central-deployment\.mjs inspect/)
+  assert.doesNotMatch(sdkNative, /node \.github\/scripts\/sonatype-central-deployment\.mjs/)
   assert.match(sdkNative, /--publishing-type "\$PUBLISHING_TYPE"/)
+  assert.match(sdkNative, /\.publishingType native-result\/maven\/sonatype-deployment\.json\)" == "\$PUBLISHING_TYPE"/)
+  assert.match(sdkNative, /sonatype-central-deployment\.mjs wait-validated/)
   assert.match(sdkNative, /staging_ref="release\/\$version"/)
   assert.match(sdkNative, /steps\.release\.outputs\.channel != 'production' && steps\.existing\.outputs\.exists != 'true'/)
   assert.match(sdkNative, /git push origin "\$\{\{ steps\.selected\.outputs\.mirror_sha \}\}:refs\/heads\/\$STAGING_REF"/)

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -131,6 +131,47 @@ test("production promotion is resumable and keeps irreversible actions behind se
   assert.equal(existsSync(new URL("../workflows/reusable-coordinated-mobile-promotion.yml", import.meta.url)), false)
 })
 
+test("stable packages publish from the frozen beta source independently of the mobile path", () => {
+  const packages = workflow("production-release-packages.yml")
+  const rollout = workflow("production-release-rollout.yml")
+  const sdkNative = workflow("reusable-coordinated-sdk-native.yml")
+
+  assert.match(packages, /workflow_dispatch:/)
+  assert.doesNotMatch(packages, /pull_request:/)
+  assert.match(packages, /ref: main/)
+  assert.match(packages, /beta_identity:/)
+  assert.match(packages, /options:\n\s+- publish\n\s+- release/)
+  // Keyed on the beta plan, built from its exact source, only once main contains it.
+  assert.match(packages, /git merge-base --is-ancestor "\$source_commit" origin\/main/)
+  assert.match(packages, /ref: \$\{\{ steps\.beta\.outputs\.source_commit \}\}/)
+  assert.match(packages, /production-packages\.mjs plan \\\n\s+--root release-source/)
+  assert.match(packages, /source_commit: \$\{\{ needs\.load\.outputs\.source_commit \}\}/)
+  // The promotion state machine is read, never transitioned; evidence is additive.
+  assert.match(packages, /download-latest-attempt/)
+  assert.match(packages, /production-promotion-state\.mjs packages-link/)
+  assert.match(packages, /production-promotion-state\.mjs append/)
+  assert.doesNotMatch(packages, /production-promotion-state\.mjs transition/)
+  assert.doesNotMatch(packages, /attest-transition|--to [a-z-]+/)
+  assert.doesNotMatch(packages, /stores-approved|store-review-approved|production-store-release|production-cloud|reusable-coordinated-cloud-v2|reusable-coordinated-mobile/)
+  // Staging and public release are separate protected approvals.
+  assert.match(packages, /name: production-packages\n/)
+  assert.match(packages, /name: production-packages-release\n/)
+  assert.match(packages, /npm_tag: \$\{\{ needs\.load\.outputs\.npm_tag \}\}/)
+  assert.match(packages, /promote-npm-latest\.mjs/)
+  assert.match(packages, /sonatype-central-deployment\.mjs publish/)
+  assert.match(packages, /git push origin "refs\/tags\/\$VERSION"/)
+  assert.match(packages, /release_id: \$\{\{ needs\.load\.outputs\.stable_release_id \}\}/)
+  // Both workflows must recognize the same stable draft container.
+  assert.match(rollout, /body: "Canonical production release records\. Publish manually only after the completed promotion and final public-availability checks\."/)
+  assert.match(packages, /production-packages\.mjs ensure-container/)
+  // The reusable native job stages production without publishing.
+  assert.match(sdkNative, /publishing_type=USER_MANAGED/)
+  assert.match(sdkNative, /--publishing-type "\$PUBLISHING_TYPE"/)
+  assert.match(sdkNative, /staging_ref="release\/\$version"/)
+  assert.match(sdkNative, /steps\.release\.outputs\.channel != 'production' && steps\.existing\.outputs\.exists != 'true'/)
+  assert.match(sdkNative, /git push origin "\$\{\{ steps\.selected\.outputs\.mirror_sha \}\}:refs\/heads\/\$STAGING_REF"/)
+})
+
 test("Cloud V2 deploys once per coordinated environment before mobile publication", () => {
   const coordinator = workflow("coordinated-release.yml")
   const cloud = workflow("reusable-coordinated-cloud-v2.yml")

--- a/.github/scripts/prepare-production-promotion.mjs
+++ b/.github/scripts/prepare-production-promotion.mjs
@@ -50,19 +50,10 @@ function validateCurrentMentraApp(previousManifest, inventory) {
   }
 }
 
-export function prepareProductionPromotion({
-  family,
-  betaPlan,
-  betaManifest,
-  betaManifestUrl,
-  betaManifestSha256,
-  previousManifest,
-  mentraInventory,
-  attempt,
-  actor,
-  createdAt,
-  provenanceUrl,
-}) {
+// Shared by promotion preparation and stable package publication: the selected
+// beta must be complete, internally consistent, pinned to an immutable OTA
+// manifest, and belong to the checked-out release family.
+export function validateSelectedBeta({family, betaPlan, betaManifest}) {
   if (
     betaPlan.channel !== "beta" ||
     betaManifest.channel !== "beta" ||
@@ -83,6 +74,23 @@ export function prepareProductionPromotion({
   ) {
     throw new Error("Selected beta has no immutable OTA manifest pin")
   }
+  return betaPlan
+}
+
+export function prepareProductionPromotion({
+  family,
+  betaPlan,
+  betaManifest,
+  betaManifestUrl,
+  betaManifestSha256,
+  previousManifest,
+  mentraInventory,
+  attempt,
+  actor,
+  createdAt,
+  provenanceUrl,
+}) {
+  validateSelectedBeta({family, betaPlan, betaManifest})
   validateInventory(mentraInventory, {bundleId: "com.mentra.mentra", allowNoCurrent: false})
   const currentMentraApp = validateCurrentMentraApp(previousManifest, mentraInventory)
   const lastMentraBuildNumber = Math.max(

--- a/.github/scripts/production-packages.mjs
+++ b/.github/scripts/production-packages.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Stable package publication for a promoted beta.
+//
+// production-release-packages.yml republishes the exact source of a completed
+// coordinated beta as plain X.Y.Z package versions (npm latest, Maven Central,
+// SwiftPM) after that source reached main. This module freezes the production
+// plan those reusable jobs consume and manages the stable draft release
+// container `mentra-vX.Y.Z` that holds their immutable records. It never
+// touches the mobile or Cloud promotion state machine; package evidence is an
+// additive record on a live promotion attempt, appended by
+// production-promotion-state.mjs `append`.
+import {createHash} from "node:crypto"
+import {execFileSync} from "node:child_process"
+import {appendFileSync, readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+import {isDeepStrictEqual} from "node:util"
+
+import {validateSelectedBeta} from "./prepare-production-promotion.mjs"
+import {createReleasePlan, loadReleaseFamily, serializeReleaseRecord} from "./release-family.mjs"
+
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+// Identical to the body production-release-rollout.yml writes when it stages
+// the canonical records, so whichever workflow allocates the draft first, the
+// other one recognizes and reuses it.
+export const STABLE_CONTAINER_BODY =
+  "Canonical production release records. Publish manually only after the completed promotion and final public-availability checks."
+
+export function npmCandidateTag(releaseIdentity) {
+  if (!VERSION_PATTERN.test(releaseIdentity || "")) throw new Error("release identity must be X.Y.Z")
+  return `candidate-${releaseIdentity}`
+}
+
+export function createProductionPackagesPlan({family, betaPlan, betaManifest, betaManifestUrl, betaManifestSha256}) {
+  validateSelectedBeta({family, betaPlan, betaManifest})
+  if (!/^https:\/\//.test(betaManifestUrl || "")) throw new Error("beta manifest URL must be HTTPS")
+  if (!/^[0-9a-f]{64}$/.test(betaManifestSha256 || "")) throw new Error("beta manifest SHA-256 is invalid")
+  // The native build number is frozen by the mobile promotion, which allocates
+  // it from store inventories. Package publication never uploads an app, so
+  // the beta's own number keeps this plan deterministic without store access.
+  const plan = createReleasePlan({
+    family,
+    channel: "production",
+    sourceCommit: betaPlan.sourceCommit,
+    nativeBuildNumber: betaPlan.native.buildNumber,
+    otaInputs: betaPlan.otaInputs,
+  })
+  if (!isDeepStrictEqual(plan.changelog, betaPlan.changelog)) {
+    throw new Error("Selected beta changelog does not match its frozen source checkout")
+  }
+  if (!isDeepStrictEqual(Object.keys(plan.members).sort(), Object.keys(betaPlan.members).sort())) {
+    throw new Error("Selected beta release family does not match its frozen source checkout")
+  }
+  plan.promotion = {
+    selectedBetaReleaseSetId: betaPlan.releaseSetId,
+    selectedBetaIdentity: betaPlan.releaseIdentity,
+    selectedBetaManifest: {url: betaManifestUrl, sha256: betaManifestSha256},
+    otaManifest: betaManifest.otaManifest,
+  }
+  return plan
+}
+
+export function stableContainerPayload(plan) {
+  if (plan?.channel !== "production" || !VERSION_PATTERN.test(plan.releaseIdentity || "")) {
+    throw new Error("A frozen production plan is required")
+  }
+  return {
+    tag_name: plan.artifactContainerTag,
+    target_commitish: plan.sourceCommit,
+    name: plan.artifactContainerName,
+    body: STABLE_CONTAINER_BODY,
+    draft: true,
+    prerelease: false,
+  }
+}
+
+export function requireStableContainer(release, plan) {
+  const expected = stableContainerPayload(plan)
+  if (
+    !release ||
+    release.tag_name !== expected.tag_name ||
+    release.name !== expected.name ||
+    release.draft !== true ||
+    release.prerelease !== false ||
+    release.target_commitish !== expected.target_commitish
+  ) {
+    throw new Error(`Stable release container ${expected.tag_name} does not match the frozen production plan`)
+  }
+  return release
+}
+
+export function planStableContainer(releases, plan) {
+  const expected = stableContainerPayload(plan)
+  const matches = releases.filter((release) => release.tag_name === expected.tag_name)
+  if (matches.length > 1) throw new Error(`Multiple releases are tagged ${expected.tag_name}`)
+  if (matches.length === 1) return {action: "reuse", release: requireStableContainer(matches[0], plan)}
+  return {action: "create", payload: expected}
+}
+
+function gh(args, options = {}) {
+  const stdin = options.input === undefined ? "ignore" : "pipe"
+  return execFileSync("gh", args, {stdio: [stdin, "pipe", "inherit"], encoding: "utf8", ...options})
+}
+
+function listReleases(repository) {
+  return JSON.parse(gh(["api", "--paginate", "--slurp", `repos/${repository}/releases?per_page=100`])).flat()
+}
+
+function ensureStableContainer({repository, plan}) {
+  const allocation = planStableContainer(listReleases(repository), plan)
+  if (allocation.action === "reuse") return allocation.release
+  const created = JSON.parse(
+    gh(["api", "--method", "POST", `repos/${repository}/releases`, "--input", "-"], {
+      input: JSON.stringify(allocation.payload),
+    }),
+  )
+  return requireStableContainer(created, plan)
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function output(values, githubOutput) {
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`)
+  for (const line of lines) console.log(line)
+  if (githubOutput) appendFileSync(path.resolve(githubOutput), `${lines.join("\n")}\n`)
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(path.resolve(file), "utf8"))
+}
+
+function main() {
+  const command = process.argv[2]
+  const args = parseArgs(process.argv.slice(3))
+  if (command === "plan") {
+    const betaManifestPath = path.resolve(args["beta-manifest"])
+    const plan = createProductionPackagesPlan({
+      family: loadReleaseFamily({rootDir: path.resolve(args.root || process.cwd()), requireVersionMirrors: true}),
+      betaPlan: readJson(args["beta-plan"]),
+      betaManifest: readJson(betaManifestPath),
+      betaManifestUrl: args["beta-manifest-url"],
+      betaManifestSha256: createHash("sha256").update(readFileSync(betaManifestPath)).digest("hex"),
+    })
+    writeFileSync(path.resolve(args.output), serializeReleaseRecord(plan))
+    output(
+      {
+        release_identity: plan.releaseIdentity,
+        release_set_id: plan.releaseSetId,
+        source_commit: plan.sourceCommit,
+        stable_tag: plan.artifactContainerTag,
+        ota_manifest_url: plan.promotion.otaManifest.url,
+        ota_manifest_sha256: plan.promotion.otaManifest.sha256,
+        npm_tag: npmCandidateTag(plan.releaseIdentity),
+      },
+      args["github-output"],
+    )
+    return
+  }
+  if (command === "ensure-container") {
+    const release = ensureStableContainer({repository: args.repository, plan: readJson(args.plan)})
+    output({release_id: release.id, tag: release.tag_name}, args["github-output"])
+    return
+  }
+  throw new Error(`Unknown production packages command ${JSON.stringify(command)}`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/production-packages.mjs
+++ b/.github/scripts/production-packages.mjs
@@ -17,6 +17,7 @@ import {fileURLToPath} from "node:url"
 import {isDeepStrictEqual} from "node:util"
 
 import {validateSelectedBeta} from "./prepare-production-promotion.mjs"
+import {RELEASE_LIST_FIELDS, parseJsonLines} from "./production-promotion-assets.mjs"
 import {createReleasePlan, loadReleaseFamily, serializeReleaseRecord} from "./release-family.mjs"
 
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
@@ -104,11 +105,24 @@ export function planStableContainer(releases, plan) {
 
 function gh(args, options = {}) {
   const stdin = options.input === undefined ? "ignore" : "pipe"
-  return execFileSync("gh", args, {stdio: [stdin, "pipe", "inherit"], encoding: "utf8", ...options})
+  return execFileSync("gh", args, {
+    stdio: [stdin, "pipe", "inherit"],
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  })
 }
 
 function listReleases(repository) {
-  return JSON.parse(gh(["api", "--paginate", "--slurp", `repos/${repository}/releases?per_page=100`])).flat()
+  return parseJsonLines(
+    gh([
+      "api",
+      "--paginate",
+      `repos/${repository}/releases?per_page=100`,
+      "--jq",
+      `.[] | ${RELEASE_LIST_FIELDS} | tojson`,
+    ]),
+  )
 }
 
 function ensureStableContainer({repository, plan}) {

--- a/.github/scripts/production-packages.mjs
+++ b/.github/scripts/production-packages.mjs
@@ -4,11 +4,11 @@
 // production-release-packages.yml republishes the exact source of a completed
 // coordinated beta as plain X.Y.Z package versions (npm latest, Maven Central,
 // SwiftPM) after that source reached main. This module freezes the production
-// plan those reusable jobs consume and manages the stable draft release
-// container `mentra-vX.Y.Z` that holds their immutable records. It never
-// touches the mobile or Cloud promotion state machine; package evidence is an
-// additive record on a live promotion attempt, appended by
-// production-promotion-state.mjs `append`.
+// plan those reusable jobs consume and manages the stable release container
+// `mentra-vX.Y.Z` that holds their immutable records. It never touches the
+// mobile or Cloud promotion state machine: package evidence lives only in that
+// container, and a live promotion attempt is read solely to refuse a
+// conflicting frozen beta.
 import {createHash} from "node:crypto"
 import {execFileSync} from "node:child_process"
 import {appendFileSync, readFileSync, writeFileSync} from "node:fs"
@@ -75,13 +75,17 @@ export function stableContainerPayload(plan) {
   }
 }
 
+// The container starts as a draft and is published by hand after the mobile
+// rollout completes. Packages may still be published after that, so a
+// published (non-draft, non-prerelease) release with the same identity is
+// accepted; only a prerelease or a different source is rejected.
 export function requireStableContainer(release, plan) {
   const expected = stableContainerPayload(plan)
   if (
     !release ||
     release.tag_name !== expected.tag_name ||
     release.name !== expected.name ||
-    release.draft !== true ||
+    typeof release.draft !== "boolean" ||
     release.prerelease !== false ||
     release.target_commitish !== expected.target_commitish
   ) {
@@ -110,12 +114,20 @@ function listReleases(repository) {
 function ensureStableContainer({repository, plan}) {
   const allocation = planStableContainer(listReleases(repository), plan)
   if (allocation.action === "reuse") return allocation.release
-  const created = JSON.parse(
-    gh(["api", "--method", "POST", `repos/${repository}/releases`, "--input", "-"], {
-      input: JSON.stringify(allocation.payload),
-    }),
-  )
-  return requireStableContainer(created, plan)
+  try {
+    const created = JSON.parse(
+      gh(["api", "--method", "POST", `repos/${repository}/releases`, "--input", "-"], {
+        input: JSON.stringify(allocation.payload),
+      }),
+    )
+    return requireStableContainer(created, plan)
+  } catch (error) {
+    // Another workflow (the rollout finalization) may have created the same
+    // tag between our listing and this POST; accept it if it matches.
+    const retry = planStableContainer(listReleases(repository), plan)
+    if (retry.action === "reuse") return retry.release
+    throw error
+  }
 }
 
 function parseArgs(args) {

--- a/.github/scripts/production-packages.test.mjs
+++ b/.github/scripts/production-packages.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  STABLE_CONTAINER_BODY,
+  createProductionPackagesPlan,
+  npmCandidateTag,
+  planStableContainer,
+  requireStableContainer,
+  stableContainerPayload,
+} from "./production-packages.mjs"
+import {createReleasePlan, loadReleaseFamily, releaseRecordSha256} from "./release-family.mjs"
+
+const family = loadReleaseFamily()
+const betaPlan = createReleasePlan({
+  family,
+  channel: "beta",
+  sequence: 192,
+  sourceCommit: "a".repeat(40),
+  nativeBuildNumber: 310000192,
+})
+const betaManifest = {
+  schemaVersion: 1,
+  releaseSetId: betaPlan.releaseSetId,
+  releaseIdentity: betaPlan.releaseIdentity,
+  familyBaseVersion: betaPlan.familyBaseVersion,
+  channel: "beta",
+  sourceCommit: betaPlan.sourceCommit,
+  native: betaPlan.native,
+  releasePlanSha256: releaseRecordSha256(betaPlan),
+  completedAt: "2026-09-10T10:00:00.000Z",
+  otaManifest: {url: "https://example.com/ota.json", sha256: "d".repeat(64)},
+}
+const betaManifestUrl = `https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v${betaPlan.familyBaseVersion}/beta.json`
+
+function packagesPlan(overrides = {}) {
+  return createProductionPackagesPlan({
+    family,
+    betaPlan,
+    betaManifest,
+    betaManifestUrl,
+    betaManifestSha256: "b".repeat(64),
+    ...overrides,
+  })
+}
+
+test("derives a deterministic production plan from the frozen beta source", () => {
+  const plan = packagesPlan()
+  assert.equal(plan.channel, "production")
+  assert.equal(plan.releaseIdentity, family.familyBaseVersion)
+  assert.equal(plan.sourceCommit, betaPlan.sourceCommit)
+  assert.equal(plan.artifactContainerTag, `mentra-v${family.familyBaseVersion}`)
+  assert.equal(plan.native.buildNumber, betaPlan.native.buildNumber)
+  assert.deepEqual(plan.promotion, {
+    selectedBetaReleaseSetId: betaPlan.releaseSetId,
+    selectedBetaIdentity: betaPlan.releaseIdentity,
+    selectedBetaManifest: {url: betaManifestUrl, sha256: "b".repeat(64)},
+    otaManifest: betaManifest.otaManifest,
+  })
+  for (const member of Object.values(plan.members)) assert.equal(member.version, plan.releaseIdentity)
+  assert.deepEqual(packagesPlan(), plan)
+})
+
+test("rejects an incomplete, mismatched, or unpinned beta", () => {
+  assert.throws(() => packagesPlan({betaManifest: {...betaManifest, completedAt: undefined}}), /not complete/)
+  assert.throws(() => packagesPlan({betaManifest: {...betaManifest, sourceCommit: "e".repeat(40)}}), /do not match/)
+  assert.throws(
+    () =>
+      packagesPlan({betaManifest: {...betaManifest, otaManifest: {url: "http://example.com", sha256: "d".repeat(64)}}}),
+    /OTA manifest pin/,
+  )
+  assert.throws(() => packagesPlan({betaManifestUrl: "http://example.com/beta.json"}), /must be HTTPS/)
+  assert.throws(() => packagesPlan({betaManifestSha256: "nope"}), /SHA-256/)
+  assert.throws(
+    () => packagesPlan({betaPlan: {...betaPlan, changelog: {...betaPlan.changelog, sha256: "0".repeat(64)}}}),
+    /do not match|changelog/,
+  )
+})
+
+test("names a candidate dist-tag that npm cannot mistake for a version", () => {
+  assert.equal(npmCandidateTag("3.1.0"), "candidate-3.1.0")
+  assert.match(npmCandidateTag("3.1.0"), /^[a-z][a-z0-9._-]*$/)
+  assert.throws(() => npmCandidateTag("3.1.0-beta.1"), /X\.Y\.Z/)
+})
+
+test("allocates or reuses the stable draft container the rollout finalization also uses", () => {
+  const plan = packagesPlan()
+  const payload = stableContainerPayload(plan)
+  assert.deepEqual(payload, {
+    tag_name: plan.artifactContainerTag,
+    target_commitish: plan.sourceCommit,
+    name: plan.artifactContainerName,
+    body: STABLE_CONTAINER_BODY,
+    draft: true,
+    prerelease: false,
+  })
+  assert.deepEqual(planStableContainer([], plan), {action: "create", payload})
+  const release = {id: 7, ...payload}
+  assert.deepEqual(planStableContainer([{id: 1, tag_name: "other"}, release], plan), {action: "reuse", release})
+  assert.throws(() => planStableContainer([release, {...release, id: 8}], plan), /Multiple releases/)
+  assert.throws(() => requireStableContainer({...release, draft: false}, plan), /does not match/)
+  assert.throws(() => requireStableContainer({...release, target_commitish: "b".repeat(40)}, plan), /does not match/)
+  assert.throws(() => stableContainerPayload(betaPlan), /production plan is required/)
+})

--- a/.github/scripts/production-packages.test.mjs
+++ b/.github/scripts/production-packages.test.mjs
@@ -98,7 +98,9 @@ test("allocates or reuses the stable draft container the rollout finalization al
   const release = {id: 7, ...payload}
   assert.deepEqual(planStableContainer([{id: 1, tag_name: "other"}, release], plan), {action: "reuse", release})
   assert.throws(() => planStableContainer([release, {...release, id: 8}], plan), /Multiple releases/)
-  assert.throws(() => requireStableContainer({...release, draft: false}, plan), /does not match/)
+  assert.deepEqual(requireStableContainer({...release, draft: false}, plan), {...release, draft: false})
+  assert.throws(() => requireStableContainer({...release, draft: false, prerelease: true}, plan), /does not match/)
+  assert.throws(() => requireStableContainer({...release, name: "Mentra nightly"}, plan), /does not match/)
   assert.throws(() => requireStableContainer({...release, target_commitish: "b".repeat(40)}, plan), /does not match/)
   assert.throws(() => stableContainerPayload(betaPlan), /production plan is required/)
 })

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -168,6 +168,14 @@ export function planPromotionContainerAllocation(
   return {action: "create", attempt: containers.length === 0 ? 1 : containers.at(-1).attempt + 1}
 }
 
+// The newest promotion attempt for a release identity, or null when none was
+// ever allocated. Stable package publication uses this to link its evidence to
+// a live promotion without requiring the operator to name the attempt.
+export function latestPromotionContainer(releases, releaseIdentity) {
+  const matches = matchingPromotionContainers(releases, releaseIdentity)
+  return matches.length === 0 ? null : matches.at(-1)
+}
+
 export function stateAssets(assets, releaseIdentity, attempt) {
   const pattern = new RegExp(
     `^production-promotion-${releaseIdentity.replaceAll(".", "\\.")}-attempt-${attempt}-(\\d{2,})-([a-z-]+)\\.json$`,
@@ -280,9 +288,46 @@ function downloadLatest({repository, releaseIdentity, attempt, outputFile}) {
   return {release, latest, record}
 }
 
+function downloadLatestAttempt({repository, releaseIdentity, outputFile}) {
+  const releases = listReleases(repository)
+  const latest = latestPromotionContainer(releases, releaseIdentity)
+  if (!latest) return null
+  const release = requirePromotionContainer(releases, releaseIdentity, latest.attempt)
+  const loaded = loadPromotionState({repository, releaseIdentity, attempt: latest.attempt, release})
+  if (!loaded) return null
+  mkdirSync(path.dirname(outputFile), {recursive: true})
+  writeFileSync(outputFile, loaded.latest.bytes)
+  return {attempt: latest.attempt, ...loaded}
+}
+
 function main() {
   const command = process.argv[2]
   const args = parseArgs(process.argv.slice(3))
+  if (command === "download-latest-attempt") {
+    const result = downloadLatestAttempt({
+      repository: args.repository,
+      releaseIdentity: args.release,
+      outputFile: path.resolve(args.output),
+    })
+    if (!result) {
+      output({found: false}, args["github-output"])
+      return
+    }
+    output(
+      {
+        found: true,
+        attempt: result.attempt,
+        release_id: result.release.id,
+        tag: result.release.tag_name,
+        asset_id: result.latest.asset.id,
+        asset_name: result.latest.asset.name,
+        state: result.record.state,
+        sequence: result.record.sequence,
+      },
+      args["github-output"],
+    )
+    return
+  }
   if (command === "selection-digest") {
     const readJson = (name) => JSON.parse(readFileSync(path.resolve(args[name]), "utf8"))
     const fileSha256 = (name) =>

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -16,7 +16,27 @@ const SHA256_PATTERN = /^[0-9a-f]{64}$/
 
 function gh(args, options = {}) {
   const stdin = options.input === undefined ? "ignore" : "pipe"
-  return execFileSync("gh", args, {stdio: [stdin, "pipe", "inherit"], encoding: "utf8", ...options})
+  return execFileSync("gh", args, {
+    stdio: [stdin, "pipe", "inherit"],
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  })
+}
+
+// The releases endpoint inlines every asset of every release; with hundreds of
+// coordinated build assets per family that exceeds Node's default 1 MiB
+// subprocess buffer. Keep only the fields the promotion logic reads.
+export const RELEASE_LIST_FIELDS = "{id, tag_name, name, body, draft, prerelease, target_commitish}"
+export const ASSET_LIST_FIELDS = "{id, name, url, size}"
+
+// gh cannot combine --slurp with --jq, so paginated listings are streamed as
+// one JSON object per line and reassembled here.
+export function parseJsonLines(output) {
+  return output
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line))
 }
 
 function parseArgs(args) {
@@ -30,15 +50,20 @@ function parseArgs(args) {
   return values
 }
 
-function output(values, githubOutput) {
+export function writeOutputs(values, githubOutput) {
   for (const [key, value] of Object.entries(values)) console.log(`${key}=${value}`)
   if (githubOutput) {
     const lines = Object.entries(values)
       .map(([key, value]) => `${key}=${value}`)
       .join("\n")
+    // The output file may sit in a directory nothing else has created yet, for
+    // example when download-latest-attempt finds no promotion at all.
+    mkdirSync(path.dirname(path.resolve(githubOutput)), {recursive: true})
     appendFileSync(path.resolve(githubOutput), `${lines}\n`)
   }
 }
+
+const output = writeOutputs
 
 export function promotionContainerTag(releaseIdentity, attempt) {
   if (!VERSION_PATTERN.test(releaseIdentity || "")) throw new Error("release identity must be X.Y.Z")
@@ -214,13 +239,27 @@ export function validateStateRecordChain(entries, releaseIdentity, attempt) {
 }
 
 function listReleases(repository) {
-  return JSON.parse(gh(["api", "--paginate", "--slurp", `repos/${repository}/releases?per_page=100`])).flat()
+  return parseJsonLines(
+    gh([
+      "api",
+      "--paginate",
+      `repos/${repository}/releases?per_page=100`,
+      "--jq",
+      `.[] | ${RELEASE_LIST_FIELDS} | tojson`,
+    ]),
+  )
 }
 
 function listAssets(repository, releaseId) {
-  return JSON.parse(
-    gh(["api", "--paginate", "--slurp", `repos/${repository}/releases/${releaseId}/assets?per_page=100`]),
-  ).flat()
+  return parseJsonLines(
+    gh([
+      "api",
+      "--paginate",
+      `repos/${repository}/releases/${releaseId}/assets?per_page=100`,
+      "--jq",
+      `.[] | ${ASSET_LIST_FIELDS} | tojson`,
+    ]),
+  )
 }
 
 function resolveContainer(repository, releaseIdentity, attempt) {

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -169,8 +169,8 @@ export function planPromotionContainerAllocation(
 }
 
 // The newest promotion attempt for a release identity, or null when none was
-// ever allocated. Stable package publication uses this to link its evidence to
-// a live promotion without requiring the operator to name the attempt.
+// ever allocated. Stable package publication reads it to refuse publishing an
+// identity that a live promotion froze from a different beta.
 export function latestPromotionContainer(releases, releaseIdentity) {
   const matches = matchingPromotionContainers(releases, releaseIdentity)
   return matches.length === 0 ? null : matches.at(-1)
@@ -294,7 +294,13 @@ function downloadLatestAttempt({repository, releaseIdentity, outputFile}) {
   if (!latest) return null
   const release = requirePromotionContainer(releases, releaseIdentity, latest.attempt)
   const loaded = loadPromotionState({repository, releaseIdentity, attempt: latest.attempt, release})
-  if (!loaded) return null
+  // An allocated container already reserves a frozen selection in its body;
+  // treating it as absent would skip the conflicting-beta guard.
+  if (!loaded) {
+    throw new Error(
+      `Promotion ${releaseIdentity} attempt ${latest.attempt} was allocated but has no state record; rerun or abort it first`,
+    )
+  }
   mkdirSync(path.dirname(outputFile), {recursive: true})
   writeFileSync(outputFile, loaded.latest.bytes)
   return {attempt: latest.attempt, ...loaded}

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -281,3 +281,16 @@ test("resolves the newest promotion attempt for stable package evidence", () => 
   assert.equal(latest.releaseIdentity, "3.1.0")
   assert.equal(latestPromotionContainer(releases, "3.2.0"), null)
 })
+
+test("writes step outputs into a directory that does not exist yet", () => {
+  const {writeOutputs} = assetsModule
+  const file = path.join(mkdtempSync(path.join(tmpdir(), "promotion-outputs-")), "promotion-input", "outputs.env")
+  writeOutputs({found: false}, file)
+  assert.equal(readFileSync(file, "utf8"), "found=false\n")
+})
+
+test("reassembles paginated gh listings streamed as JSON lines", () => {
+  const {parseJsonLines} = assetsModule
+  assert.deepEqual(parseJsonLines('{"id":1}\n{"id":2}\n\n'), [{id: 1}, {id: 2}])
+  assert.deepEqual(parseJsonLines(""), [])
+})

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -18,6 +18,7 @@ import {
   stateAssets,
   validateStateRecordChain,
 } from "./production-promotion-assets.mjs"
+import * as assetsModule from "./production-promotion-assets.mjs"
 import {
   abortPromotionRecord,
   createInitialPromotionRecord,
@@ -264,4 +265,19 @@ test("validates every immutable state and digest before returning latest", () =>
   const tampered = structuredClone(entries)
   tampered[1].record.coordinates.candidates.mentraApp.ios.buildNumber += 1
   assert.throws(() => validateStateRecordChain(tampered, "3.1.0", 1), /digest|frozen field coordinates/)
+})
+
+test("resolves the newest promotion attempt for stable package evidence", () => {
+  const {latestPromotionContainer} = assetsModule
+  assert.equal(latestPromotionContainer([], "3.1.0"), null)
+  const releases = [
+    {tag_name: "mentra-production-promotion-v3.1.0-attempt-2"},
+    {tag_name: "mentra-production-promotion-v3.0.0-attempt-4"},
+    {tag_name: "mentra-production-promotion-v3.1.0-attempt-1"},
+    {tag_name: "mentra-builds-v3.1.0"},
+  ]
+  const latest = latestPromotionContainer(releases, "3.1.0")
+  assert.equal(latest.attempt, 2)
+  assert.equal(latest.releaseIdentity, "3.1.0")
+  assert.equal(latestPromotionContainer(releases, "3.2.0"), null)
 })

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import {appendFileSync, readFileSync, writeFileSync} from "node:fs"
+import {readFileSync, writeFileSync} from "node:fs"
 import path from "node:path"
 import {fileURLToPath} from "node:url"
 import {isDeepStrictEqual} from "node:util"
@@ -257,10 +257,6 @@ export function validatePromotionChain(previous, next) {
     const previousIndex = STATE_INDEX.get(previous.state)
     const nextIndex = STATE_INDEX.get(next.state)
     const rolloutUpdate = previous.state === "rolling-out" && next.state === "rolling-out"
-    const packagesUpdate =
-      previous.state === next.state &&
-      previous.state !== "finalizing" &&
-      PACKAGE_EVIDENCE_KIND_SET.has(next.evidence.at(-1)?.kind)
     const compatibilityLabUpdate =
       previous.state === "selected" &&
       next.state === "selected" &&
@@ -276,7 +272,7 @@ export function validatePromotionChain(previous, next) {
     ) {
       fail("staging-compatible requires lab build evidence followed by Mobile N acceptance")
     }
-    if (!rolloutUpdate && !compatibilityLabUpdate && !packagesUpdate && nextIndex !== previousIndex + 1) {
+    if (!rolloutUpdate && !compatibilityLabUpdate && nextIndex !== previousIndex + 1) {
       fail(`transition ${previous.state} -> ${next.state} is not contiguous`)
     }
   }
@@ -350,32 +346,21 @@ export function abortPromotionRecord({record, actor, createdAt, provenanceUrl, r
   return validatePromotionChain(record, next)
 }
 
-export function appendPromotionEvidence({record, actor, createdAt, provenanceUrl, evidence}) {
+// Stable package publication (production-release-packages.yml) never writes to
+// this chain: its evidence lives in the stable draft release, so it cannot race
+// a mobile or Cloud transition. It only reads the newest attempt to make sure a
+// live promotion did not freeze a different beta or source under the identity
+// it is about to publish.
+export function requirePromotionMatchesPackages(record, {betaIdentity, sourceCommit}) {
   validatePromotionRecord(record)
-  if (TERMINAL_PROMOTION_STATES.includes(record.state)) fail(`cannot append after terminal state ${record.state}`)
-  if (!PACKAGE_EVIDENCE_KIND_SET.has(evidence?.kind)) {
-    fail(`only package evidence can be appended without a state transition, not ${JSON.stringify(evidence?.kind)}`)
-  }
-  return transitionPromotionRecord({record, to: record.state, actor, createdAt, provenanceUrl, evidence})
-}
-
-// Decide whether a stable package run for the selected beta may append its
-// evidence to this promotion attempt. A live attempt that froze a different
-// beta or source is a hard stop: two sources cannot share one release identity.
-export function packagesEvidenceLink(record, {betaIdentity, sourceCommit}) {
-  validatePromotionRecord(record)
+  if (record.state === "aborted") return {state: record.state, attempt: record.attempt}
   if (record.selectedBeta.identity !== betaIdentity) {
     fail(`promotion attempt ${record.attempt} selected ${record.selectedBeta.identity}, not ${betaIdentity}`)
   }
   if (record.source.mentraosCommit !== sourceCommit) {
     fail(`promotion attempt ${record.attempt} froze source ${record.source.mentraosCommit}, not ${sourceCommit}`)
   }
-  if (record.state === "aborted") return {append: false, reason: `attempt ${record.attempt} is aborted`}
-  if (record.state === "completed") return {append: false, reason: `attempt ${record.attempt} is completed`}
-  if (record.state === "finalizing") {
-    return {append: false, reason: `attempt ${record.attempt} is at the finalizing checkpoint; resume it first`}
-  }
-  return {append: true, reason: `attempt ${record.attempt} is ${record.state}`}
+  return {state: record.state, attempt: record.attempt}
 }
 
 function secretLike(value) {
@@ -526,25 +511,12 @@ function main() {
     writeFileSync(path.resolve(args.output), serializeReleaseRecord(record))
     return
   }
-  if (command === "append") {
-    const record = appendPromotionEvidence({
-      record: readJson(args.record),
-      actor: args.actor,
-      createdAt: args["created-at"],
-      provenanceUrl: args["provenance-url"],
-      evidence: readJson(args.evidence),
-    })
-    writeFileSync(path.resolve(args.output), serializeReleaseRecord(record))
-    return
-  }
-  if (command === "packages-link") {
-    const link = packagesEvidenceLink(readJson(args.record), {
+  if (command === "packages-guard") {
+    const result = requirePromotionMatchesPackages(readJson(args.record), {
       betaIdentity: args.beta,
       sourceCommit: args["source-commit"],
     })
-    const lines = [`append=${link.append}`, `reason=${link.reason}`]
-    for (const line of lines) console.log(line)
-    if (args["github-output"]) appendFileSync(path.resolve(args["github-output"]), `${lines.join("\n")}\n`)
+    console.log(`promotion attempt ${result.attempt} (${result.state}) matches ${args.beta}`)
     return
   }
   if (command === "abort") {

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import {readFileSync, writeFileSync} from "node:fs"
+import {appendFileSync, readFileSync, writeFileSync} from "node:fs"
 import path from "node:path"
 import {fileURLToPath} from "node:url"
 import {isDeepStrictEqual} from "node:util"
@@ -78,6 +78,16 @@ export const NEXT_ACTIONS = Object.freeze({
   "completed": {kind: "none"},
   "aborted": {kind: "none"},
 })
+
+// Stable package publication (npm latest, Maven Central, SwiftPM) runs from
+// production-release-packages.yml independently of the mobile path. Its
+// evidence is appended to the chain without changing the promotion state, so
+// it can land before, during, or after store review. It is refused at the
+// finalizing checkpoint, whose last evidence entry must stay the 100 percent
+// rollout observation, and after a terminal state.
+export const PACKAGE_EVIDENCE_KINDS = Object.freeze(["production-packages-publication", "production-packages-release"])
+
+const PACKAGE_EVIDENCE_KIND_SET = new Set(PACKAGE_EVIDENCE_KINDS)
 
 function fail(message) {
   throw new Error(`Invalid production promotion: ${message}`)
@@ -247,6 +257,10 @@ export function validatePromotionChain(previous, next) {
     const previousIndex = STATE_INDEX.get(previous.state)
     const nextIndex = STATE_INDEX.get(next.state)
     const rolloutUpdate = previous.state === "rolling-out" && next.state === "rolling-out"
+    const packagesUpdate =
+      previous.state === next.state &&
+      previous.state !== "finalizing" &&
+      PACKAGE_EVIDENCE_KIND_SET.has(next.evidence.at(-1)?.kind)
     const compatibilityLabUpdate =
       previous.state === "selected" &&
       next.state === "selected" &&
@@ -262,7 +276,7 @@ export function validatePromotionChain(previous, next) {
     ) {
       fail("staging-compatible requires lab build evidence followed by Mobile N acceptance")
     }
-    if (!rolloutUpdate && !compatibilityLabUpdate && nextIndex !== previousIndex + 1) {
+    if (!rolloutUpdate && !compatibilityLabUpdate && !packagesUpdate && nextIndex !== previousIndex + 1) {
       fail(`transition ${previous.state} -> ${next.state} is not contiguous`)
     }
   }
@@ -334,6 +348,34 @@ export function abortPromotionRecord({record, actor, createdAt, provenanceUrl, r
     abort: {reason: requireString(reason, "abort.reason", 1000)},
   }
   return validatePromotionChain(record, next)
+}
+
+export function appendPromotionEvidence({record, actor, createdAt, provenanceUrl, evidence}) {
+  validatePromotionRecord(record)
+  if (TERMINAL_PROMOTION_STATES.includes(record.state)) fail(`cannot append after terminal state ${record.state}`)
+  if (!PACKAGE_EVIDENCE_KIND_SET.has(evidence?.kind)) {
+    fail(`only package evidence can be appended without a state transition, not ${JSON.stringify(evidence?.kind)}`)
+  }
+  return transitionPromotionRecord({record, to: record.state, actor, createdAt, provenanceUrl, evidence})
+}
+
+// Decide whether a stable package run for the selected beta may append its
+// evidence to this promotion attempt. A live attempt that froze a different
+// beta or source is a hard stop: two sources cannot share one release identity.
+export function packagesEvidenceLink(record, {betaIdentity, sourceCommit}) {
+  validatePromotionRecord(record)
+  if (record.selectedBeta.identity !== betaIdentity) {
+    fail(`promotion attempt ${record.attempt} selected ${record.selectedBeta.identity}, not ${betaIdentity}`)
+  }
+  if (record.source.mentraosCommit !== sourceCommit) {
+    fail(`promotion attempt ${record.attempt} froze source ${record.source.mentraosCommit}, not ${sourceCommit}`)
+  }
+  if (record.state === "aborted") return {append: false, reason: `attempt ${record.attempt} is aborted`}
+  if (record.state === "completed") return {append: false, reason: `attempt ${record.attempt} is completed`}
+  if (record.state === "finalizing") {
+    return {append: false, reason: `attempt ${record.attempt} is at the finalizing checkpoint; resume it first`}
+  }
+  return {append: true, reason: `attempt ${record.attempt} is ${record.state}`}
 }
 
 function secretLike(value) {
@@ -482,6 +524,27 @@ function main() {
       evidence: readJson(args.evidence),
     })
     writeFileSync(path.resolve(args.output), serializeReleaseRecord(record))
+    return
+  }
+  if (command === "append") {
+    const record = appendPromotionEvidence({
+      record: readJson(args.record),
+      actor: args.actor,
+      createdAt: args["created-at"],
+      provenanceUrl: args["provenance-url"],
+      evidence: readJson(args.evidence),
+    })
+    writeFileSync(path.resolve(args.output), serializeReleaseRecord(record))
+    return
+  }
+  if (command === "packages-link") {
+    const link = packagesEvidenceLink(readJson(args.record), {
+      betaIdentity: args.beta,
+      sourceCommit: args["source-commit"],
+    })
+    const lines = [`append=${link.append}`, `reason=${link.reason}`]
+    for (const line of lines) console.log(line)
+    if (args["github-output"]) appendFileSync(path.resolve(args["github-output"]), `${lines.join("\n")}\n`)
     return
   }
   if (command === "abort") {

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -79,16 +79,6 @@ export const NEXT_ACTIONS = Object.freeze({
   "aborted": {kind: "none"},
 })
 
-// Stable package publication (npm latest, Maven Central, SwiftPM) runs from
-// production-release-packages.yml independently of the mobile path. Its
-// evidence is appended to the chain without changing the promotion state, so
-// it can land before, during, or after store review. It is refused at the
-// finalizing checkpoint, whose last evidence entry must stay the 100 percent
-// rollout observation, and after a terminal state.
-export const PACKAGE_EVIDENCE_KINDS = Object.freeze(["production-packages-publication", "production-packages-release"])
-
-const PACKAGE_EVIDENCE_KIND_SET = new Set(PACKAGE_EVIDENCE_KINDS)
-
 function fail(message) {
   throw new Error(`Invalid production promotion: ${message}`)
 }

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -15,6 +15,7 @@ import {
   validatePromotionChain,
   validatePromotionRecord,
 } from "./production-promotion-state.mjs"
+import * as stateModule from "./production-promotion-state.mjs"
 
 const now = "2026-08-28T20:00:00.000Z"
 const runUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
@@ -409,4 +410,114 @@ test("allows append-only rollout observations before completion", () => {
   })
   assert.equal(completed.state, "completed")
   assert.equal(completed.previous.assetName, promotionAssetName(finalizing))
+})
+
+test("appends stable package evidence without moving the mobile path", () => {
+  const {PACKAGE_EVIDENCE_KINDS, appendPromotionEvidence, packagesEvidenceLink} = stateModule
+  const link = {betaIdentity: "3.1.0-beta.57", sourceCommit: "a".repeat(40)}
+  for (const state of PROMOTION_STATES.filter((candidate) => !["finalizing", "completed"].includes(candidate))) {
+    const record = atState(state)
+    assert.deepEqual(packagesEvidenceLink(record, link).append, true, state)
+    let next = record
+    for (const kind of PACKAGE_EVIDENCE_KINDS) {
+      next = appendPromotionEvidence({
+        record: next,
+        actor: "release-owner",
+        createdAt: now,
+        provenanceUrl: runUrl,
+        evidence: evidence(kind),
+      })
+      assert.equal(next.state, state)
+      assert.equal(next.evidence.at(-1).kind, kind)
+    }
+    assert.equal(next.sequence, record.sequence + PACKAGE_EVIDENCE_KINDS.length)
+    assert.deepEqual(nextAction(next), nextAction(record))
+  }
+
+  const selected = appendPromotionEvidence({
+    record: initial(),
+    actor: "release-owner",
+    createdAt: now,
+    provenanceUrl: runUrl,
+    evidence: evidence("production-packages-publication"),
+  })
+  const labReady = withCompatibilityLab(selected)
+  assert.equal(nextAction(labReady).check, "staging-mobile-n-compatibility")
+  const compatible = transitionPromotionRecord({
+    record: labReady,
+    to: "staging-compatible",
+    actor: "operator",
+    createdAt: now,
+    provenanceUrl: runUrl,
+    evidence: evidence("staging-mobile-n-compatibility"),
+  })
+  assert.equal(compatible.state, "staging-compatible")
+
+  assert.throws(
+    () =>
+      appendPromotionEvidence({
+        record: initial(),
+        actor: "release-owner",
+        createdAt: now,
+        provenanceUrl: runUrl,
+        evidence: evidence("production-cloud-v2-deployment"),
+      }),
+    /only package evidence/,
+  )
+  assert.throws(
+    () =>
+      transitionPromotionRecord({
+        record: initial(),
+        to: "selected",
+        actor: "release-owner",
+        createdAt: now,
+        provenanceUrl: runUrl,
+        evidence: evidence("production-cloud-v2-deployment"),
+      }),
+    /not contiguous/,
+  )
+})
+
+test("refuses package evidence at the finalizing checkpoint and after terminal states", () => {
+  const {appendPromotionEvidence, packagesEvidenceLink} = stateModule
+  const link = {betaIdentity: "3.1.0-beta.57", sourceCommit: "a".repeat(40)}
+  const finalizing = atState("finalizing")
+  assert.match(packagesEvidenceLink(finalizing, link).reason, /finalizing checkpoint/)
+  assert.throws(
+    () =>
+      appendPromotionEvidence({
+        record: finalizing,
+        actor: "release-owner",
+        createdAt: now,
+        provenanceUrl: runUrl,
+        evidence: evidence("production-packages-release"),
+      }),
+    /not contiguous/,
+  )
+  const completed = atState("completed")
+  assert.equal(packagesEvidenceLink(completed, link).append, false)
+  const aborted = abortPromotionRecord({
+    record: initial(),
+    actor: "release-owner",
+    createdAt: now,
+    provenanceUrl: runUrl,
+    reason: "withdrawn",
+  })
+  assert.equal(packagesEvidenceLink(aborted, link).append, false)
+  assert.throws(
+    () =>
+      appendPromotionEvidence({
+        record: aborted,
+        actor: "release-owner",
+        createdAt: now,
+        provenanceUrl: runUrl,
+        evidence: evidence("production-packages-release"),
+      }),
+    /terminal state/,
+  )
+  assert.throws(
+    () => packagesEvidenceLink(initial(), {...link, betaIdentity: "3.1.0-beta.58"}),
+    /selected 3\.1\.0-beta\.57/,
+  )
+  assert.throws(() => packagesEvidenceLink(initial(), {...link, sourceCommit: "e".repeat(40)}), /froze source/)
 })

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -9,13 +9,13 @@ import {
   createInitialPromotionRecord,
   nextAction,
   promotionAssetName,
+  requirePromotionMatchesPackages,
   transitionPromotionRecord,
   transitionWithAttestation,
   validateAttestation,
   validatePromotionChain,
   validatePromotionRecord,
 } from "./production-promotion-state.mjs"
-import * as stateModule from "./production-promotion-state.mjs"
 
 const now = "2026-08-28T20:00:00.000Z"
 const runUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
@@ -412,57 +412,27 @@ test("allows append-only rollout observations before completion", () => {
   assert.equal(completed.previous.assetName, promotionAssetName(finalizing))
 })
 
-test("appends stable package evidence without moving the mobile path", () => {
-  const {PACKAGE_EVIDENCE_KINDS, appendPromotionEvidence, packagesEvidenceLink} = stateModule
+test("stable packages only read the promotion to reject a conflicting frozen beta", () => {
   const link = {betaIdentity: "3.1.0-beta.57", sourceCommit: "a".repeat(40)}
-  for (const state of PROMOTION_STATES.filter((candidate) => !["finalizing", "completed"].includes(candidate))) {
+  for (const state of PROMOTION_STATES) {
     const record = atState(state)
-    assert.deepEqual(packagesEvidenceLink(record, link).append, true, state)
-    let next = record
-    for (const kind of PACKAGE_EVIDENCE_KINDS) {
-      next = appendPromotionEvidence({
-        record: next,
-        actor: "release-owner",
-        createdAt: now,
-        provenanceUrl: runUrl,
-        evidence: evidence(kind),
-      })
-      assert.equal(next.state, state)
-      assert.equal(next.evidence.at(-1).kind, kind)
-    }
-    assert.equal(next.sequence, record.sequence + PACKAGE_EVIDENCE_KINDS.length)
-    assert.deepEqual(nextAction(next), nextAction(record))
+    assert.deepEqual(requirePromotionMatchesPackages(record, link), {state, attempt: 1})
   }
-
-  const selected = appendPromotionEvidence({
+  const aborted = abortPromotionRecord({
     record: initial(),
     actor: "release-owner",
     createdAt: now,
     provenanceUrl: runUrl,
-    evidence: evidence("production-packages-publication"),
+    reason: "withdrawn",
   })
-  const labReady = withCompatibilityLab(selected)
-  assert.equal(nextAction(labReady).check, "staging-mobile-n-compatibility")
-  const compatible = transitionPromotionRecord({
-    record: labReady,
-    to: "staging-compatible",
-    actor: "operator",
-    createdAt: now,
-    provenanceUrl: runUrl,
-    evidence: evidence("staging-mobile-n-compatibility"),
-  })
-  assert.equal(compatible.state, "staging-compatible")
-
+  assert.equal(requirePromotionMatchesPackages(aborted, {...link, betaIdentity: "3.1.0-beta.58"}).state, "aborted")
   assert.throws(
-    () =>
-      appendPromotionEvidence({
-        record: initial(),
-        actor: "release-owner",
-        createdAt: now,
-        provenanceUrl: runUrl,
-        evidence: evidence("production-cloud-v2-deployment"),
-      }),
-    /only package evidence/,
+    () => requirePromotionMatchesPackages(initial(), {...link, betaIdentity: "3.1.0-beta.58"}),
+    /selected 3\.1\.0-beta\.57/,
+  )
+  assert.throws(
+    () => requirePromotionMatchesPackages(initial(), {...link, sourceCommit: "e".repeat(40)}),
+    /froze source/,
   )
   assert.throws(
     () =>
@@ -472,52 +442,8 @@ test("appends stable package evidence without moving the mobile path", () => {
         actor: "release-owner",
         createdAt: now,
         provenanceUrl: runUrl,
-        evidence: evidence("production-cloud-v2-deployment"),
+        evidence: evidence("production-packages-publication"),
       }),
     /not contiguous/,
   )
-})
-
-test("refuses package evidence at the finalizing checkpoint and after terminal states", () => {
-  const {appendPromotionEvidence, packagesEvidenceLink} = stateModule
-  const link = {betaIdentity: "3.1.0-beta.57", sourceCommit: "a".repeat(40)}
-  const finalizing = atState("finalizing")
-  assert.match(packagesEvidenceLink(finalizing, link).reason, /finalizing checkpoint/)
-  assert.throws(
-    () =>
-      appendPromotionEvidence({
-        record: finalizing,
-        actor: "release-owner",
-        createdAt: now,
-        provenanceUrl: runUrl,
-        evidence: evidence("production-packages-release"),
-      }),
-    /not contiguous/,
-  )
-  const completed = atState("completed")
-  assert.equal(packagesEvidenceLink(completed, link).append, false)
-  const aborted = abortPromotionRecord({
-    record: initial(),
-    actor: "release-owner",
-    createdAt: now,
-    provenanceUrl: runUrl,
-    reason: "withdrawn",
-  })
-  assert.equal(packagesEvidenceLink(aborted, link).append, false)
-  assert.throws(
-    () =>
-      appendPromotionEvidence({
-        record: aborted,
-        actor: "release-owner",
-        createdAt: now,
-        provenanceUrl: runUrl,
-        evidence: evidence("production-packages-release"),
-      }),
-    /terminal state/,
-  )
-  assert.throws(
-    () => packagesEvidenceLink(initial(), {...link, betaIdentity: "3.1.0-beta.58"}),
-    /selected 3\.1\.0-beta\.57/,
-  )
-  assert.throws(() => packagesEvidenceLink(initial(), {...link, sourceCommit: "e".repeat(40)}), /froze source/)
 })

--- a/.github/scripts/promote-npm-latest.mjs
+++ b/.github/scripts/promote-npm-latest.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Flip the npm `latest` dist-tag to the plain versions a production package run
+// already published under its candidate dist-tag.
+//
+// publish-release-npm.mjs refuses to publish a production plan straight to
+// `latest`: the stable run publishes X.Y.Z under `candidate-X.Y.Z` first, a
+// human approves the protected release phase, and only then does this script
+// move `latest`. Moving a dist-tag needs a real npm token (NODE_AUTH_TOKEN);
+// trusted-publisher OIDC only covers `npm publish`.
+import {execFileSync} from "node:child_process"
+import {mkdirSync, readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {resolveNpmReleaseTag} from "./publish-release-npm.mjs"
+import {serializeReleaseRecord} from "./release-family.mjs"
+
+const VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/
+
+export function compareVersions(left, right) {
+  const a = VERSION_PATTERN.exec(left || "")
+  const b = VERSION_PATTERN.exec(right || "")
+  if (!a || !b) throw new Error(`Cannot compare npm versions ${JSON.stringify(left)} and ${JSON.stringify(right)}`)
+  for (let index = 1; index <= 3; index += 1) {
+    const difference = Number(a[index]) - Number(b[index])
+    if (difference !== 0) return Math.sign(difference)
+  }
+  if (a[4] === b[4]) return 0
+  if (a[4] === undefined) return 1
+  if (b[4] === undefined) return -1
+  return a[4] < b[4] ? -1 : 1
+}
+
+export function latestFlipDecision({version, candidateTag, distTags}) {
+  const tags = distTags || {}
+  if (tags.latest === version) return {action: "reused", previousLatest: version}
+  if (tags[candidateTag] !== version) {
+    throw new Error(
+      `${candidateTag} points at ${JSON.stringify(tags[candidateTag] ?? null)}, not ${version}; run the publish phase first`,
+    )
+  }
+  if (tags.latest && compareVersions(tags.latest, version) > 0) {
+    throw new Error(`latest already points at the newer version ${tags.latest}; refusing to move it back to ${version}`)
+  }
+  return {action: "published", previousLatest: tags.latest ?? null}
+}
+
+export function npmMembersFromPlan(plan) {
+  if (!Array.isArray(plan?.publicationOrder) || !plan?.members) throw new Error("A release plan is required")
+  return plan.publicationOrder.filter((name) => plan.members[name]?.publishTargets?.includes("npm"))
+}
+
+function npmView(spec, field) {
+  try {
+    return execFileSync("npm", ["view", spec, field, "--json", "--registry=https://registry.npmjs.org"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim()
+  } catch (error) {
+    const output = `${error.stdout || ""}${error.stderr || ""}`
+    if (/"code":\s*"E404"/.test(output) || /code E404/.test(output)) return null
+    throw new Error(`npm view ${spec} failed with a non-404 error:\n${output}`)
+  }
+}
+
+function parseViewValue(output) {
+  if (output === null || output === "") return null
+  try {
+    return JSON.parse(output)
+  } catch {
+    return output
+  }
+}
+
+function run(command, args) {
+  console.log(`$ ${command} ${args.join(" ")}`)
+  execFileSync(command, args, {stdio: "inherit"})
+}
+
+export function promoteNpmLatest({
+  plan,
+  npmTag,
+  outputDir,
+  dryRun = false,
+  view = npmView,
+  exec = run,
+  log = console.log,
+}) {
+  if (plan?.channel !== "production") throw new Error("Only a production plan can move npm latest")
+  const version = plan.releaseIdentity
+  const candidateTag = resolveNpmReleaseTag(plan.channel, npmTag)
+  const publications = {}
+  for (const name of npmMembersFromPlan(plan)) {
+    const coordinate = `${name}@${version}`
+    const integrity = parseViewValue(view(coordinate, "dist.integrity"))
+    if (typeof integrity !== "string" || !integrity.startsWith("sha512-")) {
+      throw new Error(`${coordinate} is not published on npm; run the publish phase first`)
+    }
+    const distTags = parseViewValue(view(name, "dist-tags")) || {}
+    const decision = latestFlipDecision({version, candidateTag, distTags})
+    let status = decision.action
+    if (decision.action === "published" && dryRun) {
+      status = "built"
+      log(`Dry run: would move ${name} latest from ${decision.previousLatest ?? "<unset>"} to ${version}`)
+    } else if (decision.action === "published") {
+      exec("npm", ["dist-tag", "add", coordinate, "latest"])
+      const observed = parseViewValue(view(name, "dist-tags")) || {}
+      if (observed.latest !== version) {
+        throw new Error(`${name} latest reads back as ${JSON.stringify(observed.latest ?? null)}, expected ${version}`)
+      }
+    }
+    if (!dryRun && status !== "built") {
+      const current = parseViewValue(view(name, "dist-tags")) || {}
+      if (current[candidateTag] === version) exec("npm", ["dist-tag", "rm", name, candidateTag])
+    }
+    publications[name] = {
+      npm: {
+        status,
+        coordinate,
+        tag: "latest",
+        candidateTag,
+        previousLatest: decision.previousLatest,
+        integrity,
+        url: `https://www.npmjs.com/package/${name}/v/${version}`,
+        provenanceUrl: `https://github.com/${process.env.GITHUB_REPOSITORY || "Mentra-Community/MentraOS"}/actions/runs/${process.env.GITHUB_RUN_ID || "0"}`,
+      },
+    }
+  }
+  const result = {schemaVersion: 1, releaseSetId: plan.releaseSetId, releaseIdentity: version, publications}
+  if (outputDir) {
+    mkdirSync(outputDir, {recursive: true})
+    writeFileSync(path.join(outputDir, "npm-latest.json"), serializeReleaseRecord(result))
+  }
+  return result
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  for (const required of ["plan", "npm-tag", "output-dir"]) {
+    if (!args[required]) throw new Error(`Missing --${required}`)
+  }
+  promoteNpmLatest({
+    plan: JSON.parse(readFileSync(path.resolve(args.plan), "utf8")),
+    npmTag: args["npm-tag"],
+    outputDir: path.resolve(args["output-dir"]),
+    dryRun: args["dry-run"] === "true",
+  })
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/promote-npm-latest.mjs
+++ b/.github/scripts/promote-npm-latest.mjs
@@ -89,15 +89,21 @@ export function promoteNpmLatest({
   if (plan?.channel !== "production") throw new Error("Only a production plan can move npm latest")
   const version = plan.releaseIdentity
   const candidateTag = resolveNpmReleaseTag(plan.channel, npmTag)
-  const publications = {}
-  for (const name of npmMembersFromPlan(plan)) {
+
+  // Decide for the whole family before touching any dist-tag, so a member that
+  // is unpublished or already ahead stops the run with nothing moved.
+  const planned = npmMembersFromPlan(plan).map((name) => {
     const coordinate = `${name}@${version}`
     const integrity = parseViewValue(view(coordinate, "dist.integrity"))
     if (typeof integrity !== "string" || !integrity.startsWith("sha512-")) {
       throw new Error(`${coordinate} is not published on npm; run the publish phase first`)
     }
     const distTags = parseViewValue(view(name, "dist-tags")) || {}
-    const decision = latestFlipDecision({version, candidateTag, distTags})
+    return {name, coordinate, integrity, decision: latestFlipDecision({version, candidateTag, distTags})}
+  })
+
+  const publications = {}
+  for (const {name, coordinate, integrity, decision} of planned) {
     let status = decision.action
     if (decision.action === "published" && dryRun) {
       status = "built"
@@ -109,7 +115,7 @@ export function promoteNpmLatest({
         throw new Error(`${name} latest reads back as ${JSON.stringify(observed.latest ?? null)}, expected ${version}`)
       }
     }
-    if (!dryRun && status !== "built") {
+    if (!dryRun) {
       const current = parseViewValue(view(name, "dist-tags")) || {}
       if (current[candidateTag] === version) exec("npm", ["dist-tag", "rm", name, candidateTag])
     }

--- a/.github/scripts/promote-npm-latest.test.mjs
+++ b/.github/scripts/promote-npm-latest.test.mjs
@@ -138,3 +138,41 @@ test("refuses unpublished versions and does nothing in a dry run", () => {
   )
   assert.throws(() => promoteNpmLatest({plan, npmTag: undefined, view: fake.view}), /explicit candidate dist-tag/)
 })
+
+test("moves nothing when any member would be unpublished or downgraded", () => {
+  const members = npmMembersFromPlan(plan)
+  const ahead = registry(
+    Object.fromEntries(
+      members.map((name, index) => [
+        name,
+        index === members.length - 1
+          ? [["latest", "3.2.0"]]
+          : [
+              [candidateTag, version],
+              ["latest", "3.0.0"],
+            ],
+      ]),
+    ),
+  )
+  assert.throws(
+    () => promoteNpmLatest({plan, npmTag: candidateTag, view: ahead.view, exec: ahead.exec, log: () => {}}),
+    /run the publish phase first|refusing to move it back/,
+  )
+  assert.deepEqual(ahead.commands, [])
+
+  const missing = registry(Object.fromEntries(members.map((name) => [name, [[candidateTag, version]]])))
+  const last = members.at(-1)
+  assert.throws(
+    () =>
+      promoteNpmLatest({
+        plan,
+        npmTag: candidateTag,
+        view: (spec, field) =>
+          field === "dist.integrity" && spec.startsWith(`${last}@`) ? null : missing.view(spec, field),
+        exec: missing.exec,
+        log: () => {},
+      }),
+    /is not published on npm/,
+  )
+  assert.deepEqual(missing.commands, [])
+})

--- a/.github/scripts/promote-npm-latest.test.mjs
+++ b/.github/scripts/promote-npm-latest.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict"
+import {mkdtempSync, readFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {compareVersions, latestFlipDecision, npmMembersFromPlan, promoteNpmLatest} from "./promote-npm-latest.mjs"
+import {createReleasePlan, loadReleaseFamily} from "./release-family.mjs"
+
+const family = loadReleaseFamily()
+const plan = createReleasePlan({
+  family,
+  channel: "production",
+  sourceCommit: "a".repeat(40),
+  nativeBuildNumber: 310000057,
+})
+const version = plan.releaseIdentity
+const candidateTag = `candidate-${version}`
+
+test("orders plain versions and treats a prerelease as older than its plain release", () => {
+  assert.equal(compareVersions("3.1.0", "3.1.0"), 0)
+  assert.equal(compareVersions("3.2.0", "3.1.9"), 1)
+  assert.equal(compareVersions("3.1.0-beta.57", "3.1.0"), -1)
+  assert.equal(compareVersions("3.1.0", "3.1.0-beta.57"), 1)
+  assert.throws(() => compareVersions("latest", "3.1.0"), /Cannot compare/)
+})
+
+test("moves latest only from a published candidate tag and never backwards", () => {
+  assert.deepEqual(latestFlipDecision({version, candidateTag, distTags: {latest: version}}), {
+    action: "reused",
+    previousLatest: version,
+  })
+  assert.deepEqual(latestFlipDecision({version, candidateTag, distTags: {[candidateTag]: version, beta: "x"}}), {
+    action: "published",
+    previousLatest: null,
+  })
+  assert.deepEqual(latestFlipDecision({version, candidateTag, distTags: {[candidateTag]: version, latest: "3.0.2"}}), {
+    action: "published",
+    previousLatest: "3.0.2",
+  })
+  assert.throws(() => latestFlipDecision({version, candidateTag, distTags: {latest: "3.0.2"}}), /run the publish phase/)
+  assert.throws(
+    () => latestFlipDecision({version, candidateTag, distTags: {[candidateTag]: version, latest: "3.2.0"}}),
+    /refusing to move it back/,
+  )
+})
+
+test("selects the npm members of the frozen plan in publication order", () => {
+  const members = npmMembersFromPlan(plan)
+  assert.ok(members.includes("@mentra/engine"))
+  assert.ok(!members.includes("mentraos"))
+  assert.ok(members.indexOf("@mentra/bluetooth-sdk") < members.indexOf("@mentra/engine"))
+  assert.throws(() => npmMembersFromPlan({channel: "production"}), /release plan is required/)
+})
+
+function registry(initialTags) {
+  const tags = new Map(Object.entries(initialTags).map(([name, entries]) => [name, new Map(entries)]))
+  const commands = []
+  return {
+    commands,
+    view(spec, field) {
+      if (field === "dist.integrity") return JSON.stringify(`sha512-${spec}`)
+      const name = spec
+      return JSON.stringify(Object.fromEntries(tags.get(name) || []))
+    },
+    exec(command, args) {
+      commands.push(`${command} ${args.join(" ")}`)
+      const [, action, coordinate, tag] = args
+      if (action === "add") {
+        const name = coordinate.slice(0, coordinate.lastIndexOf("@"))
+        tags.get(name).set(tag, coordinate.slice(name.length + 1))
+      }
+      if (action === "rm") tags.get(coordinate).delete(tag)
+    },
+  }
+}
+
+test("flips latest for every npm member, reads it back, and retires the candidate tag", () => {
+  const members = npmMembersFromPlan(plan)
+  const initial = Object.fromEntries(
+    members.map((name) => [
+      name,
+      [
+        [candidateTag, version],
+        ["latest", "3.0.0"],
+      ],
+    ]),
+  )
+  initial["@mentra/engine"] = [["latest", version]]
+  const fake = registry(initial)
+  const outputDir = mkdtempSync(path.join(tmpdir(), "npm-latest-"))
+  const result = promoteNpmLatest({
+    plan,
+    npmTag: candidateTag,
+    outputDir,
+    view: fake.view,
+    exec: fake.exec,
+    log: () => {},
+  })
+  assert.equal(result.publications["@mentra/engine"].npm.status, "reused")
+  assert.equal(result.publications["@mentra/bluetooth-sdk"].npm.status, "published")
+  assert.equal(result.publications["@mentra/bluetooth-sdk"].npm.previousLatest, "3.0.0")
+  assert.ok(fake.commands.includes(`npm dist-tag add @mentra/bluetooth-sdk@${version} latest`))
+  assert.ok(fake.commands.includes(`npm dist-tag rm @mentra/bluetooth-sdk ${candidateTag}`))
+  assert.ok(!fake.commands.some((command) => command.includes("@mentra/engine@")))
+  const written = JSON.parse(readFileSync(path.join(outputDir, "npm-latest.json"), "utf8"))
+  assert.equal(written.releaseSetId, plan.releaseSetId)
+  assert.equal(Object.keys(written.publications).length, members.length)
+})
+
+test("refuses unpublished versions and does nothing in a dry run", () => {
+  const members = npmMembersFromPlan(plan)
+  const fake = registry(Object.fromEntries(members.map((name) => [name, [[candidateTag, version]]])))
+  const dry = promoteNpmLatest({
+    plan,
+    npmTag: candidateTag,
+    dryRun: true,
+    view: fake.view,
+    exec: fake.exec,
+    log: () => {},
+  })
+  assert.equal(dry.publications["@mentra/engine"].npm.status, "built")
+  assert.deepEqual(fake.commands, [])
+
+  assert.throws(
+    () =>
+      promoteNpmLatest({
+        plan,
+        npmTag: candidateTag,
+        view: (spec, field) => (field === "dist.integrity" ? null : "{}"),
+        exec: fake.exec,
+      }),
+    /is not published on npm/,
+  )
+  assert.throws(
+    () => promoteNpmLatest({plan: {...plan, channel: "beta"}, npmTag: candidateTag}),
+    /Only a production plan/,
+  )
+  assert.throws(() => promoteNpmLatest({plan, npmTag: undefined, view: fake.view}), /explicit candidate dist-tag/)
+})

--- a/.github/scripts/sonatype-central-deployment.mjs
+++ b/.github/scripts/sonatype-central-deployment.mjs
@@ -139,6 +139,44 @@ export async function inspectDeployment({record, token, fetchImpl = fetch}) {
   return {...record, disposition: "resume", deploymentState: status.deploymentState, purls}
 }
 
+// Wait until Sonatype has validated a USER_MANAGED deployment (or already
+// published it). The production publish phase requires this before it succeeds
+// so the later release phase never moves npm latest ahead of a Maven bundle
+// that would then fail to publish.
+export async function waitForValidatedDeployment({
+  record,
+  token,
+  fetchImpl = fetch,
+  sleepImpl = sleep,
+  statusAttempts = 180,
+  pollIntervalMs = 10_000,
+}) {
+  requireDeploymentRecord(record)
+  if (!token) throw new Error("Sonatype token is required")
+  const headers = {Authorization: `Bearer ${token}`}
+  for (let attempt = 1; attempt <= statusAttempts; attempt += 1) {
+    const status = requireMatchingStatus(
+      record,
+      await deploymentStatus({fetchImpl, headers, deploymentId: record.deploymentId}),
+    )
+    if (status.deploymentState === "FAILED") {
+      throw new Error(`Sonatype deployment ${record.deploymentName} failed: ${JSON.stringify(status.errors || [])}`)
+    }
+    if (status.deploymentState === "VALIDATED" || status.deploymentState === "PUBLISHED") {
+      return {...record, deploymentState: status.deploymentState, purls: status.purls || []}
+    }
+    if (!WAITING_STATES.has(status.deploymentState)) {
+      throw new Error(
+        `Sonatype deployment ${record.deploymentName} has unknown state ${JSON.stringify(status.deploymentState)}`,
+      )
+    }
+    if (attempt < statusAttempts) await sleepImpl(pollIntervalMs)
+  }
+  throw new Error(
+    `Sonatype deployment ${record.deploymentName} was not validated after ${statusAttempts} status checks`,
+  )
+}
+
 export async function publishDeployment({
   record,
   token,
@@ -203,6 +241,11 @@ async function main() {
     })
   } else if (command === "inspect") {
     result = await inspectDeployment({
+      record: JSON.parse(readFileSync(path.resolve(args.record), "utf8")),
+      token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
+    })
+  } else if (command === "wait-validated") {
+    result = await waitForValidatedDeployment({
       record: JSON.parse(readFileSync(path.resolve(args.record), "utf8")),
       token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
     })

--- a/.github/scripts/sonatype-central-deployment.mjs
+++ b/.github/scripts/sonatype-central-deployment.mjs
@@ -37,14 +37,38 @@ function requireDeploymentRecord(record) {
   return record
 }
 
-export async function uploadAutomaticDeployment({bundle, token, deploymentName, expectedPurls, fetchImpl = fetch}) {
+// AUTOMATIC deployments publish to Maven Central as soon as validation passes
+// (dev and beta). USER_MANAGED deployments stop at VALIDATED and stay private
+// until publishDeployment requests publication; the production channel uses
+// that so stable coordinates only go public in the separate release phase.
+export const PUBLISHING_TYPES = Object.freeze(["AUTOMATIC", "USER_MANAGED"])
+
+export function requirePublishingType(value = "AUTOMATIC") {
+  if (!PUBLISHING_TYPES.includes(value))
+    throw new Error(`Unsupported Sonatype publishing type ${JSON.stringify(value)}`)
+  return value
+}
+
+export function uploadAutomaticDeployment(options) {
+  return uploadDeployment({...options, publishingType: "AUTOMATIC"})
+}
+
+export async function uploadDeployment({
+  bundle,
+  token,
+  deploymentName,
+  expectedPurls,
+  publishingType = "AUTOMATIC",
+  fetchImpl = fetch,
+}) {
   if (!bundle || !token || !deploymentName || expectedPurls.length === 0) {
     throw new Error("Bundle, token, deployment name, and expected PURLs are required")
   }
+  requirePublishingType(publishingType)
   const bytes = readFileSync(bundle)
   const url = new URL("/api/v1/publisher/upload", BASE_URL)
   url.searchParams.set("name", deploymentName)
-  url.searchParams.set("publishingType", "AUTOMATIC")
+  url.searchParams.set("publishingType", publishingType)
   const form = new FormData()
   form.append("bundle", new Blob([bytes], {type: "application/octet-stream"}), path.basename(bundle))
   const response = await fetchImpl(url, {
@@ -63,6 +87,7 @@ export async function uploadAutomaticDeployment({bundle, token, deploymentName, 
     deploymentName,
     bundleSha256: createHash("sha256").update(bytes).digest("hex"),
     expectedPurls,
+    publishingType,
   }
 }
 
@@ -169,11 +194,12 @@ async function main() {
   const args = parseArgs(process.argv.slice(3))
   let result
   if (command === "upload") {
-    result = await uploadAutomaticDeployment({
+    result = await uploadDeployment({
       bundle: path.resolve(args.bundle),
       token: process.env.MAVEN_CENTRAL_TOKEN_BASE64,
       deploymentName: args.name,
       expectedPurls: args["expected-purls"].split(","),
+      publishingType: args["publishing-type"] || "AUTOMATIC",
     })
   } else if (command === "inspect") {
     result = await inspectDeployment({

--- a/.github/scripts/sonatype-central-deployment.test.mjs
+++ b/.github/scripts/sonatype-central-deployment.test.mjs
@@ -4,7 +4,13 @@ import {tmpdir} from "node:os"
 import path from "node:path"
 import test from "node:test"
 
-import {inspectDeployment, publishDeployment, uploadAutomaticDeployment} from "./sonatype-central-deployment.mjs"
+import {
+  inspectDeployment,
+  publishDeployment,
+  requirePublishingType,
+  uploadAutomaticDeployment,
+  uploadDeployment,
+} from "./sonatype-central-deployment.mjs"
 
 const deploymentId = "28570f16-da32-4c14-bd2e-c1acc0782365"
 const deploymentName = "mentra-3.1.0-beta.57-android-sdk"
@@ -52,6 +58,38 @@ test("uploads an automatically published deployment and returns a durable recove
   assert.equal(result.deploymentId, deploymentId)
   assert.equal(result.bundleSha256.length, 64)
   assert.deepEqual(result.expectedPurls, expectedPurls)
+})
+
+test("uploads a user-managed deployment for the production channel without publishing it", async () => {
+  let request
+  const result = await uploadDeployment({
+    bundle: bundle(),
+    token: "token",
+    deploymentName: "mentra-3.1.0-android-sdk",
+    expectedPurls: ["pkg:maven/com.mentraglass/bluetooth-sdk@3.1.0", "pkg:maven/com.mentraglass/lc3Lib@3.1.0"],
+    publishingType: "USER_MANAGED",
+    fetchImpl: async (url, options) => {
+      request = {url: String(url), options}
+      return new Response(deploymentId, {status: 201})
+    },
+  })
+
+  assert.match(request.url, /publishingType=USER_MANAGED/)
+  assert.equal(result.publishingType, "USER_MANAGED")
+  assert.equal(requirePublishingType(undefined), "AUTOMATIC")
+  assert.throws(() => requirePublishingType("MANUAL"), /Unsupported Sonatype publishing type/)
+  await assert.rejects(
+    () =>
+      uploadDeployment({
+        bundle: bundle(),
+        token: "token",
+        deploymentName,
+        expectedPurls,
+        publishingType: "manual",
+        fetchImpl: async () => new Response(deploymentId, {status: 201}),
+      }),
+    /Unsupported Sonatype publishing type/,
+  )
 })
 
 test("publishes a persisted deployment only after validation", async () => {

--- a/.github/scripts/sonatype-central-deployment.test.mjs
+++ b/.github/scripts/sonatype-central-deployment.test.mjs
@@ -10,6 +10,7 @@ import {
   requirePublishingType,
   uploadAutomaticDeployment,
   uploadDeployment,
+  waitForValidatedDeployment,
 } from "./sonatype-central-deployment.mjs"
 
 const deploymentId = "28570f16-da32-4c14-bd2e-c1acc0782365"
@@ -195,4 +196,37 @@ test("preserves partial published PURLs for observability", async () => {
   })
 
   assert.deepEqual(result.purls, [expectedPurls[0]])
+})
+
+test("waits for a user-managed deployment to validate without requesting publication", async () => {
+  const states = ["PENDING", "VALIDATING", "VALIDATED"]
+  let publicationRequests = 0
+  const result = await waitForValidatedDeployment({
+    record: {...record(), publishingType: "USER_MANAGED"},
+    token: "token",
+    sleepImpl: async () => {},
+    fetchImpl: async (url, options) => {
+      const target = String(url)
+      if (target.includes("/api/v1/publisher/status")) {
+        return jsonResponse({deploymentId, deploymentName, deploymentState: states.shift()})
+      }
+      if (target.includes(`/api/v1/publisher/deployment/${deploymentId}`) && options.method === "POST") {
+        publicationRequests += 1
+        return new Response("", {status: 204})
+      }
+      throw new Error(`Unexpected request ${target}`)
+    },
+  })
+  assert.equal(result.deploymentState, "VALIDATED")
+  assert.equal(publicationRequests, 0)
+  await assert.rejects(
+    () =>
+      waitForValidatedDeployment({
+        record: record(),
+        token: "token",
+        sleepImpl: async () => {},
+        fetchImpl: async () => jsonResponse({deploymentId, deploymentName, deploymentState: "FAILED", errors: {a: 1}}),
+      }),
+    /failed/,
+  )
 })

--- a/.github/workflows/production-release-packages.yml
+++ b/.github/workflows/production-release-packages.yml
@@ -6,9 +6,9 @@ name: Production Release - Stable Packages
 # This is deliberately separate from the Cloud deployment and the Mentra App
 # promotion. It is keyed on the frozen beta release plan, builds from that
 # plan's exact sourceCommit once it is contained in main, and may run before,
-# during, or after store review. When a live promotion attempt exists for the
-# release identity, the package evidence is appended to it as an additive
-# record; the promotion state never changes and no mobile step waits on it.
+# during, or after store review. Its evidence lives only in the stable release
+# container mentra-vX.Y.Z; the promotion state machine is read solely to refuse
+# an identity that a live attempt froze from a different beta, never written.
 #
 # publish  - stage: npm X.Y.Z under `candidate-X.Y.Z`, a validated but
 #            unpublished USER_MANAGED Sonatype deployment, and the exported
@@ -37,7 +37,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: production-release-packages-${{ inputs.beta_identity }}
+  # One package run at a time: two betas of the same base version share the
+  # stable X.Y.Z coordinates and container.
+  group: production-release-packages
   cancel-in-progress: false
 
 jobs:
@@ -54,11 +56,7 @@ jobs:
       npm_tag: ${{ steps.plan.outputs.npm_tag }}
       plan_artifact: ${{ steps.artifact.outputs.name }}
       stable_release_id: ${{ steps.container.outputs.release_id }}
-      promotion_found: ${{ steps.promotion.outputs.found }}
-      promotion_attempt: ${{ steps.promotion.outputs.attempt }}
-      promotion_state: ${{ steps.promotion.outputs.state }}
-      promotion_append: ${{ steps.link.outputs.append }}
-      promotion_reason: ${{ steps.link.outputs.reason }}
+      promotion_note: ${{ steps.guard.outputs.note }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,35 +130,28 @@ jobs:
           [[ "$(jq -er .releaseIdentity release-intent/release-plan.json)" == "${{ steps.identity.outputs.release_identity }}" ]]
           [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "${{ steps.beta.outputs.source_commit }}" ]]
 
-      - name: Resolve a live promotion attempt for additive package evidence
-        id: promotion
+      - name: Refuse an identity that a live promotion froze from another beta
+        id: guard
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          node .github/scripts/production-promotion-assets.mjs download-latest-attempt
-          --repository "$GITHUB_REPOSITORY"
-          --release "${{ steps.identity.outputs.release_identity }}"
-          --output promotion-input/current.json
-          --github-output "$GITHUB_OUTPUT"
-
-      - name: Decide whether the promotion chain accepts package evidence
-        id: link
         run: |
           set -euo pipefail
-          if [[ "${{ steps.promotion.outputs.found }}" != "true" ]]; then
-            {
-              echo "append=false"
-              echo "reason=no promotion attempt exists for ${{ steps.identity.outputs.release_identity }}"
-            } >> "$GITHUB_OUTPUT"
+          node .github/scripts/production-promotion-assets.mjs download-latest-attempt \
+            --repository "$GITHUB_REPOSITORY" \
+            --release "${{ steps.identity.outputs.release_identity }}" \
+            --output promotion-input/current.json \
+            --github-output promotion-input/outputs.env
+          if ! grep -qx 'found=true' promotion-input/outputs.env; then
+            echo "note=no promotion attempt exists for ${{ steps.identity.outputs.release_identity }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          node .github/scripts/production-promotion-state.mjs packages-link \
+          node .github/scripts/production-promotion-state.mjs packages-guard \
             --record promotion-input/current.json \
             --beta "${{ inputs.beta_identity }}" \
-            --source-commit "${{ steps.beta.outputs.source_commit }}" \
-            --github-output "$GITHUB_OUTPUT"
+            --source-commit "${{ steps.beta.outputs.source_commit }}"
+          echo "note=promotion attempt $(sed -n 's/^attempt=//p' promotion-input/outputs.env) ($(sed -n 's/^state=//p' promotion-input/outputs.env)) selected the same beta" >> "$GITHUB_OUTPUT"
 
-      - name: Allocate or reuse the stable draft release container
+      - name: Allocate or reuse the stable release container
         id: container
         env:
           GH_TOKEN: ${{ github.token }}
@@ -191,7 +182,7 @@ jobs:
             echo "- Source: \`${{ steps.plan.outputs.source_commit }}\`"
             echo "- Stable container: \`${{ steps.plan.outputs.stable_tag }}\`"
             echo "- npm candidate dist-tag: \`${{ steps.plan.outputs.npm_tag }}\`"
-            echo "- Promotion chain: ${{ steps.link.outputs.reason }} (append: \`${{ steps.link.outputs.append }}\`)"
+            echo "- Promotion: ${{ steps.guard.outputs.note }}"
             echo
             echo "This phase does not deploy Cloud, upload a mobile app, or change any store."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -309,7 +300,7 @@ jobs:
             --output-directory packages-output/evidence-assets \
             --github-output "$GITHUB_OUTPUT"
 
-      - name: Publish the evidence into the stable draft container
+      - name: Publish the evidence into the stable release container
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
@@ -318,51 +309,6 @@ jobs:
           --name "${{ steps.evidence.outputs.asset_name }}"
           --release-id "${{ needs.load.outputs.stable_release_id }}"
           --repository "$GITHUB_REPOSITORY"
-
-      - name: Append the evidence to the live promotion attempt
-        if: needs.load.outputs.promotion_append == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          node .github/scripts/production-promotion-assets.mjs download-latest \
-            --repository "$GITHUB_REPOSITORY" \
-            --release "${{ needs.load.outputs.release_identity }}" \
-            --attempt "${{ needs.load.outputs.promotion_attempt }}" \
-            --output promotion-input/current.json \
-            --github-output promotion-input/outputs.env
-          promotion_release_id=$(sed -n 's/^release_id=//p' promotion-input/outputs.env)
-          link=$(node .github/scripts/production-promotion-state.mjs packages-link \
-            --record promotion-input/current.json \
-            --beta "${{ inputs.beta_identity }}" \
-            --source-commit "${{ needs.load.outputs.source_commit }}")
-          if ! grep -qx 'append=true' <<< "$link"; then
-            echo "::notice::Promotion chain moved since the run started; evidence stays in the stable container only. $link"
-            exit 0
-          fi
-          node .github/scripts/publish-immutable-release-asset.mjs \
-            --file "${{ steps.evidence.outputs.asset_path }}" \
-            --name "${{ steps.evidence.outputs.asset_name }}" \
-            --release-id "$promotion_release_id" \
-            --repository "$GITHUB_REPOSITORY"
-          mkdir -p promotion-output
-          node .github/scripts/production-promotion-state.mjs append \
-            --record promotion-input/current.json \
-            --actor "$GITHUB_ACTOR" \
-            --created-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-            --provenance-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --evidence packages-output/evidence.json \
-            --output promotion-output/next.json
-          name=$(node --input-type=module -e '
-            import {readFileSync} from "node:fs";
-            import {promotionAssetName} from "./.github/scripts/production-promotion-state.mjs";
-            process.stdout.write(promotionAssetName(JSON.parse(readFileSync("promotion-output/next.json", "utf8"))));
-          ')
-          mv promotion-output/next.json "promotion-output/$name"
-          node .github/scripts/production-promotion-assets.mjs publish-record \
-            --record "promotion-output/$name" \
-            --release-id "$promotion_release_id" \
-            --repository "$GITHUB_REPOSITORY"
 
       - name: Summarize the staged publication
         run: |
@@ -374,7 +320,7 @@ jobs:
             echo "- Maven Central: USER_MANAGED deployment validated, not published"
             echo "- SwiftPM: export staged on \`release/${{ needs.load.outputs.release_identity }}\`; no public tag"
             echo "- Evidence: \`${{ steps.evidence.outputs.asset_name }}\` in \`${{ needs.load.outputs.stable_tag }}\`"
-            echo "- Promotion chain: ${{ needs.load.outputs.promotion_reason }} (append: \`${{ needs.load.outputs.promotion_append }}\`)"
+            echo "- Promotion: ${{ needs.load.outputs.promotion_note }}"
             echo
             echo "Run the release phase to move npm latest, publish Maven Central, and push the SwiftPM tag."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -413,16 +359,19 @@ jobs:
           test -n "$MAVEN_CENTRAL_TOKEN_BASE64"
           test -n "$PUSH_TOKEN"
 
-      - name: Move npm latest to the staged plain versions
+      # Every public mutation below is irreversible, so all three targets are
+      # checked first and nothing moves until each one is ready.
+      - name: Preflight npm without moving any dist-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: >-
           node .github/scripts/promote-npm-latest.mjs
           --plan release-intent/release-plan.json
           --npm-tag "${{ needs.load.outputs.npm_tag }}"
-          --output-dir packages-output/npm
+          --output-dir packages-output/npm-preflight
+          --dry-run true
 
-      - name: Publish the validated Sonatype deployment to Maven Central
+      - name: Preflight the validated Sonatype deployment
         env:
           GH_TOKEN: ${{ github.token }}
           MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
@@ -437,10 +386,12 @@ jobs:
           gh api -H "Accept: application/octet-stream" \
             "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > packages-output/maven/sonatype-deployment.json
           [[ "$(jq -er .deploymentName packages-output/maven/sonatype-deployment.json)" == "mentra-$VERSION-android-sdk" ]]
-          node .github/scripts/sonatype-central-deployment.mjs publish \
+          [[ "$(jq -er .publishingType packages-output/maven/sonatype-deployment.json)" == "USER_MANAGED" ]]
+          node .github/scripts/sonatype-central-deployment.mjs inspect \
             --record packages-output/maven/sonatype-deployment.json \
-            --output packages-output/maven/sonatype-publication.json
-          [[ "$(jq -er .deploymentState packages-output/maven/sonatype-publication.json)" == "PUBLISHED" ]]
+            --output packages-output/maven/sonatype-inspection.json
+          state=$(jq -er .deploymentState packages-output/maven/sonatype-inspection.json)
+          [[ "$state" == VALIDATED || "$state" == PUBLISHED || "$state" == PUBLISHING ]]
 
       - name: Checkout the SwiftPM mirror
         uses: actions/checkout@v4
@@ -450,7 +401,7 @@ jobs:
           token: ${{ secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
           fetch-depth: 0
 
-      - name: Push the public SwiftPM tag at the staged, archived commit
+      - name: Preflight the staged SwiftPM commit against its archived export
         id: swiftpm
         env:
           GH_TOKEN: ${{ github.token }}
@@ -476,22 +427,50 @@ jobs:
             echo "The mirror has neither tag $VERSION nor branch release/$VERSION; run the publish phase first." >&2
             exit 1
           fi
-          git archive --format=tar "$mirror_sha" > "$RUNNER_TEMP/staged-swiftpm.tar"
-          cmp "$RUNNER_TEMP/staged-swiftpm.tar" "$GITHUB_WORKSPACE/packages-output/swiftpm/$archive_name"
-          if [[ "$status" == published ]]; then
-            git tag "$VERSION" "$mirror_sha"
-            git push origin "refs/tags/$VERSION"
-            if git merge-base --is-ancestor "refs/remotes/origin/main" "$mirror_sha"; then
-              git push origin "$mirror_sha:refs/heads/main"
-            else
-              echo "::notice::Mirror main has moved past the staged $VERSION commit; the tag is public and main is left unchanged."
-            fi
-          fi
+          # git archive stamps the archived commit into the tar's pax header, so the
+          # archive identifies its commit without re-archiving on a different runner.
+          archived_sha=$(git get-tar-commit-id < "$GITHUB_WORKSPACE/packages-output/swiftpm/$archive_name")
+          [[ "$archived_sha" == "$mirror_sha" ]]
           {
             echo "mirror_sha=$mirror_sha"
             echo "status=$status"
             echo "tag_url=https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/$VERSION"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Move npm latest to the staged plain versions
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >-
+          node .github/scripts/promote-npm-latest.mjs
+          --plan release-intent/release-plan.json
+          --npm-tag "${{ needs.load.outputs.npm_tag }}"
+          --output-dir packages-output/npm
+
+      - name: Publish the validated Sonatype deployment to Maven Central
+        env:
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/sonatype-central-deployment.mjs publish \
+            --record packages-output/maven/sonatype-deployment.json \
+            --output packages-output/maven/sonatype-publication.json
+          [[ "$(jq -er .deploymentState packages-output/maven/sonatype-publication.json)" == "PUBLISHED" ]]
+
+      - name: Push the public SwiftPM tag at the staged commit
+        if: steps.swiftpm.outputs.status == 'published'
+        working-directory: mentra-bluetooth-sdk-ios
+        env:
+          VERSION: ${{ needs.load.outputs.release_identity }}
+          MIRROR_SHA: ${{ steps.swiftpm.outputs.mirror_sha }}
+        run: |
+          set -euo pipefail
+          git tag "$VERSION" "$MIRROR_SHA"
+          git push origin "refs/tags/$VERSION"
+          if git merge-base --is-ancestor "refs/remotes/origin/main" "$MIRROR_SHA"; then
+            git push origin "$MIRROR_SHA:refs/heads/main"
+          else
+            echo "::notice::Mirror main has moved past the staged $VERSION commit; the tag is public and main is left unchanged."
+          fi
 
       - name: Assemble immutable release evidence
         id: evidence
@@ -539,7 +518,7 @@ jobs:
             --output-directory packages-output/evidence-assets \
             --github-output "$GITHUB_OUTPUT"
 
-      - name: Publish the evidence into the stable draft container
+      - name: Publish the evidence into the stable release container
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
@@ -548,51 +527,6 @@ jobs:
           --name "${{ steps.evidence.outputs.asset_name }}"
           --release-id "${{ needs.load.outputs.stable_release_id }}"
           --repository "$GITHUB_REPOSITORY"
-
-      - name: Append the evidence to the live promotion attempt
-        if: needs.load.outputs.promotion_append == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          node .github/scripts/production-promotion-assets.mjs download-latest \
-            --repository "$GITHUB_REPOSITORY" \
-            --release "${{ needs.load.outputs.release_identity }}" \
-            --attempt "${{ needs.load.outputs.promotion_attempt }}" \
-            --output promotion-input/current.json \
-            --github-output promotion-input/outputs.env
-          promotion_release_id=$(sed -n 's/^release_id=//p' promotion-input/outputs.env)
-          link=$(node .github/scripts/production-promotion-state.mjs packages-link \
-            --record promotion-input/current.json \
-            --beta "${{ inputs.beta_identity }}" \
-            --source-commit "${{ needs.load.outputs.source_commit }}")
-          if ! grep -qx 'append=true' <<< "$link"; then
-            echo "::notice::Promotion chain moved since the run started; evidence stays in the stable container only. $link"
-            exit 0
-          fi
-          node .github/scripts/publish-immutable-release-asset.mjs \
-            --file "${{ steps.evidence.outputs.asset_path }}" \
-            --name "${{ steps.evidence.outputs.asset_name }}" \
-            --release-id "$promotion_release_id" \
-            --repository "$GITHUB_REPOSITORY"
-          mkdir -p promotion-output
-          node .github/scripts/production-promotion-state.mjs append \
-            --record promotion-input/current.json \
-            --actor "$GITHUB_ACTOR" \
-            --created-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-            --provenance-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --evidence packages-output/evidence.json \
-            --output promotion-output/next.json
-          name=$(node --input-type=module -e '
-            import {readFileSync} from "node:fs";
-            import {promotionAssetName} from "./.github/scripts/production-promotion-state.mjs";
-            process.stdout.write(promotionAssetName(JSON.parse(readFileSync("promotion-output/next.json", "utf8"))));
-          ')
-          mv promotion-output/next.json "promotion-output/$name"
-          node .github/scripts/production-promotion-assets.mjs publish-record \
-            --record "promotion-output/$name" \
-            --release-id "$promotion_release_id" \
-            --repository "$GITHUB_REPOSITORY"
 
       - name: Summarize the public package release
         run: |
@@ -604,7 +538,7 @@ jobs:
             echo "- Maven Central: deployment \`$(jq -er .deploymentState packages-output/maven/sonatype-publication.json)\` (sync to search can lag)"
             echo "- SwiftPM: ${{ steps.swiftpm.outputs.tag_url }} (\`${{ steps.swiftpm.outputs.status }}\`)"
             echo "- Evidence: \`${{ steps.evidence.outputs.asset_name }}\` in \`${{ needs.load.outputs.stable_tag }}\`"
-            echo "- Promotion chain: ${{ needs.load.outputs.promotion_reason }} (append: \`${{ needs.load.outputs.promotion_append }}\`)"
+            echo "- Promotion: ${{ needs.load.outputs.promotion_note }}"
             echo
             echo "This workflow did not deploy Cloud or change an app store."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/production-release-packages.yml
+++ b/.github/workflows/production-release-packages.yml
@@ -1,0 +1,610 @@
+name: Production Release - Stable Packages
+
+# Publishes the plain X.Y.Z package versions of a promoted coordinated beta:
+# npm `latest`, the stable Maven Central coordinates, and the SwiftPM tag.
+#
+# This is deliberately separate from the Cloud deployment and the Mentra App
+# promotion. It is keyed on the frozen beta release plan, builds from that
+# plan's exact sourceCommit once it is contained in main, and may run before,
+# during, or after store review. When a live promotion attempt exists for the
+# release identity, the package evidence is appended to it as an additive
+# record; the promotion state never changes and no mobile step waits on it.
+#
+# publish  - stage: npm X.Y.Z under `candidate-X.Y.Z`, a validated but
+#            unpublished USER_MANAGED Sonatype deployment, and the exported
+#            SwiftPM commit on the mirror branch `release/X.Y.Z`.
+# release  - go public: move npm `latest`, request the Sonatype publication,
+#            and push the SwiftPM tag `X.Y.Z`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      beta_identity:
+        description: Promoted coordinated beta whose frozen source publishes the stable packages, for example 3.1.0-beta.192
+        required: true
+        type: string
+      phase:
+        description: publish stages the plain versions without moving any default pointer; release makes them public
+        required: true
+        type: choice
+        options:
+          - publish
+          - release
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+
+concurrency:
+  group: production-release-packages-${{ inputs.beta_identity }}
+  cancel-in-progress: false
+
+jobs:
+  load:
+    name: Freeze the promoted beta source and package plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      release_identity: ${{ steps.plan.outputs.release_identity }}
+      source_commit: ${{ steps.plan.outputs.source_commit }}
+      stable_tag: ${{ steps.plan.outputs.stable_tag }}
+      ota_url: ${{ steps.plan.outputs.ota_manifest_url }}
+      ota_sha256: ${{ steps.plan.outputs.ota_manifest_sha256 }}
+      npm_tag: ${{ steps.plan.outputs.npm_tag }}
+      plan_artifact: ${{ steps.artifact.outputs.name }}
+      stable_release_id: ${{ steps.container.outputs.release_id }}
+      promotion_found: ${{ steps.promotion.outputs.found }}
+      promotion_attempt: ${{ steps.promotion.outputs.attempt }}
+      promotion_state: ${{ steps.promotion.outputs.state }}
+      promotion_append: ${{ steps.link.outputs.append }}
+      promotion_reason: ${{ steps.link.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Validate dispatch and selected beta identity
+        id: identity
+        env:
+          BETA_IDENTITY: ${{ inputs.beta_identity }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF_NAME" == "main" ]]
+          [[ "$BETA_IDENTITY" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*$ ]]
+          release_identity="${BETA_IDENTITY%%-*}"
+          {
+            echo "release_identity=$release_identity"
+            echo "beta_tag=mentra-builds-v$release_identity"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify the completed selected beta
+        id: beta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BETA_IDENTITY: ${{ inputs.beta_identity }}
+          BETA_TAG: ${{ steps.identity.outputs.beta_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p packages-input/beta
+          state=$(gh release view "$BETA_TAG" --json isDraft,isPrerelease --jq '[.isDraft,.isPrerelease] | @tsv')
+          [[ "$state" == $'false\ttrue' ]]
+          gh release download "$BETA_TAG" \
+            --pattern "mentra-release-plan-$BETA_IDENTITY.json" \
+            --pattern "mentra-release-$BETA_IDENTITY.json" \
+            --dir packages-input/beta
+          mv "packages-input/beta/mentra-release-plan-$BETA_IDENTITY.json" packages-input/beta/release-plan.json
+          mv "packages-input/beta/mentra-release-$BETA_IDENTITY.json" packages-input/beta/release-manifest.json
+          [[ "$(jq -er .completedAt packages-input/beta/release-manifest.json)" != "" ]]
+          node .github/scripts/verify-release-artifacts.mjs --manifest packages-input/beta/release-manifest.json
+          source_commit=$(jq -er .sourceCommit packages-input/beta/release-plan.json)
+          git cat-file -e "$source_commit^{commit}"
+          # Stable packages ship from main: the promoted beta source must already be there.
+          git merge-base --is-ancestor "$source_commit" origin/main
+          {
+            echo "source_commit=$source_commit"
+            echo "manifest_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/$BETA_TAG/mentra-release-$BETA_IDENTITY.json"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout the frozen package source separately from workflow tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.beta.outputs.source_commit }}
+          path: release-source
+
+      - name: Freeze the production package plan from the beta source
+        id: plan
+        run: |
+          set -euo pipefail
+          mkdir -p release-intent
+          node .github/scripts/production-packages.mjs plan \
+            --root release-source \
+            --beta-plan packages-input/beta/release-plan.json \
+            --beta-manifest packages-input/beta/release-manifest.json \
+            --beta-manifest-url "${{ steps.beta.outputs.manifest_url }}" \
+            --output release-intent/release-plan.json \
+            --github-output "$GITHUB_OUTPUT"
+          [[ "$(jq -er .releaseIdentity release-intent/release-plan.json)" == "${{ steps.identity.outputs.release_identity }}" ]]
+          [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "${{ steps.beta.outputs.source_commit }}" ]]
+
+      - name: Resolve a live promotion attempt for additive package evidence
+        id: promotion
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node .github/scripts/production-promotion-assets.mjs download-latest-attempt
+          --repository "$GITHUB_REPOSITORY"
+          --release "${{ steps.identity.outputs.release_identity }}"
+          --output promotion-input/current.json
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Decide whether the promotion chain accepts package evidence
+        id: link
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.promotion.outputs.found }}" != "true" ]]; then
+            {
+              echo "append=false"
+              echo "reason=no promotion attempt exists for ${{ steps.identity.outputs.release_identity }}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node .github/scripts/production-promotion-state.mjs packages-link \
+            --record promotion-input/current.json \
+            --beta "${{ inputs.beta_identity }}" \
+            --source-commit "${{ steps.beta.outputs.source_commit }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Allocate or reuse the stable draft release container
+        id: container
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node .github/scripts/production-packages.mjs ensure-container
+          --repository "$GITHUB_REPOSITORY"
+          --plan release-intent/release-plan.json
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Name the immutable plan artifact
+        id: artifact
+        run: echo "name=production-packages-plan-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: release-intent/release-plan.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Summarize frozen package inputs
+        run: |
+          {
+            echo "## Stable package inputs"
+            echo
+            echo "- Release: \`${{ steps.plan.outputs.release_identity }}\`"
+            echo "- Selected beta: \`${{ inputs.beta_identity }}\`"
+            echo "- Source: \`${{ steps.plan.outputs.source_commit }}\`"
+            echo "- Stable container: \`${{ steps.plan.outputs.stable_tag }}\`"
+            echo "- npm candidate dist-tag: \`${{ steps.plan.outputs.npm_tag }}\`"
+            echo "- Promotion chain: ${{ steps.link.outputs.reason }} (append: \`${{ steps.link.outputs.append }}\`)"
+            echo
+            echo "This phase does not deploy Cloud, upload a mobile app, or change any store."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  approve:
+    name: Approve staging the plain package versions
+    if: inputs.phase == 'publish'
+    needs: load
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: production-packages
+    steps:
+      - run: |
+          echo "Approved publishing ${{ needs.load.outputs.release_identity }} packages from ${{ needs.load.outputs.source_commit }}."
+          echo "npm publishes under ${{ needs.load.outputs.npm_tag }}; latest, Maven Central, and the SwiftPM tag wait for the release phase."
+
+  npm:
+    name: Publish plain npm versions under the candidate dist-tag
+    if: inputs.phase == 'publish'
+    needs: [load, approve]
+    uses: ./.github/workflows/reusable-coordinated-npm.yml
+    with:
+      source_commit: ${{ needs.load.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.load.outputs.plan_artifact }}
+      members: all
+      result_artifact: production-packages-npm-${{ github.run_id }}
+      ota_manifest_url: ${{ needs.load.outputs.ota_url }}
+      ota_manifest_sha256: ${{ needs.load.outputs.ota_sha256 }}
+      npm_tag: ${{ needs.load.outputs.npm_tag }}
+    secrets: inherit
+
+  sdk-native:
+    name: Stage Maven Central deployment and SwiftPM export
+    if: inputs.phase == 'publish'
+    needs: [load, approve]
+    uses: ./.github/workflows/reusable-coordinated-sdk-native.yml
+    with:
+      source_commit: ${{ needs.load.outputs.source_commit }}
+      release_plan_artifact: ${{ needs.load.outputs.plan_artifact }}
+      release_id: ${{ needs.load.outputs.stable_release_id }}
+      ota_manifest_url: ${{ needs.load.outputs.ota_url }}
+      ota_manifest_sha256: ${{ needs.load.outputs.ota_sha256 }}
+    secrets: inherit
+
+  record-publication:
+    name: Record the staged package publication
+    if: inputs.phase == 'publish'
+    needs: [load, npm, sdk-native]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.load.outputs.plan_artifact }}
+          path: release-intent
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: production-packages-npm-${{ github.run_id }}
+          path: packages-input/npm
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.sdk-native.outputs.result_artifact }}
+          path: packages-input/sdk-native
+
+      - name: Assemble immutable publication evidence
+        id: evidence
+        env:
+          NPM_TAG: ${{ needs.load.outputs.npm_tag }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          plan=release-intent/release-plan.json
+          npm=packages-input/npm/npm-publications.json
+          native=packages-input/sdk-native/sdk-native-publications.json
+          release_set_id=$(jq -er .releaseSetId "$plan")
+          [[ "$(jq -er .releaseSetId "$npm")" == "$release_set_id" ]]
+          [[ "$(jq -er .releaseSetId "$native")" == "$release_set_id" ]]
+          mkdir -p packages-output
+          jq -n \
+            --slurpfile plan "$plan" \
+            --slurpfile npm "$npm" \
+            --slurpfile native "$native" \
+            --arg tag "$NPM_TAG" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$RUN_URL" \
+            '{
+              schemaVersion: 1,
+              kind: "production-packages-publication",
+              releaseSetId: $plan[0].releaseSetId,
+              releaseIdentity: $plan[0].releaseIdentity,
+              sourceCommit: $plan[0].sourceCommit,
+              selectedBetaIdentity: $plan[0].promotion.selectedBetaIdentity,
+              npmCandidateTag: $tag,
+              npm: $npm[0],
+              sdkNative: $native[0],
+              actor: $actor,
+              provenanceUrl: $url
+            }' > packages-output/publication.json
+          node .github/scripts/production-promotion-assets.mjs prepare-evidence \
+            --file packages-output/publication.json \
+            --kind production-packages-publication \
+            --url "$RUN_URL" \
+            --output packages-output/evidence.json \
+            --output-directory packages-output/evidence-assets \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish the evidence into the stable draft container
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node .github/scripts/publish-immutable-release-asset.mjs
+          --file "${{ steps.evidence.outputs.asset_path }}"
+          --name "${{ steps.evidence.outputs.asset_name }}"
+          --release-id "${{ needs.load.outputs.stable_release_id }}"
+          --repository "$GITHUB_REPOSITORY"
+
+      - name: Append the evidence to the live promotion attempt
+        if: needs.load.outputs.promotion_append == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/production-promotion-assets.mjs download-latest \
+            --repository "$GITHUB_REPOSITORY" \
+            --release "${{ needs.load.outputs.release_identity }}" \
+            --attempt "${{ needs.load.outputs.promotion_attempt }}" \
+            --output promotion-input/current.json \
+            --github-output promotion-input/outputs.env
+          promotion_release_id=$(sed -n 's/^release_id=//p' promotion-input/outputs.env)
+          link=$(node .github/scripts/production-promotion-state.mjs packages-link \
+            --record promotion-input/current.json \
+            --beta "${{ inputs.beta_identity }}" \
+            --source-commit "${{ needs.load.outputs.source_commit }}")
+          if ! grep -qx 'append=true' <<< "$link"; then
+            echo "::notice::Promotion chain moved since the run started; evidence stays in the stable container only. $link"
+            exit 0
+          fi
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --file "${{ steps.evidence.outputs.asset_path }}" \
+            --name "${{ steps.evidence.outputs.asset_name }}" \
+            --release-id "$promotion_release_id" \
+            --repository "$GITHUB_REPOSITORY"
+          mkdir -p promotion-output
+          node .github/scripts/production-promotion-state.mjs append \
+            --record promotion-input/current.json \
+            --actor "$GITHUB_ACTOR" \
+            --created-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+            --provenance-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --evidence packages-output/evidence.json \
+            --output promotion-output/next.json
+          name=$(node --input-type=module -e '
+            import {readFileSync} from "node:fs";
+            import {promotionAssetName} from "./.github/scripts/production-promotion-state.mjs";
+            process.stdout.write(promotionAssetName(JSON.parse(readFileSync("promotion-output/next.json", "utf8"))));
+          ')
+          mv promotion-output/next.json "promotion-output/$name"
+          node .github/scripts/production-promotion-assets.mjs publish-record \
+            --record "promotion-output/$name" \
+            --release-id "$promotion_release_id" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Summarize the staged publication
+        run: |
+          {
+            echo "## Stable packages staged"
+            echo
+            echo "- Release: \`${{ needs.load.outputs.release_identity }}\` from \`${{ needs.load.outputs.source_commit }}\`"
+            echo "- npm: plain versions published under \`${{ needs.load.outputs.npm_tag }}\`; \`latest\` unchanged"
+            echo "- Maven Central: USER_MANAGED deployment validated, not published"
+            echo "- SwiftPM: export staged on \`release/${{ needs.load.outputs.release_identity }}\`; no public tag"
+            echo "- Evidence: \`${{ steps.evidence.outputs.asset_name }}\` in \`${{ needs.load.outputs.stable_tag }}\`"
+            echo "- Promotion chain: ${{ needs.load.outputs.promotion_reason }} (append: \`${{ needs.load.outputs.promotion_append }}\`)"
+            echo
+            echo "Run the release phase to move npm latest, publish Maven Central, and push the SwiftPM tag."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    name: Move latest, publish Maven Central, and tag SwiftPM
+    if: inputs.phase == 'release'
+    needs: load
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment:
+      name: production-packages-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.load.outputs.plan_artifact }}
+          path: release-intent
+
+      - name: Require registry credentials
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+          PUSH_TOKEN: ${{ secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$NPM_TOKEN"
+          test -n "$MAVEN_CENTRAL_TOKEN_BASE64"
+          test -n "$PUSH_TOKEN"
+
+      - name: Move npm latest to the staged plain versions
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >-
+          node .github/scripts/promote-npm-latest.mjs
+          --plan release-intent/release-plan.json
+          --npm-tag "${{ needs.load.outputs.npm_tag }}"
+          --output-dir packages-output/npm
+
+      - name: Publish the validated Sonatype deployment to Maven Central
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+          RELEASE_ID: ${{ needs.load.outputs.stable_release_id }}
+          VERSION: ${{ needs.load.outputs.release_identity }}
+        run: |
+          set -euo pipefail
+          mkdir -p packages-output/maven
+          asset_name="mentra-$VERSION-sonatype-deployment.json"
+          assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?per_page=100" | jq 'add')
+          asset_id=$(jq -er --arg name "$asset_name" '[.[] | select(.name == $name)] | if length == 1 then .[0].id else error("Sonatype deployment record must be unique; run the publish phase first") end' <<< "$assets")
+          gh api -H "Accept: application/octet-stream" \
+            "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > packages-output/maven/sonatype-deployment.json
+          [[ "$(jq -er .deploymentName packages-output/maven/sonatype-deployment.json)" == "mentra-$VERSION-android-sdk" ]]
+          node .github/scripts/sonatype-central-deployment.mjs publish \
+            --record packages-output/maven/sonatype-deployment.json \
+            --output packages-output/maven/sonatype-publication.json
+          [[ "$(jq -er .deploymentState packages-output/maven/sonatype-publication.json)" == "PUBLISHED" ]]
+
+      - name: Checkout the SwiftPM mirror
+        uses: actions/checkout@v4
+        with:
+          repository: Mentra-Community/mentra-bluetooth-sdk-ios
+          path: mentra-bluetooth-sdk-ios
+          token: ${{ secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Push the public SwiftPM tag at the staged, archived commit
+        id: swiftpm
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.load.outputs.stable_release_id }}
+          VERSION: ${{ needs.load.outputs.release_identity }}
+        run: |
+          set -euo pipefail
+          archive_name=$(jq -er .artifactNames.iosSdkArchive release-intent/release-plan.json)
+          mkdir -p packages-output/swiftpm
+          assets=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/$RELEASE_ID/assets?per_page=100" | jq 'add')
+          asset_id=$(jq -er --arg name "$archive_name" '[.[] | select(.name == $name)] | if length == 1 then .[0].id else error("SwiftPM archive must be unique; run the publish phase first") end' <<< "$assets")
+          gh api -H "Accept: application/octet-stream" \
+            "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > "packages-output/swiftpm/$archive_name"
+          cd mentra-bluetooth-sdk-ios
+          git fetch --tags origin
+          if git rev-parse -q --verify "refs/tags/$VERSION^{commit}" >/dev/null; then
+            mirror_sha=$(git rev-parse "refs/tags/$VERSION^{commit}")
+            status=reused
+          elif git rev-parse -q --verify "refs/remotes/origin/release/$VERSION^{commit}" >/dev/null; then
+            mirror_sha=$(git rev-parse "refs/remotes/origin/release/$VERSION^{commit}")
+            status=published
+          else
+            echo "The mirror has neither tag $VERSION nor branch release/$VERSION; run the publish phase first." >&2
+            exit 1
+          fi
+          git archive --format=tar "$mirror_sha" > "$RUNNER_TEMP/staged-swiftpm.tar"
+          cmp "$RUNNER_TEMP/staged-swiftpm.tar" "$GITHUB_WORKSPACE/packages-output/swiftpm/$archive_name"
+          if [[ "$status" == published ]]; then
+            git tag "$VERSION" "$mirror_sha"
+            git push origin "refs/tags/$VERSION"
+            if git merge-base --is-ancestor "refs/remotes/origin/main" "$mirror_sha"; then
+              git push origin "$mirror_sha:refs/heads/main"
+            else
+              echo "::notice::Mirror main has moved past the staged $VERSION commit; the tag is public and main is left unchanged."
+            fi
+          fi
+          {
+            echo "mirror_sha=$mirror_sha"
+            echo "status=$status"
+            echo "tag_url=https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/$VERSION"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assemble immutable release evidence
+        id: evidence
+        env:
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --slurpfile plan release-intent/release-plan.json \
+            --slurpfile npm packages-output/npm/npm-latest.json \
+            --slurpfile maven packages-output/maven/sonatype-publication.json \
+            --arg mirror "${{ steps.swiftpm.outputs.mirror_sha }}" \
+            --arg swiftStatus "${{ steps.swiftpm.outputs.status }}" \
+            --arg tagUrl "${{ steps.swiftpm.outputs.tag_url }}" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$RUN_URL" \
+            '{
+              schemaVersion: 1,
+              kind: "production-packages-release",
+              releaseSetId: $plan[0].releaseSetId,
+              releaseIdentity: $plan[0].releaseIdentity,
+              sourceCommit: $plan[0].sourceCommit,
+              selectedBetaIdentity: $plan[0].promotion.selectedBetaIdentity,
+              npm: $npm[0],
+              maven: {
+                deploymentId: $maven[0].deploymentId,
+                deploymentName: $maven[0].deploymentName,
+                deploymentState: $maven[0].deploymentState,
+                purls: $maven[0].purls
+              },
+              swiftpm: {
+                status: $swiftStatus,
+                tag: $plan[0].releaseIdentity,
+                mirrorCommit: $mirror,
+                url: $tagUrl
+              },
+              actor: $actor,
+              provenanceUrl: $url
+            }' > packages-output/release.json
+          node .github/scripts/production-promotion-assets.mjs prepare-evidence \
+            --file packages-output/release.json \
+            --kind production-packages-release \
+            --url "$RUN_URL" \
+            --output packages-output/evidence.json \
+            --output-directory packages-output/evidence-assets \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish the evidence into the stable draft container
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node .github/scripts/publish-immutable-release-asset.mjs
+          --file "${{ steps.evidence.outputs.asset_path }}"
+          --name "${{ steps.evidence.outputs.asset_name }}"
+          --release-id "${{ needs.load.outputs.stable_release_id }}"
+          --repository "$GITHUB_REPOSITORY"
+
+      - name: Append the evidence to the live promotion attempt
+        if: needs.load.outputs.promotion_append == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/production-promotion-assets.mjs download-latest \
+            --repository "$GITHUB_REPOSITORY" \
+            --release "${{ needs.load.outputs.release_identity }}" \
+            --attempt "${{ needs.load.outputs.promotion_attempt }}" \
+            --output promotion-input/current.json \
+            --github-output promotion-input/outputs.env
+          promotion_release_id=$(sed -n 's/^release_id=//p' promotion-input/outputs.env)
+          link=$(node .github/scripts/production-promotion-state.mjs packages-link \
+            --record promotion-input/current.json \
+            --beta "${{ inputs.beta_identity }}" \
+            --source-commit "${{ needs.load.outputs.source_commit }}")
+          if ! grep -qx 'append=true' <<< "$link"; then
+            echo "::notice::Promotion chain moved since the run started; evidence stays in the stable container only. $link"
+            exit 0
+          fi
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --file "${{ steps.evidence.outputs.asset_path }}" \
+            --name "${{ steps.evidence.outputs.asset_name }}" \
+            --release-id "$promotion_release_id" \
+            --repository "$GITHUB_REPOSITORY"
+          mkdir -p promotion-output
+          node .github/scripts/production-promotion-state.mjs append \
+            --record promotion-input/current.json \
+            --actor "$GITHUB_ACTOR" \
+            --created-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+            --provenance-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --evidence packages-output/evidence.json \
+            --output promotion-output/next.json
+          name=$(node --input-type=module -e '
+            import {readFileSync} from "node:fs";
+            import {promotionAssetName} from "./.github/scripts/production-promotion-state.mjs";
+            process.stdout.write(promotionAssetName(JSON.parse(readFileSync("promotion-output/next.json", "utf8"))));
+          ')
+          mv promotion-output/next.json "promotion-output/$name"
+          node .github/scripts/production-promotion-assets.mjs publish-record \
+            --record "promotion-output/$name" \
+            --release-id "$promotion_release_id" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Summarize the public package release
+        run: |
+          {
+            echo "## Stable packages released"
+            echo
+            echo "- Release: \`${{ needs.load.outputs.release_identity }}\` from \`${{ needs.load.outputs.source_commit }}\`"
+            echo "- npm: \`latest\` now points at the plain versions; \`${{ needs.load.outputs.npm_tag }}\` retired"
+            echo "- Maven Central: deployment \`$(jq -er .deploymentState packages-output/maven/sonatype-publication.json)\` (sync to search can lag)"
+            echo "- SwiftPM: ${{ steps.swiftpm.outputs.tag_url }} (\`${{ steps.swiftpm.outputs.status }}\`)"
+            echo "- Evidence: \`${{ steps.evidence.outputs.asset_name }}\` in \`${{ needs.load.outputs.stable_tag }}\`"
+            echo "- Promotion chain: ${{ needs.load.outputs.promotion_reason }} (append: \`${{ needs.load.outputs.promotion_append }}\`)"
+            echo
+            echo "This workflow did not deploy Cloud or change an app store."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -77,7 +77,7 @@ jobs:
           [[ "$(jq -r .name <<< "$release")" == "$(jq -er .artifactContainerName release-intent/release-plan.json)" ]]
           channel=$(jq -er .channel release-intent/release-plan.json)
           if [[ "$channel" == "production" ]]; then
-            [[ "$(jq -r .draft <<< "$release")" == "true" ]]
+            # Stable packages may follow the manual publication of mentra-vX.Y.Z.
             [[ "$(jq -r .prerelease <<< "$release")" == "false" ]]
           else
             [[ "$(jq -r .draft <<< "$release")" == "false" ]]
@@ -102,6 +102,18 @@ jobs:
         with:
           name: ${{ inputs.release_plan_artifact }}
           path: release-intent
+
+      # Registry tooling comes from the workflow revision, not from the frozen
+      # package source: a promoted beta may predate the tooling this workflow
+      # relies on (for example the USER_MANAGED upload). On dev and staging the
+      # two revisions are the same commit.
+      - name: Checkout registry tooling from the workflow revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: release-tooling
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
 
       - name: Resolve exact Maven coordinates
         id: release
@@ -288,7 +300,7 @@ jobs:
               --arg lc3 "${{ steps.release.outputs.lc3_purl }}" \
               '.expectedPurls | sort == ([$sdk, $lc3] | sort)' \
               native-result/maven/sonatype-deployment.json >/dev/null
-            node .github/scripts/sonatype-central-deployment.mjs inspect \
+            node release-tooling/.github/scripts/sonatype-central-deployment.mjs inspect \
               --record native-result/maven/sonatype-deployment.json \
               --output native-result/maven/sonatype-inspection.json
             if [[ "$(jq -er .disposition native-result/maven/sonatype-inspection.json)" == "replace" ]]; then
@@ -347,12 +359,13 @@ jobs:
           PUBLISHING_TYPE: ${{ steps.release.outputs.publishing_type }}
         run: |
           set -euo pipefail
-          node .github/scripts/sonatype-central-deployment.mjs upload \
+          node release-tooling/.github/scripts/sonatype-central-deployment.mjs upload \
             --bundle native-result/maven/central-bundle.zip \
             --name "${{ steps.release.outputs.deployment_name }}" \
             --expected-purls "${{ steps.release.outputs.sdk_purl }},${{ steps.release.outputs.lc3_purl }}" \
             --publishing-type "$PUBLISHING_TYPE" \
             --output native-result/maven/sonatype-deployment.json
+          [[ "$(jq -er .publishingType native-result/maven/sonatype-deployment.json)" == "$PUBLISHING_TYPE" ]]
           encoded_name=$(jq -rn --arg value "$ASSET_NAME" '$value | @uri')
           persisted=false
           for attempt in {1..6}; do
@@ -378,6 +391,17 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/releases/assets/$asset_id" > persisted-deployment.json
             cmp --silent native-result/maven/sonatype-deployment.json persisted-deployment.json
           fi
+
+      - name: Require the production deployment to be validated before staging succeeds
+        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true' && steps.release.outputs.channel == 'production'
+        env:
+          MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
+        run: |
+          set -euo pipefail
+          [[ "$(jq -er .publishingType native-result/maven/sonatype-deployment.json)" == "USER_MANAGED" ]]
+          node release-tooling/.github/scripts/sonatype-central-deployment.mjs wait-validated \
+            --record native-result/maven/sonatype-deployment.json \
+            --output native-result/maven/sonatype-validation.json
 
       - name: Stage locally verified Maven artifacts
         run: |

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -92,7 +92,9 @@ jobs:
     name: Build SDK and submit Maven Central publication
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Prebuild, NDK, and two Gradle publishes take up to ~20 minutes; a
+    # production run then waits up to 30 minutes for Sonatype validation.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable-coordinated-sdk-native.yml
+++ b/.github/workflows/reusable-coordinated-sdk-native.yml
@@ -111,10 +111,21 @@ jobs:
           set -euo pipefail
           version=$(jq -er '.releaseIdentity' release-intent/release-plan.json)
           source=$(jq -er '.sourceCommit' release-intent/release-plan.json)
+          channel=$(jq -er '.channel' release-intent/release-plan.json)
           [[ "$source" == "$SOURCE_COMMIT" ]]
+          # Production deployments stay USER_MANAGED: Sonatype validates them
+          # but nothing reaches Maven Central until the separate protected
+          # release phase requests publication. Prereleases publish automatically.
+          if [[ "$channel" == "production" ]]; then
+            publishing_type=USER_MANAGED
+          else
+            publishing_type=AUTOMATIC
+          fi
           base="https://repo.maven.apache.org/maven2/com/mentraglass"
           {
             echo "version=$version"
+            echo "channel=$channel"
+            echo "publishing_type=$publishing_type"
             echo "deployment_name=mentra-$version-android-sdk"
             echo "deployment_asset=mentra-$version-sonatype-deployment.json"
             echo "sdk_purl=pkg:maven/com.mentraglass/bluetooth-sdk@$version"
@@ -326,19 +337,21 @@ jobs:
             zip -q -r "$GITHUB_WORKSPACE/native-result/maven/central-bundle.zip" com
           )
 
-      - name: Submit and persist an automatically published Sonatype deployment
+      - name: Submit and persist the Sonatype deployment
         if: inputs.dry_run != true && steps.existing.outputs.exists != 'true' && steps.deployment.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
           RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
           ASSET_NAME: ${{ steps.release.outputs.deployment_asset }}
+          PUBLISHING_TYPE: ${{ steps.release.outputs.publishing_type }}
         run: |
           set -euo pipefail
           node .github/scripts/sonatype-central-deployment.mjs upload \
             --bundle native-result/maven/central-bundle.zip \
             --name "${{ steps.release.outputs.deployment_name }}" \
             --expected-purls "${{ steps.release.outputs.sdk_purl }},${{ steps.release.outputs.lc3_purl }}" \
+            --publishing-type "$PUBLISHING_TYPE" \
             --output native-result/maven/sonatype-deployment.json
           encoded_name=$(jq -rn --arg value "$ASSET_NAME" '$value | @uri')
           persisted=false
@@ -432,30 +445,48 @@ jobs:
           version=$(jq -er .releaseIdentity release-intent/release-plan.json)
           artifact_tag=$(jq -er .artifactContainerTag release-intent/release-plan.json)
           archive_name=$(jq -er .artifactNames.iosSdkArchive release-intent/release-plan.json)
+          channel=$(jq -er .channel release-intent/release-plan.json)
           [[ "$(jq -er .sourceCommit release-intent/release-plan.json)" == "$SOURCE_COMMIT" ]]
+          # A production run stages the exported commit on a release branch of
+          # the mirror. The public SwiftPM tag is pushed only by the separate
+          # protected release phase of production-release-packages.yml.
+          staging_ref=""
+          if [[ "$channel" == "production" ]]; then
+            staging_ref="release/$version"
+          fi
           {
             echo "version=$version"
+            echo "channel=$channel"
+            echo "staging_ref=$staging_ref"
             echo "archive_name=$archive_name"
             echo "release_tag=mentra-v$version"
             echo "archive_url=https://github.com/${{ github.repository }}/releases/download/$artifact_tag/$archive_name"
             echo "tag_url=https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios/tree/$version"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Check public SwiftPM tag
+      - name: Check public SwiftPM tag and staged production commit
         id: existing
         working-directory: mentra-bluetooth-sdk-ios
+        env:
+          STAGING_REF: ${{ steps.release.outputs.staging_ref }}
         run: |
           set -euo pipefail
           git fetch --tags origin
           if git rev-parse -q --verify "refs/tags/${{ steps.release.outputs.version }}^{commit}" >/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "staged=false" >> "$GITHUB_OUTPUT"
             git checkout --detach "refs/tags/${{ steps.release.outputs.version }}"
+          elif [[ -n "$STAGING_REF" ]] && git rev-parse -q --verify "refs/remotes/origin/$STAGING_REF^{commit}" >/dev/null; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "staged=true" >> "$GITHUB_OUTPUT"
+            git checkout --detach "refs/remotes/origin/$STAGING_REF"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "staged=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Stage coordinated Swift package source
-        if: steps.existing.outputs.exists != 'true'
+        if: steps.existing.outputs.exists != 'true' && steps.existing.outputs.staged != 'true'
         working-directory: MentraOS
         run: |
           npm --prefix mobile/modules/bluetooth-sdk pkg set version="${{ steps.release.outputs.version }}"
@@ -471,7 +502,7 @@ jobs:
             --verify
 
       - name: Commit exact SwiftPM export locally
-        if: steps.existing.outputs.exists != 'true'
+        if: steps.existing.outputs.exists != 'true' && steps.existing.outputs.staged != 'true'
         working-directory: mentra-bluetooth-sdk-ios
         run: |
           set -euo pipefail
@@ -499,7 +530,7 @@ jobs:
           echo "mirror_sha=$mirror_sha" >> "$GITHUB_OUTPUT"
 
       - name: Publish verified SwiftPM commit and tag
-        if: inputs.dry_run != true && steps.existing.outputs.exists != 'true'
+        if: inputs.dry_run != true && steps.release.outputs.channel != 'production' && steps.existing.outputs.exists != 'true'
         working-directory: mentra-bluetooth-sdk-ios
         run: |
           set -euo pipefail
@@ -507,6 +538,16 @@ jobs:
           git push origin "${mirror_sha}:refs/heads/main"
           git tag "${{ steps.release.outputs.version }}" "$mirror_sha"
           git push origin "refs/tags/${{ steps.release.outputs.version }}"
+
+      - name: Stage verified production SwiftPM commit without a public tag
+        if: inputs.dry_run != true && steps.release.outputs.channel == 'production' && steps.existing.outputs.exists != 'true' && steps.existing.outputs.staged != 'true'
+        working-directory: mentra-bluetooth-sdk-ios
+        env:
+          STAGING_REF: ${{ steps.release.outputs.staging_ref }}
+        run: |
+          set -euo pipefail
+          test -n "$STAGING_REF"
+          git push origin "${{ steps.selected.outputs.mirror_sha }}:refs/heads/$STAGING_REF"
 
       - name: Publish exact SwiftPM archive as immutable release asset
         if: inputs.dry_run != true
@@ -541,7 +582,7 @@ jobs:
       - name: Write SwiftPM publication record
         working-directory: MentraOS
         env:
-          STATUS: ${{ inputs.dry_run && 'built' || (steps.existing.outputs.exists == 'true' && 'reused' || 'published') }}
+          STATUS: ${{ inputs.dry_run && 'built' || (steps.existing.outputs.exists == 'true' && 'reused' || (steps.release.outputs.channel == 'production' && 'submitted' || 'published')) }}
         run: >-
           node .github/scripts/coordinated-sdk-native-records.mjs create-swiftpm
           --plan release-intent/release-plan.json

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -63,6 +63,7 @@ Commands:
   release  --release X.Y.Z [--attempt N] [--yes]
   advance  --release X.Y.Z [--attempt N] [--android-percent N | --complete] [--yes]
   abort    --release X.Y.Z [--attempt N] --reason TEXT [--yes]
+  packages --beta X.Y.Z-beta.N --phase publish|release [--yes]
   watch    --run RUN_ID
 
 This CLI dispatches protected GitHub workflows. It never reads production
@@ -448,6 +449,24 @@ export function validateAdvanceOptions(record, options) {
   return {action: options.complete ? "complete" : "advance", androidPercent: percent || "100"}
 }
 
+// Stable packages (npm latest, Maven Central, SwiftPM) are keyed on the
+// promoted beta, not on a promotion attempt, so they can ship before, during,
+// or after store review.
+export const PACKAGE_PHASES = Object.freeze(["publish", "release"])
+
+export function validatePackagesOptions(options) {
+  if (!BETA_PATTERN.test(options.beta || "")) throw commandError("packages requires --beta X.Y.Z-beta.N")
+  if (!PACKAGE_PHASES.includes(options.phase))
+    throw commandError("packages requires --phase publish or --phase release")
+  return {beta_identity: options.beta, phase: options.phase}
+}
+
+export function packagesConfirmationMessage(request) {
+  return request.phase === "publish"
+    ? `This publishes the plain ${request.beta_identity.replace(/-beta\.\d+$/, "")} package versions under a candidate npm dist-tag and stages Maven Central and SwiftPM. GitHub will still require production-packages approval.`
+    : `This moves npm latest, publishes Maven Central, and pushes the public SwiftPM tag for ${request.beta_identity.replace(/-beta\.\d+$/, "")}. GitHub will still require production-packages-release approval.`
+}
+
 export function advanceConfirmationMessage(request) {
   return request.action === "complete"
     ? "This requests final verification and completion of the public release."
@@ -498,6 +517,16 @@ async function main(argv = process.argv.slice(2)) {
     if (!BETA_PATTERN.test(options.beta || "")) throw commandError("start requires --beta X.Y.Z-beta.N")
     verifyCheckoutForStart()
     dispatch("production-release-prepare.yml", {beta_identity: options.beta})
+    return
+  }
+
+  if (command === "packages") {
+    const request = validatePackagesOptions(options)
+    await confirmEffect(packagesConfirmationMessage(request), {
+      ...options,
+      release: request.beta_identity.replace(/-beta\.\d+$/, ""),
+    })
+    dispatch("production-release-packages.yml", request)
     return
   }
 

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -4,11 +4,13 @@ import test from "node:test"
 import {
   advanceConfirmationMessage,
   branchPromotionState,
+  packagesConfirmationMessage,
   parseCliArgs,
   releaseBranchSources,
   requireCommandState,
   statusSummary,
   validateAdvanceOptions,
+  validatePackagesOptions,
 } from "./production-release.mjs"
 
 const baseRecord = {
@@ -155,4 +157,25 @@ test("prevents commands from skipping promotion states", () => {
   assert.throws(() => requireCommandState("release", baseRecord), /requires stores-approved/)
   assert.equal(requireCommandState("attest", labReadyRecord, {check: "staging-mobile-n-compatibility"}).kind, "attest")
   assert.equal(requireCommandState("advance", {...baseRecord, state: "finalizing"}).command, "advance")
+})
+
+test("dispatches stable package phases from the promoted beta without a promotion state", () => {
+  assert.deepEqual(validatePackagesOptions({beta: "3.1.0-beta.192", phase: "publish"}), {
+    beta_identity: "3.1.0-beta.192",
+    phase: "publish",
+  })
+  assert.deepEqual(validatePackagesOptions({beta: "3.1.0-beta.192", phase: "release"}).phase, "release")
+  assert.throws(() => validatePackagesOptions({beta: "3.1.0", phase: "publish"}), /--beta X\.Y\.Z-beta\.N/)
+  assert.throws(
+    () => validatePackagesOptions({beta: "3.1.0-beta.192", phase: "latest"}),
+    /--phase publish or --phase release/,
+  )
+  assert.match(
+    packagesConfirmationMessage({beta_identity: "3.1.0-beta.192", phase: "publish"}),
+    /candidate npm dist-tag/,
+  )
+  assert.match(
+    packagesConfirmationMessage({beta_identity: "3.1.0-beta.192", phase: "release"}),
+    /moves npm latest.*3\.1\.0/,
+  )
 })


### PR DESCRIPTION
## Design

**Trigger.** A new manually dispatched workflow, `production-release-packages.yml`, run on `main` with two inputs: `beta_identity` (the promoted beta, e.g. `3.1.0-beta.192`) and `phase` (`publish` | `release`). The CLI wraps it as `scripts/production-release.mjs packages --beta X.Y.Z-beta.N --phase publish|release`.

**Keyed on the frozen beta plan, not on a promotion state.** The `load` job downloads the beta's `release-plan.json` + manifest from `mentra-builds-vX.Y.Z`, re-verifies the beta is complete, checks its `sourceCommit` is an ancestor of `origin/main`, checks out that exact commit into `release-source/`, and derives a deterministic production plan from it (`production-packages.mjs plan`): channel `production`, release identity `X.Y.Z`, the beta's OTA manifest pin as `promotion.otaManifest`. Every reusable job builds from that `sourceCommit`, never from `main` HEAD.

**Which promotion states it may run from.** Any time after `promote` merged the beta into `main`: before `start`, in any live promotion state, or after rollout. It does not need a promotion attempt to exist at all. This matters today: there is no `mentra-production-promotion-v3.1.0-*` container on GitHub (3.1.0 shipped outside the state machine), so keying on `release_identity + attempt` would have blocked 3.1.0 packages on a provenance bootstrap. The promotion chain is **never written** by these phases, so they cannot race a Cloud or mobile transition. It is read once: a live attempt for the identity that froze a different beta or source is a hard stop, and an allocated attempt without a state record fails closed. `nextAction` and every mobile transition are untouched. This satisfies requirement 2: package publication is not a state transition and neither blocks nor is blocked by `stores-submitted → store-review-approved → stores-approved`.

**Staged vs. public, and what a human approves.**

| Phase | Gate | npm | Maven Central | SwiftPM |
| --- | --- | --- | --- | --- |
| `publish` | environment `production-packages` | plain `X.Y.Z` published with provenance under dist-tag `candidate-X.Y.Z` via the unchanged reusable npm workflow (`npm_tag` input); `latest` untouched | `USER_MANAGED` Sonatype deployment; the phase only succeeds once Sonatype reports it `VALIDATED`, nothing published | export committed and pushed to mirror branch `release/X.Y.Z`; no tag |
| `release` | environment `production-packages-release` | preflights every target first (npm dry run, Sonatype `inspect`, SwiftPM archive commit id via `git get-tar-commit-id`), then `promote-npm-latest.mjs` decides for the whole family before moving any `latest` (refuses if `latest` is already newer), reads back, retires the candidate tag; needs `NPM_TOKEN` because OIDC only covers `npm publish` | `sonatype-central-deployment.mjs publish` on the persisted record, waits for `PUBLISHED` | tag `X.Y.Z` pushed at the staged commit; mirror `main` fast-forwarded only when possible |

Current npm behaviour was kept: `publish-release-npm.mjs` does a direct `npm publish --provenance` (no `npm stage publish` in this code path), so the candidate publish behaves exactly like a beta publish and inherits the #3983 read-back wait and 120-minute job budget.

**Evidence.** Both phases write content-addressed JSON into the stable release `mentra-vX.Y.Z` (allocated with the same payload `production-release-rollout.yml` uses, asserted by a contract test so the two cannot drift; a container already published by hand is accepted). The native SDK job already persists the Sonatype record and SwiftPM archive there.

## Implementation

- `production-release-packages.yml` (new): `load` → `approve` → reusable `npm` + `sdk-native` → `record-publication`; or `load` → `release`.
- `reusable-coordinated-sdk-native.yml`: Sonatype tooling now runs from the workflow revision (`github.sha`) rather than the frozen package source, so a beta cut before this change still stages correctly; on the production channel the Maven upload is `USER_MANAGED`, verified and awaited to `VALIDATED`, and the SwiftPM job pushes `release/X.Y.Z` instead of `main` + tag (idempotent on rerun via the staged branch). Dev/beta paths unchanged.
- `production-promotion-state.mjs`: read-only `requirePromotionMatchesPackages` guard and CLI `packages-guard`; no chain changes.
- `production-promotion-assets.mjs`: `latestPromotionContainer` + CLI `download-latest-attempt` (fails closed on an allocated attempt without a state record). Also fixes a pre-existing defect: listing releases through `gh api` overflowed Node's 1 MiB subprocess buffer once the build containers carried ~700 assets, which would have broken every promotion command that lists releases; listings now project only the needed fields and stream as JSON lines.
- `production-packages.mjs` (new): plan derivation, candidate tag, stable container allocate/reuse.
- `promote-npm-latest.mjs` (new): latest flip with downgrade protection and read-back.
- `sonatype-central-deployment.mjs`: `--publishing-type` (AUTOMATIC | USER_MANAGED), recorded on the persisted deployment, plus `wait-validated`.
- `prepare-production-promotion.mjs`: shared `validateSelectedBeta` (no behaviour change).
- `scripts/production-release.mjs`: `packages` command.
- Runbook: new "Stable packages" section and two environment rows.

Cloud and mobile promotion behaviour is unchanged.

## Test evidence

```
node --test .github/scripts/*.test.mjs scripts/production-release.test.mjs \
  mobile/modules/bluetooth-sdk/scripts/*.test.mjs mobile/modules/engine/scripts/*.test.mjs \
  mobile/scripts/app-store-connect-build.test.mjs
# tests 241  # pass 241  # fail 0        (staging baseline: 165 in .github/scripts)
node .github/scripts/release-family-cli.mjs validate --require-version-mirrors   # OK
actionlint on both workflows: only the pre-existing `queue: max` warning
```

New coverage: the read-only promotion guard across every state and its beta/source mismatch failures, latest-attempt lookup, deterministic plan derivation and beta validation failures, stable-container reuse/mismatch, latest-flip decisions, the full fake-registry flow and the no-mutation-on-partial-failure case, USER_MANAGED upload and `wait-validated`, release-phase preflight ordering, workflow contract for the new file, and the CLI command.

## Before first use

- Create the `production-packages` and `production-packages-release` environments (required reviewers).
- The release phase needs `NPM_TOKEN`, `MAVEN_CENTRAL_TOKEN_BASE64`, and `MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN` as repository secrets (the reusable jobs get them via `secrets: inherit`).
- If npm trusted publishing is scoped per workflow file, register `production-release-packages.yml` for each family package; otherwise `NPM_TOKEN` covers the publish.
- Once phase `publish` has put `X.Y.Z` on npm, that identity is spent; an aborted promotion cannot be replaced by a different source under the same version (documented as a stop condition).


## Review

Reviewed locally by Codex (gpt-6-astra, medium reasoning), posting as the `mentra-release-coordinator` app. Pass 1 requested changes (partial npm flips, Sonatype validation timing, frozen-source tooling, chain races, published container) and pass 3 requested changes for the no-attempt guard path; both reworks are design changes rather than local patches, smoke-tested against the real repository. Final formal review: **approved at `90081cfa88`**.
