### PR TITLE
Use next dashboard row for app content

### DIFF
--- a/mintlify-docs/bluetooth-sdk/api-reference.mdx
+++ b/mintlify-docs/bluetooth-sdk/api-reference.mdx
@@ -468,7 +468,9 @@ Use `setDashboardContent` to place persistent, glanceable text below the standar
 dashboard status header. The SDK keeps the raw status placeholders and expands
 them every time the dashboard renders, so time, date, battery, and connection
 remain current. The call does not force the dashboard open. If the contextual
-dashboard is hidden, the content appears on the next head-up.
+dashboard is hidden, the content appears on the next head-up. Content starts on
+the line immediately below the header; begin it with a newline when a blank row
+is desired.
 
 <Tabs>
   <Tab title="React Native">

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -390,13 +390,13 @@ console.log(ledAck.state)
 ## Dashboard Content
 
 `setDashboardContent(content)` keeps the standard `$TIME12$ $DATE$ $GBATT$
-$CONNECTION_STATUS$` status header and places non-empty content below it after a
-blank line. Pass the exact empty string to reset the dashboard to the status
-header only. The template is held in memory for the SDK process/session, and its
-status placeholders are refreshed each time the dashboard renders. Calling this
-method does not open the dashboard; it updates an active contextual dashboard
-immediately or appears on the next head-up. Repeating the same content is a
-no-op.
+$CONNECTION_STATUS$` status header and places non-empty content on the next line.
+Start content with a newline when a blank row is desired. Pass the exact empty
+string to reset the dashboard to the status header only. The template is held in
+memory for the SDK process/session, and its status placeholders are refreshed
+each time the dashboard renders. Calling this method does not open the dashboard;
+it updates an active contextual dashboard immediately or appears on the next
+head-up. Repeating the same content is a no-op.
 
 React Native / Expo:
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/requests/DisplayRequests.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/requests/DisplayRequests.kt
@@ -4,7 +4,7 @@ internal object DashboardContentFormatter {
     const val STATUS_HEADER = "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$"
 
     fun template(content: String): String =
-        if (content.isEmpty()) STATUS_HEADER else "$STATUS_HEADER\n\n$content"
+        if (content.isEmpty()) STATUS_HEADER else "$STATUS_HEADER\n$content"
 }
 
 data class DisplayTextRequest(

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/DashboardContentFormatterTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/DashboardContentFormatterTest.kt
@@ -13,10 +13,18 @@ class DashboardContentFormatterTest {
     }
 
     @Test
-    fun nonEmptyContentIsAppendedExactlyAfterBlankLine() {
+    fun nonEmptyContentIsAppendedExactlyOnNextLine() {
         assertEquals(
-            "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$\n\n  Next meeting\nRoom 2  ",
+            "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$\n  Next meeting\nRoom 2  ",
             DashboardContentFormatter.template("  Next meeting\nRoom 2  "),
+        )
+    }
+
+    @Test
+    fun leadingNewlineKeepsOptionalBlankRow() {
+        assertEquals(
+            "\$TIME12$ \$DATE$ \$GBATT$ \$CONNECTION_STATUS$\n\nNext meeting",
+            DashboardContentFormatter.template("\nNext meeting"),
         )
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/requests/DisplayRequests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/requests/DisplayRequests.swift
@@ -4,7 +4,7 @@ enum DashboardContentFormatter {
     static let statusHeader = "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$"
 
     static func template(for content: String) -> String {
-        content.isEmpty ? statusHeader : statusHeader + "\n\n" + content
+        content.isEmpty ? statusHeader : statusHeader + "\n" + content
     }
 }
 

--- a/mobile/modules/bluetooth-sdk/ios/Tests/DashboardContentFormatterTests.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Tests/DashboardContentFormatterTests.swift
@@ -9,10 +9,17 @@ final class DashboardContentFormatterTests: XCTestCase {
         )
     }
 
-    func testNonEmptyContentIsAppendedExactlyAfterBlankLine() {
+    func testNonEmptyContentIsAppendedExactlyOnNextLine() {
         XCTAssertEqual(
             DashboardContentFormatter.template(for: "  Next meeting\nRoom 2  "),
-            "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$\n\n  Next meeting\nRoom 2  "
+            "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$\n  Next meeting\nRoom 2  "
+        )
+    }
+
+    func testLeadingNewlineKeepsOptionalBlankRow() {
+        XCTAssertEqual(
+            DashboardContentFormatter.template(for: "\nNext meeting"),
+            "$TIME12$ $DATE$ $GBATT$ $CONNECTION_STATUS$\n\nNext meeting"
         )
     }
 }


### PR DESCRIPTION
## Summary

- place custom dashboard content immediately below the status header
- recover one app-controlled display row while preserving opt-in spacing through a leading newline
- update Android and Apple formatter tests and public documentation

## Validation

- `swift test` (35 tests)
- `node --test scripts/*.test.mjs` (6 tests)
- `git diff --check`

Android compilation was not available in the sparse local checkout; CI will run the Android SDK build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Places custom dashboard content on the line immediately below the status header instead of after a blank line, recovering one display row. The blank line is still available by starting content with a leading newline; docs and formatter tests for Android and iOS are updated.

<sup>Written for commit 4aa37076ef3d1d1c2f9d9c9ff39385b7351cd3af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

