### PR TITLE
Respect host Android foreground service declarations

### DIFF
--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -115,6 +115,24 @@ Android apps should request the permissions required by the features they use:
 
 Some Android 12+ devices require Location permission and Location services before BLE scan callbacks are delivered.
 
+### Android Foreground Service Types
+
+The SDK service reads its allowed types from the merged Android manifest.
+The default manifest retains MentraOS's connected-device, microphone, location,
+media-playback and data-sync capabilities. A Bluetooth-only host can override
+`com.mentra.bluetoothsdk.services.ForegroundService` to use `connectedDevice`
+with `tools:replace="android:foregroundServiceType"`, and remove unused typed
+FGS permissions from its final manifest. Startup then uses `connectedDevice`
+instead of `dataSync`; the SDK's `CHANGE_WIFI_STATE` permission satisfies its
+startup prerequisite even before a Bluetooth runtime permission is granted.
+
+Only restrict types when the corresponding background features are unused.
+Receiving the glasses' BLE audio is distinct from selecting Android's phone or
+Bluetooth headset microphone. Hosts using Android microphone capture, location
+tracking or background media playback must retain the corresponding types and
+permissions, including those required by other native modules. At least
+`connectedDevice` or `dataSync` must remain for SDK service startup.
+
 iOS apps should include usage descriptions:
 
 ```json

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
@@ -3,6 +3,7 @@ package com.mentra.bluetoothsdk.services
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
+import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
@@ -21,14 +22,31 @@ class ForegroundService : Service() {
         const val ACTION_REFRESH_TYPES =
                 "com.mentra.bluetoothsdk.services.action.REFRESH_FOREGROUND_SERVICE_TYPES"
 
-        internal fun bootstrapServiceType(): Int =
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        internal const val DEFAULT_SERVICE_TYPES =
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+
+        internal fun bootstrapServiceType(declaredTypes: Int = DEFAULT_SERVICE_TYPES): Int {
+            // Both types can start without a while-in-use permission. The SDK declares
+            // CHANGE_WIFI_STATE, which satisfies connectedDevice's prerequisite.
+            if (declaredTypes and ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC != 0) {
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            }
+            require(declaredTypes and ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE != 0) {
+                "The SDK foreground service must declare connectedDevice or dataSync"
+            }
+            return ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+        }
 
         internal fun preferredServiceType(
                 hasConnectedDeviceAccess: Boolean,
                 hasMicrophoneAccess: Boolean,
                 hasLocationAccess: Boolean,
                 includeMediaPlayback: Boolean = true,
+                declaredTypes: Int = DEFAULT_SERVICE_TYPES,
         ): Int {
             var serviceType = 0
 
@@ -47,21 +65,31 @@ class ForegroundService : Service() {
                 serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
             }
 
-            return if (serviceType == 0) bootstrapServiceType() else serviceType
+            serviceType = serviceType and declaredTypes
+            return if (serviceType == 0) bootstrapServiceType(declaredTypes) else serviceType
         }
     }
 
     private var locationTypeRequested = false
 
+    private val declaredServiceTypes: Int by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            packageManager.getServiceInfo(ComponentName(this, ForegroundService::class.java), 0)
+                    .foregroundServiceType
+        } else {
+            DEFAULT_SERVICE_TYPES
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         Bridge.log("ForegroundService: onCreate() called")
         BleTraceLogger.logLifecycle(this, "ForegroundService", "service_create")
-        // Enter the foreground immediately with a type that has no runtime
-        // prerequisites. onStartCommand() replaces this bootstrap type with the
+        // Enter the foreground immediately using a type allowed by the host manifest.
+        // onStartCommand() replaces this bootstrap type with the
         // eligible long-running types, deliberately omitting dataSync so Android 15's
         // six-hour dataSync timer no longer applies.
-        startForegroundWithType(bootstrapServiceType())
+        startForegroundWithType(bootstrapServiceType(declaredServiceTypes))
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -114,12 +142,13 @@ class ForegroundService : Service() {
             return 0 // No service types before Android Q
         }
 
-        // Audio prompts can be initiated by glasses while the host Activity is
-        // backgrounded. mediaPlayback has no runtime prerequisite, so keep it
-        // active on the existing Mentra service for the entire connected
-        // session rather than trying to launch a second service after a wake
-        // phrase arrives.
-        Bridge.log("ForegroundService: Added mediaPlayback (supports background audio)")
+        // MentraOS uses background audio prompts; Bluetooth-only hosts can omit
+        // this type from their merged manifest.
+        val includeMediaPlayback =
+                declaredServiceTypes and ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK != 0
+        if (includeMediaPlayback) {
+            Bridge.log("ForegroundService: Added mediaPlayback (supports background audio)")
+        }
 
         // Check Bluetooth permissions
         val hasBluetoothPermission =
@@ -168,13 +197,14 @@ class ForegroundService : Service() {
 
         // Check microphone permission
         val hasMicPermission =
-                ContextCompat.checkSelfPermission(this, android.Manifest.permission.RECORD_AUDIO) ==
-                        PackageManager.PERMISSION_GRANTED
+                declaredServiceTypes and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE != 0 &&
+                        ContextCompat.checkSelfPermission(this, android.Manifest.permission.RECORD_AUDIO) ==
+                                PackageManager.PERMISSION_GRANTED
 
         if (hasMicPermission) {
             Bridge.log("ForegroundService: Added microphone (has RECORD_AUDIO permission)")
         } else {
-            Bridge.log("ForegroundService: No microphone permission")
+            Bridge.log("ForegroundService: Microphone type disabled or permission not granted")
         }
 
         val hasLocationPermission =
@@ -189,7 +219,9 @@ class ForegroundService : Service() {
         val locationManager = getSystemService(LocationManager::class.java)
         val isLocationEnabled = locationManager?.isLocationEnabled == true
 
-        val hasLocationAccess = locationTypeRequested && hasLocationPermission && isLocationEnabled
+        val hasLocationAccess =
+                declaredServiceTypes and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION != 0 &&
+                        locationTypeRequested && hasLocationPermission && isLocationEnabled
         if (hasLocationAccess) {
             Bridge.log("ForegroundService: Added location (has foreground location permission)")
         } else {
@@ -203,6 +235,8 @@ class ForegroundService : Service() {
                 hasConnectedDeviceAccess = hasConnectedDeviceAccess,
                 hasMicrophoneAccess = hasMicPermission,
                 hasLocationAccess = hasLocationAccess,
+                includeMediaPlayback = includeMediaPlayback,
+                declaredTypes = declaredServiceTypes,
         )
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/services/ForegroundServiceManifestTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/services/ForegroundServiceManifestTest.kt
@@ -1,0 +1,57 @@
+package com.mentra.bluetoothsdk.services
+
+import android.Manifest
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.location.LocationManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ForegroundServiceManifestTest {
+    @Test
+    fun `host manifest controls startup and resume even with all permissions granted`() {
+        val application = RuntimeEnvironment.getApplication()
+        val component = ComponentName(application, ForegroundService::class.java)
+        val info = application.packageManager.getServiceInfo(component, 0)
+        ReflectionHelpers.setField(info, "mForegroundServiceType", ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
+        shadowOf(application.packageManager).addOrUpdateService(info)
+        shadowOf(application).grantPermissions(
+            Manifest.permission.BLUETOOTH_CONNECT,
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        )
+        shadowOf(application.getSystemService(LocationManager::class.java)).setLocationEnabled(true)
+
+        val controller = Robolectric.buildService(ForegroundService::class.java).create()
+        val service = controller.get()
+        try {
+            assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE, service.foregroundServiceType)
+            service.onStartCommand(Intent(ForegroundService.ACTION_REFRESH_TYPES), 0, 1)
+            assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE, service.foregroundServiceType)
+            service.onStartCommand(null, 0, 2)
+            assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE, service.foregroundServiceType)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun `default library manifest retains the MentraOS startup type`() {
+        val controller = Robolectric.buildService(ForegroundService::class.java).create()
+        try {
+            assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC, controller.get().foregroundServiceType)
+        } finally {
+            controller.destroy()
+        }
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/services/ForegroundServiceTypeTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/services/ForegroundServiceTypeTest.kt
@@ -7,6 +7,58 @@ import org.junit.Test
 
 class ForegroundServiceTypeTest {
     @Test
+    fun `connected-device-only host bootstraps without dataSync`() {
+        assertEquals(
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            ForegroundService.bootstrapServiceType(ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE),
+        )
+    }
+
+    @Test
+    fun `permissions cannot enable types excluded by the host manifest`() {
+        assertEquals(
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            ForegroundService.preferredServiceType(
+                hasConnectedDeviceAccess = true,
+                hasMicrophoneAccess = true,
+                hasLocationAccess = true,
+                declaredTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            ),
+        )
+    }
+
+    @Test
+    fun `restricted host fallback never adds undeclared dataSync`() {
+        assertEquals(
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            ForegroundService.preferredServiceType(
+                hasConnectedDeviceAccess = false,
+                hasMicrophoneAccess = false,
+                hasLocationAccess = false,
+                declaredTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            ),
+        )
+    }
+
+    @Test
+    fun `MentraOS retains all eligible long-running types`() {
+        assertEquals(
+            ForegroundService.DEFAULT_SERVICE_TYPES and
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC.inv(),
+            ForegroundService.preferredServiceType(
+                hasConnectedDeviceAccess = true,
+                hasMicrophoneAccess = true,
+                hasLocationAccess = true,
+            ),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `host without a valid bootstrap type fails explicitly`() {
+        ForegroundService.bootstrapServiceType(ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+    }
+
+    @Test
     fun `bootstrap starts as dataSync`() {
         assertEquals(
             ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,


### PR DESCRIPTION
## Summary
- Read the SDK foreground service's allowed type mask from the merged host manifest.
- Respect that mask at startup, permission refresh, and sticky restart; use connectedDevice bootstrap when dataSync is omitted.
- Preserve MentraOS's default manifest and existing foreground-service behavior.
- Document the host override and add type-selection and Robolectric lifecycle tests.

## Validation
- Public-mode Android SDK assembleDebug: passed on the original dev base and previous staging base.
- 11 focused native tests: passed, including startup/resume with all permissions granted under a connected-device-only manifest.
- git diff --check: passed.
- Physical-device qualification is still pending.

## Release Order
Merge and publish this SDK change before enabling the dependent Starter Kit manifest cleanup. The example's current published SDK does not support the restricted manifest and must not be shipped with that configuration. No release or merge has been triggered by this PR creation.

Companion draft PR: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/201

Retargeted to dev at the user's request and rebuilt by cherry-picking only the fix onto fresh dev, excluding staging-only changes. CI is rerunning for the updated branch.