### PR TITLE
Make the Bluetooth example its own release notion

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -6,9 +6,16 @@ production. It covers Cloud V2 and the Mentra App on iOS and Android.
 The Bluetooth SDK Starter Kit example app is explicitly outside this production
 promotion system. These workflows do not build it, upload it to TestFlight or
 Google Play, submit it for review, or release it publicly. Do not add the example
-app manually to a promotion attempt. Its coordinated beta pipeline remains
-separate and unchanged. Publishing it to app stores later requires a reviewed
-workflow and runbook change; it is not an operator-time option.
+app manually to a promotion attempt. Publishing it to app stores later requires
+a reviewed workflow and runbook change; it is not an operator-time option.
+
+The example app is also its own release notion in the coordinated beta. A beta
+is complete, and promotable, when `finalize` writes `mentra-release-<beta>.json`
+for Cloud V2, the Mentra App, the Engine, and the Bluetooth SDK. The Starter
+Kit examples are then built against that finalized beta and recorded
+separately as `mentra-example-release-<beta>.json`, the "finalized Mentra
+Bluetooth example". An example build or store publish that fails never makes
+the beta incomplete and never blocks a promotion.
 
 The process is resumable. It records immutable state in a draft GitHub release
 named `mentra-production-promotion-vX.Y.Z-attempt-N`. Store review may take days;
@@ -16,10 +23,9 @@ no GitHub runner waits for it.
 
 ## Safety rules
 
-- Promote only a completed coordinated beta whose MentraOS and Starter Kit
-  sources already contain their respective `main` branches. If either branch
-  has production-only commits, back-merge them into `staging` and complete a new
-  beta before promotion.
+- Promote only a completed coordinated beta whose MentraOS source already
+  contains `main`. If `main` has production-only commits, back-merge them into
+  `staging` and complete a new beta before promotion.
 - Start only after the selected beta's exact sources are in `main`.
 - Never patch or re-sign a beta binary. Production mobile candidates are rebuilt
   from the frozen source with production configuration.
@@ -96,12 +102,11 @@ git pull --ff-only origin staging
 ./scripts/production-release.mjs promote --beta X.Y.Z-beta.N
 ```
 
-This creates and merges the Starter Kit `staging` to `main` pull request first,
-then the MentraOS `staging` to `main` pull request. It only advances branch
-history. It does not build or publish the Starter Kit, deploy Cloud, upload
-mobile apps, submit stores, or create production-promotion state. It fails
-before opening either pull request if the selected beta does not already
-contain both `main` heads.
+This creates and merges the MentraOS `staging` to `main` pull request. It only
+advances branch history. It does not touch the Starter Kit repository, deploy
+Cloud, upload mobile apps, submit stores, or create production-promotion state.
+It fails before opening the pull request if the selected beta does not already
+contain the `main` head.
 
 Then, from a clean, up-to-date MentraOS `main` checkout:
 

--- a/.github/scripts/assemble-coordinated-release-results.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.mjs
@@ -5,7 +5,6 @@ import path from "node:path"
 import {fileURLToPath} from "node:url"
 
 import {validateCloudV2DeploymentRecord} from "./coordinated-cloud-v2-records.mjs"
-import {validateExampleGooglePlay} from "./coordinated-example-google-play.mjs"
 import {serializeReleaseRecord} from "./release-family.mjs"
 import {createEnginePackageArtifact, mergeReleaseResultRecords} from "./release-result-records.mjs"
 
@@ -46,118 +45,6 @@ function verifyAsgSelection(plan, ota, selectionFile) {
   return {sha256, size: bytes.length}
 }
 
-function verifyExampleTestflight(plan, starterKit, exampleTestflight) {
-  const expectedGroup = plan.channel === "dev" ? "Mentra Dev" : "Mentra Staging Public"
-  const expectedAudience = plan.channel === "dev" ? "internal" : "external"
-  const distribution = exampleTestflight?.distribution
-  if (
-    exampleTestflight?.schemaVersion !== 1 ||
-    exampleTestflight.releaseSetId !== plan.releaseSetId ||
-    exampleTestflight.releaseIdentity !== plan.releaseIdentity ||
-    exampleTestflight.channel !== plan.channel ||
-    exampleTestflight.mentraosSourceCommit !== plan.sourceCommit ||
-    exampleTestflight.starterKitReleaseCommit !== starterKit.starterKit?.releaseCommit ||
-    exampleTestflight.app?.id !== "6792839366" ||
-    exampleTestflight.app?.bundleId !== "com.mentra.bluetoothsdkexample" ||
-    exampleTestflight.version?.marketingVersion !== plan.native.marketingVersion ||
-    exampleTestflight.version?.buildNumber !== plan.native.buildNumber ||
-    exampleTestflight.build?.processingState !== "VALID" ||
-    !["published", "reused"].includes(exampleTestflight.build?.uploadStatus) ||
-    typeof exampleTestflight.build?.id !== "string" ||
-    exampleTestflight.build.id.length === 0 ||
-    exampleTestflight.group?.name !== expectedGroup ||
-    typeof exampleTestflight.group?.id !== "string" ||
-    exampleTestflight.group.id.length === 0 ||
-    distribution?.audience !== expectedAudience ||
-    !["available", "submitted", "skipped"].includes(distribution?.status) ||
-    !/^https:\/\//.test(distribution?.installUrl || "") ||
-    !/^https:\/\//.test(exampleTestflight.provenanceUrl || "")
-  ) {
-    throw new Error("Example TestFlight result does not match the release plan and Starter Kit source")
-  }
-  if (
-    exampleTestflight.ipa !== undefined &&
-    (!/^[0-9a-f]{64}$/.test(exampleTestflight.ipa.sha256 || "") ||
-      !Number.isSafeInteger(exampleTestflight.ipa.size) ||
-      exampleTestflight.ipa.size < 1)
-  ) {
-    throw new Error("Example TestFlight IPA evidence is invalid")
-  }
-  if (plan.channel === "dev" && distribution.status !== "available") {
-    throw new Error("Internal example TestFlight distribution must be available")
-  }
-  if (expectedAudience === "external" && !/^https:\/\/testflight\.apple\.com\/join\//.test(distribution.installUrl)) {
-    throw new Error("External example TestFlight distribution must use a public invitation link")
-  }
-  if (distribution.status === "skipped" && !distribution.skipReason) {
-    throw new Error("Skipped example TestFlight distribution must identify its reason")
-  }
-  return exampleTestflight
-}
-
-function verifyStarterKitResult(plan, starterKit, resultUrl, exampleTestflight, exampleGooglePlay) {
-  if (!starterKit) return undefined
-  if (
-    starterKit.schemaVersion !== 1 ||
-    starterKit.releaseSetId !== plan.releaseSetId ||
-    starterKit.releaseIdentity !== plan.releaseIdentity ||
-    starterKit.familyBaseVersion !== plan.familyBaseVersion ||
-    starterKit.channel !== plan.channel ||
-    starterKit.mentraos?.sourceCommit !== plan.sourceCommit ||
-    (plan.starterKitSource && starterKit.starterKit?.baseCommit !== plan.starterKitSource.sourceCommit)
-  ) {
-    throw new Error("Starter Kit result does not match the release plan")
-  }
-  for (const packageName of ["@mentra/bluetooth-sdk", "@mentra/engine"]) {
-    if (starterKit.packages?.[packageName] !== plan.releaseIdentity) {
-      throw new Error(`Starter Kit ${packageName} version does not match the release plan`)
-    }
-  }
-  if (!/^https:\/\//.test(resultUrl || "")) throw new Error("Starter Kit result URL must be public HTTPS")
-  if (!/^https:\/\//.test(starterKit.starterKit?.validationRunUrl || "")) {
-    throw new Error("Starter Kit validation run URL must be public HTTPS")
-  }
-  if (!Array.isArray(starterKit.artifacts) || ![3, 4].includes(starterKit.artifacts.length)) {
-    throw new Error("Starter Kit result must contain the three required examples and optional native Android")
-  }
-  const keys = new Set()
-  const artifacts = starterKit.artifacts.map((artifact) => {
-    if (
-      !artifact?.key ||
-      keys.has(artifact.key) ||
-      typeof artifact.name !== "string" ||
-      !artifact.name.includes(plan.releaseIdentity) ||
-      !/^https:\/\//.test(artifact.url || "") ||
-      !/^[0-9a-f]{64}$/.test(artifact.sha256 || "") ||
-      !Number.isSafeInteger(artifact.size) ||
-      artifact.size < 1
-    ) {
-      throw new Error("Starter Kit contains an invalid or duplicate example artifact")
-    }
-    keys.add(artifact.key)
-    return {
-      status: "published",
-      coordinate: artifact.name,
-      url: artifact.url,
-      sha256: artifact.sha256,
-      size: artifact.size,
-      provenanceUrl: starterKit.starterKit.validationRunUrl,
-    }
-  })
-  for (const key of ["ios", "reactNative", "reactNativeElevenLabsAudio"]) {
-    if (!keys.has(key)) throw new Error(`Starter Kit result is missing ${key}`)
-  }
-  return {
-    record: {
-      ...starterKit,
-      resultUrl,
-      testflight: verifyExampleTestflight(plan, starterKit, exampleTestflight),
-      googlePlay: validateExampleGooglePlay(plan, starterKit, exampleGooglePlay),
-    },
-    artifacts,
-  }
-}
-
 export function assembleCoordinatedReleaseResults({
   plan,
   ota,
@@ -165,10 +52,6 @@ export function assembleCoordinatedReleaseResults({
   native,
   mobile,
   cloud,
-  starterKit,
-  starterKitResultUrl,
-  exampleTestflight,
-  exampleGooglePlay,
   asgSelectionFile,
   enginePackage,
   releaseAssetBaseUrl,
@@ -178,7 +61,6 @@ export function assembleCoordinatedReleaseResults({
   }
   const merged = mergeReleaseResultRecords({plan, records: [...npmRecords, native, mobile]})
   const selection = verifyAsgSelection(plan, ota, asgSelectionFile)
-  const verifiedStarterKit = verifyStarterKitResult(plan, starterKit, starterKitResultUrl, exampleTestflight, exampleGooglePlay)
   const verifiedCloud = validateCloudV2DeploymentRecord({plan, record: cloud, allowValidated: true})
   const otaProvenanceUrl = provenanceUrl(ota)
   const artifacts = [
@@ -220,8 +102,6 @@ export function assembleCoordinatedReleaseResults({
       }),
     )
   }
-  if (verifiedStarterKit) artifacts.push(...verifiedStarterKit.artifacts)
-
   return {
     schemaVersion: 1,
     releaseSetId: plan.releaseSetId,
@@ -236,7 +116,6 @@ export function assembleCoordinatedReleaseResults({
     },
     artifacts,
     cloud: verifiedCloud,
-    ...(verifiedStarterKit ? {starterKit: verifiedStarterKit.record} : {}),
   }
 }
 
@@ -260,10 +139,6 @@ function main() {
     native: readJson(path.resolve(args.native)),
     mobile: readJson(path.resolve(args.mobile)),
     cloud: readJson(path.resolve(args.cloud)),
-    starterKit: args["starter-kit"] ? readJson(path.resolve(args["starter-kit"])) : undefined,
-    starterKitResultUrl: args["starter-kit-result-url"],
-    exampleTestflight: args["example-testflight"] ? readJson(path.resolve(args["example-testflight"])) : undefined,
-    exampleGooglePlay: args["example-google-play"] ? readJson(path.resolve(args["example-google-play"])) : undefined,
     asgSelectionFile: path.resolve(args["asg-selection"]),
     enginePackage: args["engine-package"] ? path.resolve(args["engine-package"]) : undefined,
     releaseAssetBaseUrl: args["release-asset-base-url"],

--- a/.github/scripts/assemble-coordinated-release-results.test.mjs
+++ b/.github/scripts/assemble-coordinated-release-results.test.mjs
@@ -17,11 +17,6 @@ const plan = createReleasePlan({
   sequence: 57,
   sourceCommit: "a".repeat(40),
   nativeBuildNumber: 310000057,
-  starterKitSource: {
-    repository: "Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit",
-    branch: "staging",
-    sourceCommit: "1".repeat(40),
-  },
 })
 const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
 
@@ -144,101 +139,29 @@ test("assembles every product target and finalizes one complete release manifest
     },
     workflow: {repository: "Mentra-Community/MentraOS", runId: "123"},
   }
-  const starterKit = {
-    schemaVersion: 1,
-    releaseSetId: plan.releaseSetId,
-    releaseIdentity: plan.releaseIdentity,
-    familyBaseVersion: plan.familyBaseVersion,
-    channel: plan.channel,
-    mentraos: {sourceCommit: plan.sourceCommit, coordinatorRunUrl: provenanceUrl},
-    ota: {manifestUrl: ota.manifest.url, manifestSha256: ota.manifest.sha256},
-    starterKit: {
-      baseCommit: "1".repeat(40),
-      releaseCommit: "2".repeat(40),
-      mergeCommit: "3".repeat(40),
-      sourceTag: `sdk-${plan.releaseIdentity}`,
-      artifactContainerTag: `sdk-builds-v${plan.familyBaseVersion}`,
-      releaseUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/tag/sdk-builds-v3.1.0",
-      pullRequestUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/51",
-      validationRunUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/456",
-    },
-    packages: {
-      "@mentra/bluetooth-sdk": plan.releaseIdentity,
-      "@mentra/engine": plan.releaseIdentity,
-    },
-    artifacts: ["ios", "reactNative", "reactNativeElevenLabsAudio"].map((key, index) => ({
-      key,
-      name: `mentra-example-${key}-${plan.releaseIdentity}.${key === "ios" ? "ipa" : "apk"}`,
-      url: `https://example.com/mentra-example-${key}-${plan.releaseIdentity}`,
-      size: index + 1,
-      sha256: String(index + 1).repeat(64),
-      contentType: "application/octet-stream",
-    })),
-  }
-  const exampleTestflight = {
-    schemaVersion: 1,
-    releaseSetId: plan.releaseSetId,
-    releaseIdentity: plan.releaseIdentity,
-    channel: plan.channel,
-    mentraosSourceCommit: plan.sourceCommit,
-    starterKitReleaseCommit: starterKit.starterKit.releaseCommit,
-    app: {id: "6792839366", bundleId: "com.mentra.bluetoothsdkexample"},
-    version: {marketingVersion: plan.native.marketingVersion, buildNumber: plan.native.buildNumber},
-    build: {id: "build-1", processingState: "VALID", uploadStatus: "published"},
-    group: {id: "group-1", name: "Mentra Staging Public"},
-    distribution: {
-      audience: "external",
-      status: "submitted",
-      installUrl: "https://testflight.apple.com/join/public123",
-      reviewState: "WAITING_FOR_REVIEW",
-    },
-    provenanceUrl,
-    ipa: {size: 123, sha256: "9".repeat(64)},
-  }
-
-  const exampleGooglePlay = {
-    schemaVersion: 1, releaseSetId: plan.releaseSetId, releaseIdentity: plan.releaseIdentity,
-    channel: plan.channel, mentraosSourceCommit: plan.sourceCommit,
-    starterKitReleaseCommit: starterKit.starterKit.releaseCommit,
-    packageId: "com.mentra.bluetoothsdkexample",
-    version: {marketingVersion: plan.native.marketingVersion, buildNumber: plan.native.buildNumber},
-    track: "beta", uploadStatus: "published",
-    distribution: {status: "submitted", audience: "external", installUrl: "https://play.google.com/apps/testing/com.mentra.bluetoothsdkexample"},
-    aab: {url: `https://github.com/Mentra-Community/MentraOS/releases/download/${plan.artifactContainerTag}/mentra-example-react-native-${plan.releaseIdentity}.aab`, sha256: "8".repeat(64), size: 123},
-    provenanceUrl: "https://github.com/Mentra-Community/MentraOS/actions/runs/123",
-  }
-  const assemble = (starterKitRecord) =>
-    assembleCoordinatedReleaseResults({
-      plan,
-      ota,
-      npmRecords,
-      native,
-      mobile,
-      cloud: cloudRecordForPlan(plan),
-      starterKit: starterKitRecord,
-      starterKitResultUrl: "https://example.com/starter-kit-result.json",
-      exampleTestflight,
-      exampleGooglePlay,
-      asgSelectionFile,
-      enginePackage,
-      releaseAssetBaseUrl: "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0",
-    })
-  const results = assemble(starterKit)
+  const results = assembleCoordinatedReleaseResults({
+    plan,
+    ota,
+    npmRecords,
+    native,
+    mobile,
+    cloud: cloudRecordForPlan(plan),
+    asgSelectionFile,
+    enginePackage,
+    releaseAssetBaseUrl: "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0",
+  })
   const manifest = finalizeReleaseManifest({plan, results, completedAt: "2026-08-25T02:00:00.000Z"})
 
   assert.equal(Object.keys(manifest.publications).length, 8)
   assert.equal(manifest.publications["@mentra/bluetooth-sdk"]["maven-central"].status, "submitted")
   assert.equal(manifest.publications.mentraos["app-store-connect"].status, "published")
   assert.ok(manifest.artifacts.some((artifact) => artifact.coordinate === plan.artifactNames.asgSelection))
-  assert.equal(manifest.starterKit.resultUrl, "https://example.com/starter-kit-result.json")
-  assert.equal(manifest.starterKit.testflight.build.id, "build-1")
-  assert.equal(manifest.starterKit.googlePlay.track, "beta")
   assert.equal(manifest.cloud.environment, "staging")
-  assert.equal(manifest.artifacts.at(-1).coordinate, starterKit.artifacts.at(-1).name)
-
-  const wrongStarterSource = structuredClone(starterKit)
-  wrongStarterSource.starterKit.baseCommit = "9".repeat(40)
-  assert.throws(() => assemble(wrongStarterSource), /Starter Kit result does not match the release plan/)
+  // The Mentra beta is complete without any Starter Kit or example evidence;
+  // the Bluetooth example is finalized separately (example-release-records).
+  assert.equal(manifest.starterKit, undefined)
+  assert.equal(manifest.exampleTestflight, undefined)
+  assert.equal(manifest.artifacts.at(-1).coordinate, plan.artifactNames.enginePackage)
 
   assert.throws(
     () =>
@@ -254,25 +177,6 @@ test("assembles every product target and finalizes one complete release manifest
         releaseAssetBaseUrl: "https://example.com/release",
       }),
     /Duplicate publication record/,
-  )
-
-  assert.throws(
-    () =>
-      assembleCoordinatedReleaseResults({
-        plan,
-        ota,
-        npmRecords,
-        native,
-        mobile,
-        cloud: cloudRecordForPlan(plan),
-        starterKit: {...starterKit, releaseSetId: "mentra-other"},
-        starterKitResultUrl: "https://example.com/starter-kit-result.json",
-        exampleTestflight,
-        asgSelectionFile,
-        enginePackage,
-        releaseAssetBaseUrl: "https://example.com/release",
-      }),
-    /Starter Kit result does not match/,
   )
 
   writeFileSync(asgSelectionFile, `${JSON.stringify(asgSelection)}\n`)

--- a/.github/scripts/coordinated-example-google-play.mjs
+++ b/.github/scripts/coordinated-example-google-play.mjs
@@ -10,16 +10,18 @@ const readJson = (file) => JSON.parse(readFileSync(file, "utf8"))
 
 export function verifyExampleAabIdentity(plan, aab, bundletool, run = execFileSync) {
   const expected = {
-    package: EXAMPLE_PACKAGE_ID,
+    "package": EXAMPLE_PACKAGE_ID,
     "android:versionCode": String(plan.native.buildNumber),
     "android:versionName": plan.native.marketingVersion,
   }
   for (const [attribute, value] of Object.entries(expected)) {
-    const actual = run("java", [
-      "-jar", bundletool, "dump", "manifest", `--bundle=${aab}`, "--module=base",
-      `--xpath=/manifest/@${attribute}`,
-    ], {encoding: "utf8"}).trim()
-    if (actual !== value) throw new Error(`AAB ${attribute} ${JSON.stringify(actual)} does not match ${JSON.stringify(value)}`)
+    const actual = run(
+      "java",
+      ["-jar", bundletool, "dump", "manifest", `--bundle=${aab}`, "--module=base", `--xpath=/manifest/@${attribute}`],
+      {encoding: "utf8"},
+    ).trim()
+    if (actual !== value)
+      throw new Error(`AAB ${attribute} ${JSON.stringify(actual)} does not match ${JSON.stringify(value)}`)
   }
 }
 
@@ -31,11 +33,16 @@ export function examplePlayCoordinates(plan, starterKit, track) {
     starterKit.releaseIdentity !== plan.releaseIdentity ||
     starterKit.channel !== plan.channel ||
     starterKit.mentraos?.sourceCommit !== plan.sourceCommit ||
-    starterKit.starterKit?.baseCommit !== plan.starterKitSource?.sourceCommit ||
+    !/^[0-9a-f]{40}$/.test(starterKit.starterKit?.baseCommit || "") ||
     !/^[0-9a-f]{40}$/.test(starterKit.starterKit?.releaseCommit || "") ||
     ["@mentra/bluetooth-sdk", "@mentra/engine"].some((name) => starterKit.packages?.[name] !== plan.releaseIdentity)
-  ) throw new Error("Example Google Play source does not match the validated Starter Kit release")
-  if (!Number.isSafeInteger(plan.native?.buildNumber) || plan.native.buildNumber < 1 || plan.native.buildNumber > 2100000000) {
+  )
+    throw new Error("Example Google Play source does not match the validated Starter Kit release")
+  if (
+    !Number.isSafeInteger(plan.native?.buildNumber) ||
+    plan.native.buildNumber < 1 ||
+    plan.native.buildNumber > 2100000000
+  ) {
     throw new Error("Example Google Play requires a valid coordinated Android version code")
   }
   const aabName = `mentra-example-react-native-${plan.releaseIdentity}.aab`
@@ -54,7 +61,8 @@ export function examplePlayCoordinates(plan, starterKit, track) {
 export function configureExampleAndroid(plan, config, packageJson) {
   if (!["dev", "beta"].includes(plan.channel)) throw new Error("Only coordinated prerelease examples are supported")
   for (const name of ["@mentra/bluetooth-sdk", "@mentra/engine"]) {
-    if (packageJson.dependencies?.[name] !== plan.releaseIdentity) throw new Error(`Example ${name} must match the release`)
+    if (packageJson.dependencies?.[name] !== plan.releaseIdentity)
+      throw new Error(`Example ${name} must match the release`)
   }
   return {
     ...config,
@@ -84,13 +92,24 @@ export function validateExampleGooglePlay(plan, starterKit, record) {
     record.distribution?.installUrl !== installUrl ||
     record.aab?.url !== coordinates.aab_url ||
     !/^[0-9a-f]{64}$/.test(record.aab?.sha256 || "") ||
-    !Number.isSafeInteger(record.aab?.size) || record.aab.size < 1 ||
+    !Number.isSafeInteger(record.aab?.size) ||
+    record.aab.size < 1 ||
     !/^https:\/\/github\.com\/Mentra-Community\/MentraOS\/actions\/runs\/\d+$/.test(record.provenanceUrl || "")
-  ) throw new Error("Example Google Play publication evidence does not match the release")
+  )
+    throw new Error("Example Google Play publication evidence does not match the release")
   return record
 }
 
-export function createExampleGooglePlayRecord({plan, starterKit, track, codes, aab, artifactUrl, uploadStatus, provenanceUrl}) {
+export function createExampleGooglePlayRecord({
+  plan,
+  starterKit,
+  track,
+  codes,
+  aab,
+  artifactUrl,
+  uploadStatus,
+  provenanceUrl,
+}) {
   examplePlayCoordinates(plan, starterKit, track)
   if (!Array.isArray(codes) || !codes.map(Number).includes(plan.native.buildNumber)) {
     throw new Error("Google Play did not retain the exact coordinated version code")
@@ -141,8 +160,14 @@ function main() {
   }
   if (command !== "record") throw new Error(`Unknown command: ${command}`)
   const record = createExampleGooglePlayRecord({
-    plan, starterKit, track: options.track, codes: readJson(options.codes), aab: readFileSync(options.aab),
-    artifactUrl: options["artifact-url"], uploadStatus: options["upload-status"], provenanceUrl: options["provenance-url"],
+    plan,
+    starterKit,
+    track: options.track,
+    codes: readJson(options.codes),
+    aab: readFileSync(options.aab),
+    artifactUrl: options["artifact-url"],
+    uploadStatus: options["upload-status"],
+    provenanceUrl: options["provenance-url"],
   })
   writeFileSync(options.output, `${JSON.stringify(record, null, 2)}\n`)
 }

--- a/.github/scripts/coordinated-example-google-play.test.mjs
+++ b/.github/scripts/coordinated-example-google-play.test.mjs
@@ -1,18 +1,29 @@
 import assert from "node:assert/strict"
 import {readFileSync} from "node:fs"
 import test from "node:test"
-import {configureExampleAndroid, createExampleGooglePlayRecord, examplePlayCoordinates, validateExampleGooglePlay, verifyExampleAabIdentity} from "./coordinated-example-google-play.mjs"
+import {
+  configureExampleAndroid,
+  createExampleGooglePlayRecord,
+  examplePlayCoordinates,
+  validateExampleGooglePlay,
+  verifyExampleAabIdentity,
+} from "./coordinated-example-google-play.mjs"
 
 function fixture(channel = "beta") {
   const plan = {
-    channel, releaseIdentity: `3.1.0-${channel}.42`, releaseSetId: `mentra-3.1.0-${channel}.42`,
-    sourceCommit: "a".repeat(40), starterKitSource: {sourceCommit: "b".repeat(40)},
-    native: {marketingVersion: "3.1.0", buildNumber: 310000042}, artifactContainerTag: "mentra-builds-v3.1.0",
+    channel,
+    releaseIdentity: `3.1.0-${channel}.42`,
+    releaseSetId: `mentra-3.1.0-${channel}.42`,
+    sourceCommit: "a".repeat(40),
+    native: {marketingVersion: "3.1.0", buildNumber: 310000042},
+    artifactContainerTag: "mentra-builds-v3.1.0",
   }
   const starterKit = {
-    releaseSetId: plan.releaseSetId, releaseIdentity: plan.releaseIdentity, channel,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    channel,
     mentraos: {sourceCommit: plan.sourceCommit},
-    starterKit: {baseCommit: plan.starterKitSource.sourceCommit, releaseCommit: "c".repeat(40)},
+    starterKit: {baseCommit: "b".repeat(40), releaseCommit: "c".repeat(40)},
     packages: {"@mentra/bluetooth-sdk": plan.releaseIdentity, "@mentra/engine": plan.releaseIdentity},
   }
   const track = channel === "dev" ? "internal" : "beta"
@@ -24,8 +35,11 @@ for (const channel of ["dev", "beta"]) {
     const input = fixture(channel)
     const coordinates = examplePlayCoordinates(input.plan, input.starterKit, input.track)
     const record = createExampleGooglePlayRecord({
-      ...input, codes: [String(input.plan.native.buildNumber)], aab: Buffer.from("bundle"),
-      artifactUrl: coordinates.aab_url, uploadStatus: "published",
+      ...input,
+      codes: [String(input.plan.native.buildNumber)],
+      aab: Buffer.from("bundle"),
+      artifactUrl: coordinates.aab_url,
+      uploadStatus: "published",
       provenanceUrl: "https://github.com/Mentra-Community/MentraOS/actions/runs/123",
     })
     assert.equal(record.distribution.audience, channel === "dev" ? "internal" : "external")
@@ -33,10 +47,14 @@ for (const channel of ["dev", "beta"]) {
     assert.equal(record.aab.size, 6)
     assert.equal(record.starterKitReleaseCommit, input.starterKit.starterKit.releaseCommit)
     for (const mutation of [
-      {track: channel === "dev" ? "beta" : "internal"}, {packageId: "com.mentra.mentra"},
-      {version: {...record.version, buildNumber: 1}}, {starterKitReleaseCommit: "d".repeat(40)},
-      {aab: {...record.aab, sha256: "invalid"}}, {distribution: {...record.distribution, status: "available"}},
-    ]) assert.throws(() => validateExampleGooglePlay(input.plan, input.starterKit, {...record, ...mutation}))
+      {track: channel === "dev" ? "beta" : "internal"},
+      {packageId: "com.mentra.mentra"},
+      {version: {...record.version, buildNumber: 1}},
+      {starterKitReleaseCommit: "d".repeat(40)},
+      {aab: {...record.aab, sha256: "invalid"}},
+      {distribution: {...record.distribution, status: "available"}},
+    ])
+      assert.throws(() => validateExampleGooglePlay(input.plan, input.starterKit, {...record, ...mutation}))
   })
 }
 
@@ -45,14 +63,28 @@ test("rejects incorrect channels, source revisions, packages, and absent Play ve
   assert.throws(() => examplePlayCoordinates(plan, starterKit, "production"), /track/)
   assert.throws(() => examplePlayCoordinates({...plan, channel: "production"}, starterKit, "internal"), /track/)
   assert.throws(() => examplePlayCoordinates(plan, {...starterKit, packages: {}}, track), /source/)
-  assert.throws(() => examplePlayCoordinates(plan, {...starterKit, starterKit: {...starterKit.starterKit, baseCommit: "d".repeat(40)}}, track), /source/)
+  assert.throws(
+    () =>
+      examplePlayCoordinates(
+        plan,
+        {...starterKit, starterKit: {...starterKit.starterKit, baseCommit: "not-a-commit"}},
+        track,
+      ),
+    /source/,
+  )
   assert.throws(() => createExampleGooglePlayRecord({plan, starterKit, track, codes: [1]}), /exact coordinated version/)
   assert.throws(() => validateExampleGooglePlay(plan, starterKit, undefined))
 })
 
 test("configures only Android store identity without changing iOS or dependencies", () => {
   const {plan, starterKit} = fixture()
-  const config = {expo: {name: "Example", ios: {bundleIdentifier: "original"}, android: {package: "original", permissions: ["CAMERA"]}}}
+  const config = {
+    expo: {
+      name: "Example",
+      ios: {bundleIdentifier: "original"},
+      android: {package: "original", permissions: ["CAMERA"]},
+    },
+  }
   const result = configureExampleAndroid(plan, config, {dependencies: starterKit.packages})
   assert.equal(result.expo.android.package, "com.mentra.bluetoothsdkexample")
   assert.equal(result.expo.android.versionCode, plan.native.buildNumber)
@@ -66,25 +98,37 @@ test("configures only Android store identity without changing iOS or dependencie
 test("verifies package and both native versions from the actual bundle", () => {
   const {plan} = fixture()
   const attributes = {
-    package: "com.mentra.bluetoothsdkexample",
+    "package": "com.mentra.bluetoothsdkexample",
     "android:versionCode": String(plan.native.buildNumber),
     "android:versionName": plan.native.marketingVersion,
   }
   const readAttribute = (values) => (command, args, options) => {
     assert.equal(command, "java")
-    assert.deepEqual(args.slice(0, 6), ["-jar", "/tools/bundletool.jar", "dump", "manifest", "--bundle=/release/example.aab", "--module=base"])
+    assert.deepEqual(args.slice(0, 6), [
+      "-jar",
+      "/tools/bundletool.jar",
+      "dump",
+      "manifest",
+      "--bundle=/release/example.aab",
+      "--module=base",
+    ])
     assert.equal(options.encoding, "utf8")
     return `${values[args[6].replace("--xpath=/manifest/@", "")]}\n`
   }
-  const verify = (values) => verifyExampleAabIdentity(plan, "/release/example.aab", "/tools/bundletool.jar", readAttribute(values))
+  const verify = (values) =>
+    verifyExampleAabIdentity(plan, "/release/example.aab", "/tools/bundletool.jar", readAttribute(values))
   assert.doesNotThrow(() => verify(attributes))
   for (const attribute of Object.keys(attributes)) {
     assert.throws(() => verify({...attributes, [attribute]: "wrong"}), /does not match/)
     assert.throws(() => verify({...attributes, [attribute]: ""}), /does not match/)
   }
-  assert.throws(() => verifyExampleAabIdentity(plan, "bundle.aab", "bundletool.jar", () => {
-    throw new Error("Cannot decode bundle")
-  }), /Cannot decode bundle/)
+  assert.throws(
+    () =>
+      verifyExampleAabIdentity(plan, "bundle.aab", "bundletool.jar", () => {
+        throw new Error("Cannot decode bundle")
+      }),
+    /Cannot decode bundle/,
+  )
 })
 
 test("coordinator preserves MentraOS tracks and separates example audiences", () => {
@@ -100,13 +144,21 @@ test("coordinator preserves MentraOS tracks and separates example audiences", ()
   assert.match(channelBlock, /example_play_track=beta/)
   assert.match(workflow, /needs\.example-google-play\.result == 'success'/)
   assert.match(workflow, /--example-google-play release-input\/example-google-play/)
-  const reusable = readFileSync(new URL("../workflows/reusable-coordinated-example-google-play.yml", import.meta.url), "utf8")
+  const reusable = readFileSync(
+    new URL("../workflows/reusable-coordinated-example-google-play.yml", import.meta.url),
+    "utf8",
+  )
   assert.ok(reusable.indexOf("persist exact signed bytes") < reusable.indexOf("Upload exact App Bundle"))
   assert.match(reusable, /starter_release_commit/)
   assert.match(reusable, /cancel-in-progress: false/)
   assert.match(reusable, /queue: max/)
-  assert.ok(reusable.indexOf(".mjs verify-aab") < reusable.indexOf("node .github/scripts/publish-immutable-release-asset.mjs"))
-  const verificationStep = reusable.slice(reusable.indexOf("- name: Verify and persist"), reusable.indexOf("- name: Require Play access"))
+  assert.ok(
+    reusable.indexOf(".mjs verify-aab") < reusable.indexOf("node .github/scripts/publish-immutable-release-asset.mjs"),
+  )
+  const verificationStep = reusable.slice(
+    reusable.indexOf("- name: Verify and persist"),
+    reusable.indexOf("- name: Require Play access"),
+  )
   assert.doesNotMatch(verificationStep, /if:.*existing/)
   assert.doesNotMatch(reusable, /-PreactNativeArchitectures=/)
   assert.match(reusable, /arm64-v8a,x86_64/)

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -151,7 +151,10 @@ test("stable packages publish from the frozen beta source independently of the m
   assert.match(packages, /production-promotion-state\.mjs packages-guard/)
   assert.doesNotMatch(packages, /production-promotion-state\.mjs (transition|append|attest-transition)/)
   assert.doesNotMatch(packages, /publish-record|--to [a-z-]+/)
-  assert.doesNotMatch(packages, /stores-approved|store-review-approved|production-store-release|production-cloud|reusable-coordinated-cloud-v2|reusable-coordinated-mobile/)
+  assert.doesNotMatch(
+    packages,
+    /stores-approved|store-review-approved|production-store-release|production-cloud|reusable-coordinated-cloud-v2|reusable-coordinated-mobile/,
+  )
   assert.match(packages, /group: production-release-packages\n/)
   // Every target is checked before the first irreversible mutation.
   const releaseJob = jobBlock(packages, "release")
@@ -177,7 +180,10 @@ test("stable packages publish from the frozen beta source independently of the m
   assert.match(packages, /git push origin "refs\/tags\/\$VERSION"/)
   assert.match(packages, /release_id: \$\{\{ needs\.load\.outputs\.stable_release_id \}\}/)
   // Both workflows must recognize the same stable draft container.
-  assert.match(rollout, /body: "Canonical production release records\. Publish manually only after the completed promotion and final public-availability checks\."/)
+  assert.match(
+    rollout,
+    /body: "Canonical production release records\. Publish manually only after the completed promotion and final public-availability checks\."/,
+  )
   assert.match(packages, /production-packages\.mjs ensure-container/)
   // The reusable native job stages production without publishing, using
   // registry tooling from the workflow revision rather than the frozen source.
@@ -190,8 +196,14 @@ test("stable packages publish from the frozen beta source independently of the m
   assert.match(sdkNative, /\.publishingType native-result\/maven\/sonatype-deployment\.json\)" == "\$PUBLISHING_TYPE"/)
   assert.match(sdkNative, /sonatype-central-deployment\.mjs wait-validated/)
   assert.match(sdkNative, /staging_ref="release\/\$version"/)
-  assert.match(sdkNative, /steps\.release\.outputs\.channel != 'production' && steps\.existing\.outputs\.exists != 'true'/)
-  assert.match(sdkNative, /git push origin "\$\{\{ steps\.selected\.outputs\.mirror_sha \}\}:refs\/heads\/\$STAGING_REF"/)
+  assert.match(
+    sdkNative,
+    /steps\.release\.outputs\.channel != 'production' && steps\.existing\.outputs\.exists != 'true'/,
+  )
+  assert.match(
+    sdkNative,
+    /git push origin "\$\{\{ steps\.selected\.outputs\.mirror_sha \}\}:refs\/heads\/\$STAGING_REF"/,
+  )
 })
 
 test("Cloud V2 deploys once per coordinated environment before mobile publication", () => {
@@ -300,21 +312,42 @@ test("coordinated docs publish only after finalization to the matching channel",
   const docs = jobBlock(coordinator, "docs")
   const notify = jobBlock(coordinator, "notify-slack")
 
-  assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native\]$/m)
+  const finalize = jobBlock(coordinator, "finalize")
+  const finalizeExample = jobBlock(coordinator, "finalize-example")
+
+  // The Mentra beta (Cloud V2, Mentra App, Engine, Bluetooth SDK) is complete
+  // on its own; the Bluetooth example is built against the finalized beta and
+  // finalized as a separate record, so it can never make the beta incomplete.
+  assert.match(finalize, /^    needs: \[plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer\]$/m)
+  assert.doesNotMatch(finalize, /starter-kit|example-testflight|example-google-play/)
+  assert.match(starterKit, /^    needs: \[plan, ota, npm, sdk-native, finalize\]$/m)
   assert.match(engineConsumer, /^    needs: \[plan, npm\]$/m)
   assert.match(starterKit, /coordinated-example-release\.yml/)
-  assert.match(coordinator, /Freeze the Starter Kit channel source/)
-  assert.match(coordinator, /--starter-kit-source starter-kit-source\.json/)
-  assert.match(coordinator, /trailers:key=Starter-Kit-Source,valueonly/)
+  assert.doesNotMatch(coordinator, /Freeze the Starter Kit channel source/)
+  assert.doesNotMatch(coordinator, /--starter-kit-source|starterKitSource|Starter-Kit-Source/)
+  assert.match(
+    finalizeExample,
+    /^    needs: \[plan, finalize, starter-kit, example-testflight, example-google-play\]$/m,
+  )
+  assert.match(finalizeExample, /needs\.finalize\.result == 'success'/)
+  assert.match(finalizeExample, /needs\.plan\.outputs\.dry_run != 'true'/)
+  assert.match(finalizeExample, /name: coordinated-release-result-\$\{\{ needs\.plan\.outputs\.release_set_id \}\}/)
+  assert.match(finalizeExample, /example-release-records\.mjs/)
+  assert.match(finalizeExample, /--beta-manifest "\$beta_manifest"/)
+  assert.match(finalizeExample, /record_name="mentra-example-release-\$identity\.json"/)
+  assert.match(finalizeExample, /publish-immutable-release-asset\.mjs/)
+  assert.match(finalizeExample, /verify-public-release-asset\.mjs/)
   assert.match(plan, /Restore the release plan selected by an earlier attempt/)
   assert.match(plan, /actions\/runs\/\$GITHUB_RUN_ID\/artifacts/)
   assert.match(plan, /gh run download "\$GITHUB_RUN_ID"/)
-  assert.match(plan, /jq -e \.starterKitSource release-plan\.json > starter-kit-source\.json/)
   assert.match(plan, /output=release-plan\.verify\.json/)
   assert.match(plan, /cmp release-plan\.json "\$output"/)
-  assert.equal([...plan.matchAll(/if: steps\.restore-plan\.outputs\.restored != 'true'/g)].length, 2)
+  assert.equal([...plan.matchAll(/if: steps\.restore-plan\.outputs\.restored != 'true'/g)].length, 1)
   assert.doesNotMatch(plan, /source_timestamp/)
-  assert.match(starterKit, /expected_head=\$\(jq -er \.starterKitSource\.sourceCommit "\$plan"\)/)
+  assert.match(
+    starterKit,
+    /expected_head=\$\(git ls-remote "https:\/\/github\.com\/\$STARTER_KIT_REPOSITORY\.git" "refs\/heads\/\$target_branch"/,
+  )
   assert.doesNotMatch(starterKit, /expected_head=\$\(gh api/)
   assert.doesNotMatch(starterKit, /event_type: "coordinated_example_release"/)
   assert.doesNotMatch(starterKit, /--event repository_dispatch/)
@@ -362,12 +395,11 @@ test("coordinated docs publish only after finalization to the matching channel",
   )
   assert.match(exampleTestflight, /^    needs: \[plan, starter-kit\]$/m)
   assert.match(exampleTestflight, /reusable-coordinated-example-testflight\.yml/)
-  assert.match(jobBlock(coordinator, "finalize"), /needs\.starter-kit\.result == 'success'/)
-  assert.match(jobBlock(coordinator, "finalize"), /needs\.example-testflight\.result == 'success'/)
-  assert.match(jobBlock(coordinator, "finalize"), /needs\.engine-consumer\.result == 'success'/)
-  assert.match(docs, /^    needs: \[plan, starter-kit, example-testflight, finalize\]$/m)
+  assert.match(finalize, /needs\.engine-consumer\.result == 'success'/)
+  assert.match(docs, /^    needs: \[plan, starter-kit, example-testflight, finalize, finalize-example\]$/m)
   assert.match(docs, /needs\.starter-kit\.result == 'success'/)
   assert.match(docs, /needs\.finalize\.result == 'success'/)
+  assert.match(docs, /needs\.finalize-example\.result == 'success'/)
   assert.match(docs, /needs\.plan\.outputs\.dry_run != 'true'/)
   assert.match(docs, /project=mentraos-docs-dev/)
   assert.match(docs, /docs_url=https:\/\/docs-dev\.mentraglass\.com/)
@@ -383,8 +415,9 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(docs, /%7b%7b\[a-z0-9_-\]\+%7d%7d/)
   assert.match(
     notify,
-    /^    needs:\n      \[plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, example-testflight, example-google-play, finalize, docs\]$/m,
+    /^    needs:\n      \[plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, example-testflight, example-google-play, finalize, finalize-example, docs\]$/m,
   )
+  assert.match(notify, /FINALIZE_EXAMPLE_RESULT: \$\{\{ needs\.finalize-example\.result \}\}/)
   assert.match(notify, /STARTER_KIT_RESULT: \$\{\{ needs\.starter-kit\.result \}\}/)
   assert.match(notify, /EXAMPLE_TESTFLIGHT_RESULT: \$\{\{ needs\.example-testflight\.result \}\}/)
   assert.match(notify, /EXAMPLE_TESTFLIGHT_INSTALL_URL: \$\{\{ needs\.example-testflight\.outputs\.install_url \}\}/)
@@ -504,7 +537,10 @@ test("iOS publishes the signed artifact before submitting those same bytes to Ap
   assert.match(publish, /timeout-minutes: 5/)
   assert.match(publish, /needs\.ios\.outputs\.upload_artifact/)
   assert.match(publish, /publish-immutable-release-asset\.mjs/)
-  assert.match(publish, /inputs\.dry_run != true && inputs\.compatibility_lab != true && needs\.prepare\.outputs\.ios_asset_exists != 'true'/)
+  assert.match(
+    publish,
+    /inputs\.dry_run != true && inputs\.compatibility_lab != true && needs\.prepare\.outputs\.ios_asset_exists != 'true'/,
+  )
   assert.match(upload, /needs: \[prepare, ios, ios-publish\]/)
   assert.match(upload, /needs\.ios\.outputs\.upload_artifact/)
   assert.match(upload, /app-store-connect-build\.mjs upload/)
@@ -512,7 +548,7 @@ test("iOS publishes the signed artifact before submitting those same bytes to Ap
   assert.match(store, /needs\.ios-upload\.outputs\.upload_status/)
 })
 
-test("iOS status reports the failed phase instead of downstream skips", t => {
+test("iOS status reports the failed phase instead of downstream skips", (t) => {
   const dir = mkdtempSync(path.join(tmpdir(), "ios-status-"))
   t.after(() => rmSync(dir, {recursive: true, force: true}))
   const status = jobBlock(workflow("reusable-coordinated-mobile.yml"), "status")
@@ -525,11 +561,21 @@ test("iOS status reports the failed phase instead of downstream skips", t => {
     ["success", "success", "success", "failure", "failure"],
   ]) {
     const output = path.join(dir, `${build}-${publish}-${upload}-${store}`)
-    const result = spawnSync("bash", ["-eu", "-c", script], {encoding: "utf8", env: {
-      ...process.env, GITHUB_OUTPUT: output, ANDROID_RESULT: "success", IOS_BUILD_RESULT: build,
-      IOS_PUBLISH_RESULT: publish, IOS_UPLOAD_RESULT: upload, IOS_STORE_RESULT: store,
-      APK_NAME: "app.apk", IPA_NAME: "app.ipa", ASSET_BASE_URL: "https://example.com",
-    }})
+    const result = spawnSync("bash", ["-eu", "-c", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: output,
+        ANDROID_RESULT: "success",
+        IOS_BUILD_RESULT: build,
+        IOS_PUBLISH_RESULT: publish,
+        IOS_UPLOAD_RESULT: upload,
+        IOS_STORE_RESULT: store,
+        APK_NAME: "app.apk",
+        IPA_NAME: "app.ipa",
+        ASSET_BASE_URL: "https://example.com",
+      },
+    })
     assert.equal(result.status, 0, result.stderr)
     assert.match(readFileSync(output, "utf8"), new RegExp(`^ios_result=${expected}$`, "m"))
   }

--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -337,6 +337,18 @@ test("coordinated docs publish only after finalization to the matching channel",
   assert.match(finalizeExample, /record_name="mentra-example-release-\$identity\.json"/)
   assert.match(finalizeExample, /publish-immutable-release-asset\.mjs/)
   assert.match(finalizeExample, /verify-public-release-asset\.mjs/)
+  // Retries are idempotent: the Starter Kit head the earlier attempt used is
+  // recovered from its candidate (or release tag), and an already-published
+  // example record is reproduced byte-for-byte instead of re-minted.
+  assert.match(
+    starterKit,
+    /candidate_parent=\$\(gh api "repos\/\$STARTER_KIT_REPOSITORY\/commits\/coordinated\/\$identity" --jq '\.parents\[0\]\.sha'/,
+  )
+  assert.match(starterKit, /commits\/sdk-\$identity" --jq '\.parents\[0\]\.sha'/)
+  assert.match(finalizeExample, /--output existing-record\.json/)
+  assert.match(finalizeExample, /completed_at=\$\(jq -er \.completedAt existing-record\.json\)/)
+  assert.match(finalizeExample, /cmp existing-record\.json "finalized-example\/\$record_name"/)
+  assert.match(finalizeExample, /--completed-at "\$completed_at"/)
   assert.match(plan, /Restore the release plan selected by an earlier attempt/)
   assert.match(plan, /actions\/runs\/\$GITHUB_RUN_ID\/artifacts/)
   assert.match(plan, /gh run download "\$GITHUB_RUN_ID"/)

--- a/.github/scripts/create-release-plan.mjs
+++ b/.github/scripts/create-release-plan.mjs
@@ -21,9 +21,6 @@ const args = parseArgs(process.argv.slice(2))
 const channel = args.channel || channelForBranch(args.branch)
 const sequence = channel === "production" ? undefined : Number(args.sequence)
 const otaInputs = args["ota-inputs"] ? JSON.parse(readFileSync(path.resolve(args["ota-inputs"]), "utf8")) : {}
-const starterKitSource = args["starter-kit-source"]
-  ? JSON.parse(readFileSync(path.resolve(args["starter-kit-source"]), "utf8"))
-  : undefined
 const family = loadReleaseFamily({requireVersionMirrors: args["require-version-mirrors"] === "true"})
 const plan = createReleasePlan({
   family,
@@ -32,7 +29,6 @@ const plan = createReleasePlan({
   sourceCommit: args["source-commit"],
   nativeBuildNumber: Number(args["native-build-number"]),
   otaInputs,
-  starterKitSource,
   publicBetaTestflight: args["public-beta-testflight"] === "true",
 })
 const output = path.resolve(args.output || "release-plan.json")

--- a/.github/scripts/example-release-records.mjs
+++ b/.github/scripts/example-release-records.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// The Mentra Bluetooth example release is its own release notion.
+//
+// A coordinated Mentra beta (Cloud V2, the Mentra App, the Engine, and the
+// Bluetooth SDK) is complete when its own finalize step writes
+// mentra-release-<identity>.json. The Starter Kit examples are built afterwards
+// against that finalized beta, published to their own stores, and recorded here
+// as mentra-example-release-<identity>.json. An example that fails to build or
+// publish therefore never makes the beta incomplete, and the production
+// promotion of the beta does not depend on it.
+import {createHash} from "node:crypto"
+import {readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {validateExampleGooglePlay} from "./coordinated-example-google-play.mjs"
+import {requirePublicHttpsUrl, serializeReleaseRecord} from "./release-family.mjs"
+
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+export const EXAMPLE_RELEASE_KIND = "mentra-bluetooth-example"
+
+export function exampleReleaseAssetName(releaseIdentity) {
+  return `mentra-example-release-${releaseIdentity}.json`
+}
+
+function requireIsoUtc(value, label) {
+  const parsed = new Date(value)
+  if (!value || Number.isNaN(parsed.valueOf()) || parsed.toISOString() !== value) {
+    throw new Error(`${label} must be an ISO-8601 UTC timestamp`)
+  }
+  return value
+}
+
+export function verifyExampleTestflight(plan, starterKit, exampleTestflight) {
+  const expectedGroup = plan.channel === "dev" ? "Mentra Dev" : "Mentra Staging Public"
+  const expectedAudience = plan.channel === "dev" ? "internal" : "external"
+  const distribution = exampleTestflight?.distribution
+  if (
+    exampleTestflight?.schemaVersion !== 1 ||
+    exampleTestflight.releaseSetId !== plan.releaseSetId ||
+    exampleTestflight.releaseIdentity !== plan.releaseIdentity ||
+    exampleTestflight.channel !== plan.channel ||
+    exampleTestflight.mentraosSourceCommit !== plan.sourceCommit ||
+    exampleTestflight.starterKitReleaseCommit !== starterKit.starterKit?.releaseCommit ||
+    exampleTestflight.app?.id !== "6792839366" ||
+    exampleTestflight.app?.bundleId !== "com.mentra.bluetoothsdkexample" ||
+    exampleTestflight.version?.marketingVersion !== plan.native.marketingVersion ||
+    exampleTestflight.version?.buildNumber !== plan.native.buildNumber ||
+    exampleTestflight.build?.processingState !== "VALID" ||
+    !["published", "reused"].includes(exampleTestflight.build?.uploadStatus) ||
+    typeof exampleTestflight.build?.id !== "string" ||
+    exampleTestflight.build.id.length === 0 ||
+    exampleTestflight.group?.name !== expectedGroup ||
+    typeof exampleTestflight.group?.id !== "string" ||
+    exampleTestflight.group.id.length === 0 ||
+    distribution?.audience !== expectedAudience ||
+    !["available", "submitted", "skipped"].includes(distribution?.status) ||
+    !/^https:\/\//.test(distribution?.installUrl || "") ||
+    !/^https:\/\//.test(exampleTestflight.provenanceUrl || "")
+  ) {
+    throw new Error("Example TestFlight result does not match the release plan and Starter Kit source")
+  }
+  if (
+    exampleTestflight.ipa !== undefined &&
+    (!SHA256_PATTERN.test(exampleTestflight.ipa.sha256 || "") ||
+      !Number.isSafeInteger(exampleTestflight.ipa.size) ||
+      exampleTestflight.ipa.size < 1)
+  ) {
+    throw new Error("Example TestFlight IPA evidence is invalid")
+  }
+  if (plan.channel === "dev" && distribution.status !== "available") {
+    throw new Error("Internal example TestFlight distribution must be available")
+  }
+  if (expectedAudience === "external" && !/^https:\/\/testflight\.apple\.com\/join\//.test(distribution.installUrl)) {
+    throw new Error("External example TestFlight distribution must use a public invitation link")
+  }
+  if (distribution.status === "skipped" && !distribution.skipReason) {
+    throw new Error("Skipped example TestFlight distribution must identify its reason")
+  }
+  return exampleTestflight
+}
+
+export function verifyStarterKitResult(plan, starterKit, resultUrl, exampleTestflight, exampleGooglePlay) {
+  if (
+    starterKit?.schemaVersion !== 1 ||
+    starterKit.releaseSetId !== plan.releaseSetId ||
+    starterKit.releaseIdentity !== plan.releaseIdentity ||
+    starterKit.familyBaseVersion !== plan.familyBaseVersion ||
+    starterKit.channel !== plan.channel ||
+    starterKit.mentraos?.sourceCommit !== plan.sourceCommit ||
+    !COMMIT_PATTERN.test(starterKit.starterKit?.baseCommit || "")
+  ) {
+    throw new Error("Starter Kit result does not match the release plan")
+  }
+  for (const packageName of ["@mentra/bluetooth-sdk", "@mentra/engine"]) {
+    if (starterKit.packages?.[packageName] !== plan.releaseIdentity) {
+      throw new Error(`Starter Kit ${packageName} version does not match the release plan`)
+    }
+  }
+  if (!/^https:\/\//.test(resultUrl || "")) throw new Error("Starter Kit result URL must be public HTTPS")
+  if (!/^https:\/\//.test(starterKit.starterKit?.validationRunUrl || "")) {
+    throw new Error("Starter Kit validation run URL must be public HTTPS")
+  }
+  if (!Array.isArray(starterKit.artifacts) || ![3, 4].includes(starterKit.artifacts.length)) {
+    throw new Error("Starter Kit result must contain the three required examples and optional native Android")
+  }
+  const keys = new Set()
+  const artifacts = starterKit.artifacts.map((artifact) => {
+    if (
+      !artifact?.key ||
+      keys.has(artifact.key) ||
+      typeof artifact.name !== "string" ||
+      !artifact.name.includes(plan.releaseIdentity) ||
+      !/^https:\/\//.test(artifact.url || "") ||
+      !SHA256_PATTERN.test(artifact.sha256 || "") ||
+      !Number.isSafeInteger(artifact.size) ||
+      artifact.size < 1
+    ) {
+      throw new Error("Starter Kit contains an invalid or duplicate example artifact")
+    }
+    keys.add(artifact.key)
+    return {
+      status: "published",
+      coordinate: artifact.name,
+      url: artifact.url,
+      sha256: artifact.sha256,
+      size: artifact.size,
+      provenanceUrl: starterKit.starterKit.validationRunUrl,
+    }
+  })
+  for (const key of ["ios", "reactNative", "reactNativeElevenLabsAudio"]) {
+    if (!keys.has(key)) throw new Error(`Starter Kit result is missing ${key}`)
+  }
+  return {
+    record: {
+      ...starterKit,
+      resultUrl,
+      testflight: verifyExampleTestflight(plan, starterKit, exampleTestflight),
+      googlePlay: validateExampleGooglePlay(plan, starterKit, exampleGooglePlay),
+    },
+    artifacts,
+  }
+}
+
+function verifyBetaManifest(plan, betaManifest, betaManifestUrl, betaManifestSha256) {
+  if (
+    betaManifest?.schemaVersion !== 1 ||
+    betaManifest.releaseSetId !== plan.releaseSetId ||
+    betaManifest.releaseIdentity !== plan.releaseIdentity ||
+    betaManifest.channel !== plan.channel ||
+    betaManifest.sourceCommit !== plan.sourceCommit ||
+    typeof betaManifest.completedAt !== "string"
+  ) {
+    throw new Error("The example release requires the finalized manifest of the same coordinated beta")
+  }
+  requireIsoUtc(betaManifest.completedAt, "betaManifest.completedAt")
+  if (!SHA256_PATTERN.test(betaManifestSha256 || "")) {
+    throw new Error("betaManifest.sha256 must be a lowercase SHA-256 digest")
+  }
+  return {
+    name: plan.artifactNames.releaseManifest,
+    url: requirePublicHttpsUrl(betaManifestUrl, "betaManifest.url"),
+    sha256: betaManifestSha256,
+    completedAt: betaManifest.completedAt,
+  }
+}
+
+export function assembleExampleReleaseResults({
+  plan,
+  betaManifest,
+  betaManifestUrl,
+  betaManifestSha256,
+  starterKit,
+  starterKitResultUrl,
+  exampleTestflight,
+  exampleGooglePlay,
+  completedAt,
+  provenanceUrl,
+}) {
+  if (plan?.releaseSetId !== `mentra-${plan?.releaseIdentity}` || plan.channel === "production") {
+    throw new Error("The example release requires a coordinated dev or beta release plan")
+  }
+  const beta = verifyBetaManifest(plan, betaManifest, betaManifestUrl, betaManifestSha256)
+  const verified = verifyStarterKitResult(plan, starterKit, starterKitResultUrl, exampleTestflight, exampleGooglePlay)
+  return {
+    schemaVersion: 1,
+    kind: EXAMPLE_RELEASE_KIND,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    familyBaseVersion: plan.familyBaseVersion,
+    channel: plan.channel,
+    sourceCommit: plan.sourceCommit,
+    betaManifest: beta,
+    starterKit: verified.record,
+    artifacts: verified.artifacts,
+    completedAt: requireIsoUtc(completedAt, "completedAt"),
+    provenanceUrl: requirePublicHttpsUrl(provenanceUrl, "provenanceUrl"),
+  }
+}
+
+export function validateExampleReleaseRecord(record, plan) {
+  if (
+    record?.schemaVersion !== 1 ||
+    record.kind !== EXAMPLE_RELEASE_KIND ||
+    record.releaseSetId !== plan.releaseSetId ||
+    record.releaseIdentity !== plan.releaseIdentity ||
+    record.channel !== plan.channel ||
+    record.sourceCommit !== plan.sourceCommit ||
+    record.betaManifest?.name !== plan.artifactNames.releaseManifest ||
+    !SHA256_PATTERN.test(record.betaManifest?.sha256 || "") ||
+    !Array.isArray(record.artifacts) ||
+    record.artifacts.length < 3 ||
+    !COMMIT_PATTERN.test(record.starterKit?.starterKit?.mergeCommit || "")
+  ) {
+    throw new Error("Example release record does not describe a finalized Mentra Bluetooth example")
+  }
+  requirePublicHttpsUrl(record.betaManifest.url, "betaManifest.url")
+  requireIsoUtc(record.betaManifest.completedAt, "betaManifest.completedAt")
+  requireIsoUtc(record.completedAt, "completedAt")
+  requirePublicHttpsUrl(record.provenanceUrl, "provenanceUrl")
+  return record
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(path.resolve(file), "utf8"))
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const betaManifestBytes = readFileSync(path.resolve(args["beta-manifest"]))
+  const record = assembleExampleReleaseResults({
+    plan: readJson(args.plan),
+    betaManifest: JSON.parse(betaManifestBytes.toString("utf8")),
+    betaManifestUrl: args["beta-manifest-url"],
+    betaManifestSha256: createHash("sha256").update(betaManifestBytes).digest("hex"),
+    starterKit: readJson(args["starter-kit"]),
+    starterKitResultUrl: args["starter-kit-result-url"],
+    exampleTestflight: readJson(args["example-testflight"]),
+    exampleGooglePlay: readJson(args["example-google-play"]),
+    completedAt: args["completed-at"],
+    provenanceUrl: args["provenance-url"],
+  })
+  writeFileSync(path.resolve(args.output), serializeReleaseRecord(record))
+  console.log(`Wrote ${record.kind} ${record.releaseIdentity} to ${args.output}`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/example-release-records.test.mjs
+++ b/.github/scripts/example-release-records.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict"
+import path from "node:path"
+import test from "node:test"
+import {fileURLToPath} from "node:url"
+
+import {
+  EXAMPLE_RELEASE_KIND,
+  assembleExampleReleaseResults,
+  exampleReleaseAssetName,
+  validateExampleReleaseRecord,
+  verifyStarterKitResult,
+} from "./example-release-records.mjs"
+import {createReleasePlan, loadReleaseFamily} from "./release-family.mjs"
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const provenanceUrl = "https://github.com/Mentra-Community/MentraOS/actions/runs/123"
+
+function planFor(channel = "beta") {
+  return createReleasePlan({
+    family: loadReleaseFamily({rootDir}),
+    channel,
+    sequence: 57,
+    sourceCommit: "a".repeat(40),
+    nativeBuildNumber: 310000057,
+  })
+}
+
+function fixtures(plan) {
+  const betaManifest = {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    channel: plan.channel,
+    sourceCommit: plan.sourceCommit,
+    completedAt: "2026-08-25T01:00:00.000Z",
+  }
+  const starterKit = {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    familyBaseVersion: plan.familyBaseVersion,
+    channel: plan.channel,
+    mentraos: {sourceCommit: plan.sourceCommit, coordinatorRunUrl: provenanceUrl},
+    ota: {manifestUrl: "https://example.com/ota.json", manifestSha256: "c".repeat(64)},
+    starterKit: {
+      baseCommit: "1".repeat(40),
+      releaseCommit: "2".repeat(40),
+      mergeCommit: "3".repeat(40),
+      sourceTag: `sdk-${plan.releaseIdentity}`,
+      artifactContainerTag: `sdk-builds-v${plan.familyBaseVersion}`,
+      releaseUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/tag/sdk-builds-v3.1.0",
+      pullRequestUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/51",
+      validationRunUrl: "https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/456",
+    },
+    packages: {
+      "@mentra/bluetooth-sdk": plan.releaseIdentity,
+      "@mentra/engine": plan.releaseIdentity,
+    },
+    artifacts: ["ios", "reactNative", "reactNativeElevenLabsAudio"].map((key, index) => ({
+      key,
+      name: `mentra-example-${key}-${plan.releaseIdentity}.${key === "ios" ? "ipa" : "apk"}`,
+      url: `https://example.com/mentra-example-${key}-${plan.releaseIdentity}`,
+      size: index + 1,
+      sha256: String(index + 1).repeat(64),
+      contentType: "application/octet-stream",
+    })),
+  }
+  const exampleTestflight = {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    channel: plan.channel,
+    mentraosSourceCommit: plan.sourceCommit,
+    starterKitReleaseCommit: starterKit.starterKit.releaseCommit,
+    app: {id: "6792839366", bundleId: "com.mentra.bluetoothsdkexample"},
+    version: {marketingVersion: plan.native.marketingVersion, buildNumber: plan.native.buildNumber},
+    build: {id: "build-1", processingState: "VALID", uploadStatus: "published"},
+    group: {id: "group-1", name: "Mentra Staging Public"},
+    distribution: {
+      audience: "external",
+      status: "submitted",
+      installUrl: "https://testflight.apple.com/join/public123",
+      reviewState: "WAITING_FOR_REVIEW",
+    },
+    provenanceUrl,
+    ipa: {size: 123, sha256: "9".repeat(64)},
+  }
+  const exampleGooglePlay = {
+    schemaVersion: 1,
+    releaseSetId: plan.releaseSetId,
+    releaseIdentity: plan.releaseIdentity,
+    channel: plan.channel,
+    mentraosSourceCommit: plan.sourceCommit,
+    starterKitReleaseCommit: starterKit.starterKit.releaseCommit,
+    packageId: "com.mentra.bluetoothsdkexample",
+    version: {marketingVersion: plan.native.marketingVersion, buildNumber: plan.native.buildNumber},
+    track: "beta",
+    uploadStatus: "published",
+    distribution: {
+      status: "submitted",
+      audience: "external",
+      installUrl: "https://play.google.com/apps/testing/com.mentra.bluetoothsdkexample",
+    },
+    aab: {
+      url: `https://github.com/Mentra-Community/MentraOS/releases/download/${plan.artifactContainerTag}/mentra-example-react-native-${plan.releaseIdentity}.aab`,
+      sha256: "8".repeat(64),
+      size: 123,
+    },
+    provenanceUrl,
+  }
+  return {betaManifest, starterKit, exampleTestflight, exampleGooglePlay}
+}
+
+function assemble(plan, overrides = {}) {
+  const {betaManifest, starterKit, exampleTestflight, exampleGooglePlay} = fixtures(plan)
+  return assembleExampleReleaseResults({
+    plan,
+    betaManifest,
+    betaManifestUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/${plan.artifactContainerTag}/${plan.artifactNames.releaseManifest}`,
+    betaManifestSha256: "b".repeat(64),
+    starterKit,
+    starterKitResultUrl: "https://example.com/starter-kit-result.json",
+    exampleTestflight,
+    exampleGooglePlay,
+    completedAt: "2026-08-25T02:00:00.000Z",
+    provenanceUrl,
+    ...overrides,
+  })
+}
+
+test("finalizes the Bluetooth example as its own record against a finalized beta", () => {
+  const plan = planFor()
+  const record = assemble(plan)
+
+  assert.equal(record.kind, EXAMPLE_RELEASE_KIND)
+  assert.equal(record.releaseIdentity, plan.releaseIdentity)
+  assert.equal(record.betaManifest.name, plan.artifactNames.releaseManifest)
+  assert.equal(record.betaManifest.completedAt, "2026-08-25T01:00:00.000Z")
+  assert.equal(record.starterKit.resultUrl, "https://example.com/starter-kit-result.json")
+  assert.equal(record.starterKit.testflight.build.id, "build-1")
+  assert.equal(record.starterKit.googlePlay.track, "beta")
+  assert.deepEqual(
+    record.artifacts.map((artifact) => artifact.coordinate),
+    fixtures(plan).starterKit.artifacts.map((artifact) => artifact.name),
+  )
+  assert.equal(exampleReleaseAssetName(plan.releaseIdentity), `mentra-example-release-${plan.releaseIdentity}.json`)
+  assert.equal(validateExampleReleaseRecord(record, plan), record)
+})
+
+test("the example release cannot be assembled without the finalized beta it was built against", () => {
+  const plan = planFor()
+  const {betaManifest} = fixtures(plan)
+  assert.throws(
+    () => assemble(plan, {betaManifest: {...betaManifest, releaseIdentity: "3.1.0-beta.56"}}),
+    /finalized manifest of the same coordinated beta/,
+  )
+  assert.throws(
+    () => assemble(plan, {betaManifest: {...betaManifest, completedAt: undefined}}),
+    /finalized manifest of the same coordinated beta/,
+  )
+  assert.throws(() => assemble(plan, {betaManifestSha256: "nope"}), /SHA-256/)
+  assert.throws(() => assemble(plan, {betaManifestUrl: "http://example.com/beta.json"}), /HTTPS/)
+})
+
+test("the example release verifies the Starter Kit evidence on its own terms", () => {
+  const plan = planFor()
+  const {starterKit} = fixtures(plan)
+  assert.throws(() => assemble(plan, {starterKit: undefined}), /Starter Kit result does not match the release plan/)
+  assert.throws(
+    () => assemble(plan, {starterKit: {...starterKit, releaseSetId: "mentra-other"}}),
+    /Starter Kit result does not match the release plan/,
+  )
+  assert.throws(
+    () => assemble(plan, {starterKit: {...starterKit, starterKit: {...starterKit.starterKit, baseCommit: "abc"}}}),
+    /Starter Kit result does not match the release plan/,
+  )
+  assert.throws(
+    () => assemble(plan, {starterKit: {...starterKit, packages: {"@mentra/bluetooth-sdk": "0.0.0"}}}),
+    /version does not match/,
+  )
+  // Any Starter Kit channel head is acceptable: the Mentra plan no longer pins one.
+  const other = {...starterKit, starterKit: {...starterKit.starterKit, baseCommit: "f".repeat(40)}}
+  assert.equal(
+    verifyStarterKitResult(
+      plan,
+      other,
+      "https://example.com/r.json",
+      fixtures(plan).exampleTestflight,
+      fixtures(plan).exampleGooglePlay,
+    ).record.starterKit.baseCommit,
+    "f".repeat(40),
+  )
+})
+
+test("only dev and beta plans have an example release", () => {
+  const family = loadReleaseFamily({rootDir})
+  const production = createReleasePlan({
+    family,
+    channel: "production",
+    sourceCommit: "a".repeat(40),
+    nativeBuildNumber: 3100057,
+  })
+  assert.throws(() => assemble(production), /coordinated dev or beta release plan/)
+})
+
+test("validation rejects records that do not describe a finalized example", () => {
+  const plan = planFor()
+  const record = assemble(plan)
+  assert.throws(
+    () => validateExampleReleaseRecord({...record, kind: "other"}, plan),
+    /finalized Mentra Bluetooth example/,
+  )
+  assert.throws(
+    () => validateExampleReleaseRecord({...record, artifacts: []}, plan),
+    /finalized Mentra Bluetooth example/,
+  )
+  assert.throws(
+    () => validateExampleReleaseRecord({...record, betaManifest: {...record.betaManifest, sha256: "x"}}, plan),
+    /finalized Mentra Bluetooth example/,
+  )
+})

--- a/.github/scripts/notify-coordinated-release-slack.sh
+++ b/.github/scripts/notify-coordinated-release-slack.sh
@@ -118,7 +118,10 @@ if [[ -n "${DOCS_URL:-}" ]]; then
   docs_detail="<${DOCS_URL}|Open docs>"
 fi
 
-if [[ "${FINALIZE_RESULT:-}" == "success" && "${DOCS_RESULT:-}" == "success" ]]; then
+# The Mentra release (Cloud V2, Mentra App, Engine, Bluetooth SDK) is complete
+# when finalize succeeds. The Bluetooth example is its own release notion and
+# is reported separately below; it never makes the Mentra release incomplete.
+if [[ "${FINALIZE_RESULT:-}" == "success" ]]; then
   header_icon=":white_check_mark:"
   header_text="$channel_label release complete"
 elif [[ "$android_result" == "success" || "$ios_result" == "success" || "${OTA_RESULT:-}" == "success" ]]; then
@@ -142,12 +145,13 @@ if [[ -n "${TESTFLIGHT_INSTALL_URL:-}" ]]; then
   ios_line+=" - <${TESTFLIGHT_INSTALL_URL}|Join TestFlight>"
 fi
 asg_line="*$(icon "${OTA_RESULT:-unknown}") ASG + OTA* - $(label "${OTA_RESULT:-unknown}") - ${asg_detail}"
-starter_line="*$(icon "${STARTER_KIT_RESULT:-unknown}") Starter Kit* - $(label "${STARTER_KIT_RESULT:-unknown}") - ${starter_detail}${newline}React Native iOS TestFlight: ${example_testflight_icon} ${example_testflight_detail}"
+starter_line="*$(icon "${FINALIZE_EXAMPLE_RESULT:-unknown}") Bluetooth example* - $(label "${FINALIZE_EXAMPLE_RESULT:-unknown}") - Starter Kit build: $(icon "${STARTER_KIT_RESULT:-unknown}") $(label "${STARTER_KIT_RESULT:-unknown}") - ${starter_detail}${newline}React Native iOS TestFlight: ${example_testflight_icon} ${example_testflight_detail}"
 starter_line+="${newline}React Native Android Google Play: $(icon "${EXAMPLE_GOOGLE_PLAY_RESULT:-unknown}") ${example_play_detail}"
 docs_line="*$(icon "${DOCS_RESULT:-unknown}") Docs* - $(label "${DOCS_RESULT:-unknown}") - ${docs_detail}"
 checks_line="*Release checks*${newline}Plan: $(icon "${PLAN_RESULT:-unknown}") $(label "${PLAN_RESULT:-unknown}") | Cloud V2: $(icon "${CLOUD_V2_RESULT:-unknown}") $(label "${CLOUD_V2_RESULT:-unknown}") | Packages: $(icon "${NPM_RESULT:-unknown}") $(label "${NPM_RESULT:-unknown}") | Native SDK: $(icon "${SDK_NATIVE_RESULT:-unknown}") $(label "${SDK_NATIVE_RESULT:-unknown}") | Engine consumer: $(icon "${ENGINE_RESULT:-unknown}") $(label "${ENGINE_RESULT:-unknown}") | Examples: $(icon "${STARTER_KIT_RESULT:-unknown}") $(label "${STARTER_KIT_RESULT:-unknown}") | Example TestFlight: $(icon "${EXAMPLE_TESTFLIGHT_RESULT:-unknown}") $(label "${EXAMPLE_TESTFLIGHT_RESULT:-unknown}") | Finalize: $(icon "${FINALIZE_RESULT:-unknown}") $(label "${FINALIZE_RESULT:-unknown}")"
 
 checks_line+=" | Example Google Play: $(icon "${EXAMPLE_GOOGLE_PLAY_RESULT:-unknown}") $(label "${EXAMPLE_GOOGLE_PLAY_RESULT:-unknown}")"
+checks_line+=" | Example finalize: $(icon "${FINALIZE_EXAMPLE_RESULT:-unknown}") $(label "${FINALIZE_EXAMPLE_RESULT:-unknown}")"
 
 payload=$(jq -n \
   --arg header "$header_icon $header_text" \

--- a/.github/scripts/release-family.mjs
+++ b/.github/scripts/release-family.mjs
@@ -3,7 +3,6 @@ import {createHash} from "node:crypto"
 import path from "node:path"
 
 import {validateCloudV2DeploymentRecord} from "./coordinated-cloud-v2-records.mjs"
-import {validateExampleGooglePlay} from "./coordinated-example-google-play.mjs"
 import {validateMentraosTestflightDistribution} from "./mentraos-testflight-distribution.mjs"
 
 const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
@@ -252,7 +251,6 @@ export function createReleasePlan({
   sourceCommit,
   nativeBuildNumber,
   otaInputs = {},
-  starterKitSource,
   publicBetaTestflight = false,
 }) {
   if (!family?.members || !family?.familyBaseVersion) throw new Error("A validated release family is required")
@@ -266,16 +264,6 @@ export function createReleasePlan({
   }
 
   const releaseIdentity = deriveReleaseIdentity(family.familyBaseVersion, channel, sequence)
-  if (starterKitSource !== undefined) {
-    const expectedBranch = channel === "dev" ? "dev" : channel === "beta" ? "staging" : "main"
-    if (
-      starterKitSource.repository !== "Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit" ||
-      starterKitSource.branch !== expectedBranch ||
-      !COMMIT_PATTERN.test(starterKitSource.sourceCommit || "")
-    ) {
-      throw new Error("starterKitSource must identify the exact channel branch and commit")
-    }
-  }
   const members = Object.fromEntries(
     family.members.map((member) => [
       member.name,
@@ -306,12 +294,13 @@ export function createReleasePlan({
     native: {
       marketingVersion: family.familyBaseVersion,
       buildNumber: nativeBuildNumber,
-      ...(channel === "beta" && publicBetaTestflight ? {testflight: {group: "Mentra Staging Public", audience: "external"}} : {}),
+      ...(channel === "beta" && publicBetaTestflight
+        ? {testflight: {group: "Mentra Staging Public", audience: "external"}}
+        : {}),
     },
     products: Object.fromEntries(family.products.map((product) => [product, releaseIdentity])),
     members,
     publicationOrder: family.publicationOrder,
-    ...(starterKitSource ? {starterKitSource: {...starterKitSource}} : {}),
     artifactNames: {
       releasePlan: `mentra-release-plan-${releaseIdentity}.json`,
       releaseManifest: `mentra-release-${releaseIdentity}.json`,
@@ -391,7 +380,10 @@ function expectedPublicationCoordinate(plan, memberName, target) {
   if (target === "google-play") return `com.mentra.mentra:${plan.native.buildNumber}:${selected.play}`
   if (target === "app-store-connect") {
     const group = plan.native.testflight?.group || selected.appStore
-    if (plan.native.testflight && (plan.channel !== "beta" || group !== "Mentra Staging Public" || plan.native.testflight.audience !== "external")) {
+    if (
+      plan.native.testflight &&
+      (plan.channel !== "beta" || group !== "Mentra Staging Public" || plan.native.testflight.audience !== "external")
+    ) {
       throw new Error("Invalid MentraOS public TestFlight policy")
     }
     return `com.mentra.mentra:${plan.native.marketingVersion}:${plan.native.buildNumber}:${group}`
@@ -411,125 +403,6 @@ function requiredArtifactCoordinates(plan) {
     }
     return coordinate
   })
-}
-
-function validateStarterKitEvidence(plan, starterKit, artifacts) {
-  if (starterKit === undefined) return undefined
-  if (
-    starterKit?.schemaVersion !== 1 ||
-    starterKit.releaseSetId !== plan.releaseSetId ||
-    starterKit.releaseIdentity !== plan.releaseIdentity ||
-    starterKit.familyBaseVersion !== plan.familyBaseVersion ||
-    starterKit.channel !== plan.channel ||
-    starterKit.mentraos?.sourceCommit !== plan.sourceCommit ||
-    (plan.starterKitSource && starterKit.starterKit?.baseCommit !== plan.starterKitSource.sourceCommit) ||
-    !Array.isArray(starterKit.artifacts) ||
-    ![3, 4].includes(starterKit.artifacts.length)
-  ) {
-    throw new Error("Starter Kit evidence does not match the release plan")
-  }
-  requirePublicHttpsUrl(starterKit.resultUrl, "starterKit.resultUrl")
-  requirePublicHttpsUrl(starterKit.starterKit?.releaseUrl, "starterKit.starterKit.releaseUrl")
-  requirePublicHttpsUrl(starterKit.starterKit?.pullRequestUrl, "starterKit.starterKit.pullRequestUrl")
-  requirePublicHttpsUrl(starterKit.starterKit?.validationRunUrl, "starterKit.starterKit.validationRunUrl")
-
-  const artifactByCoordinate = new Map(artifacts.map((artifact) => [artifact.coordinate, artifact]))
-  for (const example of starterKit.artifacts) {
-    const artifact = artifactByCoordinate.get(example.name)
-    if (
-      !artifact ||
-      artifact.url !== example.url ||
-      artifact.sha256 !== example.sha256 ||
-      artifact.size !== example.size
-    ) {
-      throw new Error(`Starter Kit artifact ${example.name || "<unknown>"} differs from publication evidence`)
-    }
-  }
-  const expectedGroup = plan.channel === "dev" ? "Mentra Dev" : "Mentra Staging Public"
-  const expectedAudience = plan.channel === "dev" ? "internal" : "external"
-  const testflight = starterKit.testflight
-  if (
-    testflight?.schemaVersion !== 1 ||
-    testflight.releaseSetId !== plan.releaseSetId ||
-    testflight.releaseIdentity !== plan.releaseIdentity ||
-    testflight.channel !== plan.channel ||
-    testflight.mentraosSourceCommit !== plan.sourceCommit ||
-    testflight.starterKitReleaseCommit !== starterKit.starterKit?.releaseCommit ||
-    testflight.app?.id !== "6792839366" ||
-    testflight.app?.bundleId !== "com.mentra.bluetoothsdkexample" ||
-    testflight.version?.marketingVersion !== plan.native.marketingVersion ||
-    testflight.version?.buildNumber !== plan.native.buildNumber ||
-    testflight.build?.processingState !== "VALID" ||
-    !["published", "reused"].includes(testflight.build?.uploadStatus) ||
-    typeof testflight.build?.id !== "string" ||
-    testflight.build.id.length === 0 ||
-    testflight.group?.name !== expectedGroup ||
-    typeof testflight.group?.id !== "string" ||
-    testflight.group.id.length === 0 ||
-    testflight.distribution?.audience !== expectedAudience ||
-    !["available", "submitted", "skipped"].includes(testflight.distribution?.status) ||
-    !/^https:\/\//.test(testflight.distribution?.installUrl || "")
-  ) {
-    throw new Error("Starter Kit TestFlight evidence does not match the release plan")
-  }
-  if (plan.channel === "dev" && testflight.distribution.status !== "available") {
-    throw new Error("Internal Starter Kit TestFlight distribution must be available")
-  }
-  if (
-    expectedAudience === "external" &&
-    !/^https:\/\/testflight\.apple\.com\/join\//.test(testflight.distribution.installUrl)
-  ) {
-    throw new Error("External Starter Kit TestFlight distribution must use a public invitation link")
-  }
-  if (testflight.distribution.status === "skipped" && !testflight.distribution.skipReason) {
-    throw new Error("Skipped Starter Kit TestFlight distribution must identify its reason")
-  }
-  if (
-    testflight.ipa !== undefined &&
-    (!SHA256_PATTERN.test(testflight.ipa.sha256 || "") ||
-      !Number.isSafeInteger(testflight.ipa.size) ||
-      testflight.ipa.size < 1)
-  ) {
-    throw new Error("Starter Kit TestFlight IPA evidence is invalid")
-  }
-  requirePublicHttpsUrl(testflight.provenanceUrl, "starterKit.testflight.provenanceUrl")
-  // Older immutable manifests predate Play distribution; new assembly requires it.
-  if (starterKit.googlePlay !== undefined) validateExampleGooglePlay(plan, starterKit, starterKit.googlePlay)
-  return starterKit
-}
-
-function validateProductionExampleTestflight(plan, testflight) {
-  if (plan.channel !== "production") return undefined
-  if (
-    testflight?.schemaVersion !== 1 ||
-    testflight.releaseSetId !== plan.releaseSetId ||
-    testflight.releaseIdentity !== plan.releaseIdentity ||
-    testflight.channel !== "production" ||
-    testflight.selectedBetaReleaseSetId !== plan.promotion?.selectedBetaReleaseSetId ||
-    testflight.selectedBetaIdentity !== plan.promotion?.selectedBetaIdentity ||
-    testflight.app?.id !== "6792839366" ||
-    testflight.app?.bundleId !== "com.mentra.bluetoothsdkexample" ||
-    testflight.version?.marketingVersion !== plan.native?.marketingVersion ||
-    testflight.version?.buildNumber !== plan.native?.buildNumber ||
-    testflight.build?.processingState !== "VALID" ||
-    testflight.group?.name !== "Mentra Production Public" ||
-    testflight.distribution?.audience !== "external" ||
-    testflight.distribution?.status !== "available" ||
-    testflight.distribution?.reviewState !== "APPROVED"
-  ) {
-    throw new Error("Production example TestFlight evidence does not match the release plan")
-  }
-  requireString(testflight.build.id, "exampleTestflight.build.id")
-  requireString(testflight.group.id, "exampleTestflight.group.id")
-  requirePublicHttpsUrl(
-    testflight.build.sourceTestflightProvenanceUrl,
-    "exampleTestflight.build.sourceTestflightProvenanceUrl",
-  )
-  requirePublicHttpsUrl(testflight.provenanceUrl, "exampleTestflight.provenanceUrl")
-  if (!/^https:\/\/testflight\.apple\.com\/join\//.test(testflight.distribution.installUrl || "")) {
-    throw new Error("Production example TestFlight distribution must use a public invitation link")
-  }
-  return testflight
 }
 
 export function finalizeReleaseManifest({plan, results, completedAt}) {
@@ -588,8 +461,6 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
   for (const coordinate of requiredArtifactCoordinates(plan)) {
     if (!artifactCoordinates.has(coordinate)) throw new Error(`Missing required artifact ${coordinate}`)
   }
-  const starterKit = validateStarterKitEvidence(plan, results.starterKit, artifacts)
-  const exampleTestflight = validateProductionExampleTestflight(plan, results.exampleTestflight)
   const cloud = validateCloudV2DeploymentRecord({plan, record: results.cloud})
 
   let promotion
@@ -625,8 +496,6 @@ export function finalizeReleaseManifest({plan, results, completedAt}) {
     otaManifest,
     artifacts,
     cloud,
-    ...(starterKit ? {starterKit} : {}),
-    ...(exampleTestflight ? {exampleTestflight} : {}),
     ...(promotion ? {promotion} : {}),
   }
 }

--- a/.github/scripts/release-family.test.mjs
+++ b/.github/scripts/release-family.test.mjs
@@ -136,37 +136,6 @@ test("creates a deterministic release plan with exact dependency versions", () =
   assert.equal(productionPlan.artifactContainerName, "Mentra 3.1.0")
 })
 
-test("pins the exact Starter Kit source for the selected channel", () => {
-  const family = loadReleaseFamily({rootDir: repositoryRoot})
-  const starterKitSource = {
-    repository: "Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit",
-    branch: "staging",
-    sourceCommit: "c".repeat(40),
-  }
-  const plan = createReleasePlan({
-    family,
-    channel: "beta",
-    sequence: 57,
-    sourceCommit: "a".repeat(40),
-    nativeBuildNumber: 3100057,
-    starterKitSource,
-  })
-
-  assert.deepEqual(plan.starterKitSource, starterKitSource)
-  assert.throws(
-    () =>
-      createReleasePlan({
-        family,
-        channel: "beta",
-        sequence: 57,
-        sourceCommit: "a".repeat(40),
-        nativeBuildNumber: 3100057,
-        starterKitSource: {...starterKitSource, branch: "dev"},
-      }),
-    /exact channel branch and commit/,
-  )
-})
-
 test("serializes records canonically and finalizes only complete release results", () => {
   const family = loadReleaseFamily({rootDir: repositoryRoot})
   const plan = createReleasePlan({
@@ -221,33 +190,75 @@ test("serializes records canonically and finalizes only complete release results
   assert.deepEqual(manifest.changelog, plan.changelog)
   assert.equal(manifest.cloud.environment, "staging")
   const publicPlan = createReleasePlan({
-    family, channel: "beta", sequence: 57, sourceCommit: "a".repeat(40),
-    nativeBuildNumber: 3100057, publicBetaTestflight: true,
+    family,
+    channel: "beta",
+    sequence: 57,
+    sourceCommit: "a".repeat(40),
+    nativeBuildNumber: 3100057,
+    publicBetaTestflight: true,
   })
   assert.deepEqual(publicPlan.native.testflight, {group: "Mentra Staging Public", audience: "external"})
   const publicResults = structuredClone(results)
   const ios = publicResults.publications.mentraos["app-store-connect"]
   ios.coordinate = `com.mentra.mentra:${publicPlan.native.marketingVersion}:${publicPlan.native.buildNumber}:Mentra Staging Public`
-  assert.throws(() => finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"}), /distribution evidence/)
+  assert.throws(
+    () => finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"}),
+    /distribution evidence/,
+  )
   ios.testflight = {
-    group: "Mentra Staging Public", audience: "external", status: "submitted", buildId: "build-1",
-    installUrl: "https://testflight.apple.com/join/public123", reviewState: "WAITING_FOR_REVIEW",
+    group: "Mentra Staging Public",
+    audience: "external",
+    status: "submitted",
+    buildId: "build-1",
+    installUrl: "https://testflight.apple.com/join/public123",
+    reviewState: "WAITING_FOR_REVIEW",
   }
-  const publicManifest = finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"})
+  const publicManifest = finalizeReleaseManifest({
+    plan: publicPlan,
+    results: publicResults,
+    completedAt: "2026-08-24T20:00:00.000Z",
+  })
   assert.equal(publicManifest.publications.mentraos["app-store-connect"].testflight.status, "submitted")
   ios.testflight.status = "available"
-  assert.throws(() => finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"}), /approved review/)
+  assert.throws(
+    () => finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"}),
+    /approved review/,
+  )
   ios.testflight.reviewState = "APPROVED"
-  const approvedManifest = finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"})
+  const approvedManifest = finalizeReleaseManifest({
+    plan: publicPlan,
+    results: publicResults,
+    completedAt: "2026-08-24T20:00:00.000Z",
+  })
   assert.equal(approvedManifest.publications.mentraos["app-store-connect"].testflight.status, "available")
   ios.testflight.status = "skipped"
   ios.testflight.reviewState = "IN_REVIEW"
-  assert.throws(() => finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"}), /identify its reason/)
+  assert.throws(
+    () => finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"}),
+    /identify its reason/,
+  )
   ios.testflight.skipReason = "external_review_pending"
-  const skippedManifest = finalizeReleaseManifest({plan: publicPlan, results: publicResults, completedAt: "2026-08-24T20:00:00.000Z"})
+  const skippedManifest = finalizeReleaseManifest({
+    plan: publicPlan,
+    results: publicResults,
+    completedAt: "2026-08-24T20:00:00.000Z",
+  })
   assert.equal(skippedManifest.publications.mentraos["app-store-connect"].testflight.status, "skipped")
-  assert.equal(skippedManifest.publications.mentraos["app-store-connect"].testflight.skipReason, "external_review_pending")
-  assert.equal(createReleasePlan({family, channel: "dev", sequence: 57, sourceCommit: "a".repeat(40), nativeBuildNumber: 3100057, publicBetaTestflight: true}).native.testflight, undefined)
+  assert.equal(
+    skippedManifest.publications.mentraos["app-store-connect"].testflight.skipReason,
+    "external_review_pending",
+  )
+  assert.equal(
+    createReleasePlan({
+      family,
+      channel: "dev",
+      sequence: 57,
+      sourceCommit: "a".repeat(40),
+      nativeBuildNumber: 3100057,
+      publicBetaTestflight: true,
+    }).native.testflight,
+    undefined,
+  )
   assert.equal(serializeReleaseRecord({z: 1, a: 2}), '{\n  "a": 2,\n  "z": 1\n}\n')
 
   const incompletePlan = structuredClone(plan)

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -393,7 +393,23 @@ jobs:
             *) echo "Unsupported prerelease Starter Kit channel $channel" >&2; exit 1 ;;
           esac
 
-          expected_head=$(git ls-remote "https://github.com/$STARTER_KIT_REPOSITORY.git" "refs/heads/$target_branch" | awk '{print $1}')
+          # The Starter Kit repository builds every coordinated example from its
+          # own channel head, so nothing about it is frozen in the Mentra plan.
+          # A retry must still resend the head the earlier attempt used: the
+          # Starter Kit only accepts a byte-identical payload whose head is the
+          # parent of the candidate it already created. Recover that head from
+          # the candidate branch, or from the release tag if the candidate was
+          # already merged and the branch deleted, before sampling a new head.
+          candidate_parent=$(gh api "repos/$STARTER_KIT_REPOSITORY/commits/coordinated/$identity" --jq '.parents[0].sha' 2>/dev/null || true)
+          if [[ ! "$candidate_parent" =~ ^[0-9a-f]{40}$ ]]; then
+            candidate_parent=$(gh api "repos/$STARTER_KIT_REPOSITORY/commits/sdk-$identity" --jq '.parents[0].sha' 2>/dev/null || true)
+          fi
+          if [[ "$candidate_parent" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Reusing the Starter Kit head $candidate_parent recorded by the earlier request for $identity"
+            expected_head="$candidate_parent"
+          else
+            expected_head=$(git ls-remote "https://github.com/$STARTER_KIT_REPOSITORY.git" "refs/heads/$target_branch" | awk '{print $1}')
+          fi
           [[ "$expected_head" =~ ^[0-9a-f]{40}$ ]]
           payload=$(jq -cn \
             --arg releaseSetId "$release_set_id" \
@@ -920,6 +936,19 @@ jobs:
           test -n "$starter_kit_result"
           test -n "$example_testflight"
           record_name="mentra-example-release-$identity.json"
+          record_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/$record_name"
+          # Immutable asset: a retry after a partial publication must reproduce
+          # the exact bytes already on the release, so reuse that record's
+          # completion time and provenance instead of minting new ones.
+          completed_at=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+          provenance_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          if curl --fail --silent --show-error --location "$record_url" --output existing-record.json 2>/dev/null; then
+            echo "Reconciling against the example record already published at $record_url"
+            completed_at=$(jq -er .completedAt existing-record.json)
+            provenance_url=$(jq -er .provenanceUrl existing-record.json)
+          else
+            rm -f existing-record.json
+          fi
           node .github/scripts/example-release-records.mjs \
             --plan "$plan" \
             --beta-manifest "$beta_manifest" \
@@ -928,14 +957,17 @@ jobs:
             --starter-kit-result-url "${{ needs.starter-kit.outputs.result_url }}" \
             --example-testflight "$example_testflight" \
             --example-google-play release-input/example-google-play/example-google-play-publication.json \
-            --completed-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-            --provenance-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --completed-at "$completed_at" \
+            --provenance-url "$provenance_url" \
             --output "finalized-example/$record_name"
+          if [[ -f existing-record.json ]]; then
+            cmp existing-record.json "finalized-example/$record_name"
+          fi
           {
             echo "tag=$tag"
             echo "identity=$identity"
             echo "record_name=$record_name"
-            echo "record_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/$record_name"
+            echo "record_url=$record_url"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish and verify the immutable example release record

--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -113,7 +113,6 @@ jobs:
           artifact=$(jq -er '.[0].name' <<< "$matches")
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "$artifact" --dir restored-plan
           cp restored-plan/release-plan.json release-plan.json
-          jq -e .starterKitSource release-plan.json > starter-kit-source.json
           echo "restored=true" >> "$GITHUB_OUTPUT"
 
       - name: Collect promoted firmware inputs
@@ -121,30 +120,6 @@ jobs:
 
       - name: Verify generated changelog catalogs
         run: node .github/scripts/generate-changelog-catalog.mjs --check
-
-      - name: Freeze the Starter Kit channel source
-        if: steps.restore-plan.outputs.restored != 'true'
-        run: |
-          set -euo pipefail
-          starter_repository=Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
-          case "${{ github.ref_name }}" in
-            dev) starter_branch=dev ;;
-            staging)
-              starter_branch=staging
-              starter_head=$(git log -1 --format='%(trailers:key=Starter-Kit-Source,valueonly)' | tr -d '[:space:]')
-              ;;
-            *) echo "Unsupported Starter Kit channel for ${{ github.ref_name }}" >&2; exit 1 ;;
-          esac
-          if [[ -z "${starter_head:-}" ]]; then
-            starter_head=$(git ls-remote "https://github.com/$starter_repository.git" "refs/heads/$starter_branch" | awk '{print $1}')
-          fi
-          [[ "$starter_head" =~ ^[0-9a-f]{40}$ ]]
-          jq -n \
-            --arg repository "$starter_repository" \
-            --arg branch "$starter_branch" \
-            --arg sourceCommit "$starter_head" \
-            '{repository: $repository, branch: $branch, sourceCommit: $sourceCommit}' \
-            > starter-kit-source.json
 
       - name: Create deterministic release plan
         run: |
@@ -160,7 +135,6 @@ jobs:
             --source-commit "${{ github.sha }}" \
             --native-build-number "$((310000000 + ${{ github.run_number }}))" \
             --ota-inputs ota-release-inputs.json \
-            --starter-kit-source starter-kit-source.json \
             --require-version-mirrors true \
             --public-beta-testflight true \
             --output "$output"
@@ -175,7 +149,6 @@ jobs:
             --source-commit "${{ github.sha }}" \
             --native-build-number "$((310000000 + ${{ github.run_number }}))" \
             --ota-inputs ota-release-inputs.json \
-            --starter-kit-source starter-kit-source.json \
             --require-version-mirrors true \
             --public-beta-testflight true \
             --output release-plan.json
@@ -355,7 +328,9 @@ jobs:
 
   starter-kit:
     name: Build coordinated Starter Kit examples
-    needs: [plan, ota, npm, sdk-native]
+    # Runs only after the Mentra beta is finalized: the example is its own
+    # release notion built against a complete beta, never a gate on it.
+    needs: [plan, ota, npm, sdk-native, finalize]
     runs-on: ubuntu-latest
     timeout-minutes: 150
     outputs:
@@ -418,9 +393,8 @@ jobs:
             *) echo "Unsupported prerelease Starter Kit channel $channel" >&2; exit 1 ;;
           esac
 
-          [[ "$(jq -er .starterKitSource.repository "$plan")" == "$STARTER_KIT_REPOSITORY" ]]
-          [[ "$(jq -er .starterKitSource.branch "$plan")" == "$target_branch" ]]
-          expected_head=$(jq -er .starterKitSource.sourceCommit "$plan")
+          expected_head=$(git ls-remote "https://github.com/$STARTER_KIT_REPOSITORY.git" "refs/heads/$target_branch" | awk '{print $1}')
+          [[ "$expected_head" =~ ^[0-9a-f]{40}$ ]]
           payload=$(jq -cn \
             --arg releaseSetId "$release_set_id" \
             --arg releaseIdentity "$identity" \
@@ -711,7 +685,9 @@ jobs:
 
   finalize:
     name: Finalize immutable release bill of materials
-    needs: [plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, example-testflight, example-google-play]
+    # A Mentra beta (Cloud V2, Mentra App, Engine, Bluetooth SDK) is complete
+    # when these succeed. The Bluetooth example is finalized separately below.
+    needs: [plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer]
     if: >-
       always() &&
       needs.plan.result == 'success' &&
@@ -720,12 +696,7 @@ jobs:
       needs.npm.result == 'success' &&
       needs.sdk-native.result == 'success' &&
       needs.mobile.result == 'success' &&
-      needs.engine-consumer.result == 'success' &&
-      needs.starter-kit.result == 'success' &&
-      (needs.example-testflight.result == 'success' ||
-        (needs.plan.outputs.dry_run == 'true' && needs.example-testflight.result == 'skipped')) &&
-      (needs.example-google-play.result == 'success' ||
-        (needs.plan.outputs.dry_run == 'true' && needs.example-google-play.result == 'skipped'))
+      needs.engine-consumer.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -767,24 +738,6 @@ jobs:
           name: ${{ needs.mobile.outputs.result_artifact }}
           path: release-input/mobile
 
-      - uses: actions/download-artifact@v4
-        if: needs.plan.outputs.dry_run != 'true'
-        with:
-          name: ${{ needs.starter-kit.outputs.result_artifact }}
-          path: release-input/starter-kit
-
-      - uses: actions/download-artifact@v4
-        if: needs.plan.outputs.dry_run != 'true'
-        with:
-          name: ${{ needs.example-testflight.outputs.result_artifact }}
-          path: release-input/example-testflight
-
-      - uses: actions/download-artifact@v4
-        if: needs.plan.outputs.dry_run != 'true'
-        with:
-          name: ${{ needs.example-google-play.outputs.result_artifact }}
-          path: release-input/example-google-play
-
       - name: Assemble complete publication evidence
         id: results
         run: |
@@ -797,19 +750,6 @@ jobs:
           test -f "$asg_selection"
           engine_package=$(find release-input/npm -type f -name 'mentra-engine-*.tgz' -print -quit)
           test -n "$engine_package"
-          starter_kit_args=()
-          if [[ "${{ needs.plan.outputs.dry_run }}" != "true" ]]; then
-            starter_kit_result=$(find release-input/starter-kit -type f -name 'starter-kit-release-*.json' -print -quit)
-            example_testflight=$(find release-input/example-testflight -type f -name 'example-testflight-publication.json' -print -quit)
-            test -n "$starter_kit_result"
-            test -n "$example_testflight"
-            starter_kit_args=(
-              --starter-kit "$starter_kit_result"
-              --starter-kit-result-url "${{ needs.starter-kit.outputs.result_url }}"
-              --example-testflight "$example_testflight"
-              --example-google-play release-input/example-google-play/example-google-play-publication.json
-            )
-          fi
           node .github/scripts/assemble-coordinated-release-results.mjs \
             --plan "$plan" \
             --ota release-input/ota/ota-result.json \
@@ -817,7 +757,6 @@ jobs:
             --native release-input/sdk-native/sdk-native-publications.json \
             --mobile release-input/mobile/mobile-publications.json \
             --cloud release-input/cloud-v2/cloud-v2-deployment.json \
-            "${starter_kit_args[@]}" \
             --asg-selection "$asg_selection" \
             --engine-package "$engine_package" \
             --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag" \
@@ -913,10 +852,127 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  finalize-example:
+    name: Finalize the Mentra Bluetooth example release
+    # The example release is a separate notion from the Mentra beta: it is
+    # built against the finalized beta and recorded in its own asset, so an
+    # example failure never makes the beta incomplete.
+    needs: [plan, finalize, starter-kit, example-testflight, example-google-play]
+    if: >-
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.dry_run != 'true' &&
+      needs.finalize.result == 'success' &&
+      needs.starter-kit.result == 'success' &&
+      needs.example-testflight.result == 'success' &&
+      needs.example-google-play.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      record_url: ${{ steps.results.outputs.record_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.source_commit }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.plan_artifact }}
+          path: release-input/plan
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coordinated-release-result-${{ needs.plan.outputs.release_set_id }}
+          path: release-input/finalized
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.starter-kit.outputs.result_artifact }}
+          path: release-input/starter-kit
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.example-testflight.outputs.result_artifact }}
+          path: release-input/example-testflight
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.example-google-play.outputs.result_artifact }}
+          path: release-input/example-google-play
+
+      - name: Assemble the example release record against the finalized beta
+        id: results
+        run: |
+          set -euo pipefail
+          mkdir -p finalized-example
+          plan=release-input/plan/release-plan.json
+          identity=$(jq -er .releaseIdentity "$plan")
+          tag=$(jq -er .artifactContainerTag "$plan")
+          manifest_name=$(jq -er .artifactNames.releaseManifest "$plan")
+          beta_manifest="release-input/finalized/$manifest_name"
+          test -s "$beta_manifest"
+          starter_kit_result=$(find release-input/starter-kit -type f -name 'starter-kit-release-*.json' -print -quit)
+          example_testflight=$(find release-input/example-testflight -type f -name 'example-testflight-publication.json' -print -quit)
+          test -n "$starter_kit_result"
+          test -n "$example_testflight"
+          record_name="mentra-example-release-$identity.json"
+          node .github/scripts/example-release-records.mjs \
+            --plan "$plan" \
+            --beta-manifest "$beta_manifest" \
+            --beta-manifest-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/$manifest_name" \
+            --starter-kit "$starter_kit_result" \
+            --starter-kit-result-url "${{ needs.starter-kit.outputs.result_url }}" \
+            --example-testflight "$example_testflight" \
+            --example-google-play release-input/example-google-play/example-google-play-publication.json \
+            --completed-at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+            --provenance-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output "finalized-example/$record_name"
+          {
+            echo "tag=$tag"
+            echo "identity=$identity"
+            echo "record_name=$record_name"
+            echo "record_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/$tag/$record_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish and verify the immutable example release record
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/publish-immutable-release-asset.mjs \
+            --file "finalized-example/${{ steps.results.outputs.record_name }}" \
+            --name "${{ steps.results.outputs.record_name }}" \
+            --release-id "${{ needs.plan.outputs.release_id }}" \
+            --repository "${{ github.repository }}"
+          node .github/scripts/verify-public-release-asset.mjs \
+            --file "finalized-example/${{ steps.results.outputs.record_name }}" \
+            --url "${{ steps.results.outputs.record_url }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coordinated-example-release-result-${{ needs.plan.outputs.release_set_id }}
+          path: finalized-example
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize the example release
+        run: |
+          {
+            echo "## Mentra Bluetooth example release"
+            echo ""
+            echo "- Release: \`${{ steps.results.outputs.identity }}\`"
+            echo "- Record: ${{ steps.results.outputs.record_url }}"
+            echo "- Starter Kit builds: ${{ needs.starter-kit.outputs.release_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   docs:
     name: Publish release-matched documentation
-    needs: [plan, starter-kit, example-testflight, finalize]
-    if: needs.plan.result == 'success' && needs.starter-kit.result == 'success' && needs.example-testflight.result == 'success' && needs.finalize.result == 'success' && needs.plan.outputs.dry_run != 'true'
+    needs: [plan, starter-kit, example-testflight, finalize, finalize-example]
+    if: needs.plan.result == 'success' && needs.starter-kit.result == 'success' && needs.example-testflight.result == 'success' && needs.finalize.result == 'success' && needs.finalize-example.result == 'success' && needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -1062,7 +1118,7 @@ jobs:
   notify-slack:
     name: Notify release Slack channel
     needs:
-      [plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, example-testflight, example-google-play, finalize, docs]
+      [plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer, starter-kit, example-testflight, example-google-play, finalize, finalize-example, docs]
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -1100,6 +1156,7 @@ jobs:
           EXAMPLE_GOOGLE_PLAY_TRACK: ${{ needs.plan.outputs.example_play_track }}
           EXAMPLE_GOOGLE_PLAY_INSTALL_URL: ${{ needs.example-google-play.outputs.install_url }}
           FINALIZE_RESULT: ${{ needs.finalize.result }}
+          FINALIZE_EXAMPLE_RESULT: ${{ needs.finalize-example.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
           DOCS_URL: ${{ needs.docs.outputs.docs_url }}
           APK_NAME: ${{ needs.mobile.outputs.apk_name }}

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -16,7 +16,6 @@ import {
 import {ATTESTATION_CHECKS, nextAction, validateAttestation} from "../.github/scripts/production-promotion-state.mjs"
 
 const REPOSITORY = "Mentra-Community/MentraOS"
-const STARTER_KIT_REPOSITORY = "Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit"
 const DEFAULT_REF = "main"
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 const BETA_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.([1-9]\d*)$/
@@ -228,12 +227,9 @@ export function releaseBranchSources(result, betaIdentity) {
     throw new Error(`The coordinated release result does not describe completed beta ${betaIdentity}`)
   }
   const mentraosCommit = result.sourceCommit
-  const starterKitCommit = result.starterKit?.starterKit?.mergeCommit
   if (!SHA_PATTERN.test(mentraosCommit || "")) throw new Error("The beta result has no valid MentraOS source commit")
-  if (!SHA_PATTERN.test(starterKitCommit || ""))
-    throw new Error("The beta result has no valid Starter Kit merge commit")
   if (!result.completedAt) throw new Error("The beta result is not complete")
-  return {mentraosCommit, starterKitCommit}
+  return {mentraosCommit}
 }
 
 function loadReleaseBranchSources(betaIdentity) {
@@ -373,7 +369,7 @@ async function confirmBranchPromotion(betaIdentity, options) {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("Refusing branch promotion without an interactive terminal; rerun with --yes after reviewing it")
   }
-  console.log(`This promotes the exact ${betaIdentity} Starter Kit and MentraOS sources from staging to main.`)
+  console.log(`This promotes the exact ${betaIdentity} MentraOS source from staging to main.`)
   const reader = createInterface({input: process.stdin, output: process.stdout})
   const answer = await reader.question("Type the beta identity to continue: ")
   reader.close()
@@ -492,22 +488,13 @@ async function main(argv = process.argv.slice(2)) {
     verifyCheckoutForPromotion()
     const sources = loadReleaseBranchSources(options.beta)
     ensureCommitIsOnBranch(REPOSITORY, sources.mentraosCommit, "staging")
-    ensureCommitIsOnBranch(STARTER_KIT_REPOSITORY, sources.starterKitCommit, "staging")
     requirePromotionRelationship(REPOSITORY, "main", sources.mentraosCommit)
-    requirePromotionRelationship(STARTER_KIT_REPOSITORY, "main", sources.starterKitCommit)
     await confirmBranchPromotion(options.beta, options)
-    promoteExactCommit({
-      repository: STARTER_KIT_REPOSITORY,
-      sourceCommit: sources.starterKitCommit,
-      target: "main",
-      releaseIdentity: options.beta,
-    })
     promoteExactCommit({
       repository: REPOSITORY,
       sourceCommit: sources.mentraosCommit,
       target: "main",
       releaseIdentity: options.beta,
-      mergeBody: `Starter-Kit-Source: ${sources.starterKitCommit}`,
     })
     console.log(`Branch promotion for ${options.beta} is complete. Continue from a clean, up-to-date main checkout.`)
     return

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -70,11 +70,10 @@ test("reads exact branch sources from a completed coordinated beta", () => {
         channel: "beta",
         completedAt: "2026-08-31T18:40:40.000Z",
         sourceCommit: "a".repeat(40),
-        starterKit: {starterKit: {mergeCommit: "b".repeat(40)}},
       },
       "3.1.0-beta.105",
     ),
-    {mentraosCommit: "a".repeat(40), starterKitCommit: "b".repeat(40)},
+    {mentraosCommit: "a".repeat(40)},
   )
 })
 
@@ -92,13 +91,12 @@ test("rejects incomplete or mismatched beta branch sources", () => {
     channel: "beta",
     completedAt: "2026-08-31T18:40:40.000Z",
     sourceCommit: "a".repeat(40),
-    starterKit: {starterKit: {mergeCommit: "b".repeat(40)}},
   }
   assert.throws(() => releaseBranchSources(result, "3.1.0-beta.106"), /does not describe completed beta/)
   assert.throws(() => releaseBranchSources({...result, completedAt: undefined}, result.releaseIdentity), /not complete/)
   assert.throws(
-    () => releaseBranchSources({...result, starterKit: {starterKit: {}}}, result.releaseIdentity),
-    /no valid Starter Kit merge commit/,
+    () => releaseBranchSources({...result, sourceCommit: "short"}, result.releaseIdentity),
+    /no valid MentraOS source commit/,
   )
 })
 


### PR DESCRIPTION
## Why

Every staging beta since 3.1.0-beta.182 has failed to finalize, and the persistent cause is the Starter Kit example app: it is still a draft in Google Play, so its beta-track upload is rejected ("Only releases with status draft may be created on draft app"), `finalize` is skipped, no `mentra-release-<beta>.json` is written, and `promote` refuses the beta. The runbook already says the example app is outside the production promotion, yet the beta's notion of "complete" required it.

## What changes

The example app becomes its own release notion, the **finalized Mentra Bluetooth example**, separate from the Mentra beta:

- **`finalize` needs only the Mentra products** (plan, cloud-v2, ota, npm, sdk-native, mobile, engine-consumer). The beta manifest no longer carries Starter Kit or example evidence.
- **The Starter Kit job runs after `finalize`**, consuming the finalized beta. It reads the Starter Kit channel head itself at dispatch time; the Mentra release plan no longer freezes a `starterKitSource`, and the `Starter-Kit-Source` merge trailer is gone.
- **New `finalize-example` job** assembles, publishes, and verifies `mentra-example-release-<identity>.json` (kind `mentra-bluetooth-example`), which points at the finalized beta manifest by name, URL, and SHA-256 and carries the verified Starter Kit, TestFlight, and Google Play evidence. Docs publish after it; the Slack summary reports the Mentra release and the Bluetooth example separately.
- **New module `example-release-records.mjs`** holds the Starter Kit and example verifiers (moved from the beta assembler) plus the example assembler and validator.
- **`promote` merges only the MentraOS source.** The Starter Kit repository is no longer touched by the promotion, and the runbook drops the Starter Kit containment rule and documents the two notions.

## Verification

- `node --test` over the same 45 suites CI runs: 246 pass, 0 fail (new `example-release-records.test.mjs`; contract, assembler, release-family, Play coordinates, and promotion tests updated).
- `release-family-cli.mjs validate --require-version-mirrors` passes; a staging plan generated from this head has no `starterKitSource`.
- The workflow YAML parses; job graph: finalize ← Mentra products; starter-kit ← finalize; finalize-example ← finalize + starter-kit + examples; docs ← finalize-example.

## Effect on the current promotion

Merging this onto `staging` allocates a new beta. Its Mentra half finalizes regardless of the example app's Play Console state, so it can be promoted. The example half will keep failing on Google Play until the example app's Play listing is published, and that no longer blocks anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
