### PR TITLE
Keep the promotion CLI's gh output under Node's spawn buffer

### DIFF
--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -83,7 +83,15 @@ function branchHead(repository, branch) {
 }
 
 function compareCommits(repository, base, head) {
-  return ghJson(["api", `repos/${repository}/compare/${base}...${head}`])
+  // Only the relationship is needed. The full compare payload lists commits
+  // and file patches, which for a whole release cycle exceeds the spawn buffer
+  // (spawnSync gh ENOBUFS), so trim it in gh before it reaches this process.
+  return ghJson([
+    "api",
+    `repos/${repository}/compare/${base}...${head}?per_page=1`,
+    "--jq",
+    "{status: .status, ahead_by: .ahead_by, behind_by: .behind_by}",
+  ])
 }
 
 function ensureCommitIsOnBranch(repository, commit, branch) {

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -70,12 +70,39 @@ credentials or directly calls Porter, App Store Connect, or Google Play.
 See .github/production-release/README.md for the complete procedure.`
 }
 
+// Node's default spawn buffer is 1 MB. GitHub listings for this repository
+// already exceed it (the release list is several megabytes and the builds
+// release alone has hundreds of assets), so every gh call gets a generous
+// buffer AND the listings below ask gh to project only the fields used.
+const GH_MAX_BUFFER = 64 * 1024 * 1024
+const RELEASE_FIELDS = "{id, tag_name, name, draft, prerelease, body, target_commitish}"
+const ASSET_FIELDS = "{id, name, digest, size, url, browser_download_url}"
+
 function execGh(args, options = {}) {
-  return execFileSync("gh", args, {encoding: "utf8", stdio: ["ignore", "pipe", "inherit"], ...options})
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    maxBuffer: GH_MAX_BUFFER,
+    ...options,
+  })
 }
 
 function ghJson(args) {
   return JSON.parse(execGh(args))
+}
+
+export function parseJsonLines(output) {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
+// `gh api --paginate` cannot combine --slurp with --jq, so page through with a
+// projection that emits one JSON object per line and parse those lines.
+function ghPaginated(endpoint, projection) {
+  return parseJsonLines(execGh(["api", "--paginate", endpoint, "--jq", `.[] | ${projection} | tojson`]))
 }
 
 function branchHead(repository, branch) {
@@ -243,8 +270,21 @@ export function releaseBranchSources(result, betaIdentity) {
 function loadReleaseBranchSources(betaIdentity) {
   const family = betaIdentity.slice(0, betaIdentity.indexOf("-beta."))
   const assetName = `mentra-release-${betaIdentity}.json`
-  const release = ghJson(["release", "view", `mentra-builds-v${family}`, "--repo", REPOSITORY, "--json", "assets"])
-  const asset = release.assets.find((candidate) => candidate.name === assetName)
+  const matches = parseJsonLines(
+    execGh([
+      "release",
+      "view",
+      `mentra-builds-v${family}`,
+      "--repo",
+      REPOSITORY,
+      "--json",
+      "assets",
+      "--jq",
+      `.assets[] | select(.name == ${JSON.stringify(assetName)}) | {name, apiUrl, digest} | tojson`,
+    ]),
+  )
+  if (matches.length > 1) throw new Error(`Release contains duplicate asset ${assetName}`)
+  const asset = matches[0]
   if (!asset) throw new Error(`Completed release asset ${assetName} was not found`)
   const contents = execGh(["api", "-H", "Accept: application/octet-stream", asset.apiUrl], {
     maxBuffer: 20 * 1024 * 1024,
@@ -257,7 +297,7 @@ function loadReleaseBranchSources(betaIdentity) {
 }
 
 function listReleases() {
-  return ghJson(["api", "--paginate", "--slurp", `repos/${REPOSITORY}/releases?per_page=100`]).flat()
+  return ghPaginated(`repos/${REPOSITORY}/releases?per_page=100`, RELEASE_FIELDS)
 }
 
 function resolveAttempt(releases, releaseIdentity, requestedAttempt) {
@@ -276,12 +316,7 @@ function loadLatestRecord(releaseIdentity, requestedAttempt) {
   const releases = listReleases()
   const attempt = resolveAttempt(releases, releaseIdentity, requestedAttempt)
   const release = requirePromotionContainer(releases, releaseIdentity, attempt)
-  const assets = ghJson([
-    "api",
-    "--paginate",
-    "--slurp",
-    `repos/${REPOSITORY}/releases/${release.id}/assets?per_page=100`,
-  ]).flat()
+  const assets = ghPaginated(`repos/${REPOSITORY}/releases/${release.id}/assets?per_page=100`, ASSET_FIELDS)
   const states = stateAssets(assets, releaseIdentity, attempt)
   if (states.length === 0) throw new Error(`Promotion ${releaseIdentity} attempt ${attempt} has no state record`)
   const entries = states.map((state) => {

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -6,6 +6,7 @@ import {
   branchPromotionState,
   packagesConfirmationMessage,
   parseCliArgs,
+  parseJsonLines,
   releaseBranchSources,
   requireCommandState,
   statusSummary,
@@ -176,4 +177,13 @@ test("dispatches stable package phases from the promoted beta without a promotio
     packagesConfirmationMessage({beta_identity: "3.1.0-beta.192", phase: "release"}),
     /moves npm latest.*3\.1\.0/,
   )
+})
+
+test("parses line-delimited gh projections and ignores blank lines", () => {
+  assert.deepEqual(parseJsonLines('{"id":1,"tag_name":"a"}\n\n{"id":2,"tag_name":"b"}\n'), [
+    {id: 1, tag_name: "a"},
+    {id: 2, tag_name: "b"},
+  ])
+  assert.deepEqual(parseJsonLines(""), [])
+  assert.throws(() => parseJsonLines("{not json}"), SyntaxError)
 })


### PR DESCRIPTION
## Why

`./scripts/production-release.mjs promote --beta 3.1.0-beta.205` failed with `spawnSync gh ENOBUFS`. Node's default spawn buffer is 1 MB, and an audit of every synchronous `gh` call in the release tooling on `staging` and `dev` found three places in this CLI that fetch more than that from GitHub:

| Call | Used by | Live size before | After |
| --- | --- | --- | --- |
| compare between the beta source and `main` (full payload with commits and patches) | `promote` | several MB for 4627 commits | 49 bytes |
| `releases?per_page=100 --paginate --slurp` | `status`, `next`, `attest`, `release`, `advance`, `abort`, `packages` | 3.6 MB | 59 KB |
| `gh release view mentra-builds-v3.1.0 --json assets` (716 assets) | `promote` | 399 KB, growing ~7 assets per beta | 221 bytes |

The second one means every command after `promote` would have failed the same way.

## What changes

- The `gh` wrapper gets a 64 MB buffer, matching `production-promotion-assets.mjs`, `production-packages.mjs`, and `release-sdk-metadata.mjs`.
- Each listing asks `gh` to project only the fields the CLI consumes: the compare is reduced to `status`, `ahead_by`, `behind_by`; releases and promotion-container assets are paged as one JSON object per line (gh cannot combine `--slurp` with `--jq`); the beta manifest asset is selected by name inside `gh`.
- `parseJsonLines` is exported and unit-tested.

## Audit notes

`publish-immutable-release-asset.mjs` already filters its asset listing inside `gh`. `production-promotion-assets.mjs`, `production-packages.mjs`, `release-sdk-metadata.mjs`, and `release-bundle-config.mjs` already set explicit buffers. `npm view` calls fetch single fields. The only other instance is `scripts/promote-release-family.mjs`, which exists on `dev` only and still fetches the full compare payload; it should get the same treatment when `dev` is next reconciled.

## Verification

- `node --test scripts/production-release.test.mjs`: 10 pass.
- Live: `status --release 3.1.0` now gets through the release listing and stops at the expected "No production promotion exists for 3.1.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
