### PR TITLE
Fix ACS SoftAP permission rejection and WHIP 500 during call startup

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -126,12 +126,8 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
         "ACCESS_NETWORK_STATE",
         "CHANGE_WIFI_STATE",
         "CHANGE_NETWORK_STATE",
-        // SoftAP calling runs a WHIP server on the glasses' hotspot subnet: it accepts
-        // inbound TCP and exchanges UDP on a private LAN address. Android 17 enforces this
-        // permission for apps targeting SDK 37+; targetSdkVersion is 36 today so access is
-        // still implicit, but declaring it now avoids the architecture breaking silently on
-        // the targetSdk bump.
-        "ACCESS_LOCAL_NETWORK",
+        // Local-network access is implicit through INTERNET while targeting SDK 36.
+        // Declare and request ACCESS_LOCAL_NETWORK when moving to target SDK 37+.
       ],
       // The Google Navigation SDK manifest merges in ACCESS_BACKGROUND_LOCATION,
       // but navigation runs in a location foreground service and works with

--- a/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsMeetingModule.kt
+++ b/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/AcsMeetingModule.kt
@@ -1,5 +1,6 @@
 package com.mentra.acsmeeting
 
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.SystemClock
@@ -47,6 +48,12 @@ class AcsMeetingModule : Module() {
    * the session's ingest source and this join agree on the same [android.net.Network].
    */
   private var scopedNetwork: ScopedSoftApNetwork? = null
+
+  // prepareAgent creates the session before joinScopedNetwork runs. Give it the same holder
+  // now, so its ingest source sees the network populated later instead of retaining null.
+  @Synchronized
+  private fun getOrCreateScopedNetwork(context: Context): ScopedSoftApNetwork =
+    scopedNetwork ?: ScopedSoftApNetwork(context.applicationContext).also { scopedNetwork = it }
 
   /**
    * Holds cellular up across the hotspot join, and reports what the default network became.
@@ -117,7 +124,7 @@ class AcsMeetingModule : Module() {
     AsyncFunction("joinScopedNetwork") { ssid: String, passphrase: String ->
       traced("join_scoped_network", "ssid" to ssid) {
         val context = appContext.reactContext ?: throw IllegalStateException("no react context")
-        val scoped = scopedNetwork ?: ScopedSoftApNetwork(context.applicationContext).also { scopedNetwork = it }
+        val scoped = getOrCreateScopedNetwork(context)
         // Cellular first, and validated, because the next line is what takes office Wi-Fi away. A
         // phone whose cellular cannot carry TLS strands the ACS join for its whole timeout with
         // device-wide DNS failures, which reads as a hotspot problem and is not one.
@@ -267,7 +274,7 @@ class AcsMeetingModule : Module() {
               mapOf("base64" to base64, "sampleRate" to rate, "channels" to channels),
             )
           },
-          scopedNetwork = scopedNetwork ?: ScopedSoftApNetwork(context.applicationContext).also { scopedNetwork = it },
+          scopedNetwork = getOrCreateScopedNetwork(context),
         ).also { session = it }
         val hold = internetHold ?: InternetHold(context.applicationContext).also { internetHold = it }
         // Request cellular rather than trusting it to be up: a phone sitting on Wi-Fi may have the
@@ -318,7 +325,7 @@ class AcsMeetingModule : Module() {
               mapOf("base64" to base64, "sampleRate" to rate, "channels" to channels),
             )
           },
-          scopedNetwork = scopedNetwork ?: ScopedSoftApNetwork(context.applicationContext).also { scopedNetwork = it },
+          scopedNetwork = getOrCreateScopedNetwork(context),
         ).also { session = it }
         // The process is already pinned to cellular by now (sign-in and the scoped join both pin, and
         // ACS keeps the route its sockets were created with). Lift it only across the WHIP listener

--- a/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/network/ScopedNetworkError.kt
+++ b/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/network/ScopedNetworkError.kt
@@ -101,10 +101,8 @@ sealed class ScopedNetworkError(val code: String, message: String) : Exception(m
             }
 
         /**
-         * Enforced for apps targeting SDK 37+. `targetSdkVersion` is 35 today, so access is still
-         * implicit, but the WHIP ingest server accepts inbound TCP and exchanges UDP on a private
-         * LAN address — exactly the operations this permission governs — so it is declared now
-         * rather than discovered on the targetSdk bump.
+         * Enforced on Android 17+ for apps targeting SDK 37+. Hosts targeting older SDKs
+         * retain implicit access through INTERNET and must not request this permission.
          */
         const val LOCAL_NETWORK_PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
     }

--- a/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/network/ScopedSoftApNetwork.kt
+++ b/mobile/modules/acs-meeting/android/src/main/java/com/mentra/acsmeeting/network/ScopedSoftApNetwork.kt
@@ -188,11 +188,11 @@ class ScopedSoftApNetwork(private val context: Context) {
      * Whether the local-network permission is granted. Below the SDK level that enforces it, access
      * is implicit and this reports true.
      */
-    fun hasLocalNetworkPermission(): Boolean {
-        if (Build.VERSION.SDK_INT < LOCAL_NETWORK_ENFORCED_SDK) return true
-        return context.checkSelfPermission(ScopedNetworkError.LOCAL_NETWORK_PERMISSION) ==
-            PackageManager.PERMISSION_GRANTED
-    }
+    fun hasLocalNetworkPermission(): Boolean =
+        hasLocalNetworkPermission(Build.VERSION.SDK_INT, context.applicationInfo.targetSdkVersion) {
+            context.checkSelfPermission(ScopedNetworkError.LOCAL_NETWORK_PERMISSION) ==
+                PackageManager.PERMISSION_GRANTED
+        }
 
     /**
      * Join [ssid] and block until it is usable or the request fails.
@@ -626,6 +626,16 @@ class ScopedSoftApNetwork(private val context: Context) {
     companion object {
         /** Android 17. `ACCESS_LOCAL_NETWORK` is enforced for apps targeting SDK 37+. */
         const val LOCAL_NETWORK_ENFORCED_SDK = 37
+
+        /** Legacy targets retain implicit LAN access, even when the runtime grant reports denied. */
+        internal fun hasLocalNetworkPermission(
+            sdkInt: Int,
+            targetSdkInt: Int,
+            permissionGranted: () -> Boolean,
+        ): Boolean =
+            sdkInt < LOCAL_NETWORK_ENFORCED_SDK ||
+                targetSdkInt < LOCAL_NETWORK_ENFORCED_SDK ||
+                permissionGranted()
 
         private const val AWAIT_GRACE_MS = 2_000L
 

--- a/mobile/modules/acs-meeting/android/src/test/java/com/mentra/acsmeeting/network/ScopedLocalNetworkPermissionTest.kt
+++ b/mobile/modules/acs-meeting/android/src/test/java/com/mentra/acsmeeting/network/ScopedLocalNetworkPermissionTest.kt
@@ -1,0 +1,35 @@
+package com.mentra.acsmeeting.network
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ScopedLocalNetworkPermissionTest {
+    @Test
+    fun `Android 17 preserves implicit access for the SDK 36 host`() {
+        assertThat(ScopedSoftApNetwork.hasLocalNetworkPermission(37, 36) {
+            error("Legacy targets must not query the unneeded runtime grant")
+        }).isTrue()
+    }
+
+    @Test
+    fun `older Android does not query a permission it cannot enforce`() {
+        assertThat(ScopedSoftApNetwork.hasLocalNetworkPermission(36, 37) {
+            error("Older Android must not query the new permission")
+        }).isTrue()
+    }
+
+    @Test
+    fun `Android 17 denies a target 37 host without the grant`() {
+        assertThat(ScopedSoftApNetwork.hasLocalNetworkPermission(37, 37) { false }).isFalse()
+    }
+
+    @Test
+    fun `Android 17 allows a target 37 host with the grant`() {
+        assertThat(ScopedSoftApNetwork.hasLocalNetworkPermission(37, 37) { true }).isTrue()
+    }
+
+    @Test
+    fun `future Android and target versions still enforce the grant`() {
+        assertThat(ScopedSoftApNetwork.hasLocalNetworkPermission(38, 38) { false }).isFalse()
+    }
+}


### PR DESCRIPTION
Fix two phone-side blockers encountered when starting a Teams call over the glasses hotspot on an Android 17 phone with the app targeting SDK 36.

## Why the call failed

- The local-network permission guard checked only the device OS version. It rejected the SDK 36 app with `PermissionDenied` even though legacy targets retain implicit LAN access through `INTERNET`. Check both runtime and target SDK, and remove the premature `ACCESS_LOCAL_NETWORK` declaration from Expo config. A target SDK 37 migration must add the declaration and runtime request together.
- `prepareAgent()` constructs `AcsMeetingSession` before `joinScopedNetwork()` creates the hotspot holder. The session retained a null reference, so its ingest source could not apply the existing hotspot address correction to its SDP answer. The glasses offer was accepted, but the phone advertised its cellular address and rejected its own answer with `only_non_hotspot_candidates`, returning WHIP HTTP 500. Create and reuse one module-owned holder from both session construction paths and the hotspot join.

## Validation

- Native ACS module: 496 unit tests passed, including five permission cases covering older OS versions, legacy targets, and granted/denied permissions for target SDK 37+.
- Android release build passed; installed on the Samsung phone and tested with Mentra Live glasses.
- Before: `ingest_factory_ready scopedNetwork=false`, followed by `ingest_answer_rejected code=only_non_hotspot_candidates`.
- After: `scopedNetwork=true`; `ingest_answer_pinned` (cellular address replaced with hotspot address); `whip_answer_sent`; ICE and ACS `CONNECTED`; `ingest_first_frame`. Video reached the phone and was submitted to ACS at 960×540, approximately 14–15 fps. Audio uplink reported zero send failures. Remote Teams playback was not independently verified.
- `git diff --check` passed.

Hardware validation required a separate local-network access setting correction on the test device. That environmental recovery is not implemented by this PR; the code does not override OS access controls. No glasses code changes are included.
