### PR TITLE
Gate the promotion pull request on the ci-gate status

### DIFF
--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import {execFileSync} from "node:child_process"
+import {execFileSync, spawnSync} from "node:child_process"
 import {createHash} from "node:crypto"
 import {copyFileSync, mkdtempSync, readFileSync} from "node:fs"
 import {tmpdir} from "node:os"
@@ -180,6 +180,61 @@ function ensurePromotionBranch(repository, branch, commit) {
   ])
 }
 
+// A promotion pull request's head is the exact beta source commit, so every
+// check-run of the coordinated release that built that beta is attached to it,
+// including jobs that do not gate the beta (the Bluetooth example's store
+// publishes). `gh pr checks --fail-fast` would count those, and the advisory
+// pull-request bots, as merge blockers. The promotion gate is therefore the
+// repository's own aggregate of required area builds, the `ci-gate-*` commit
+// status, and only if no such status exists on the head do the pull-request
+// triggered check-runs (never push-triggered ones) decide.
+const CI_GATE_CONTEXT = /^ci-gate(-[a-z0-9-]+)?$/
+const PROMOTION_GATE_POLL_SECONDS = 30
+const PROMOTION_GATE_TIMEOUT_SECONDS = 4 * 60 * 60
+
+export function promotionGateState(rows) {
+  if (!Array.isArray(rows)) throw new Error("Pull request checks must be an array")
+  const gates = rows.filter((row) => CI_GATE_CONTEXT.test(row.name || "") && !row.workflow)
+  const relevant = gates.length > 0 ? gates : rows.filter((row) => row.event === "pull_request")
+  const failed = relevant.filter((row) => row.bucket === "fail" || row.bucket === "cancel")
+  if (failed.length > 0) return {state: "failed", rows: failed}
+  const pending = relevant.filter((row) => row.bucket === "pending")
+  if (pending.length > 0) return {state: "pending", rows: pending}
+  return {state: "passed", rows: relevant}
+}
+
+function pullRequestChecks(url, repository) {
+  // gh exits 8 while checks are pending and 1 when any failed; the JSON is
+  // still complete in both cases, so read stdout regardless of the status.
+  const result = spawnSync(
+    "gh",
+    ["pr", "checks", url, "--repo", repository, "--json", "name,workflow,event,bucket,description"],
+    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: GH_MAX_BUFFER},
+  )
+  if (result.error) throw result.error
+  const output = (result.stdout || "").trim()
+  if (!output.startsWith("[")) {
+    throw new Error(`gh pr checks failed for ${url}: ${(result.stderr || output).trim()}`)
+  }
+  return JSON.parse(output)
+}
+
+function waitForPromotionGate(url, repository) {
+  const deadline = Date.now() + PROMOTION_GATE_TIMEOUT_SECONDS * 1000
+  for (;;) {
+    const gate = promotionGateState(pullRequestChecks(url, repository))
+    const names = gate.rows.map((row) => row.name).join(", ")
+    if (gate.state === "failed") throw new Error(`${url} has failing checks: ${names}`)
+    if (gate.state === "passed") {
+      console.log(`Checks passed for ${url}${names ? `: ${names}` : ""}`)
+      return
+    }
+    if (Date.now() > deadline) throw new Error(`${url} checks are still pending: ${names}`)
+    console.log(`Waiting on: ${names}`)
+    execFileSync("sleep", [String(PROMOTION_GATE_POLL_SECONDS)])
+  }
+}
+
 function promoteExactCommit({repository, sourceCommit, target, releaseIdentity, mergeBody}) {
   ensureCommitIsOnBranch(repository, sourceCommit, "staging")
   const relationship = requirePromotionRelationship(repository, target, sourceCommit)
@@ -239,9 +294,7 @@ function promoteExactCommit({repository, sourceCommit, target, releaseIdentity, 
   if (pull.state !== "OPEN") throw new Error(`${pull.url} is ${pull.state.toLowerCase()}`)
 
   console.log(`Waiting for ${pull.url}`)
-  execFileSync("gh", ["pr", "checks", pull.url, "--repo", repository, "--watch", "--fail-fast"], {
-    stdio: "inherit",
-  })
+  waitForPromotionGate(pull.url, repository)
   const currentTargetHead = branchHead(repository, target)
   if (currentTargetHead !== targetHead) {
     throw new Error(

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -191,8 +191,14 @@ function ensurePromotionBranch(repository, branch, commit) {
 const CI_GATE_CONTEXT = /^ci-gate(-[a-z0-9-]+)?$/
 const PROMOTION_GATE_POLL_SECONDS = 30
 const PROMOTION_GATE_TIMEOUT_SECONDS = 4 * 60 * 60
+// Right after the pull request is created only the beta's push-triggered rows
+// exist; the pull request's own builders and the ci-gate status register over
+// the following minutes. Until that settling window has elapsed, an empty gate
+// means "not registered yet", never "nothing to run".
+const PROMOTION_GATE_SETTLE_SECONDS = 15 * 60
+const PROMOTION_GATE_CALL_TIMEOUT_MS = 2 * 60 * 1000
 
-export function promotionGateState(rows) {
+export function promotionGateState(rows, {settled = false} = {}) {
   if (!Array.isArray(rows)) throw new Error("Pull request checks must be an array")
   const gates = rows.filter((row) => CI_GATE_CONTEXT.test(row.name || "") && !row.workflow)
   const relevant = gates.length > 0 ? gates : rows.filter((row) => row.event === "pull_request")
@@ -200,6 +206,7 @@ export function promotionGateState(rows) {
   if (failed.length > 0) return {state: "failed", rows: failed}
   const pending = relevant.filter((row) => row.bucket === "pending")
   if (pending.length > 0) return {state: "pending", rows: pending}
+  if (relevant.length === 0 && !settled) return {state: "pending", rows: []}
   return {state: "passed", rows: relevant}
 }
 
@@ -209,7 +216,12 @@ function pullRequestChecks(url, repository) {
   const result = spawnSync(
     "gh",
     ["pr", "checks", url, "--repo", repository, "--json", "name,workflow,event,bucket,description"],
-    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: GH_MAX_BUFFER},
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: GH_MAX_BUFFER,
+      timeout: PROMOTION_GATE_CALL_TIMEOUT_MS,
+    },
   )
   if (result.error) throw result.error
   const output = (result.stdout || "").trim()
@@ -220,10 +232,12 @@ function pullRequestChecks(url, repository) {
 }
 
 function waitForPromotionGate(url, repository) {
-  const deadline = Date.now() + PROMOTION_GATE_TIMEOUT_SECONDS * 1000
+  const started = Date.now()
+  const deadline = started + PROMOTION_GATE_TIMEOUT_SECONDS * 1000
   for (;;) {
-    const gate = promotionGateState(pullRequestChecks(url, repository))
-    const names = gate.rows.map((row) => row.name).join(", ")
+    const settled = Date.now() - started >= PROMOTION_GATE_SETTLE_SECONDS * 1000
+    const gate = promotionGateState(pullRequestChecks(url, repository), {settled})
+    const names = gate.rows.map((row) => row.name).join(", ") || "checks to register"
     if (gate.state === "failed") throw new Error(`${url} has failing checks: ${names}`)
     if (gate.state === "passed") {
       console.log(`Checks passed for ${url}${names ? `: ${names}` : ""}`)

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -189,6 +189,19 @@ function ensurePromotionBranch(repository, branch, commit) {
 // status, and only if no such status exists on the head do the pull-request
 // triggered check-runs (never push-triggered ones) decide.
 const CI_GATE_CONTEXT = /^ci-gate(-[a-z0-9-]+)?$/
+// The area builders the ci-gate aggregates (its allowlist in ci-gate.yml).
+// When no gate status has registered on the head, only these decide; advisory
+// bots and helpers on the pull request never gate a promotion.
+const CI_GATE_WORKFLOWS = new Set([
+  "Mobile App iOS Build",
+  "Mobile App Android Build",
+  "MentraOS ASG Client Build",
+  "Mobile App Quality Checks",
+  "OEM Host Boundary Gate",
+  "Coordinated Release Family Checks",
+  "Bun Lockfile Checks",
+  "Cloud V2 Validation",
+])
 const PROMOTION_GATE_POLL_SECONDS = 30
 const PROMOTION_GATE_TIMEOUT_SECONDS = 4 * 60 * 60
 // Right after the pull request is created only the beta's push-triggered rows
@@ -201,7 +214,10 @@ const PROMOTION_GATE_CALL_TIMEOUT_MS = 2 * 60 * 1000
 export function promotionGateState(rows, {settled = false} = {}) {
   if (!Array.isArray(rows)) throw new Error("Pull request checks must be an array")
   const gates = rows.filter((row) => CI_GATE_CONTEXT.test(row.name || "") && !row.workflow)
-  const relevant = gates.length > 0 ? gates : rows.filter((row) => row.event === "pull_request")
+  const relevant =
+    gates.length > 0
+      ? gates
+      : rows.filter((row) => row.event === "pull_request" && CI_GATE_WORKFLOWS.has(row.workflow || ""))
   const failed = relevant.filter((row) => row.bucket === "fail" || row.bucket === "cancel")
   if (failed.length > 0) return {state: "failed", rows: failed}
   const pending = relevant.filter((row) => row.bucket === "pending")

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -7,6 +7,7 @@ import {
   packagesConfirmationMessage,
   parseCliArgs,
   parseJsonLines,
+  promotionGateState,
   releaseBranchSources,
   requireCommandState,
   statusSummary,
@@ -186,4 +187,39 @@ test("parses line-delimited gh projections and ignores blank lines", () => {
   ])
   assert.deepEqual(parseJsonLines(""), [])
   assert.throws(() => parseJsonLines("{not json}"), SyntaxError)
+})
+
+test("the promotion gate follows the ci-gate status and ignores push-triggered beta jobs", () => {
+  const betaJob = {
+    name: "Publish React Native example to Google Play / Build",
+    workflow: "Coordinated Mentra Release",
+    event: "push",
+    bucket: "fail",
+  }
+  const bot = {name: "Plan agent cycle", workflow: "PR Agent Orchestrator", event: "pull_request", bucket: "fail"}
+  const build = {
+    name: "Mobile App iOS Build",
+    workflow: "Mobile App iOS Build",
+    event: "pull_request",
+    bucket: "pending",
+  }
+  const gatePending = {
+    name: "ci-gate-dev",
+    workflow: "",
+    event: "",
+    bucket: "pending",
+    description: "Waiting on: Mobile App iOS Build",
+  }
+  const gatePassed = {...gatePending, bucket: "pass", description: "All required area builds passed"}
+  const gateFailed = {...gatePending, bucket: "fail"}
+
+  assert.equal(promotionGateState([betaJob, bot, build, gatePending]).state, "pending")
+  assert.equal(promotionGateState([betaJob, bot, build, gatePassed]).state, "passed")
+  assert.deepEqual(promotionGateState([betaJob, bot, gateFailed]).rows, [gateFailed])
+  // Without a ci-gate status only pull-request-triggered checks decide.
+  assert.equal(promotionGateState([betaJob, build]).state, "pending")
+  assert.equal(promotionGateState([betaJob, {...build, bucket: "pass"}]).state, "passed")
+  assert.equal(promotionGateState([betaJob, bot, {...build, bucket: "pass"}]).state, "failed")
+  assert.equal(promotionGateState([betaJob]).state, "passed")
+  assert.throws(() => promotionGateState(null), /must be an array/)
 })

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -220,6 +220,12 @@ test("the promotion gate follows the ci-gate status and ignores push-triggered b
   assert.equal(promotionGateState([betaJob, build]).state, "pending")
   assert.equal(promotionGateState([betaJob, {...build, bucket: "pass"}]).state, "passed")
   assert.equal(promotionGateState([betaJob, bot, {...build, bucket: "pass"}]).state, "failed")
-  assert.equal(promotionGateState([betaJob]).state, "passed")
+  // Only the beta's push rows exist right after the PR is created: keep waiting
+  // until registration has settled, then an empty gate means nothing applies.
+  assert.equal(promotionGateState([betaJob]).state, "pending")
+  assert.equal(promotionGateState([betaJob], {settled: false}).state, "pending")
+  assert.equal(promotionGateState([betaJob], {settled: true}).state, "passed")
+  assert.equal(promotionGateState([betaJob, build], {settled: true}).state, "pending")
+  assert.equal(promotionGateState([betaJob, {...build, bucket: "fail"}], {settled: true}).state, "failed")
   assert.throws(() => promotionGateState(null), /must be an array/)
 })

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -216,10 +216,13 @@ test("the promotion gate follows the ci-gate status and ignores push-triggered b
   assert.equal(promotionGateState([betaJob, bot, build, gatePending]).state, "pending")
   assert.equal(promotionGateState([betaJob, bot, build, gatePassed]).state, "passed")
   assert.deepEqual(promotionGateState([betaJob, bot, gateFailed]).rows, [gateFailed])
-  // Without a ci-gate status only pull-request-triggered checks decide.
+  // Without a ci-gate status only the pull request's gated area builders
+  // decide; an advisory bot failing on the pull request never aborts.
   assert.equal(promotionGateState([betaJob, build]).state, "pending")
   assert.equal(promotionGateState([betaJob, {...build, bucket: "pass"}]).state, "passed")
-  assert.equal(promotionGateState([betaJob, bot, {...build, bucket: "pass"}]).state, "failed")
+  assert.equal(promotionGateState([betaJob, bot, {...build, bucket: "pass"}]).state, "passed")
+  assert.equal(promotionGateState([betaJob, bot, {...build, bucket: "fail"}]).state, "failed")
+  assert.equal(promotionGateState([betaJob, bot], {settled: true}).state, "passed")
   // Only the beta's push rows exist right after the PR is created: keep waiting
   // until registration has settled, then an empty gate means nothing applies.
   assert.equal(promotionGateState([betaJob]).state, "pending")


### PR DESCRIPTION
## Why

`promote --beta 3.1.0-beta.205` opened #3998 and then aborted in `gh pr checks --watch --fail-fast`. The PR's head is the exact beta source commit, so every check-run of the coordinated release that built beta.205 is attached to it. Two of those rows fail and neither should block a promotion:

- `Coordinated Mentra Release / Publish React Native example to Google Play` (push event): the Bluetooth example's store publish, which #3992 deliberately removed from the beta's completeness.
- `PR Agent Orchestrator / Plan agent cycle` (pull_request event): an advisory bot that failed because `scripts/pr-agent` does not exist on the promoted source.

Main has no required status checks configured, so `--required` reports nothing.

## What changes

`promote` now waits on the repository's own aggregate of required area builds, the `ci-gate-*` commit status on the head (the same context `ci-gate.yml` documents as the single required check), and only if no such status exists falls back to check-runs triggered by the pull request itself, never push-triggered ones. It polls every 30 seconds for up to four hours, prints what is pending, and fails on a failed gate. `promotionGateState` is exported and unit-tested; evaluated live against #3998's checks it reports `pending -> ci-gate-dev`, waiting on the mobile builds.

## Verification

- `node --test scripts/production-release.test.mjs`: 11 pass.
- Live evaluation of the new gate on #3998 as above.

Merging this onto `staging` allocates another beta, which does not affect promoting 3.1.0-beta.205: rerunning `promote` after pulling staging finds the open #3998 with the matching head and resumes at the wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
