### PR TITLE
Let the first coordinated promotion freeze the store-observed Mentra App

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -56,7 +56,8 @@ The required order is:
 
 Mobile N+1 compatibility with Cloud N is not a normal gate. Customers will
 inevitably keep Mobile N after Cloud N+1 is deployed, so Mobile N with Cloud N+1
-is mandatory.
+is mandatory. Step 1 needs the current app's source provenance; the first
+coordinated promotion has none and keeps only step 3 (see "Phase 1").
 
 ## One-time repository and account setup
 
@@ -155,8 +156,9 @@ release this one publishes and runs Phase 2 normally.
 If preparation stops before `status` can find an initial state record, rerun
 `start` with the same beta. That interrupted bootstrap may leave an empty draft
 attempt, but it has not deployed Cloud, uploaded an app, or consumed a store
-build coordinate. Once `status` returns `selected`, resume that attempt with
-`next` rather than starting another one.
+build coordinate. Once `status` returns `selected` (or `staging-compatible` for
+a first coordinated promotion), resume that attempt with `next` rather than
+starting another one.
 
 ## Phase 2 - Mobile N against staging Cloud N+1
 

--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -138,9 +138,19 @@ Preparation fails if:
 - its source is not contained in `main`;
 - the public Mentra App does not match the previous production manifest;
 - store build numbers cannot be allocated monotonically; or
-- the current production release lacks provenance. For a one-time provenance
-  bootstrap, create and review an accurate immutable current-production record;
-  do not invent coordinates in the workflow.
+- a published `mentra-vX.Y.Z` release exists but its record does not describe
+  the public Mentra App.
+
+When no published `mentra-vX.Y.Z` release exists yet (the first coordinated
+promotion), the public Mentra App predates this system and cannot be rebuilt
+from provenance. Preparation then freezes the app exactly as both stores serve
+it (`currentMentraApp.provenance` is `store-observed`, with the App Store build
+number and the Play production version code), publishes the store inventory
+into the attempt container, and creates the initial record directly in
+`staging-compatible`: Phase 2 does not exist for that attempt because there is
+no source to build a lab app from. Phase 5 still verifies the real store app
+against production Cloud N+1. Every later promotion finds the `mentra-vX.Y.Z`
+release this one publishes and runs Phase 2 normally.
 
 If preparation stops before `status` can find an initial state record, rerun
 `start` with the same beta. That interrupted bootstrap may leave an empty draft
@@ -149,6 +159,10 @@ build coordinate. Once `status` returns `selected`, resume that attempt with
 `next` rather than starting another one.
 
 ## Phase 2 - Mobile N against staging Cloud N+1
+
+This phase only exists when the current production app has coordinated
+provenance. `status` shows a first coordinated promotion already in
+`staging-compatible`; continue with Phase 3.
 
 Run the next action and watch it to completion:
 

--- a/.github/scripts/finalize-production-promotion.mjs
+++ b/.github/scripts/finalize-production-promotion.mjs
@@ -3,7 +3,7 @@ import {readFileSync, writeFileSync} from "node:fs"
 import path from "node:path"
 import {fileURLToPath} from "node:url"
 
-import {promotionAssetName, validatePromotionRecord} from "./production-promotion-state.mjs"
+import {hasCompatibilityLab, promotionAssetName, validatePromotionRecord} from "./production-promotion-state.mjs"
 import {releaseRecordSha256, requirePublicHttpsUrl, serializeReleaseRecord} from "./release-family.mjs"
 
 function fail(message) {
@@ -47,9 +47,13 @@ export function finalizeProductionPromotion({plan, record, checkpointUrl}) {
   }
   requirePublicHttpsUrl(checkpointUrl, "promotion checkpoint URL")
   const evidenceKinds = new Set(record.evidence.map(({kind}) => kind))
+  // A store-observed current app has no Phase 2, so its chain legitimately
+  // carries no staging Mobile N evidence; every later gate is unconditional.
+  const phaseTwoKinds = hasCompatibilityLab(record)
+    ? ["staging-mobile-n-compatibility-lab", "staging-mobile-n-compatibility"]
+    : []
   for (const kind of [
-    "staging-mobile-n-compatibility-lab",
-    "staging-mobile-n-compatibility",
+    ...phaseTwoKinds,
     "production-cloud-config-preflight",
     "production-cloud-v2-deployment",
     "production-mobile-n-compatibility",

--- a/.github/scripts/finalize-production-promotion.test.mjs
+++ b/.github/scripts/finalize-production-promotion.test.mjs
@@ -66,6 +66,7 @@ function finalizingRecord() {
     source: {mentraosCommit: "a".repeat(40)},
     coordinates: {
       currentMentraApp: {
+        provenance: "coordinated",
         sourceCommit: "f".repeat(40),
         provenanceUrl: "https://example.com/current.json",
         ios: {marketingVersion: "3.0.0", buildNumber: 300000100},

--- a/.github/scripts/finalize-production-promotion.test.mjs
+++ b/.github/scripts/finalize-production-promotion.test.mjs
@@ -109,6 +109,76 @@ function finalizingRecord() {
   return record
 }
 
+function storeObservedFinalizingRecord() {
+  let record = createInitialPromotionRecord({
+    releaseIdentity: "3.1.0",
+    attempt: 2,
+    selectedBeta: {
+      identity: "3.1.0-beta.101",
+      releaseSetId: "mentra-3.1.0-beta.101",
+      manifestUrl: "https://example.com/beta.json",
+      manifestSha256: "b".repeat(64),
+    },
+    source: {mentraosCommit: "a".repeat(40)},
+    coordinates: {
+      currentMentraApp: {
+        provenance: "store-observed",
+        sourceCommit: null,
+        provenanceUrl: null,
+        ios: {marketingVersion: "3.0", buildNumber: 51180073},
+        android: {marketingVersion: "3.0", buildNumber: 51180031},
+      },
+      compatibilityLab: null,
+      candidates: {
+        mentraApp: {
+          ios: {marketingVersion: "3.1.0", buildNumber: 310000102},
+          android: {marketingVersion: "3.1.0", buildNumber: 310000102},
+        },
+      },
+    },
+    actor: "release-owner",
+    createdAt: "2026-08-28T10:00:00.000Z",
+    provenanceUrl: "https://github.com/Mentra-Community/MentraOS/actions/runs/1",
+    evidence: [evidence("selected-beta-manifest")],
+  })
+  assert.equal(record.state, "staging-compatible")
+  for (const state of PROMOTION_STATES.slice(2, PROMOTION_STATES.indexOf("finalizing") + 1)) {
+    record = transitionPromotionRecord({
+      record,
+      to: state,
+      actor: "release-owner",
+      createdAt: `2026-08-28T10:${String(record.sequence + 2).padStart(2, "0")}:00.000Z`,
+      provenanceUrl: `https://github.com/Mentra-Community/MentraOS/actions/runs/${record.sequence + 3}`,
+      evidence: evidence(kinds.get(state)),
+    })
+  }
+  return record
+}
+
+test("finalizes a first promotion whose current app was only store-observed", () => {
+  const record = storeObservedFinalizingRecord()
+  const manifest = finalizeProductionPromotion({
+    plan,
+    record,
+    checkpointUrl: `https://github.com/Mentra-Community/MentraOS/releases/download/promotion/${record.promotionId}.json`,
+  })
+  assert.equal(manifest.kind, "mentra-production-release")
+  assert.equal(manifest.native.buildNumber, 310000102)
+  assert.ok(!record.evidence.some(({kind}) => kind.startsWith("staging-mobile-n")))
+})
+
+test("a coordinated current app still needs both Phase 2 evidence kinds to finalize", () => {
+  const record = finalizingRecord()
+  const withoutLab = {
+    ...record,
+    evidence: record.evidence.filter(({kind}) => kind !== "staging-mobile-n-compatibility-lab"),
+  }
+  assert.throws(
+    () => finalizeProductionPromotion({plan, record: withoutLab, checkpointUrl: "https://example.com/checkpoint.json"}),
+    /missing staging-mobile-n-compatibility-lab evidence/,
+  )
+})
+
 test("creates the canonical production manifest from the finalizing checkpoint", () => {
   const record = finalizingRecord()
   const manifest = finalizeProductionPromotion({

--- a/.github/scripts/prepare-compatibility-lab.test.mjs
+++ b/.github/scripts/prepare-compatibility-lab.test.mjs
@@ -30,6 +30,7 @@ const record = {
   source: {mentraosCommit: commit("c")},
   coordinates: {
     currentMentraApp: {
+      provenance: "coordinated",
       sourceCommit: currentSource,
       provenanceUrl: "https://example.com/current.json",
       ios: {marketingVersion: currentVersion, buildNumber: 100},

--- a/.github/scripts/prepare-production-promotion.mjs
+++ b/.github/scripts/prepare-production-promotion.mjs
@@ -30,6 +30,20 @@ function validateInventory(inventory, {bundleId, allowNoCurrent}) {
 }
 
 function validateCurrentMentraApp(previousManifest, inventory) {
+  if (previousManifest === null) {
+    // First coordinated promotion: no mentra-vX.Y.Z release describes the public
+    // app, so freeze exactly what both stores serve today. The app cannot be
+    // rebuilt for the compatibility lab, but Phase 5 still verifies it against
+    // production Cloud N+1 using these coordinates.
+    const {marketingVersion, buildNumber} = inventory.apple.current
+    return {
+      provenance: "store-observed",
+      sourceCommit: null,
+      provenanceUrl: null,
+      ios: {marketingVersion, buildNumber},
+      android: {marketingVersion, buildNumber: inventory.google.currentVersionCode},
+    }
+  }
   const expected = previousManifest.native
   if (
     !expected ||
@@ -43,6 +57,7 @@ function validateCurrentMentraApp(previousManifest, inventory) {
     throw new Error("Previous production manifest has no full source commit")
   }
   return {
+    provenance: "coordinated",
     sourceCommit: previousManifest.sourceCommit,
     provenanceUrl: previousManifest.url,
     ios: {marketingVersion: expected.marketingVersion, buildNumber: expected.buildNumber},
@@ -98,8 +113,9 @@ export function prepareProductionPromotion({
     mentraInventory.google.maxVersionCode,
     betaPlan.native.buildNumber,
   )
-  const compatibilityLabBuildNumber = lastMentraBuildNumber + 1
-  const mentraBuildNumber = lastMentraBuildNumber + 2
+  const hasCompatibilityLab = currentMentraApp.provenance === "coordinated"
+  const compatibilityLabBuildNumber = hasCompatibilityLab ? lastMentraBuildNumber + 1 : null
+  const mentraBuildNumber = lastMentraBuildNumber + (hasCompatibilityLab ? 2 : 1)
   const productionPlan = createReleasePlan({
     family,
     channel: "production",
@@ -125,13 +141,15 @@ export function prepareProductionPromotion({
     source: {mentraosCommit: betaPlan.sourceCommit},
     coordinates: {
       currentMentraApp,
-      compatibilityLab: {
-        ios: {marketingVersion: currentMentraApp.ios.marketingVersion, buildNumber: compatibilityLabBuildNumber},
-        android: {
-          marketingVersion: currentMentraApp.android.marketingVersion,
-          buildNumber: compatibilityLabBuildNumber,
-        },
-      },
+      compatibilityLab: hasCompatibilityLab
+        ? {
+            ios: {marketingVersion: currentMentraApp.ios.marketingVersion, buildNumber: compatibilityLabBuildNumber},
+            android: {
+              marketingVersion: currentMentraApp.android.marketingVersion,
+              buildNumber: compatibilityLabBuildNumber,
+            },
+          }
+        : null,
       candidates: {
         mentraApp: {
           ios: {marketingVersion: productionPlan.native.marketingVersion, buildNumber: mentraBuildNumber},
@@ -172,8 +190,11 @@ function readJson(file) {
 function main() {
   const args = parseArgs(process.argv.slice(2))
   const betaManifestPath = path.resolve(args["beta-manifest"])
-  const previousManifest = readJson(args["previous-manifest"])
-  previousManifest.url = args["previous-manifest-url"]
+  let previousManifest = null
+  if (args["previous-manifest"] || args["previous-manifest-url"]) {
+    previousManifest = readJson(args["previous-manifest"])
+    previousManifest.url = args["previous-manifest-url"]
+  }
   const result = prepareProductionPromotion({
     family: loadReleaseFamily({rootDir: path.resolve(args.root || process.cwd()), requireVersionMirrors: true}),
     betaPlan: readJson(args["beta-plan"]),

--- a/.github/scripts/prepare-production-promotion.test.mjs
+++ b/.github/scripts/prepare-production-promotion.test.mjs
@@ -74,6 +74,44 @@ test("freezes selected source and allocates new store build numbers", () => {
   assert.deepEqual(Object.keys(record.source), ["mentraosCommit"])
   assert.deepEqual(productionPlan.promotion.otaManifest, betaManifest.otaManifest)
   assert.equal(record.coordinates.currentMentraApp.sourceCommit, "f".repeat(40))
+  assert.equal(record.coordinates.currentMentraApp.provenance, "coordinated")
+  assert.equal(record.state, "selected")
+})
+
+test("first promotion freezes the store-observed public app and skips the compatibility lab", () => {
+  const {productionPlan, record} = prepare({
+    previousManifest: null,
+    mentraInventory: {
+      apple: {
+        bundleId: "com.mentra.mentra",
+        current: {marketingVersion: "3.0", buildNumber: 51180073},
+        maxBuildNumber: 310000060,
+      },
+      google: {packageName: "com.mentra.mentra", currentVersionCode: 51180031, maxVersionCode: 310000059},
+    },
+  })
+  assert.equal(record.state, "staging-compatible")
+  assert.deepEqual(record.coordinates.currentMentraApp, {
+    provenance: "store-observed",
+    sourceCommit: null,
+    provenanceUrl: null,
+    ios: {marketingVersion: "3.0", buildNumber: 51180073},
+    android: {marketingVersion: "3.0", buildNumber: 51180031},
+  })
+  assert.equal(record.coordinates.compatibilityLab, null)
+  assert.equal(productionPlan.native.buildNumber, 310000061)
+  assert.equal(record.coordinates.candidates.mentraApp.android.buildNumber, 310000061)
+})
+
+test("first promotion still requires a public app in both stores", () => {
+  assert.throws(
+    () =>
+      prepare({
+        previousManifest: null,
+        mentraInventory: inventory("com.mentra.mentra", null, 310000060, 310000059),
+      }),
+    /has no current public store release/,
+  )
 })
 
 test("rejects store state that does not match current production provenance", () => {

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -385,9 +385,11 @@ function main() {
       betaManifest: readJson("beta-manifest"),
       betaManifestSha256: fileSha256("beta-manifest"),
       betaManifestUrl: args["beta-manifest-url"],
-      previousPlanSha256: fileSha256("previous-plan"),
-      previousManifestSha256: fileSha256("previous-manifest"),
-      previousManifestUrl: args["previous-manifest-url"],
+      // A first coordinated promotion has no previous production release; its
+      // selection is still fingerprinted on the store inventories.
+      previousPlanSha256: args["previous-plan"] ? fileSha256("previous-plan") : null,
+      previousManifestSha256: args["previous-manifest"] ? fileSha256("previous-manifest") : null,
+      previousManifestUrl: args["previous-manifest-url"] || null,
       mentraInventory: readJson("mentra-inventory"),
     })
     output({selection_digest: digest}, args["github-output"])

--- a/.github/scripts/production-promotion-assets.mjs
+++ b/.github/scripts/production-promotion-assets.mjs
@@ -27,7 +27,7 @@ function gh(args, options = {}) {
 // The releases endpoint inlines every asset of every release; with hundreds of
 // coordinated build assets per family that exceeds Node's default 1 MiB
 // subprocess buffer. Keep only the fields the promotion logic reads.
-export const RELEASE_LIST_FIELDS = "{id, tag_name, name, body, draft, prerelease, target_commitish}"
+export const RELEASE_LIST_FIELDS = "{id, tag_name, name, body, draft, prerelease, target_commitish, published_at}"
 export const ASSET_LIST_FIELDS = "{id, name, url, size}"
 
 // gh cannot combine --slurp with --jq, so paginated listings are streamed as
@@ -117,6 +117,23 @@ export function prepareEvidenceAsset({file, kind, url, outputDirectory, assetPre
       assetName,
     },
   }
+}
+
+const PRODUCTION_RELEASE_TAG_PATTERN = /^mentra-v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$/
+
+// The newest published (non-draft, non-prerelease) coordinated production
+// release, or null when none exists yet. Callers must pass the complete
+// paginated release listing: a truncated listing could hide an older
+// mentra-vX.Y.Z behind newer unrelated releases and wrongly classify the
+// public app as store-observed, skipping Phase 2.
+export function latestProductionRelease(releases) {
+  const published = releases
+    .filter((release) => release.draft === false && release.prerelease === false)
+    .map((release) => ({release, match: PRODUCTION_RELEASE_TAG_PATTERN.exec(release.tag_name || "")}))
+    .filter(({release, match}) => match && typeof release.published_at === "string")
+    .sort((left, right) => left.release.published_at.localeCompare(right.release.published_at))
+  const latest = published.at(-1)
+  return latest ? {releaseIdentity: latest.match[1], tag: latest.release.tag_name, release: latest.release} : null
 }
 
 export function parsePromotionContainer(release) {
@@ -393,6 +410,14 @@ function main() {
       mentraInventory: readJson("mentra-inventory"),
     })
     output({selection_digest: digest}, args["github-output"])
+    return
+  }
+  if (command === "latest-production-release") {
+    const latest = latestProductionRelease(listReleases(args.repository))
+    output(
+      latest ? {found: true, tag: latest.tag, identity: latest.releaseIdentity} : {found: false},
+      args["github-output"],
+    )
     return
   }
   if (command === "create-container") {

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path"
 import test from "node:test"
 
 import {
+  latestProductionRelease,
   matchingPromotionContainers,
   nextPromotionAttempt,
   planPromotionContainerAllocation,
@@ -294,4 +295,33 @@ test("reassembles paginated gh listings streamed as JSON lines", () => {
   const {parseJsonLines} = assetsModule
   assert.deepEqual(parseJsonLines('{"id":1}\n{"id":2}\n\n'), [{id: 1}, {id: 2}])
   assert.deepEqual(parseJsonLines(""), [])
+})
+
+test("finds the newest published coordinated production release across the whole listing", () => {
+  const release = (tag_name, published_at, extra = {}) => ({
+    id: tag_name,
+    tag_name,
+    draft: false,
+    prerelease: false,
+    published_at,
+    ...extra,
+  })
+  const unrelated = Array.from({length: 150}, (_, index) =>
+    release(`v2.${index}`, `2026-09-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`),
+  )
+  assert.equal(latestProductionRelease(unrelated), null)
+  assert.equal(latestProductionRelease([]), null)
+  const listing = [
+    ...unrelated,
+    release("mentra-v3.0.0", "2026-08-01T00:00:00Z"),
+    release("mentra-v3.1.0", "2026-08-20T00:00:00Z"),
+    release("mentra-v3.2.0", "2026-08-25T00:00:00Z", {draft: true}),
+    release("mentra-v3.3.0", "2026-08-26T00:00:00Z", {prerelease: true}),
+    release("mentra-builds-v3.4.0", "2026-08-27T00:00:00Z"),
+    release("mentra-production-promotion-v3.1.0-attempt-1", "2026-08-28T00:00:00Z"),
+  ]
+  const latest = latestProductionRelease(listing)
+  assert.equal(latest.tag, "mentra-v3.1.0")
+  assert.equal(latest.releaseIdentity, "3.1.0")
+  assert.equal(latestProductionRelease(listing.slice(0, 100)), null)
 })

--- a/.github/scripts/production-promotion-assets.test.mjs
+++ b/.github/scripts/production-promotion-assets.test.mjs
@@ -121,6 +121,7 @@ function initialRecord() {
     source: {mentraosCommit: "a".repeat(40)},
     coordinates: {
       currentMentraApp: {
+        provenance: "coordinated",
         sourceCommit: "f".repeat(40),
         provenanceUrl: "https://example.com/current.json",
         ios: coordinate(1),

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -130,6 +130,43 @@ function validateAppCoordinate(value, label) {
   return value
 }
 
+// The current public Mentra App is either "coordinated" (its source commit and
+// provenance come from the previous mentra-vX.Y.Z release, so Phase 2 can rebuild
+// it as a compatibility-lab app) or "store-observed" (only the store inventories
+// describe it, because no coordinated production release exists yet). A
+// store-observed app cannot be rebuilt, so its promotion has no compatibility
+// lab and starts at staging-compatible instead of selected.
+export const CURRENT_APP_PROVENANCES = Object.freeze(["coordinated", "store-observed"])
+
+export function hasCompatibilityLab(record) {
+  return record.coordinates.currentMentraApp.provenance === "coordinated"
+}
+
+function validateCurrentMentraApp(coordinates) {
+  const current = coordinates.currentMentraApp
+  if (!current || typeof current !== "object" || Array.isArray(current)) {
+    fail("coordinates.currentMentraApp must be an object")
+  }
+  if (!CURRENT_APP_PROVENANCES.includes(current.provenance)) {
+    fail("coordinates.currentMentraApp.provenance must be coordinated or store-observed")
+  }
+  validateAppCoordinate(current.ios, "coordinates.currentMentraApp.ios")
+  validateAppCoordinate(current.android, "coordinates.currentMentraApp.android")
+  if (current.provenance === "coordinated") {
+    requireCommit(current.sourceCommit, "coordinates.currentMentraApp.sourceCommit")
+    requireHttps(current.provenanceUrl, "coordinates.currentMentraApp.provenanceUrl")
+    validateAppCoordinate(coordinates.compatibilityLab?.ios, "coordinates.compatibilityLab.ios")
+    validateAppCoordinate(coordinates.compatibilityLab?.android, "coordinates.compatibilityLab.android")
+    return
+  }
+  if (current.sourceCommit !== null || current.provenanceUrl !== null) {
+    fail("a store-observed current Mentra App has no source commit or provenance URL")
+  }
+  if (coordinates.compatibilityLab !== null) {
+    fail("a store-observed current Mentra App cannot have compatibility-lab coordinates")
+  }
+}
+
 function validatePromotionSource(source) {
   if (!source || typeof source !== "object" || Array.isArray(source)) fail("source must be an object")
   if (!isDeepStrictEqual(Object.keys(source).sort(), ["mentraosCommit"])) {
@@ -192,12 +229,10 @@ export function validatePromotionRecord(record) {
   requireHttps(record.selectedBeta.manifestUrl, "selectedBeta.manifestUrl")
   requireSha256(record.selectedBeta.manifestSha256, "selectedBeta.manifestSha256")
   if (!record.coordinates || typeof record.coordinates !== "object") fail("coordinates must be an object")
-  requireCommit(record.coordinates.currentMentraApp.sourceCommit, "coordinates.currentMentraApp.sourceCommit")
-  requireHttps(record.coordinates.currentMentraApp.provenanceUrl, "coordinates.currentMentraApp.provenanceUrl")
-  validateAppCoordinate(record.coordinates.currentMentraApp.ios, "coordinates.currentMentraApp.ios")
-  validateAppCoordinate(record.coordinates.currentMentraApp.android, "coordinates.currentMentraApp.android")
-  validateAppCoordinate(record.coordinates.compatibilityLab.ios, "coordinates.compatibilityLab.ios")
-  validateAppCoordinate(record.coordinates.compatibilityLab.android, "coordinates.compatibilityLab.android")
+  validateCurrentMentraApp(record.coordinates)
+  if (!hasCompatibilityLab(record) && record.state === "selected") {
+    fail("a promotion without a compatibility lab cannot be in state selected")
+  }
   if (!isDeepStrictEqual(Object.keys(record.coordinates.candidates).sort(), ["mentraApp"])) {
     fail("coordinates.candidates must contain only mentraApp")
   }
@@ -286,7 +321,9 @@ export function createInitialPromotionRecord({
     promotionId: `mentra-${releaseIdentity}-attempt-${attempt}`,
     releaseIdentity,
     attempt,
-    state: "selected",
+    // Without a rebuildable current app there is no Phase 2, so the promotion
+    // starts where Phase 2 would have ended.
+    state: coordinates?.currentMentraApp?.provenance === "store-observed" ? "staging-compatible" : "selected",
     sequence: 0,
     previous: null,
     createdAt,
@@ -388,7 +425,8 @@ export function validateAttestation(attestation, record, expectedCheck) {
   if (!check || (expectedCheck && attestation.check !== expectedCheck)) fail("attestation check is not expected")
   if (
     attestation.check === "staging-mobile-n-compatibility" &&
-    !record.evidence.some((item) => item.kind === "staging-mobile-n-compatibility-lab")
+    (!hasCompatibilityLab(record) ||
+      !record.evidence.some((item) => item.kind === "staging-mobile-n-compatibility-lab"))
   ) {
     fail("staging Mobile N acceptance requires recorded compatibility-lab build evidence")
   }

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -37,6 +37,7 @@ function initial() {
     source: {mentraosCommit: "a".repeat(40)},
     coordinates: {
       currentMentraApp: {
+        provenance: "coordinated",
         sourceCommit: "f".repeat(40),
         provenanceUrl: "https://github.com/Mentra-Community/MentraOS/releases/tag/mentra-v3.0.0",
         ios: coordinate(300000100),
@@ -45,6 +46,36 @@ function initial() {
       compatibilityLab: {ios: coordinate(310000090), android: coordinate(310000090)},
       candidates: {
         mentraApp: {ios: coordinate(310000100), android: coordinate(310000101)},
+      },
+    },
+    actor: "release-owner",
+    createdAt: now,
+    provenanceUrl: runUrl,
+  })
+}
+
+function storeObserved() {
+  return createInitialPromotionRecord({
+    releaseIdentity: "3.1.0",
+    attempt: 1,
+    selectedBeta: {
+      identity: "3.1.0-beta.57",
+      releaseSetId: "mentra-3.1.0-beta.57",
+      manifestUrl: "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/beta.json",
+      manifestSha256: "b".repeat(64),
+    },
+    source: {mentraosCommit: "a".repeat(40)},
+    coordinates: {
+      currentMentraApp: {
+        provenance: "store-observed",
+        sourceCommit: null,
+        provenanceUrl: null,
+        ios: {marketingVersion: "3.0", buildNumber: 51180073},
+        android: {marketingVersion: "3.0", buildNumber: 51180031},
+      },
+      compatibilityLab: null,
+      candidates: {
+        mentraApp: {ios: coordinate(310000100), android: coordinate(310000100)},
       },
     },
     actor: "release-owner",
@@ -446,4 +477,117 @@ test("stable packages only read the promotion to reject a conflicting frozen bet
       }),
     /not contiguous/,
   )
+})
+
+test("a store-observed current app skips the compatibility lab and starts at staging-compatible", () => {
+  const record = storeObserved()
+  assert.equal(record.state, "staging-compatible")
+  assert.equal(record.sequence, 0)
+  assert.deepEqual(nextAction(record), {
+    kind: "workflow",
+    workflow: "production-release-cloud.yml",
+    phase: "preflight",
+  })
+  const next = transitionPromotionRecord({
+    record,
+    to: "production-config-ready",
+    actor: "release-owner",
+    createdAt: now,
+    provenanceUrl: runUrl,
+    evidence: evidence("production-config-ready"),
+  })
+  assert.equal(next.state, "production-config-ready")
+  assert.throws(
+    () => validatePromotionRecord({...record, state: "selected"}),
+    /without a compatibility lab cannot be in state selected/,
+  )
+})
+
+test("a store-observed current app cannot carry coordinated provenance or lab coordinates", () => {
+  const record = storeObserved()
+  assert.throws(
+    () =>
+      validatePromotionRecord({
+        ...record,
+        coordinates: {
+          ...record.coordinates,
+          currentMentraApp: {...record.coordinates.currentMentraApp, sourceCommit: "f".repeat(40)},
+        },
+      }),
+    /has no source commit or provenance URL/,
+  )
+  assert.throws(
+    () =>
+      validatePromotionRecord({
+        ...record,
+        coordinates: {...record.coordinates, compatibilityLab: {ios: coordinate(1), android: coordinate(1)}},
+      }),
+    /cannot have compatibility-lab coordinates/,
+  )
+  assert.throws(
+    () =>
+      validatePromotionRecord({
+        ...record,
+        coordinates: {
+          ...record.coordinates,
+          currentMentraApp: {...record.coordinates.currentMentraApp, provenance: "legacy"},
+        },
+      }),
+    /provenance must be coordinated or store-observed/,
+  )
+  const coordinated = initial()
+  assert.throws(
+    () =>
+      validatePromotionRecord({
+        ...coordinated,
+        coordinates: {...coordinated.coordinates, compatibilityLab: null},
+      }),
+    /compatibilityLab\.ios must be an object/,
+  )
+})
+
+test("the store-observed app is still attested against production Cloud N+1 by its store coordinates", () => {
+  let record = storeObserved()
+  for (const state of ["production-config-ready", "cloud-deployed"]) {
+    record = transitionPromotionRecord({
+      record,
+      to: state,
+      actor: "release-owner",
+      createdAt: now,
+      provenanceUrl: runUrl,
+      evidence: evidence(state),
+    })
+  }
+  assert.deepEqual(nextAction(record), {kind: "attest", check: "production-mobile-n-compatibility"})
+  const attestation = {
+    schemaVersion: 1,
+    promotionId: record.promotionId,
+    releaseIdentity: record.releaseIdentity,
+    check: "production-mobile-n-compatibility",
+    result: "pass",
+    performedAt: now,
+    tester: {githubLogin: "tester"},
+    tests: [
+      {
+        product: "mentra-app",
+        platform: "ios",
+        result: "pass",
+        appVersion: "3.0",
+        appBuild: "51180073",
+        deviceModel: "iPhone",
+        osVersion: "26.0",
+      },
+      {
+        product: "mentra-app",
+        platform: "android",
+        result: "pass",
+        appVersion: "3.0",
+        appBuild: "51180031",
+        deviceModel: "Pixel",
+        osVersion: "16",
+      },
+    ],
+    evidenceUrls: [runUrl],
+  }
+  assert.equal(validateAttestation(attestation, record), attestation)
 })

--- a/.github/scripts/record-production-compatibility-lab.test.mjs
+++ b/.github/scripts/record-production-compatibility-lab.test.mjs
@@ -25,6 +25,7 @@ const record = {
   source: {mentraosCommit: sha("a").slice(0, 40)},
   coordinates: {
     currentMentraApp: {
+      provenance: "coordinated",
       sourceCommit: sha("f").slice(0, 40),
       provenanceUrl: "https://example.com/current.json",
       ios: {marketingVersion: "3.0.0", buildNumber: 100},

--- a/.github/workflows/production-release-prepare.yml
+++ b/.github/workflows/production-release-prepare.yml
@@ -87,6 +87,14 @@ jobs:
           latest=$(gh release list --exclude-drafts --exclude-pre-releases --limit 100 \
             --json tagName,publishedAt \
             --jq '[.[] | select(.tagName | test("^mentra-v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.publishedAt) | last')
+          if [[ "$latest" == "null" || -z "$latest" ]]; then
+            # First coordinated promotion. The public app predates this system,
+            # so it is frozen from the store inventories instead and has no
+            # compatibility lab; see "Phase 1" in the runbook.
+            echo "Warning: no published mentra-vX.Y.Z release exists; freezing the current Mentra App from the stores." >&2
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           tag=$(jq -er .tagName <<< "$latest")
           identity="${tag#mentra-v}"
           name="mentra-release-$identity.json"
@@ -101,6 +109,7 @@ jobs:
             --file promotion-input/current/release-manifest.json \
             --url "$url"
           {
+            echo "found=true"
             echo "tag=$tag"
             echo "identity=$identity"
             echo "manifest_url=$url"
@@ -161,16 +170,25 @@ jobs:
           BETA_IDENTITY: ${{ inputs.beta_identity }}
           BETA_TAG: ${{ steps.identity.outputs.beta_tag }}
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          node .github/scripts/production-promotion-assets.mjs selection-digest
-          --beta-plan promotion-input/beta/release-plan.json
-          --beta-manifest promotion-input/beta/release-manifest.json
-          --beta-manifest-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$BETA_TAG/mentra-release-$BETA_IDENTITY.json"
-          --previous-plan promotion-input/current/release-plan.json
-          --previous-manifest promotion-input/current/release-manifest.json
-          --previous-manifest-url "${{ steps.previous.outputs.manifest_url }}"
-          --mentra-inventory promotion-input/stores/mentra-inventory.json
-          --github-output "$GITHUB_OUTPUT"
+          PREVIOUS_FOUND: ${{ steps.previous.outputs.found }}
+          PREVIOUS_MANIFEST_URL: ${{ steps.previous.outputs.manifest_url }}
+        run: |
+          set -euo pipefail
+          previous=()
+          if [[ "$PREVIOUS_FOUND" == "true" ]]; then
+            previous=(
+              --previous-plan promotion-input/current/release-plan.json
+              --previous-manifest promotion-input/current/release-manifest.json
+              --previous-manifest-url "$PREVIOUS_MANIFEST_URL"
+            )
+          fi
+          node .github/scripts/production-promotion-assets.mjs selection-digest \
+            --beta-plan promotion-input/beta/release-plan.json \
+            --beta-manifest promotion-input/beta/release-manifest.json \
+            --beta-manifest-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/$BETA_TAG/mentra-release-$BETA_IDENTITY.json" \
+            "${previous[@]}" \
+            --mentra-inventory promotion-input/stores/mentra-inventory.json \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Allocate append-only promotion container
         id: container
@@ -191,17 +209,25 @@ jobs:
           BETA_IDENTITY: ${{ inputs.beta_identity }}
           BETA_TAG: ${{ steps.identity.outputs.beta_tag }}
           GH_TOKEN: ${{ github.token }}
+          PREVIOUS_FOUND: ${{ steps.previous.outputs.found }}
+          PREVIOUS_MANIFEST_URL: ${{ steps.previous.outputs.manifest_url }}
         run: |
           set -euo pipefail
           beta_manifest_name="mentra-release-$BETA_IDENTITY.json"
           beta_manifest_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$BETA_TAG/$beta_manifest_name"
+          previous=()
+          if [[ "$PREVIOUS_FOUND" == "true" ]]; then
+            previous=(
+              --previous-manifest promotion-input/current/release-manifest.json
+              --previous-manifest-url "$PREVIOUS_MANIFEST_URL"
+            )
+          fi
           mkdir -p promotion-output
           node .github/scripts/prepare-production-promotion.mjs \
             --beta-plan promotion-input/beta/release-plan.json \
             --beta-manifest promotion-input/beta/release-manifest.json \
             --beta-manifest-url "$beta_manifest_url" \
-            --previous-manifest promotion-input/current/release-manifest.json \
-            --previous-manifest-url "${{ steps.previous.outputs.manifest_url }}" \
+            "${previous[@]}" \
             --mentra-inventory promotion-input/stores/mentra-inventory.json \
             --attempt "${{ steps.container.outputs.attempt }}" \
             --actor "$GITHUB_ACTOR" \
@@ -225,14 +251,21 @@ jobs:
             --name "$plan_name" \
             --release-id "${{ steps.container.outputs.release_id }}" \
             --repository "$GITHUB_REPOSITORY"
+          if [[ "${{ steps.previous.outputs.found }}" == "true" ]]; then
+            node .github/scripts/publish-immutable-release-asset.mjs \
+              --file promotion-input/current/release-plan.json \
+              --name current-production-release-plan.json \
+              --release-id "${{ steps.container.outputs.release_id }}" \
+              --repository "$GITHUB_REPOSITORY"
+            node .github/scripts/publish-immutable-release-asset.mjs \
+              --file promotion-input/current/release-manifest.json \
+              --name current-production-release-manifest.json \
+              --release-id "${{ steps.container.outputs.release_id }}" \
+              --repository "$GITHUB_REPOSITORY"
+          fi
           node .github/scripts/publish-immutable-release-asset.mjs \
-            --file promotion-input/current/release-plan.json \
-            --name current-production-release-plan.json \
-            --release-id "${{ steps.container.outputs.release_id }}" \
-            --repository "$GITHUB_REPOSITORY"
-          node .github/scripts/publish-immutable-release-asset.mjs \
-            --file promotion-input/current/release-manifest.json \
-            --name current-production-release-manifest.json \
+            --file promotion-input/stores/mentra-inventory.json \
+            --name current-production-store-inventory.json \
             --release-id "${{ steps.container.outputs.release_id }}" \
             --repository "$GITHUB_REPOSITORY"
           node .github/scripts/production-promotion-assets.mjs publish-record \
@@ -250,7 +283,12 @@ jobs:
             echo "- Attempt: \`${{ steps.container.outputs.attempt }}\`"
             echo "- Selected beta: \`${{ inputs.beta_identity }}\`"
             echo "- MentraOS source: \`$(jq -er .source.mentraosCommit "$record")\`"
-            echo "- State: \`selected\`"
+            echo "- State: \`$(jq -er .state "$record")\`"
+            echo "- Current Mentra App: \`$(jq -er '.coordinates.currentMentraApp | "\(.provenance) \(.ios.marketingVersion) (iOS \(.ios.buildNumber), Android \(.android.buildNumber))"' "$record")\`"
             echo
-            echo "No Cloud or app-store state was changed. The next action builds non-promotable Mobile N compatibility-lab apps."
+            if [[ "$(jq -er .coordinates.currentMentraApp.provenance "$record")" == "coordinated" ]]; then
+              echo "No Cloud or app-store state was changed. The next action builds non-promotable Mobile N compatibility-lab apps."
+            else
+              echo "No Cloud or app-store state was changed. The current Mentra App predates coordinated releases, so there is no compatibility lab; the next action is the Cloud configuration preflight."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/production-release-prepare.yml
+++ b/.github/workflows/production-release-prepare.yml
@@ -84,10 +84,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          latest=$(gh release list --exclude-drafts --exclude-pre-releases --limit 100 \
-            --json tagName,publishedAt \
-            --jq '[.[] | select(.tagName | test("^mentra-v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.publishedAt) | last')
-          if [[ "$latest" == "null" || -z "$latest" ]]; then
+          # Walks every release page: a truncated listing could hide an older
+          # mentra-vX.Y.Z and wrongly skip Phase 2.
+          node .github/scripts/production-promotion-assets.mjs latest-production-release \
+            --repository "$GITHUB_REPOSITORY" \
+            --github-output promotion-input/latest-production.env
+          if ! grep -qx 'found=true' promotion-input/latest-production.env; then
             # First coordinated promotion. The public app predates this system,
             # so it is frozen from the store inventories instead and has no
             # compatibility lab; see "Phase 1" in the runbook.
@@ -95,8 +97,9 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          tag=$(jq -er .tagName <<< "$latest")
-          identity="${tag#mentra-v}"
+          tag=$(sed -n 's/^tag=//p' promotion-input/latest-production.env)
+          identity=$(sed -n 's/^identity=//p' promotion-input/latest-production.env)
+          [[ "$tag" == "mentra-v$identity" ]]
           name="mentra-release-$identity.json"
           plan_name="mentra-release-plan-$identity.json"
           mkdir -p promotion-input/current

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -34,6 +34,7 @@ const baseRecord = {
   source: {mentraosCommit: "a".repeat(40)},
   coordinates: {
     currentMentraApp: {
+      provenance: "coordinated",
       sourceCommit: "f".repeat(40),
       provenanceUrl: "https://github.com/Mentra-Community/MentraOS/releases/tag/mentra-v3.0.0",
       ios: {marketingVersion: "3.0.0", buildNumber: 1},


### PR DESCRIPTION
## Why

`start --beta 3.1.0-beta.205` failed in `production-release-prepare.yml` at "Download current production provenance": no published `mentra-vX.Y.Z` release exists because this is the first coordinated promotion. The runbook asked for a one-time hand-written provenance bootstrap, but that cannot describe the legacy 3.0 release honestly:

- the legacy release scripts derived build numbers from the wall clock separately per platform, so every 3.0 build has a different iOS build number and Android versionCode, while `validateCurrentMentraApp` requires them to be one integer;
- the compatibility lab (Phase 2) rebuilds the current app from its source commit with the coordinated mobile workflow, and the commits that produced 3.0 predate `.github/release-family.json` and the coordinated scripts.

## What

When no published `mentra-vX.Y.Z` release exists, preparation now:

- freezes the public Mentra App exactly as both stores serve it: `coordinates.currentMentraApp` gets `provenance: "store-observed"`, `sourceCommit: null`, `provenanceUrl: null`, the App Store marketing version and build number for iOS, and the Play production version code for Android;
- sets `coordinates.compatibilityLab` to `null` and allocates only one new build number (the candidate);
- creates the initial record directly in `staging-compatible`, so `next` goes to the Cloud preflight. There is no source to build a lab app from, so Phase 2 does not exist for the attempt;
- publishes the store inventory into the attempt container as `current-production-store-inventory.json` (in both modes) and skips the frozen `current-production-release-*.json` assets when there is nothing to freeze;
- fingerprints the selection without the absent previous release.

Records with a coordinated current app are unchanged apart from the explicit `provenance: "coordinated"` field. The state machine rejects a store-observed record in `selected`, a store-observed app carrying a commit or lab coordinates, and a coordinated app without lab coordinates. Phase 5 (`production-mobile-n-compatibility`) still attests the real store app against production Cloud N+1 using the frozen store coordinates. The next promotion finds the `mentra-vX.Y.Z` release this one publishes and runs Phase 2 as before.

Targets `main` because the promotion workflows and scripts run from `main`; it must be reconciled into `staging` and `dev` afterwards.

## Test evidence

- `node --test` over `.github/scripts/*.test.mjs`, `mobile/scripts/app-store-connect-build.test.mjs`, `scripts/production-release.test.mjs`: 237 passed, 0 failed.
- Dry run of `prepare-production-promotion.mjs` with beta.205-shaped inputs, a store inventory of the real 3.0 numbers (iOS 51180073, Android 51180031), and no `--previous-manifest`: produces `production-promotion-3.1.0-attempt-1-00-staging-compatible.json`; `production-promotion-state.mjs validate` accepts it and `next` returns the `production-release-cloud.yml` preflight.
- Edited workflow parses as YAML (16 steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
