### PR TITLE
Retry a spurious App Store Connect 401 on read requests

### DIFF
--- a/mobile/scripts/app-store-connect-build.mjs
+++ b/mobile/scripts/app-store-connect-build.mjs
@@ -59,7 +59,13 @@ export function createAppStoreConnectClient({
         return body ? JSON.parse(body) : null
       } catch (error) {
         lastError = error
-        if (!canRetry || !isTransientAppStoreConnectError(error) || attempt === attempts) throw error
+        if (
+          !canRetry ||
+          !(isTransientAppStoreConnectError(error) || isSpuriousAuthenticationError(error)) ||
+          attempt === attempts
+        ) {
+          throw error
+        }
         console.warn(
           `App Store Connect temporarily failed ${method} ${resource} (${transientAppStoreConnectErrorLabel(error)}); retrying`,
         )
@@ -175,6 +181,16 @@ function isTransientAppStoreConnectError(error) {
     TRANSIENT_NETWORK_ERROR_CODES.has(error?.code) ||
     TRANSIENT_NETWORK_ERROR_CODES.has(error?.cause?.code)
   )
+}
+
+// App Store Connect intermittently answers a correctly signed request with
+// HTTP 401 "Authentication credentials are missing or invalid" and accepts the
+// next one. Every attempt above signs a fresh token, so a read is retried
+// through the same bounded budget as a network failure. Only the request loop
+// treats it that way: a 401 that survives every attempt is a real credential
+// problem and must not keep a long polling loop alive.
+function isSpuriousAuthenticationError(error) {
+  return error?.status === 401
 }
 
 function transientAppStoreConnectErrorLabel(error) {

--- a/mobile/scripts/app-store-connect-build.test.mjs
+++ b/mobile/scripts/app-store-connect-build.test.mjs
@@ -100,6 +100,47 @@ test("retries App Store Connect reads terminated while consuming the response bo
   assert.equal(requests, 2)
 })
 
+test("retries a spurious App Store Connect 401 on reads with a freshly signed token", async () => {
+  const unauthorized = response(401, {errors: [{title: "Authentication credentials are missing or invalid."}]})
+  const responses = [unauthorized, response(200, {data: {id: "app-1", attributes: {bundleId: "com.mentra.example"}}})]
+  const tokens = []
+  const api = createAppStoreConnectClient({
+    issuerId: "issuer",
+    keyId: "key",
+    privateKey: TEST_PRIVATE_KEY,
+    delay: 0,
+    sleep: async () => {},
+    fetchImpl: async (_url, options) => {
+      tokens.push(options.headers.Authorization)
+      return responses.shift()
+    },
+  })
+
+  const app = await findApp(api, "com.mentra.example", "app-1")
+  assert.equal(app.id, "app-1")
+  assert.equal(tokens.length, 2)
+  assert.notEqual(tokens[0], tokens[1])
+})
+
+test("a persistent App Store Connect 401 still fails after the retry budget", async () => {
+  let requests = 0
+  const api = createAppStoreConnectClient({
+    issuerId: "issuer",
+    keyId: "key",
+    privateKey: TEST_PRIVATE_KEY,
+    attempts: 3,
+    delay: 0,
+    sleep: async () => {},
+    fetchImpl: async () => {
+      requests += 1
+      return response(401, {errors: [{title: "Authentication credentials are missing or invalid."}]})
+    },
+  })
+
+  await assert.rejects(() => findApp(api, "com.mentra.example", "app-1"), /failed with HTTP 401/)
+  assert.equal(requests, 3)
+})
+
 test("does not retry permanent App Store Connect request failures", async () => {
   let requests = 0
   const api = createAppStoreConnectClient({


### PR DESCRIPTION
## Why

The coordinated 3.1.0-beta.212 release ([run 34631045667](https://github.com/Mentra-Community/MentraOS/actions/runs/34631045667)) lost its "Process iOS upload and assign TestFlight group" job when App Store Connect answered one `GET /v1/builds` poll with HTTP 401 "Authentication credentials are missing or invalid", two and a half minutes into the wait and seconds after it had accepted identically signed requests (and retried a 500). Every attempt signs a fresh 19-minute token, so this was not expiry; Apple's API intermittently returns 401 for valid tokens. The client treated it as permanent and the job failed. The rerun of the failed jobs is expected to pass, which is the operational fix for beta.212; this PR stops the flake from failing future runs.

## What

`createAppStoreConnectClient` retries a 401 on `GET`/`HEAD` through the same bounded `attempts` budget as a network failure or 5xx, re-signing the token on each attempt. The classification is deliberately local to the request loop: `isTransientAppStoreConnectError` is unchanged, so `waitForProcessedBuild` and the other polling loops still treat a 401 that survived every attempt as a real credential problem instead of polling for an hour.

Tests: a 401 followed by 200 resolves with two distinct tokens; three 401s fail with the 401 error after exactly three requests; existing transient and permanent-failure tests unchanged.

## Test evidence

`node --test mobile/scripts/app-store-connect-build.test.mjs`: all tests pass, including the two new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
