### PR TITLE
Promote staging to main for 3.1.0-beta.212

### DIFF
--- a/.github/scripts/allocate-asg-version.mjs
+++ b/.github/scripts/allocate-asg-version.mjs
@@ -4,16 +4,34 @@ import path from "node:path"
 import {fileURLToPath} from "node:url"
 
 const ASSET_PATTERN = /^mentra-live-asg-(\d+)-([0-9a-f]{64})\.(apk|json)$/
-// The legacy publisher allocated seconds since 2025-01-01 and had already crossed
-// 50 million before this allocator replaced it. Keep the coordinated namespace
-// permanently above that range so the first cutover build is always an upgrade.
-const COORDINATED_VERSION_CODE_BASELINE = 100_000_000
+// ASG version codes are derived from the family base version so the code and
+// the versionName describe the same release: MAJOR*100_000_000 +
+// MINOR*1_000_000 + PATCH*10_000 + SEQUENCE, where SEQUENCE counts the distinct
+// ASG builds of that base version (1..9999). Two legacy namespaces sit below
+// it: the original publisher allocated seconds since 2025-01-01 (below 60
+// million) and the first coordinated allocator used 100_000_000 + run number.
+// Requiring MAJOR >= 2 keeps every derived code above both, so the first
+// derived build of any family is still an upgrade for every glasses in the
+// field, and MAJOR <= 20 keeps it inside the Android-safe range.
+const BASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+const MAJOR_WEIGHT = 100_000_000
+const MINOR_WEIGHT = 1_000_000
+const PATCH_WEIGHT = 10_000
+const MAX_SEQUENCE = PATCH_WEIGHT - 1
 
-export function allocateAsgVersion({assets, fingerprint, runNumber}) {
+export function asgVersionCodePrefix(baseVersion) {
+  const match = BASE_VERSION_PATTERN.exec(baseVersion || "")
+  if (!match) throw new Error(`ASG base version ${JSON.stringify(baseVersion)} must be a plain X.Y.Z version`)
+  const [major, minor, patch] = match.slice(1).map(Number)
+  if (major < 2 || major > 20) throw new Error(`ASG base version major ${major} must be between 2 and 20`)
+  if (minor > 99 || patch > 99) throw new Error("ASG base version minor and patch must be at most 99")
+  return major * MAJOR_WEIGHT + minor * MINOR_WEIGHT + patch * PATCH_WEIGHT
+}
+
+export function allocateAsgVersion({assets, fingerprint, baseVersion}) {
   if (!Array.isArray(assets)) throw new Error("GitHub release assets must be an array")
   if (!/^[0-9a-f]{64}$/.test(fingerprint)) throw new Error("Invalid ASG fingerprint")
-  if (!Number.isSafeInteger(runNumber) || runNumber <= 0) throw new Error("runNumber must be a positive integer")
-
+  const prefix = asgVersionCodePrefix(baseVersion)
   const recognized = assets.flatMap((asset) => {
     const match = ASSET_PATTERN.exec(asset.name ?? "")
     if (!match) return []
@@ -23,10 +41,14 @@ export function allocateAsgVersion({assets, fingerprint, runNumber}) {
   const apks = matching.filter((asset) => asset.type === "apk")
   const provenance = matching.filter((asset) => asset.type === "json")
   if (apks.length > 1 || provenance.length > 1) throw new Error("Duplicate immutable ASG release assets found")
-
   if (apks.length === 1 && provenance.length === 1) {
     if (apks[0].versionCode !== provenance[0].versionCode) {
       throw new Error("ASG artifact and provenance use different version codes")
+    }
+    // The versionName is part of the fingerprint, so a complete pair for this
+    // fingerprint was built for this base version and must carry its prefix.
+    if (apks[0].versionCode - prefix < 1 || apks[0].versionCode - prefix > MAX_SEQUENCE) {
+      throw new Error(`Existing ASG versionCode ${apks[0].versionCode} does not belong to base version ${baseVersion}`)
     }
     return {
       exists: true,
@@ -36,10 +58,12 @@ export function allocateAsgVersion({assets, fingerprint, runNumber}) {
       orphanAssetIds: [],
     }
   }
-
-  const maxRecordedVersionCode = recognized.reduce((maximum, asset) => Math.max(maximum, asset.versionCode), 0)
-  const versionCode = Math.max(COORDINATED_VERSION_CODE_BASELINE + runNumber, maxRecordedVersionCode + 1)
-  if (versionCode > 2_100_000_000) throw new Error("Allocated ASG versionCode exceeds the Android-safe range")
+  const usedSequences = recognized
+    .map((asset) => asset.versionCode - prefix)
+    .filter((sequence) => sequence >= 1 && sequence <= MAX_SEQUENCE)
+  const sequence = usedSequences.length === 0 ? 1 : Math.max(...usedSequences) + 1
+  if (sequence > MAX_SEQUENCE) throw new Error(`Base version ${baseVersion} has exhausted its ASG version codes`)
+  const versionCode = prefix + sequence
   return {
     exists: false,
     versionCode,
@@ -65,7 +89,7 @@ function main() {
   const result = allocateAsgVersion({
     assets: JSON.parse(readFileSync(path.resolve(args.assets), "utf8")),
     fingerprint: args.fingerprint,
-    runNumber: Number(args["run-number"]),
+    baseVersion: args["base-version"],
   })
   writeFileSync(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`)
 }

--- a/.github/scripts/allocate-asg-version.test.mjs
+++ b/.github/scripts/allocate-asg-version.test.mjs
@@ -1,77 +1,116 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import {allocateAsgVersion} from "./allocate-asg-version.mjs"
+import {allocateAsgVersion, asgVersionCodePrefix} from "./allocate-asg-version.mjs"
 
 const fingerprint = "a".repeat(64)
+const other = "b".repeat(64)
 
 function asset(id, versionCode, selectedFingerprint, extension) {
   return {id, name: `mentra-live-asg-${versionCode}-${selectedFingerprint}.${extension}`}
 }
 
-test("allocates from the monotonic workflow run number for a new fingerprint", () => {
-  const result = allocateAsgVersion({assets: [], fingerprint, runNumber: 57})
+test("derives the version code prefix from the family base version", () => {
+  assert.equal(asgVersionCodePrefix("3.1.0"), 301_000_000)
+  assert.equal(asgVersionCodePrefix("3.2.4"), 302_040_000)
+  assert.equal(asgVersionCodePrefix("20.99.99"), 2_099_990_000)
+  assert.throws(() => asgVersionCodePrefix("3.1.0-beta.5"), /plain X\.Y\.Z/)
+  assert.throws(() => asgVersionCodePrefix("1.9.0"), /major 1 must be between 2 and 20/)
+  assert.throws(() => asgVersionCodePrefix("21.0.0"), /major 21 must be between 2 and 20/)
+  assert.throws(() => asgVersionCodePrefix("3.100.0"), /at most 99/)
+})
+
+test("allocates the first code of a base version above every legacy namespace", () => {
+  const result = allocateAsgVersion({
+    assets: [
+      asset(1, 52_000_000, other, "apk"),
+      asset(2, 52_000_000, other, "json"),
+      asset(3, 100_000_173, "c".repeat(64), "apk"),
+      asset(4, 100_000_173, "c".repeat(64), "json"),
+    ],
+    fingerprint,
+    baseVersion: "3.1.0",
+  })
   assert.equal(result.exists, false)
-  assert.equal(result.versionCode, 100_000_057)
+  assert.equal(result.versionCode, 301_000_001)
+  assert.ok(result.versionCode > 100_000_173)
+  assert.equal(result.apkAsset, `mentra-live-asg-301000001-${fingerprint}.apk`)
   assert.deepEqual(result.orphanAssetIds, [])
 })
 
-test("allocates above the complete legacy timestamp namespace at cutover", () => {
+test("counts distinct builds within one base version and ignores other versions", () => {
   const result = allocateAsgVersion({
-    assets: [asset(1, 52_000_000, "b".repeat(64), "apk"), asset(2, 52_000_000, "b".repeat(64), "json")],
+    assets: [
+      asset(1, 301_000_001, other, "apk"),
+      asset(2, 301_000_001, other, "json"),
+      asset(3, 301_000_002, "c".repeat(64), "apk"),
+      asset(4, 301_000_002, "c".repeat(64), "json"),
+      asset(5, 302_000_007, "d".repeat(64), "apk"),
+      asset(6, 302_000_007, "d".repeat(64), "json"),
+    ],
     fingerprint,
-    runNumber: 1,
+    baseVersion: "3.1.0",
   })
-  assert.equal(result.versionCode, 100_000_001)
+  assert.equal(result.versionCode, 301_000_003)
+  assert.equal(allocateAsgVersion({assets: [], fingerprint, baseVersion: "3.2.0"}).versionCode, 302_000_001)
 })
 
 test("reuses the recorded code for an existing complete fingerprint", () => {
   const result = allocateAsgVersion({
-    assets: [asset(1, 100_000_042, fingerprint, "apk"), asset(2, 100_000_042, fingerprint, "json")],
+    assets: [asset(1, 301_000_042, fingerprint, "apk"), asset(2, 301_000_042, fingerprint, "json")],
     fingerprint,
-    runNumber: 99,
+    baseVersion: "3.1.0",
   })
   assert.equal(result.exists, true)
-  assert.equal(result.versionCode, 100_000_042)
-})
-
-test("allocates above all published codes when retrying an older workflow run", () => {
-  const result = allocateAsgVersion({
-    assets: [asset(1, 100_000_120, "b".repeat(64), "apk"), asset(2, 100_000_120, "b".repeat(64), "json")],
-    fingerprint,
-    runNumber: 57,
-  })
-  assert.equal(result.versionCode, 100_000_121)
+  assert.equal(result.versionCode, 301_000_042)
+  assert.throws(
+    () =>
+      allocateAsgVersion({
+        assets: [asset(1, 100_000_173, fingerprint, "apk"), asset(2, 100_000_173, fingerprint, "json")],
+        fingerprint,
+        baseVersion: "3.1.0",
+      }),
+    /does not belong to base version 3\.1\.0/,
+  )
 })
 
 test("marks an interrupted asset pair for removal before rebuilding", () => {
   const result = allocateAsgVersion({
-    assets: [asset(7, 100_000_057, fingerprint, "apk")],
+    assets: [asset(7, 301_000_005, fingerprint, "apk")],
     fingerprint,
-    runNumber: 57,
+    baseVersion: "3.1.0",
   })
   assert.equal(result.exists, false)
-  assert.equal(result.versionCode, 100_000_058)
+  assert.equal(result.versionCode, 301_000_006)
   assert.deepEqual(result.orphanAssetIds, [7])
 })
 
-test("rejects duplicate and mismatched complete pairs", () => {
+test("rejects duplicate and mismatched complete pairs and an exhausted base version", () => {
   assert.throws(
     () =>
       allocateAsgVersion({
-        assets: [asset(1, 100_000_057, fingerprint, "apk"), asset(2, 100_000_057, fingerprint, "apk")],
+        assets: [asset(1, 301_000_057, fingerprint, "apk"), asset(2, 301_000_057, fingerprint, "apk")],
         fingerprint,
-        runNumber: 57,
+        baseVersion: "3.1.0",
       }),
     /Duplicate/,
   )
   assert.throws(
     () =>
       allocateAsgVersion({
-        assets: [asset(1, 100_000_057, fingerprint, "apk"), asset(2, 100_000_058, fingerprint, "json")],
+        assets: [asset(1, 301_000_057, fingerprint, "apk"), asset(2, 301_000_058, fingerprint, "json")],
         fingerprint,
-        runNumber: 57,
+        baseVersion: "3.1.0",
       }),
     /different version codes/,
+  )
+  assert.throws(
+    () =>
+      allocateAsgVersion({
+        assets: [asset(1, 301_009_999, other, "apk"), asset(2, 301_009_999, other, "json")],
+        fingerprint,
+        baseVersion: "3.1.0",
+      }),
+    /exhausted/,
   )
 })

--- a/.github/scripts/compute-asg-build-identity.mjs
+++ b/.github/scripts/compute-asg-build-identity.mjs
@@ -12,6 +12,19 @@ const BUILD_INPUT_PATHS = [
 ]
 const EXCLUDED_PREFIXES = ["asg_client/ota_manifests/"]
 const BUILD_CONTRACT = {androidBuildVariant: "release", javaVersion: "17"}
+// The ASG client is named after the family base version (root package.json),
+// never after the beta or dev identity that first built it: every coordinated
+// release of one family, and the production release promoted from it, ship an
+// ASG client whose versionName is that plain X.Y.Z. The name is part of the
+// build fingerprint because it is baked into the APK.
+const BASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+export function requireAsgVersionName(versionName) {
+  if (typeof versionName !== "string" || !BASE_VERSION_PATTERN.test(versionName)) {
+    throw new Error(`ASG versionName ${JSON.stringify(versionName)} must be the plain X.Y.Z family base version`)
+  }
+  return versionName
+}
 
 function canonicalize(value) {
   if (Array.isArray(value)) return value.map(canonicalize)
@@ -25,8 +38,14 @@ function canonicalize(value) {
   return value
 }
 
-export function computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, contract = BUILD_CONTRACT}) {
+export function computeAsgBuildFingerprint({
+  entries,
+  latestInputCommitTimestamp,
+  versionName,
+  contract = BUILD_CONTRACT,
+}) {
   if (!Array.isArray(entries) || entries.length === 0) throw new Error("ASG build inputs must not be empty")
+  requireAsgVersionName(versionName)
   if (!Number.isSafeInteger(latestInputCommitTimestamp) || latestInputCommitTimestamp <= 0) {
     throw new Error("latestInputCommitTimestamp must be a positive integer")
   }
@@ -38,7 +57,7 @@ export function computeAsgBuildFingerprint({entries, latestInputCommitTimestamp,
       return {mode, object, path: entryPath}
     })
     .sort((left, right) => left.path.localeCompare(right.path))
-  const payload = canonicalize({schemaVersion: 1, contract, entries: normalizedEntries})
+  const payload = canonicalize({schemaVersion: 1, contract, versionName, entries: normalizedEntries})
   const fingerprint = createHash("sha256")
     .update(`${JSON.stringify(payload)}\n`)
     .digest("hex")
@@ -47,6 +66,7 @@ export function computeAsgBuildFingerprint({entries, latestInputCommitTimestamp,
     fingerprint,
     latestInputCommitTimestamp,
     contract,
+    versionName,
     entries: normalizedEntries,
   }
 }
@@ -57,7 +77,12 @@ export function finalizeAsgBuildIdentity({buildFingerprint, versionCode, version
   if (!Number.isSafeInteger(versionCode) || versionCode <= 0 || versionCode > 2_100_000_000) {
     throw new Error(`Allocated ASG versionCode ${versionCode} is outside the Android-safe range`)
   }
-  if (!versionName) throw new Error("ASG versionName is required")
+  requireAsgVersionName(versionName)
+  if (versionName !== buildFingerprint.versionName) {
+    throw new Error(
+      `ASG versionName ${versionName} does not match the fingerprinted name ${buildFingerprint.versionName}`,
+    )
+  }
   return {
     ...buildFingerprint,
     versionCode,
@@ -67,9 +92,15 @@ export function finalizeAsgBuildIdentity({buildFingerprint, versionCode, version
   }
 }
 
-export function computeAsgBuildIdentity({entries, latestInputCommitTimestamp, versionCode, versionName, contract = BUILD_CONTRACT}) {
+export function computeAsgBuildIdentity({
+  entries,
+  latestInputCommitTimestamp,
+  versionCode,
+  versionName,
+  contract = BUILD_CONTRACT,
+}) {
   return finalizeAsgBuildIdentity({
-    buildFingerprint: computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, contract}),
+    buildFingerprint: computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, versionName, contract}),
     versionCode,
     versionName,
   })
@@ -79,8 +110,9 @@ function git(repoRoot, args) {
   return execFileSync("git", args, {cwd: repoRoot, encoding: "utf8"}).trim()
 }
 
-export function computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit}) {
+export function computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit, versionName}) {
   if (!/^[0-9a-f]{40}$/.test(sourceCommit)) throw new Error("sourceCommit must be a full lowercase Git SHA")
+  requireAsgVersionName(versionName)
   const tree = git(repoRoot, ["ls-tree", "-r", sourceCommit, "--", ...BUILD_INPUT_PATHS])
   const entries = tree
     .split("\n")
@@ -102,7 +134,7 @@ export function computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit}) {
       ...EXCLUDED_PREFIXES.map((prefix) => `:(exclude)${prefix}**`),
     ]),
   )
-  return computeAsgBuildFingerprint({entries, latestInputCommitTimestamp})
+  return computeAsgBuildFingerprint({entries, latestInputCommitTimestamp, versionName})
 }
 
 function parseArgs(args) {
@@ -121,7 +153,11 @@ function main() {
   const repoRoot = path.resolve(args["repo-root"] || process.cwd())
   const sourceCommit = args["source-commit"] || git(repoRoot, ["rev-parse", "HEAD"])
   const output = path.resolve(repoRoot, args.output || "asg-build-identity.json")
-  const buildFingerprint = computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit})
+  const buildFingerprint = computeAsgBuildFingerprintFromGit({
+    repoRoot,
+    sourceCommit,
+    versionName: args["version-name"],
+  })
   const identity = args["version-code"]
     ? finalizeAsgBuildIdentity({
         buildFingerprint,

--- a/.github/scripts/compute-asg-build-identity.test.mjs
+++ b/.github/scripts/compute-asg-build-identity.test.mjs
@@ -11,10 +11,15 @@ const entries = [
   {mode: "100644", object: "a".repeat(40), path: "asg_client/app/build.gradle"},
   {mode: "160000", object: "b".repeat(40), path: "asg_client/StreamPackLite"},
 ]
-const versionName = "3.1.0-beta.57"
+const versionName = "3.1.0"
 
 test("derives a deterministic content-addressed ASG identity", () => {
-  const first = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057, versionName})
+  const first = computeAsgBuildIdentity({
+    entries,
+    latestInputCommitTimestamp: 1_782_000_000,
+    versionCode: 100_057,
+    versionName,
+  })
   const reordered = computeAsgBuildIdentity({
     entries: [...entries].reverse(),
     latestInputCommitTimestamp: 1_782_000_000,
@@ -30,7 +35,12 @@ test("derives a deterministic content-addressed ASG identity", () => {
 })
 
 test("changes identity when an effective source or build contract changes", () => {
-  const baseline = computeAsgBuildIdentity({entries, latestInputCommitTimestamp: 1_782_000_000, versionCode: 100_057, versionName})
+  const baseline = computeAsgBuildIdentity({
+    entries,
+    latestInputCommitTimestamp: 1_782_000_000,
+    versionCode: 100_057,
+    versionName,
+  })
   const sourceChange = computeAsgBuildIdentity({
     entries: [{...entries[0], object: "c".repeat(40)}, entries[1]],
     latestInputCommitTimestamp: 1_782_000_100,
@@ -45,13 +55,36 @@ test("changes identity when an effective source or build contract changes", () =
     contract: {androidBuildVariant: "release", javaVersion: "21"},
   })
 
+  const nameChange = computeAsgBuildIdentity({
+    entries,
+    latestInputCommitTimestamp: 1_782_000_000,
+    versionCode: 100_057,
+    versionName: "3.2.0",
+  })
+
   assert.notEqual(sourceChange.fingerprint, baseline.fingerprint)
   assert.notEqual(sourceChange.versionCode, baseline.versionCode)
   assert.notEqual(contractChange.fingerprint, baseline.fingerprint)
+  assert.notEqual(nameChange.fingerprint, baseline.fingerprint)
+  assert.equal(nameChange.versionName, "3.2.0")
+})
+
+test("the ASG versionName is the plain family base version and part of the fingerprint", () => {
+  assert.throws(
+    () =>
+      computeAsgBuildFingerprint({entries, latestInputCommitTimestamp: 1_782_000_000, versionName: "3.1.0-beta.57"}),
+    /plain X\.Y\.Z family base version/,
+  )
+  const fingerprint = computeAsgBuildFingerprint({entries, latestInputCommitTimestamp: 1_782_000_000, versionName})
+  assert.equal(fingerprint.versionName, versionName)
+  assert.throws(
+    () => finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 301_000_001, versionName: "3.2.0"}),
+    /does not match the fingerprinted name/,
+  )
 })
 
 test("allocates the externally selected version code without changing the content fingerprint", () => {
-  const fingerprint = computeAsgBuildFingerprint({entries, latestInputCommitTimestamp: 1_782_000_000})
+  const fingerprint = computeAsgBuildFingerprint({entries, latestInputCommitTimestamp: 1_782_000_000, versionName})
   const first = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_057, versionName})
   const later = finalizeAsgBuildIdentity({buildFingerprint: fingerprint, versionCode: 100_099, versionName})
 

--- a/.github/workflows/reusable-coordinated-ota.yml
+++ b/.github/workflows/reusable-coordinated-ota.yml
@@ -140,11 +140,24 @@ jobs:
           }
           EOF
 
+      # The ASG client is named and numbered after the family base version
+      # (root package.json), so every dev, beta, and promoted production release
+      # of one family shares an ASG client that reports the plain X.Y.Z and no
+      # OTA prompt separates the Mentra App from other Bluetooth SDK apps.
+      - name: Resolve the family base version for the ASG client
+        id: asg-base
+        run: |
+          set -euo pipefail
+          base_version=$(jq -er .familyBaseVersion release-intent/release-plan.json)
+          [[ "$base_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "version=$base_version" >> "$GITHUB_OUTPUT"
+
       - name: Compute effective ASG build fingerprint
         id: asg-fingerprint
         run: >-
           node .github/scripts/compute-asg-build-identity.mjs
           --source-commit "${{ github.sha }}"
+          --version-name "${{ steps.asg-base.outputs.version }}"
           --output coordinated-ota-work/asg-build-fingerprint.json
 
       - name: Allocate or reuse the ASG version code
@@ -152,7 +165,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ASG_FINGERPRINT: ${{ steps.asg-fingerprint.outputs.fingerprint }}
-          WORKFLOW_RUN_NUMBER: ${{ github.run_number }}
+          ASG_BASE_VERSION: ${{ steps.asg-base.outputs.version }}
         run: |
           set -euo pipefail
           mkdir -p coordinated-ota-work
@@ -171,7 +184,7 @@ jobs:
           node .github/scripts/allocate-asg-version.mjs \
             --assets coordinated-ota-work/release-assets.json \
             --fingerprint "$ASG_FINGERPRINT" \
-            --run-number "$WORKFLOW_RUN_NUMBER" \
+            --base-version "$ASG_BASE_VERSION" \
             --output coordinated-ota-work/asg-allocation.json
 
           if [[ "${{ inputs.dry_run }}" != "true" ]]; then
@@ -194,12 +207,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PROVENANCE_ASSET: ${{ steps.existing-asg.outputs.provenance_asset }}
+          ASG_BASE_VERSION: ${{ steps.asg-base.outputs.version }}
         run: |
-          version_name=$(jq -er .releaseIdentity release-intent/release-plan.json)
+          set -euo pipefail
+          version_name="$ASG_BASE_VERSION"
           if [[ "${{ steps.existing-asg.outputs.exists }}" == "true" ]]; then
             gh release download "$ASG_RELEASE_TAG" --pattern "$PROVENANCE_ASSET" --dir coordinated-ota-work
             mv "coordinated-ota-work/$PROVENANCE_ASSET" coordinated-ota-work/asg-provenance.json
-            version_name=$(jq -er .versionName coordinated-ota-work/asg-provenance.json)
+            recorded=$(jq -er .versionName coordinated-ota-work/asg-provenance.json)
+            if [[ "$recorded" != "$version_name" ]]; then
+              echo "Reused ASG build is named $recorded, not the family base version $version_name." >&2
+              exit 1
+            fi
           fi
           echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
 

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -83,7 +83,15 @@ function branchHead(repository, branch) {
 }
 
 function compareCommits(repository, base, head) {
-  return ghJson(["api", `repos/${repository}/compare/${base}...${head}`])
+  // Only the relationship is needed. The full compare payload lists commits
+  // and file patches, which for a whole release cycle exceeds the spawn buffer
+  // (spawnSync gh ENOBUFS), so trim it in gh before it reaches this process.
+  return ghJson([
+    "api",
+    `repos/${repository}/compare/${base}...${head}?per_page=1`,
+    "--jq",
+    "{status: .status, ahead_by: .ahead_by, behind_by: .behind_by}",
+  ])
 }
 
 function ensureCommitIsOnBranch(repository, commit, branch) {

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -70,12 +70,39 @@ credentials or directly calls Porter, App Store Connect, or Google Play.
 See .github/production-release/README.md for the complete procedure.`
 }
 
+// Node's default spawn buffer is 1 MB. GitHub listings for this repository
+// already exceed it (the release list is several megabytes and the builds
+// release alone has hundreds of assets), so every gh call gets a generous
+// buffer AND the listings below ask gh to project only the fields used.
+const GH_MAX_BUFFER = 64 * 1024 * 1024
+const RELEASE_FIELDS = "{id, tag_name, name, draft, prerelease, body, target_commitish}"
+const ASSET_FIELDS = "{id, name, digest, size, url, browser_download_url}"
+
 function execGh(args, options = {}) {
-  return execFileSync("gh", args, {encoding: "utf8", stdio: ["ignore", "pipe", "inherit"], ...options})
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    maxBuffer: GH_MAX_BUFFER,
+    ...options,
+  })
 }
 
 function ghJson(args) {
   return JSON.parse(execGh(args))
+}
+
+export function parseJsonLines(output) {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
+// `gh api --paginate` cannot combine --slurp with --jq, so page through with a
+// projection that emits one JSON object per line and parse those lines.
+function ghPaginated(endpoint, projection) {
+  return parseJsonLines(execGh(["api", "--paginate", endpoint, "--jq", `.[] | ${projection} | tojson`]))
 }
 
 function branchHead(repository, branch) {
@@ -243,8 +270,21 @@ export function releaseBranchSources(result, betaIdentity) {
 function loadReleaseBranchSources(betaIdentity) {
   const family = betaIdentity.slice(0, betaIdentity.indexOf("-beta."))
   const assetName = `mentra-release-${betaIdentity}.json`
-  const release = ghJson(["release", "view", `mentra-builds-v${family}`, "--repo", REPOSITORY, "--json", "assets"])
-  const asset = release.assets.find((candidate) => candidate.name === assetName)
+  const matches = parseJsonLines(
+    execGh([
+      "release",
+      "view",
+      `mentra-builds-v${family}`,
+      "--repo",
+      REPOSITORY,
+      "--json",
+      "assets",
+      "--jq",
+      `.assets[] | select(.name == ${JSON.stringify(assetName)}) | {name, apiUrl, digest} | tojson`,
+    ]),
+  )
+  if (matches.length > 1) throw new Error(`Release contains duplicate asset ${assetName}`)
+  const asset = matches[0]
   if (!asset) throw new Error(`Completed release asset ${assetName} was not found`)
   const contents = execGh(["api", "-H", "Accept: application/octet-stream", asset.apiUrl], {
     maxBuffer: 20 * 1024 * 1024,
@@ -257,7 +297,7 @@ function loadReleaseBranchSources(betaIdentity) {
 }
 
 function listReleases() {
-  return ghJson(["api", "--paginate", "--slurp", `repos/${REPOSITORY}/releases?per_page=100`]).flat()
+  return ghPaginated(`repos/${REPOSITORY}/releases?per_page=100`, RELEASE_FIELDS)
 }
 
 function resolveAttempt(releases, releaseIdentity, requestedAttempt) {
@@ -276,12 +316,7 @@ function loadLatestRecord(releaseIdentity, requestedAttempt) {
   const releases = listReleases()
   const attempt = resolveAttempt(releases, releaseIdentity, requestedAttempt)
   const release = requirePromotionContainer(releases, releaseIdentity, attempt)
-  const assets = ghJson([
-    "api",
-    "--paginate",
-    "--slurp",
-    `repos/${REPOSITORY}/releases/${release.id}/assets?per_page=100`,
-  ]).flat()
+  const assets = ghPaginated(`repos/${REPOSITORY}/releases/${release.id}/assets?per_page=100`, ASSET_FIELDS)
   const states = stateAssets(assets, releaseIdentity, attempt)
   if (states.length === 0) throw new Error(`Promotion ${releaseIdentity} attempt ${attempt} has no state record`)
   const entries = states.map((state) => {

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -6,6 +6,7 @@ import {
   branchPromotionState,
   packagesConfirmationMessage,
   parseCliArgs,
+  parseJsonLines,
   releaseBranchSources,
   requireCommandState,
   statusSummary,
@@ -176,4 +177,13 @@ test("dispatches stable package phases from the promoted beta without a promotio
     packagesConfirmationMessage({beta_identity: "3.1.0-beta.192", phase: "release"}),
     /moves npm latest.*3\.1\.0/,
   )
+})
+
+test("parses line-delimited gh projections and ignores blank lines", () => {
+  assert.deepEqual(parseJsonLines('{"id":1,"tag_name":"a"}\n\n{"id":2,"tag_name":"b"}\n'), [
+    {id: 1, tag_name: "a"},
+    {id: 2, tag_name: "b"},
+  ])
+  assert.deepEqual(parseJsonLines(""), [])
+  assert.throws(() => parseJsonLines("{not json}"), SyntaxError)
 })


### PR DESCRIPTION
Promote the exact coordinated beta source `d1ead9b78b26bc44c45009a27a211c23fc56c22a` from `staging` into `main`.

This pull request was created by `production-release promote` and must retain the exact recorded head.