### PR TITLE
Write Google Play inventories to absolute paths in the production workflows

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -592,3 +592,19 @@ test("iOS status reports the failed phase instead of downstream skips", (t) => {
     assert.match(readFileSync(output, "utf8"), new RegExp(`^ios_result=${expected}$`, "m"))
   }
 })
+
+test("Play lane outputs in the production workflows are absolute paths", () => {
+  // fastlane runs every lane from inside the fastlane/ directory, so a
+  // relative output path lands one level deeper than the caller expects.
+  for (const name of [
+    "production-release-prepare.yml",
+    "production-release-status.yml",
+    "production-release-store-release.yml",
+    "production-release-store-submit.yml",
+  ]) {
+    const source = workflow(name)
+    for (const match of source.matchAll(/GOOGLE_PLAY_[A-Z_]*OUTPUT=(\S+)/g)) {
+      assert.match(match[1], /^"\$GITHUB_WORKSPACE\//, `${name}: ${match[0]}`)
+    }
+  }
+})

--- a/.github/workflows/production-release-prepare.yml
+++ b/.github/workflows/production-release-prepare.yml
@@ -161,7 +161,7 @@ jobs:
         run: |
           set -euo pipefail
           APP_PACKAGE_NAME=com.mentra.mentra \
-            GOOGLE_PLAY_INVENTORY_OUTPUT=../stores/mentra-google.json \
+            GOOGLE_PLAY_INVENTORY_OUTPUT="$GITHUB_WORKSPACE/promotion-input/stores/mentra-google.json" \
             bundle exec fastlane google_play_inventory
           jq -s '{apple: .[0], google: .[1]}' \
             ../stores/mentra-apple.json ../stores/mentra-google.json \

--- a/.github/workflows/production-release-status.yml
+++ b/.github/workflows/production-release-status.yml
@@ -90,7 +90,7 @@ jobs:
           cp mobile/Gemfile mobile/Gemfile.lock store-status/play/
           cd store-status/play
           bundle install
-          APP_PACKAGE_NAME=com.mentra.mentra GOOGLE_PLAY_INVENTORY_OUTPUT=mentraApp.json bundle exec fastlane google_play_inventory
+          APP_PACKAGE_NAME=com.mentra.mentra GOOGLE_PLAY_INVENTORY_OUTPUT="$GITHUB_WORKSPACE/store-status/play/mentraApp.json" bundle exec fastlane google_play_inventory
 
       - name: Summarize observed state and exact next action
         run: |

--- a/.github/workflows/production-release-store-release.yml
+++ b/.github/workflows/production-release-store-release.yml
@@ -92,7 +92,7 @@ jobs:
           cd play-status
           bundle install
           expected=$(jq -er .coordinates.candidates.mentraApp.android.buildNumber ../promotion-input/current.json)
-          APP_PACKAGE_NAME=com.mentra.mentra GOOGLE_PLAY_INVENTORY_OUTPUT=mentraApp.json bundle exec fastlane google_play_inventory
+          APP_PACKAGE_NAME=com.mentra.mentra GOOGLE_PLAY_INVENTORY_OUTPUT="$GITHUB_WORKSPACE/play-status/mentraApp.json" bundle exec fastlane google_play_inventory
           node ../.github/scripts/validate-google-play-release.mjs \
             --inventory mentraApp.json \
             --version-code "$expected" \

--- a/.github/workflows/production-release-store-submit.yml
+++ b/.github/workflows/production-release-store-submit.yml
@@ -116,10 +116,10 @@ jobs:
             GOOGLE_PLAY_TARGET_TRACK=production \
             GOOGLE_PLAY_VERSION_CODE="$build" \
             GOOGLE_PLAY_RELEASE_STATUS=draft \
-            GOOGLE_PLAY_PROMOTION_OUTPUT=../promotion-output/play/mentra.json \
+            GOOGLE_PLAY_PROMOTION_OUTPUT="$GITHUB_WORKSPACE/promotion-output/play/mentra.json" \
             bundle exec fastlane promote_google_play
           APP_PACKAGE_NAME=com.mentra.mentra \
-            GOOGLE_PLAY_INVENTORY_OUTPUT=mentraApp-inventory.json \
+            GOOGLE_PLAY_INVENTORY_OUTPUT="$GITHUB_WORKSPACE/play-tools/mentraApp-inventory.json" \
             bundle exec fastlane google_play_inventory
           node ../.github/scripts/validate-google-play-release.mjs \
             --inventory mentraApp-inventory.json \


### PR DESCRIPTION
## Why

The first real `production-release-prepare.yml` run for 3.1.0 ([run 34646742935](https://github.com/Mentra-Community/MentraOS/actions/runs/34646742935)) got past the provenance step and failed at "Read Google Play inventories" with `Errno::ENOENT ... ../stores/mentra-google.json`. The Play API call succeeded; the write failed because fastlane runs every lane from inside the `fastlane/` directory, so a relative output path resolves one level deeper than the calling step expects. The coordinated workflows already pass absolute `${{ runner.temp }}` paths for the same lanes; the four production workflows used relative ones and had never been exercised.

## What

Every `GOOGLE_PLAY_*_OUTPUT` in `production-release-prepare.yml`, `production-release-status.yml`, `production-release-store-release.yml`, and `production-release-store-submit.yml` is now `"$GITHUB_WORKSPACE/<the path the step reads back>"`. Read-back paths are unchanged. A contract test asserts every Play lane output in these workflows is absolute.

Targets `main` because the promotion workflows run from it. Reconcile into staging and dev afterwards.

## Test evidence

- `node --test .github/scripts/coordinated-workflow-contract.test.mjs`: 15 passed.
- All four workflows parse as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
