### PR TITLE
Read all Google Play tracks inside one edit in the inventory lane

### DIFF
--- a/mobile/ci/fastlane-android/Fastfile
+++ b/mobile/ci/fastlane-android/Fastfile
@@ -15,12 +15,16 @@ platform :android do
     output = ENV.fetch("GOOGLE_PLAY_INVENTORY_OUTPUT")
     tracks = ENV.fetch("GOOGLE_PLAY_INVENTORY_TRACKS", "internal,beta,production").split(",")
     package_name = ENV.fetch("APP_PACKAGE_NAME", "com.mentra.mentra")
+    # Google meters edit creation per day, and every coordinated build and
+    # store lane spends some. Read every track inside one edit: the release
+    # inventory already carries the version codes, so the per-track
+    # google_play_track_version_codes action (one more edit each) is not
+    # opened.
     releases = {}
-    versions = tracks.to_h do |track|
-      action_codes = google_play_track_version_codes(track: track).map(&:to_i).sort
-      client = Supply::Client.make_from_config
-      client.begin_edit(package_name: package_name)
-      begin
+    client = Supply::Client.make_from_config
+    client.begin_edit(package_name: package_name)
+    begin
+      tracks.each do |track|
         releases[track] = client.track_releases(track).map do |release|
           {
             name: release.name,
@@ -29,12 +33,12 @@ platform :android do
             versionCodes: (release.version_codes || []).map(&:to_i).sort,
           }
         end
-      ensure
-        client.abort_current_edit
       end
-      release_codes = releases.fetch(track).flat_map { |release| release.fetch(:versionCodes) }.uniq.sort
-      UI.user_error!("Google Play #{track} release inventory disagrees with its version-code inventory") unless release_codes == action_codes
-      [track, action_codes]
+    ensure
+      client.abort_current_edit
+    end
+    versions = tracks.to_h do |track|
+      [track, releases.fetch(track).flat_map { |release| release.fetch(:versionCodes) }.uniq.sort]
     end
     all_codes = versions.values.flatten
     public_statuses = ["inProgress", "completed"]

--- a/mobile/ci/fastlane-android/Fastfile
+++ b/mobile/ci/fastlane-android/Fastfile
@@ -21,6 +21,15 @@ platform :android do
     # google_play_track_version_codes action (one more edit each) is not
     # opened.
     releases = {}
+    # Supply's client reads its credentials from Supply.config, which the
+    # google_play_track_version_codes action used to populate as a side effect.
+    # Build it from Supply's own options so the Appfile defaults (package name,
+    # json_key_file) still apply.
+    require "supply"
+    Supply.config = FastlaneCore::Configuration.create(
+      Supply::Options.available_options,
+      { package_name: package_name },
+    )
     client = Supply::Client.make_from_config
     client.begin_edit(package_name: package_name)
     begin


### PR DESCRIPTION
## Why

The second `production-release-prepare.yml` run for 3.1.0 ([run 34647809539](https://github.com/Mentra-Community/MentraOS/actions/runs/34647809539)) read the App Store inventory and the Play `internal` and `beta` tracks, then failed on `production` with `Google Api Error: Invalid request - Daily edit creation quota exceeded`. The `google_play_inventory` lane opened six Play edits per run: an explicit `begin_edit` per track plus the edit each `google_play_track_version_codes` action opens internally. Every coordinated beta build, example upload, and store lane also spends edits, so the promotion's read-only inventory ran out on a busy day.

## What

`google_play_inventory` opens one edit, reads every requested track's releases from it, and derives each track's version codes from those releases instead of re-reading them through the per-track action. The `tracks`, `releases`, `currentVersionCode`, and `maxVersionCode` output is unchanged. The dropped cross-check compared two views of the same API and only ever guarded against the action and the edit disagreeing.

Other lanes (`track_version_codes`, `promote_google_play`) are untouched.

Targets `main` because the promotion workflows check out and run this Fastfile from `main`. Reconcile into staging and dev afterwards.

## Test evidence

- `ruby -c mobile/ci/fastlane-android/Fastfile`: syntax OK.
- `node --test .github/scripts/coordinated-workflow-contract.test.mjs`: 15 passed.
- Not exercised against Google Play: the quota is exhausted for today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
