### PR TITLE
Pin PR Android builds to a per-PR glasses OTA manifest

### DIFF
--- a/.github/CI_GATE.md
+++ b/.github/CI_GATE.md
@@ -52,7 +52,7 @@ below. `Recovery Worker Build` is deliberately excluded.
 | ----------- | ----------------------------------- | --------------------------------------------------------- |
 | iOS         | `Mobile App iOS Build`              | `mobile/**`                                               |
 | Android     | `Mobile App Android Build`          | `mobile/**`                                               |
-| ASG         | `MentraOS ASG Client Build`         | `asg_client/**`                                           |
+| ASG         | `MentraOS ASG Client Build`         | `asg_client/**`, `mobile/**` (publishes the PR OTA pin)   |
 | Mobile jest | `Mobile App Quality Checks`         | `mobile/**`                                               |
 | Release     | `Coordinated Release Family Checks` | coordinated release definitions and workflows             |
 | Lockfiles   | `Bun Lockfile Checks`               | root/mobile/sdk lockfiles and workspace package manifests |

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -57,6 +57,8 @@ ciGates:
     workflows:
       - "Mobile App Quality Checks"
       - "Mobile App Android Build"
+      # Publishes the OTA manifest every PR Android APK pins.
+      - "MentraOS ASG Client Build"
   - paths:
       - "asg_client/**"
     workflows:

--- a/.github/scripts/build-bluetooth-sdk-ota-manifest.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-manifest.mjs
@@ -19,9 +19,15 @@ for (const key of requiredEnv) {
   }
 }
 
+// Coordinated releases label the manifest with their release identity. Pull
+// request builds (mentra-asg-client-build.yml) label it pr-<number>-<sha>; the
+// app treats that as "no coordinated release" and shows the ASG versionName.
 const releaseVersion = process.env.RELEASE_VERSION.trim();
-if (!/^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/.test(releaseVersion)) {
-  throw new Error(`Invalid coordinated release version: ${releaseVersion}`);
+if (
+  !/^\d+\.\d+\.\d+(?:-(?:dev|beta)\.[1-9]\d*)?$/.test(releaseVersion) &&
+  !/^pr-[1-9]\d*-[0-9a-f]{7,40}$/.test(releaseVersion)
+) {
+  throw new Error(`Invalid release version (expected X.Y.Z[-dev.N|-beta.N] or pr-<number>-<sha>): ${releaseVersion}`);
 }
 
 const versionCode = Number(process.env.ASG_VERSION_CODE);

--- a/.github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs
+++ b/.github/scripts/build-bluetooth-sdk-ota-manifest.test.mjs
@@ -52,8 +52,16 @@ test('writes the coordinated release version independently of the ASG version', 
   assert.deepEqual(JSON.parse(readFileSync(inputsPath, 'utf8')).mtkFullOta, manifest.mtk_full_ota);
 });
 
+test('labels a pull request build manifest with its PR number and commit', () => {
+  const {outputPath, result} = runManifestBuild('pr-3927-4987210f6e');
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(readFileSync(outputPath, 'utf8')).releaseVersion, 'pr-3927-4987210f6e');
+});
+
 test('rejects a value outside the coordinated release identity format', () => {
-  const {result} = runManifestBuild('asg.40');
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Invalid coordinated release version/);
+  for (const invalid of ['asg.40', 'pr-3927', 'pr-0-4987210', 'pr-3927-branch']) {
+    const {result} = runManifestBuild(invalid);
+    assert.notEqual(result.status, 0, invalid);
+    assert.match(result.stderr, /Invalid release version/);
+  }
 });

--- a/.github/scripts/select-pr-asg.mjs
+++ b/.github/scripts/select-pr-asg.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Select the ASG client a pull request build should ship.
+//
+// A PR mobile APK pins an OTA manifest that must point at an ASG client built
+// from the PR's own ASG sources. Building one on every PR is wasteful: most
+// PRs never touch asg_client, and the coordinated release lane already keeps a
+// content-addressed ASG artifact (APK + provenance) per source fingerprint on
+// the mentra-coordinated-asg GitHub release. This script computes the PR's
+// fingerprint with the same rules as that lane and reports whether such an
+// artifact exists ("reuse") or the PR has to build its own ("build").
+import {mkdirSync, readFileSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {allocateAsgVersion} from "./allocate-asg-version.mjs"
+import {computeAsgBuildFingerprintFromGit, requireAsgVersionName} from "./compute-asg-build-identity.mjs"
+
+export function selectPrAsg({assets, fingerprint, baseVersion}) {
+  // The allocator implements the release lane's matching rules (complete
+  // APK + provenance pair, version code inside the family namespace); its
+  // allocation of a new code on a miss is irrelevant here and ignored.
+  const allocation = allocateAsgVersion({assets, fingerprint, baseVersion})
+  if (allocation.exists) {
+    return {
+      mode: "reuse",
+      fingerprint,
+      baseVersion,
+      versionCode: allocation.versionCode,
+      apkAsset: allocation.apkAsset,
+      provenanceAsset: allocation.provenanceAsset,
+    }
+  }
+  return {mode: "build", fingerprint, baseVersion}
+}
+
+export function readFamilyBaseVersion(repoRoot) {
+  const {version} = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"))
+  return requireAsgVersionName(version)
+}
+
+function parseArgs(args) {
+  const values = {}
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return values
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const repoRoot = path.resolve(args["repo-root"] || process.cwd())
+  const sourceCommit = args["source-commit"]
+  if (!sourceCommit) throw new Error("Missing --source-commit")
+  if (!args.assets) throw new Error("Missing --assets")
+  const output = path.resolve(repoRoot, args.output || "pr-asg-selection.json")
+
+  const baseVersion = readFamilyBaseVersion(repoRoot)
+  const {fingerprint} = computeAsgBuildFingerprintFromGit({repoRoot, sourceCommit, versionName: baseVersion})
+  const assets = JSON.parse(readFileSync(path.resolve(args.assets), "utf8"))
+  const selection = selectPrAsg({assets, fingerprint, baseVersion})
+
+  mkdirSync(path.dirname(output), {recursive: true})
+  writeFileSync(output, `${JSON.stringify(selection, null, 2)}\n`)
+  if (process.env.GITHUB_OUTPUT) {
+    const lines = [
+      `mode=${selection.mode}`,
+      `fingerprint=${selection.fingerprint}`,
+      `version_code=${selection.versionCode ?? ""}`,
+      `apk_asset=${selection.apkAsset ?? ""}`,
+      `provenance_asset=${selection.provenanceAsset ?? ""}`,
+    ]
+    writeFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`, {flag: "a"})
+  }
+  console.log(
+    selection.mode === "reuse"
+      ? `ASG sources match coordinated build ${selection.versionCode} (${selection.apkAsset}); reusing it.`
+      : `No coordinated ASG build matches fingerprint ${selection.fingerprint}; this PR builds its own.`,
+  )
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/.github/scripts/select-pr-asg.test.mjs
+++ b/.github/scripts/select-pr-asg.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import {mkdtempSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {readFamilyBaseVersion, selectPrAsg} from "./select-pr-asg.mjs"
+
+const fingerprint = "a".repeat(64)
+const other = "b".repeat(64)
+
+function asset(id, versionCode, selectedFingerprint, extension) {
+  return {id, name: `mentra-live-asg-${versionCode}-${selectedFingerprint}.${extension}`}
+}
+
+test("reuses the coordinated build whose fingerprint matches the PR sources", () => {
+  const selection = selectPrAsg({
+    assets: [
+      asset(1, 302_000_001, other, "apk"),
+      asset(2, 302_000_001, other, "json"),
+      asset(3, 302_000_002, fingerprint, "apk"),
+      asset(4, 302_000_002, fingerprint, "json"),
+    ],
+    fingerprint,
+    baseVersion: "3.2.0",
+  })
+  assert.deepEqual(selection, {
+    mode: "reuse",
+    fingerprint,
+    baseVersion: "3.2.0",
+    versionCode: 302_000_002,
+    apkAsset: `mentra-live-asg-302000002-${fingerprint}.apk`,
+    provenanceAsset: `mentra-live-asg-302000002-${fingerprint}.json`,
+  })
+})
+
+test("builds when no coordinated artifact carries the PR fingerprint", () => {
+  const selection = selectPrAsg({
+    assets: [asset(1, 302_000_001, other, "apk"), asset(2, 302_000_001, other, "json")],
+    fingerprint,
+    baseVersion: "3.2.0",
+  })
+  assert.deepEqual(selection, {mode: "build", fingerprint, baseVersion: "3.2.0"})
+})
+
+test("builds when the coordinated pair for the fingerprint is incomplete", () => {
+  // An APK without its provenance (or vice versa) is an interrupted release
+  // upload; the release lane rebuilds it and so does the PR.
+  const selection = selectPrAsg({
+    assets: [asset(1, 302_000_002, fingerprint, "apk")],
+    fingerprint,
+    baseVersion: "3.2.0",
+  })
+  assert.equal(selection.mode, "build")
+})
+
+test("reads the family base version from the root package manifest", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "mentra-select-pr-asg-"))
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.2.0"}))
+  assert.equal(readFamilyBaseVersion(root), "3.2.0")
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({version: "3.2.0-dev.4"}))
+  assert.throws(() => readFamilyBaseVersion(root), /plain X\.Y\.Z family base version/)
+})

--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -2,6 +2,9 @@ name: Mobile App Android Build
 
 on:
   pull_request:
+    # Every PR APK pins the OTA manifest that mentra-asg-client-build.yml
+    # publishes for the same PR head, so that workflow's pull_request paths
+    # must stay a superset of these.
     paths:
       - "mobile/**"
       - ".github/workflows/mentra-app-android-build.yml"
@@ -43,7 +46,12 @@ jobs:
       EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
       EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
       MENTRAOS_PINNED_BUILD_NUMBER: ${{ inputs.build_number || '' }}
-      EXPO_PUBLIC_ASG_OTA_VERSION_URL: ${{ inputs.ota_manifest_url || '' }}
+      # Glasses OTA pin. A pull request pins the manifest that MentraOS ASG
+      # Client Build publishes for the same PR head (ota-pr-<n>-<sha>.json on
+      # the pr-builds release), so a PR APK updates Mentra Live glasses to the
+      # ASG client built from the PR's own ASG sources. Pushes stay unpinned
+      # compile checks; a dispatch may pass an explicit manifest URL.
+      EXPO_PUBLIC_ASG_OTA_VERSION_URL: ${{ inputs.ota_manifest_url || (github.event_name == 'pull_request' && format('https://github.com/{0}/releases/download/pr-builds/ota-pr-{1}-{2}.json', github.repository, github.event.pull_request.number, github.event.pull_request.head.sha)) || '' }}
       # Compile-check APKs are phone sideloads. Full ABI belongs on the
       # coordinated release workflow, not on this compile-check workflow.
       ORG_GRADLE_PROJECT_reactNativeArchitectures: arm64-v8a
@@ -364,7 +372,7 @@ jobs:
           fi
 
       - name: Verify embedded OTA manifest pin
-        if: inputs.ota_manifest_url != ''
+        if: env.EXPO_PUBLIC_ASG_OTA_VERSION_URL != ''
         run: |
           python3 - <<'PY'
           import os
@@ -491,11 +499,14 @@ jobs:
             if (!comment) return;
 
             const prNumber = context.payload.pull_request.number;
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const headSha = context.payload.pull_request.head.sha;
+            const sha = headSha.substring(0, 7);
             const apkName = `mobile-pr-${prNumber}-${sha}.apk`;
-            const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds/${apkName}`;
+            const releaseBase = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds`;
+            const downloadUrl = `${releaseBase}/${apkName}`;
+            const manifestName = `ota-pr-${prNumber}-${headSha}.json`;
 
-            const buildStatus = `### 📱 Mobile App Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download APK**](${downloadUrl})`;
+            const buildStatus = `### 📱 Mobile App Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download APK**](${downloadUrl})\n\n🕶️ Updates Mentra Live glasses to this PR's ASG client via OTA (pinned to [${manifestName}](${releaseBase}/${manifestName}), published by the ASG Client Build job).`;
 
             const newBody = comment.body.replace(
               /<!-- android-build-status -->[\s\S]*?<!-- \/android-build-status -->/,

--- a/.github/workflows/mentra-asg-client-build.yml
+++ b/.github/workflows/mentra-asg-client-build.yml
@@ -1,10 +1,32 @@
 name: MentraOS ASG Client Build
 
+# Pull requests: publish the ASG client a PR mobile build pins for glasses OTA.
+#
+# Every Mobile App Android Build PR APK embeds the OTA manifest URL
+# https://github.com/<repo>/releases/download/pr-builds/ota-pr-<n>-<head sha>.json
+# and this workflow is the only producer of that manifest, so its pull_request
+# paths must stay a superset of that workflow's. The manifest points at an ASG
+# client built from the PR's own ASG sources: the `select` job fingerprints
+# those sources exactly like the coordinated release lane and reuses the
+# coordinated artifact when one exists (the common case for PRs that leave
+# asg_client untouched); otherwise the `build` job builds one and publishes it
+# next to the manifest on the pr-builds release.
+#
+# Pushes to dev/main and manual dispatches only compile-check the ASG client.
+
 on:
   pull_request:
     paths:
       - "asg_client/**"
+      - "mobile/**"
+      # The root version is the ASG versionName and part of the fingerprint.
+      - "package.json"
       - ".github/workflows/mentra-asg-client-build.yml"
+      - ".github/workflows/mentra-app-android-build.yml"
+      - ".github/scripts/select-pr-asg.mjs"
+      - ".github/scripts/compute-asg-build-identity.mjs"
+      - ".github/scripts/allocate-asg-version.mjs"
+      - ".github/scripts/build-bluetooth-sdk-ota-manifest.mjs"
   push:
     branches:
       - main
@@ -22,8 +44,110 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  # Content-addressed ASG artifacts of the coordinated release lane
+  # (reusable-coordinated-ota.yml): mentra-live-asg-<versionCode>-<fingerprint>.{apk,json}.
+  ASG_RELEASE_TAG: mentra-coordinated-asg
+  PR_BUILDS_TAG: pr-builds
+
 jobs:
+  select:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      mode: ${{ steps.select.outputs.mode }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # The fingerprint script needs the commit history for its
+          # path-limited `git log`; trees are enough, blobs stay remote.
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Select the ASG client for this pull request
+        id: select
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p pr-asg-work
+          release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${ASG_RELEASE_TAG}" --jq .id)
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
+            | jq 'add' > pr-asg-work/coordinated-asg-assets.json
+          node .github/scripts/select-pr-asg.mjs \
+            --source-commit "$GITHUB_SHA" \
+            --assets pr-asg-work/coordinated-asg-assets.json \
+            --output pr-asg-work/selection.json
+
+      - name: Publish the OTA manifest for the reused ASG client
+        if: steps.select.outputs.mode == 'reuse'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROVENANCE_ASSET: ${{ steps.select.outputs.provenance_asset }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gh release download "$ASG_RELEASE_TAG" --pattern "$PROVENANCE_ASSET" --dir pr-asg-work
+          provenance="pr-asg-work/${PROVENANCE_ASSET}"
+          ASG_APK_URL=$(jq -er .apk.url "$provenance")
+          ASG_APK_SHA256=$(jq -er .apk.sha256 "$provenance")
+          ASG_APK_SIZE=$(jq -er .apk.size "$provenance")
+          ASG_VERSION_CODE=$(jq -er .versionCode "$provenance")
+          ASG_VERSION_NAME=$(jq -er .versionName "$provenance")
+          RELEASE_VERSION="pr-${PR_NUMBER}-${HEAD_SHA}"
+          FIRMWARE_MANIFEST=asg_client/ota_manifests/firmware_live.json
+          OUTPUT_PATH="pr-asg-work/ota-pr-${PR_NUMBER}-${HEAD_SHA}.json"
+          export ASG_APK_URL ASG_APK_SHA256 ASG_APK_SIZE ASG_VERSION_CODE ASG_VERSION_NAME
+          export RELEASE_VERSION FIRMWARE_MANIFEST OUTPUT_PATH
+          node .github/scripts/build-bluetooth-sdk-ota-manifest.mjs
+          gh release upload "$PR_BUILDS_TAG" "$OUTPUT_PATH" --clobber
+          echo "Published ${OUTPUT_PATH##*/} pinning coordinated ASG ${ASG_VERSION_CODE} (${ASG_VERSION_NAME})."
+
+      - name: Update PR comment - Reused coordinated build
+        if: steps.select.outputs.mode == 'reuse'
+        uses: actions/github-script@v7
+        env:
+          ASG_VERSION_CODE: ${{ steps.select.outputs.version_code }}
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '<!-- pr-review-helper -->';
+            const comment = comments.data.find(c => c.body.includes(marker));
+            if (!comment) return;
+
+            const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+            const sha = headSha.substring(0, 7);
+            const manifestName = `ota-pr-${prNumber}-${headSha}.json`;
+            const manifestUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds/${manifestName}`;
+
+            const buildStatus = `### 🕶️ ASG Client Build\n♻️ **Unchanged in this PR** (commit \`${sha}\`) - reusing coordinated ASG build \`${process.env.ASG_VERSION_CODE}\`\n\n🔄 **OTA manifest:** [${manifestName}](${manifestUrl}) - the Mobile App PR build updates Mentra Live glasses to this ASG client.`;
+
+            const newBody = comment.body.replace(
+              /<!-- asg-build-status -->[\s\S]*?<!-- \/asg-build-status -->/,
+              `<!-- asg-build-status -->\n${buildStatus}\n<!-- /asg-build-status -->`
+            );
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+              body: newBody
+            });
+
   build:
+    needs: select
+    # Pushes and dispatches always build; a pull request builds only when no
+    # coordinated ASG artifact matches its sources (select decided "build").
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.select.outputs.mode == 'build') }}
     # Blacksmith 4 vCPU Ubuntu. Signing creds come from secrets via inject-signing
     # (no longer needs the mac runners' ~/.mentra/credentials), keeping mac
     # capacity free for iOS + staging/release builds. Faster than the free
@@ -115,6 +239,19 @@ jobs:
         run: |
           # Create .env from example
           cp .env.example .env
+
+      - name: Pin the ASG version code
+        # asg_client/app/build.gradle treats an unpinned build as a development
+        # build: its versionName gets a "-dev" suffix that opts the glasses out
+        # of OTA. CI pins the same time-derived code the mobile app uses
+        # (mobile/scripts/build-number.mjs), so the APK and the OTA manifest
+        # written below agree and the build is OTA-installable.
+        run: |
+          set -euo pipefail
+          code=$(node --input-type=module -e "import('./mobile/scripts/build-number.mjs').then(m => console.log(m.getBuildNumber()))")
+          [[ "$code" =~ ^[1-9][0-9]*$ ]]
+          echo "ASG_VERSION_CODE=$code" >> "$GITHUB_ENV"
+          echo "ASG versionCode pinned to $code"
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v4
@@ -224,6 +361,7 @@ jobs:
           path: asg_client/app/build/outputs/apk/release/app-release.apk
 
       - name: Upload APK to pr-builds release
+        id: upload-apk
         if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v7
@@ -272,6 +410,40 @@ jobs:
 
             console.log(`Successfully uploaded ${apkName}`);
 
+      - name: Publish the OTA manifest for this build
+        # Only once the APK it points at is on the release, and never on push
+        # or dispatch runs, which have no PR manifest to publish.
+        if: github.event_name == 'pull_request' && steps.upload-apk.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          apk=asg_client/app/build/outputs/apk/release/app-release.apk
+          aapt=$(find "$ANDROID_HOME/build-tools" -type f -name aapt -perm -111 | LC_ALL=C sort | tail -1)
+          test -n "$aapt"
+          badging=$("$aapt" dump badging "$apk" | sed -n '1p')
+          version_code=$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<< "$badging")
+          version_name=$(sed -n "s/.*versionName='\([^']*\)'.*/\1/p" <<< "$badging")
+          if [[ "$version_code" != "$ASG_VERSION_CODE" ]]; then
+            echo "::error::Built APK carries versionCode ${version_code:-<missing>}, expected the pinned ${ASG_VERSION_CODE}."
+            exit 1
+          fi
+          mkdir -p pr-asg-work
+          ASG_APK_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${PR_BUILDS_TAG}/asg-pr-${PR_NUMBER}-${HEAD_SHA:0:7}.apk"
+          ASG_APK_SHA256=$(sha256sum "$apk" | cut -d' ' -f1)
+          ASG_APK_SIZE=$(stat -c %s "$apk")
+          ASG_VERSION_NAME="$version_name"
+          RELEASE_VERSION="pr-${PR_NUMBER}-${HEAD_SHA}"
+          FIRMWARE_MANIFEST=asg_client/ota_manifests/firmware_live.json
+          OUTPUT_PATH="pr-asg-work/ota-pr-${PR_NUMBER}-${HEAD_SHA}.json"
+          export ASG_APK_URL ASG_APK_SHA256 ASG_APK_SIZE ASG_VERSION_CODE ASG_VERSION_NAME
+          export RELEASE_VERSION FIRMWARE_MANIFEST OUTPUT_PATH
+          node .github/scripts/build-bluetooth-sdk-ota-manifest.mjs
+          gh release upload "$PR_BUILDS_TAG" "$OUTPUT_PATH" --clobber
+          echo "Published ${OUTPUT_PATH##*/} pinning ASG ${ASG_VERSION_CODE} (${ASG_VERSION_NAME})."
+
       - name: Cleanup old release assets
         if: github.event_name == 'pull_request'
         continue-on-error: true
@@ -318,11 +490,14 @@ jobs:
             if (!comment) return;
 
             const prNumber = context.payload.pull_request.number;
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const headSha = context.payload.pull_request.head.sha;
+            const sha = headSha.substring(0, 7);
             const apkName = `asg-pr-${prNumber}-${sha}.apk`;
-            const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds/${apkName}`;
+            const releaseBase = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds`;
+            const downloadUrl = `${releaseBase}/${apkName}`;
+            const manifestName = `ota-pr-${prNumber}-${headSha}.json`;
 
-            const buildStatus = `### 🕶️ ASG Client Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download ASG APK**](${downloadUrl})`;
+            const buildStatus = `### 🕶️ ASG Client Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download ASG APK**](${downloadUrl})\n\n🔄 **OTA manifest:** [${manifestName}](${releaseBase}/${manifestName}) - the Mobile App PR build updates Mentra Live glasses to this ASG build.`;
 
             const newBody = comment.body.replace(
               /<!-- asg-build-status -->[\s\S]*?<!-- \/asg-build-status -->/,

--- a/.github/workflows/mentra-asg-client-build.yml
+++ b/.github/workflows/mentra-asg-client-build.yml
@@ -350,10 +350,6 @@ jobs:
       #   working-directory: ./asg_client
       #   run: ./gradlew spotlessCheck
 
-      - name: Mark build succeeded
-        id: build-ok
-        run: echo "ok=true" >> $GITHUB_OUTPUT
-
       - name: Upload Release APK (artifact)
         uses: actions/upload-artifact@v4
         with:
@@ -361,9 +357,11 @@ jobs:
           path: asg_client/app/build/outputs/apk/release/app-release.apk
 
       - name: Upload APK to pr-builds release
-        id: upload-apk
+        # Required, not best-effort: the PR mobile APK pins the manifest
+        # published below, which points at this asset. A failed upload must
+        # fail the workflow rather than leave the phone pinned to a manifest
+        # that never appears.
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -411,9 +409,9 @@ jobs:
             console.log(`Successfully uploaded ${apkName}`);
 
       - name: Publish the OTA manifest for this build
-        # Only once the APK it points at is on the release, and never on push
-        # or dispatch runs, which have no PR manifest to publish.
-        if: github.event_name == 'pull_request' && steps.upload-apk.outcome == 'success'
+        # Runs after the APK it points at is on the release; push and dispatch
+        # runs have no PR manifest to publish.
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -443,6 +441,12 @@ jobs:
           node .github/scripts/build-bluetooth-sdk-ota-manifest.mjs
           gh release upload "$PR_BUILDS_TAG" "$OUTPUT_PATH" --clobber
           echo "Published ${OUTPUT_PATH##*/} pinning ASG ${ASG_VERSION_CODE} (${ASG_VERSION_NAME})."
+
+      - name: Mark build published
+        # Everything a tester needs exists from here on: the APK, its release
+        # asset and the OTA manifest (on PRs). Later steps are best-effort.
+        id: build-ok
+        run: echo "ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Cleanup old release assets
         if: github.event_name == 'pull_request'
@@ -534,7 +538,7 @@ jobs:
             const previousShaMatch = comment.body.match(/🕶️ ASG Client[\s\S]*?✅ \*\*Ready to test!\*\* \(commit `([a-f0-9]+)`\)/)
                                   || comment.body.match(/📦 \*\*Previous build:\*\* \(commit `([a-f0-9]+)`\)/);
 
-            let buildStatus = `### 🕶️ ASG Client Build\n❌ **Build failed** (commit \`${sha}\`) - [View logs](${runUrl})`;
+            let buildStatus = `### 🕶️ ASG Client Build\n❌ **Build or publication failed** (commit \`${sha}\`) - [View logs](${runUrl})`;
 
             if (previousDownloadMatch && previousShaMatch && previousShaMatch[1] !== sha) {
               buildStatus += `\n\n📦 **Previous build:** (commit \`${previousShaMatch[1]}\`) - [📥 **Download ASG APK**](${previousDownloadMatch[1]})`;

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -40,6 +40,13 @@ derives `X.Y.Z-dev.N` or `X.Y.Z-beta.N` identities without source edits.
   `EXPO_PUBLIC_ASG_OTA_VERSION_URL` release pin. Local and compile-only builds
   without a pin fail closed; a Super Mode manifest override remains available
   for deliberate local OTA testing.
+- Pull request Android APKs are pinned to `ota-pr-<n>-<head sha>.json` on the
+  `pr-builds` GitHub release, published by the `MentraOS ASG Client Build`
+  workflow for the same PR head. It points at the coordinated ASG artifact
+  whose source fingerprint matches the PR (no ASG build needed) or, when none
+  exists, at an ASG client built from the PR. Installing a PR ASG over a
+  coordinated build is a version-code downgrade that the exact-pin OTA flow
+  handles through the uninstall-then-reinstall detour.
 
 ### Testing
 


### PR DESCRIPTION
## Problem

PR CI built the Mentra App APK and the ASG client APK as unrelated artifacts. The phone APK carried no OTA manifest pin (`EXPO_PUBLIC_ASG_OTA_VERSION_URL` empty, no embedded release metadata), so a tester who installed a PR build could not move their Mentra Live glasses onto the PR's ASG client. Testing a cross-cutting PR like #3927 required adb sideloading.

## Design

Ports the coordinated release lane's ASG selection to the PR lane, keyed on the ASG source fingerprint (repo-wide "does a build of exactly this source already exist?") rather than on changed paths.

- **`MentraOS ASG Client Build`** now runs for every PR that can produce a mobile APK (`asg_client/**`, `mobile/**`, the fingerprint scripts, root `package.json`). Its paths are a superset of the Android workflow's, because every PR Android APK pins this workflow's manifest.
  - New `select` job (ubuntu-latest, blob-less clone): `.github/scripts/select-pr-asg.mjs` computes the PR's ASG fingerprint with `compute-asg-build-identity.mjs` and matches it against the `mentra-coordinated-asg` release with `allocate-asg-version.mjs`'s rules.
  - **Hit** (any PR that leaves ASG sources identical to an already-released tree, e.g. mobile-only PRs): write the OTA manifest from the artifact's provenance JSON, no build. PR comment says which coordinated ASG build is reused.
  - **Miss**: the existing `build` job runs, now with `ASG_VERSION_CODE` pinned (same time-derived formula as `mobile/scripts/build-number.mjs`, so the APK is OTA-installable instead of carrying the `-dev` opt-out suffix), reads versionCode/versionName back from the APK with aapt, and publishes the manifest after the APK upload succeeded.
  - Either way the PR gets `ota-pr-<n>-<head sha>.json` on the `pr-builds` release (covered by the existing 7-day cleanup).
- **`Mobile App Android Build`** pins `EXPO_PUBLIC_ASG_OTA_VERSION_URL` to that URL on `pull_request` events and runs the existing bundle verification step for it (previously dispatch-only). Pushes stay unpinned compile checks.
- `build-bluetooth-sdk-ota-manifest.mjs` accepts `pr-<n>-<sha>` release labels. The app's `resolveOtaReleaseVersion` treats them as "no coordinated release" and shows the ASG versionName.

### Version code semantics

PR-built ASG clients keep the time-derived version code (~53.7M today). That is above the exact-pin downgrade floor (51518114) and below the coordinated namespace (302000xxx), so installing a PR ASG over a coordinated build takes the uninstall-then-reinstall detour the OTA flow already supports, and the next coordinated release upgrades over it normally. PR APKs are not registered on `mentra-coordinated-asg` because their codes would break that release's allocator.

Accepted limitation (Codex connector P2): two ASG `build` jobs of different PRs that reach the pin step in the same second get the same version code, so glasses on one of those two builds cannot exact-pin to the other until either PR gets a new commit. A collision-free scheme would have to leave the time-derived namespace that keeps PR codes between the floor and the coordinated codes.

## Test evidence

- `node --test .github/scripts/*.test.mjs`: 229 pass (4 new for `select-pr-asg`, 2 updated for the manifest label).
- `select-pr-asg.mjs` run locally against dev HEAD with the live `mentra-coordinated-asg` asset list: `mode=reuse`, fingerprint `ca55789f…`, versionCode 302000002, matching the `mentra-live-asg-selection-3.2.0-dev.216.json` release record.
- Reuse-path manifest generated locally from that artifact's provenance and dev's `firmware_live.json`: valid `apps` entry, 8 MTK patches, full OTA, BES 26.9.7.0.
- `actionlint`: no new findings on either workflow (baseline runner-label / setup-java warnings unchanged).
- This PR touches `mobile/AGENTS.md`, so both workflows run on it end-to-end: expect `select` to reuse 302000002 and publish `ota-pr-<n>-<sha>.json`, and the Android build to verify that URL in its bundle.

## Not in scope

- iOS PR builds are compile checks with no distributable, unchanged.
- Reusing PR-built ASG clients across PRs by fingerprint (they live on `pr-builds` under `asg-pr-<n>-<sha>.apk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
