### PR TITLE
Check Cloud V2 signing keys in the form the service stores them

### DIFF
--- a/.github/production-release/cloud-config-contract.json
+++ b/.github/production-release/cloud-config-contract.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "contractVersion": "2026-08-28.1",
+  "contractVersion": "2026-09-11.1",
   "required": {
     "AUDIO_PROVIDER": {"kind": "enum", "values": ["soniox"], "acceptanceTest": "runtime-transcription"},
     "AUDIO_UDP_ADVERTISED_HOST": {"kind": "host", "acceptanceTest": "runtime-audio-transport"},
@@ -27,7 +27,11 @@
     "MENTRA_MINIAPP_JWT_PRIVATE_KEY": {"kind": "private-key", "acceptanceTest": "miniapp-token"},
     "MENTRA_MINIAPP_JWT_PUBLIC_KEY": {"kind": "public-key", "acceptanceTest": "miniapp-token"},
     "MONGO_URL": {"kind": "mongo-url", "acceptanceTest": "core-readiness"},
-    "NODE_ENV": {"kind": "enum", "values": ["production"], "acceptanceTest": "service-readiness"},
+    "NODE_ENV": {
+      "kind": "enum",
+      "valuesByEnvironment": {"staging": ["staging", "production"], "prod": ["production"]},
+      "acceptanceTest": "service-readiness"
+    },
     "PORTAL_URL": {"kind": "https-url", "acceptanceTest": "portal-login"},
     "REDIS_URL": {"kind": "redis-url", "acceptanceTest": "runtime-readiness"},
     "REFRESH_TOKEN_PEPPER": {"kind": "secret", "acceptanceTest": "session-restoration"},

--- a/.github/scripts/validate-production-cloud-config.mjs
+++ b/.github/scripts/validate-production-cloud-config.mjs
@@ -120,12 +120,31 @@ function validateValue(value, rule, label, environment) {
   if (rule.kind === "host" && (!/^[A-Za-z0-9.-]+$/.test(value) || !value.includes("."))) {
     throw new Error(`${label} is not a hostname`)
   }
-  if (rule.kind === "private-key" && !/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(value)) {
-    throw new Error(`${label} is not private-key PEM`)
+  if (rule.kind === "private-key") {
+    try {
+      createPrivateKey(keyMaterial(value, "PRIVATE KEY"))
+    } catch {
+      throw new Error(`${label} is not a private key (PEM or PKCS#8 base64 body)`)
+    }
   }
-  if (rule.kind === "public-key" && !/-----BEGIN (?:PUBLIC KEY|CERTIFICATE)-----/.test(value)) {
-    throw new Error(`${label} is not public-key PEM`)
+  if (rule.kind === "public-key") {
+    try {
+      createPublicKey(keyMaterial(value, "PUBLIC KEY"))
+    } catch {
+      throw new Error(`${label} is not a public key (PEM or SPKI base64 body)`)
+    }
   }
+}
+
+// Cloud V2 stores its Ed25519 signing keys as bare base64 PKCS#8 / SPKI bodies
+// and rebuilds the PEM armour when loading them (signing-keys.service.ts
+// toPem). Accept that form as well as full PEM, so the contract checks the
+// same material the service will actually load.
+export function keyMaterial(value, label) {
+  const text = String(value).replace(/\\n/g, "\n").trim()
+  if (text.includes("-----BEGIN ")) return text
+  if (!/^[A-Za-z0-9+/=\s]+$/.test(text)) throw new Error("not key material")
+  return `-----BEGIN ${label}-----\n${text.replace(/\s+/g, "")}\n-----END ${label}-----`
 }
 
 export function validateProductionCloudConfig({contract, environment, values}) {
@@ -156,8 +175,14 @@ export function validateProductionCloudConfig({contract, environment, values}) {
     let derived
     let supplied
     try {
-      derived = createPublicKey(createPrivateKey(values[pair.privateKey])).export({type: "spki", format: "pem"})
-      supplied = createPublicKey(values[pair.publicKey]).export({type: "spki", format: "pem"})
+      derived = createPublicKey(createPrivateKey(keyMaterial(values[pair.privateKey], "PRIVATE KEY"))).export({
+        type: "spki",
+        format: "pem",
+      })
+      supplied = createPublicKey(keyMaterial(values[pair.publicKey], "PUBLIC KEY")).export({
+        type: "spki",
+        format: "pem",
+      })
     } catch {
       throw new Error(`${pair.id} contains an invalid key pair`)
     }

--- a/.github/scripts/validate-production-cloud-config.mjs
+++ b/.github/scripts/validate-production-cloud-config.mjs
@@ -142,7 +142,15 @@ function validateValue(value, rule, label, environment) {
 // same material the service will actually load.
 export function keyMaterial(value, label) {
   const text = String(value).replace(/\\n/g, "\n").trim()
-  if (text.includes("-----BEGIN ")) return text
+  if (text.includes("-----BEGIN ")) {
+    // A PEM must be of the slot's own type: createPublicKey would happily
+    // derive a public key from private material, but the service's
+    // importSPKI would not, so private PEM in a public slot must fail here.
+    const expected =
+      label === "PUBLIC KEY" ? /^-----BEGIN (?:PUBLIC KEY|CERTIFICATE)-----/m : /^-----BEGIN [A-Z ]*PRIVATE KEY-----/m
+    if (!expected.test(text)) throw new Error("not key material of the expected type")
+    return text
+  }
   if (!/^[A-Za-z0-9+/=\s]+$/.test(text)) throw new Error("not key material")
   return `-----BEGIN ${label}-----\n${text.replace(/\s+/g, "")}\n-----END ${label}-----`
 }

--- a/.github/scripts/validate-production-cloud-config.test.mjs
+++ b/.github/scripts/validate-production-cloud-config.test.mjs
@@ -149,6 +149,43 @@ test("accepts the bare base64 key bodies Cloud V2 stores, and rejects mismatched
   )
 })
 
+test("private key material is rejected in a public-key slot, in PEM and escaped form", () => {
+  const {privateKey, publicKey} = generateKeyPairSync("ed25519")
+  const privatePem = privateKey.export({type: "pkcs8", format: "pem"})
+  const privateBody = privateKey.export({type: "pkcs8", format: "der"}).toString("base64")
+  const publicBody = publicKey.export({type: "spki", format: "der"}).toString("base64")
+  const pairContract = {
+    schemaVersion: 1,
+    contractVersion: "test",
+    required: {PRIVATE_KEY: {kind: "private-key"}, PUBLIC_KEY: {kind: "public-key"}},
+    keyPairs: [{id: "pair", privateKey: "PRIVATE_KEY", publicKey: "PUBLIC_KEY", acceptanceTest: "auth"}],
+  }
+  for (const publicSlot of [privatePem, privatePem.replace(/\n/g, "\\n")]) {
+    assert.throws(
+      () =>
+        validateProductionCloudConfig({
+          contract: pairContract,
+          environment: "prod",
+          values: {PRIVATE_KEY: privateBody, PUBLIC_KEY: publicSlot},
+        }),
+      /not a public key/,
+    )
+  }
+  assert.throws(
+    () =>
+      keyMaterial(publicBody && `-----BEGIN PUBLIC KEY-----\n${publicBody}\n-----END PUBLIC KEY-----`, "PRIVATE KEY"),
+    /expected type/,
+  )
+  assert.equal(
+    validateProductionCloudConfig({
+      contract: pairContract,
+      environment: "prod",
+      values: {PRIVATE_KEY: privateBody, PUBLIC_KEY: publicBody},
+    }).checks.find((check) => check.id === "pair").status,
+    "pass",
+  )
+})
+
 test("staging may run with NODE_ENV=staging while prod must be production", () => {
   const rule = {kind: "enum", valuesByEnvironment: {staging: ["staging", "production"], prod: ["production"]}}
   const single = {schemaVersion: 1, contractVersion: "test", required: {NODE_ENV: rule}}

--- a/.github/scripts/validate-production-cloud-config.test.mjs
+++ b/.github/scripts/validate-production-cloud-config.test.mjs
@@ -6,6 +6,7 @@ import {
   parseEnvironmentFile,
   validateContractCoverage,
   validateProductionCloudConfig,
+  keyMaterial,
 } from "./validate-production-cloud-config.mjs"
 
 const keys = generateKeyPairSync("rsa", {modulusLength: 1024})
@@ -96,5 +97,68 @@ test("fails for missing, forbidden, local, and unclassified config", () => {
   assert.throws(
     () => validateContractCoverage(contract, ["NODE_ENV", "NEW_REQUIRED_FEATURE_KEY"]),
     /NEW_REQUIRED_FEATURE_KEY/,
+  )
+})
+
+test("accepts the bare base64 key bodies Cloud V2 stores, and rejects mismatched or garbage keys", () => {
+  const {privateKey, publicKey} = generateKeyPairSync("ed25519")
+  const body = (key, type) => key.export({type, format: "der"}).toString("base64")
+  const bodies = {
+    privateKey: body(privateKey, "pkcs8"),
+    publicKey: body(publicKey, "spki"),
+  }
+  assert.match(
+    keyMaterial(bodies.privateKey, "PRIVATE KEY"),
+    /^-----BEGIN PRIVATE KEY-----\n[A-Za-z0-9+/=]+\n-----END PRIVATE KEY-----$/,
+  )
+  assert.equal(
+    keyMaterial("-----BEGIN PUBLIC KEY-----\\nabc\\n-----END PUBLIC KEY-----", "PUBLIC KEY"),
+    "-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----",
+  )
+  const rules = {PRIVATE_KEY: {kind: "private-key"}, PUBLIC_KEY: {kind: "public-key"}}
+  const pairContract = {
+    schemaVersion: 1,
+    contractVersion: "test",
+    required: rules,
+    keyPairs: [{id: "pair", privateKey: "PRIVATE_KEY", publicKey: "PUBLIC_KEY", acceptanceTest: "auth"}],
+  }
+  const result = validateProductionCloudConfig({
+    contract: pairContract,
+    environment: "prod",
+    values: {PRIVATE_KEY: bodies.privateKey, PUBLIC_KEY: bodies.publicKey},
+  })
+  assert.equal(result.checks.find((check) => check.id === "pair").status, "pass")
+  const other = generateKeyPairSync("ed25519")
+  assert.throws(
+    () =>
+      validateProductionCloudConfig({
+        contract: pairContract,
+        environment: "prod",
+        values: {PRIVATE_KEY: bodies.privateKey, PUBLIC_KEY: body(other.publicKey, "spki")},
+      }),
+    /do not correspond/,
+  )
+  assert.throws(
+    () =>
+      validateProductionCloudConfig({
+        contract: pairContract,
+        environment: "prod",
+        values: {PRIVATE_KEY: "not a key at all!", PUBLIC_KEY: bodies.publicKey},
+      }),
+    /not a private key/,
+  )
+})
+
+test("staging may run with NODE_ENV=staging while prod must be production", () => {
+  const rule = {kind: "enum", valuesByEnvironment: {staging: ["staging", "production"], prod: ["production"]}}
+  const single = {schemaVersion: 1, contractVersion: "test", required: {NODE_ENV: rule}}
+  assert.equal(
+    validateProductionCloudConfig({contract: single, environment: "staging", values: {NODE_ENV: "staging"}}).checks[0]
+      .status,
+    "pass",
+  )
+  assert.throws(
+    () => validateProductionCloudConfig({contract: single, environment: "prod", values: {NODE_ENV: "staging"}}),
+    /not an allowed prod value/,
   )
 })


### PR DESCRIPTION
## Why

The first Cloud preflight for 3.1.0 ([run 34653321152](https://github.com/Mentra-Community/MentraOS/actions/runs/34653321152)) pulled both Porter environment groups and failed the contract on the first missing key. Running the contract locally against both groups (key names only, no values) showed two classes of failure. This PR fixes the class where the contract was wrong about the running system:

- **Signing keys.** `MENTRA_JWT_*`, `MENTRA_ACCOUNT_JWT_*`, and `MENTRA_MINIAPP_JWT_*` are stored as bare base64 PKCS#8 / SPKI bodies; `signing-keys.service.ts` wraps them in PEM armour at load time (`toPem`). The validator required PEM armour and would have rejected all six keys in both environments. It now accepts either form, parses the material with `createPrivateKey` / `createPublicKey` instead of matching a header, and compares key pairs from the same material. Verified locally: both environments' three key pairs parse and correspond.
- **`NODE_ENV` on staging.** Staging runs with `NODE_ENV=staging`; the contract demanded `production` for both environments. Staging now accepts `staging` or `production`; prod still requires `production`.

Contract version moves to `2026-09-11.1`.

The other class, genuine configuration gaps (missing `CAMERA_WEBHOOK_SECRET`, `COOKIE_SECURE`, `EMAIL_SENDER`, `STREAM_PROVIDER`, a scheme-less `CLOUD_ADMIN_CONSOLE_URL`, `STORAGE_PROVIDER=local`), is being handled in Doppler and is not changed here.

## Test evidence

- `node --test .github/scripts/validate-production-cloud-config.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs`: 24 passed, 0 failed, including base64-body acceptance, mismatched-pair rejection, garbage rejection, and the per-environment `NODE_ENV` rule.
- The fixed validator run locally against the real staging and prod groups reports only the configuration gaps listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
