### PR TITLE
Make runtime storage requirements conditional in the Cloud config contract

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -227,6 +227,12 @@ Run `next` once for preflight and, after it succeeds, again for deployment:
 Preflight loads staging and production configuration into temporary mode-0600
 files, validates the versioned contract, and publishes only key names and
 pass/fail results. It never compares or publishes raw values or secret hashes.
+Some requirements are conditional (`requiredWhen` in the contract): the
+runtime's storage-event webhook secret and its R2/S3 credentials apply only
+while `STORAGE_PROVIDER` is `r2` or `s3`. Production runs the `local` provider
+for managed photos (the cloud photo path is being retired), so those checks
+report `inactive` rather than failing; keys that are present anyway are still
+validated.
 
 Before approving `production-cloud`, compare the frozen source, target, previous
 revision, migration notes, and rollback coordinates in the workflow summary.

--- a/.github/production-release/cloud-config-contract.json
+++ b/.github/production-release/cloud-config-contract.json
@@ -1,11 +1,15 @@
 {
   "schemaVersion": 1,
-  "contractVersion": "2026-09-11.1",
+  "contractVersion": "2026-09-11.2",
   "required": {
     "AUDIO_PROVIDER": {"kind": "enum", "values": ["soniox"], "acceptanceTest": "runtime-transcription"},
     "AUDIO_UDP_ADVERTISED_HOST": {"kind": "host", "acceptanceTest": "runtime-audio-transport"},
     "AUDIO_UDP_ADVERTISED_PORT": {"kind": "integer", "acceptanceTest": "runtime-audio-transport"},
-    "CAMERA_WEBHOOK_SECRET": {"kind": "secret", "acceptanceTest": "camera-upload"},
+    "CAMERA_WEBHOOK_SECRET": {
+      "kind": "secret",
+      "requiredWhen": {"key": "STORAGE_PROVIDER", "values": ["r2", "s3"]},
+      "acceptanceTest": "camera-upload"
+    },
     "CLOUD_ADMIN_CONSOLE_URL": {"kind": "https-url", "acceptanceTest": "incident-admin-link"},
     "CLOUD_CORE_ENVIRONMENT": {
       "kind": "enum",
@@ -37,7 +41,7 @@
     "REFRESH_TOKEN_PEPPER": {"kind": "secret", "acceptanceTest": "session-restoration"},
     "RESEND_API_KEY": {"kind": "secret", "acceptanceTest": "transactional-email"},
     "SONIOX_API_KEY": {"kind": "secret", "acceptanceTest": "runtime-transcription"},
-    "STORAGE_PROVIDER": {"kind": "enum", "values": ["r2", "s3"], "acceptanceTest": "camera-upload"},
+    "STORAGE_PROVIDER": {"kind": "enum", "values": ["local", "r2", "s3"], "acceptanceTest": "camera-upload"},
     "STREAM_PROVIDER": {"kind": "enum", "values": ["cloudflare"], "acceptanceTest": "managed-stream"},
     "SUPABASE_ANON_KEY": {"kind": "secret", "acceptanceTest": "account-token-exchange"},
     "SUPABASE_SERVICE_ROLE_KEY": {"kind": "secret", "acceptanceTest": "account-token-exchange"},
@@ -85,24 +89,28 @@
     },
     {
       "id": "runtime-storage-endpoint",
+      "requiredWhen": {"key": "STORAGE_PROVIDER", "values": ["r2", "s3"]},
       "keys": ["STORAGE_S3_ENDPOINT", "R2_ENDPOINT", "CLOUDFLARE_R2_S3_ENDPOINT"],
       "kind": "https-url",
       "acceptanceTest": "camera-upload"
     },
     {
       "id": "runtime-storage-bucket",
+      "requiredWhen": {"key": "STORAGE_PROVIDER", "values": ["r2", "s3"]},
       "keys": ["STORAGE_S3_BUCKET", "R2_BUCKET", "CLOUDFLARE_R2_GALLERY_BUCKET"],
       "kind": "string",
       "acceptanceTest": "camera-upload"
     },
     {
       "id": "runtime-storage-access-key",
+      "requiredWhen": {"key": "STORAGE_PROVIDER", "values": ["r2", "s3"]},
       "keys": ["STORAGE_S3_ACCESS_KEY_ID", "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID"],
       "kind": "secret",
       "acceptanceTest": "camera-upload"
     },
     {
       "id": "runtime-storage-secret-key",
+      "requiredWhen": {"key": "STORAGE_PROVIDER", "values": ["r2", "s3"]},
       "keys": ["STORAGE_S3_SECRET_ACCESS_KEY", "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY"],
       "kind": "secret",
       "acceptanceTest": "camera-upload"

--- a/.github/scripts/validate-production-cloud-config.mjs
+++ b/.github/scripts/validate-production-cloud-config.mjs
@@ -73,7 +73,36 @@ export function validateContractCoverage(contract, sourceKeys) {
   }
   if (overlaps.length > 0)
     throw new Error(`Cloud configuration keys have conflicting classifications: ${overlaps.join(", ")}`)
+  const rules = [
+    ...Object.entries(contract.required || {}).map(([id, rule]) => ({id, rule})),
+    ...(contract.requiredAnyOf || []).map((rule) => ({id: rule.id, rule})),
+  ]
+  for (const {id, rule} of rules) {
+    const condition = rule.requiredWhen
+    if (condition === undefined) continue
+    const selector = contract.required?.[condition.key]
+    const allowed = new Set([...(selector?.values || []), ...Object.values(selector?.valuesByEnvironment || {}).flat()])
+    if (
+      !selector ||
+      selector.kind !== "enum" ||
+      !Array.isArray(condition.values) ||
+      condition.values.length === 0 ||
+      condition.values.some((value) => !allowed.has(value))
+    ) {
+      throw new Error(`${id} is conditional on ${condition.key}, which is not a required enum offering those values`)
+    }
+  }
   return true
+}
+
+// A requirement with `requiredWhen` only applies while the selecting key holds
+// one of the listed values (for example the runtime storage webhook secret and
+// R2 credentials, which only matter when STORAGE_PROVIDER is r2 or s3). While
+// inactive, the keys may still be present and are then validated as usual.
+function requirementActive(rule, values) {
+  const condition = rule.requiredWhen
+  if (condition === undefined) return true
+  return condition.values.includes(values[condition.key])
 }
 
 function parseUrl(value, protocols, label) {
@@ -159,13 +188,24 @@ export function validateProductionCloudConfig({contract, environment, values}) {
   if (!new Set(["staging", "prod"]).has(environment)) throw new Error(`Unsupported environment ${environment}`)
   validateContractCoverage(contract, [])
   const checks = []
+  const isPresent = (key) => typeof values[key] === "string" && values[key].trim() !== ""
   for (const [key, rule] of Object.entries(contract.required)) {
+    if (!requirementActive(rule, values) && !isPresent(key)) {
+      checks.push({id: key, keys: [], status: "inactive", acceptanceTest: rule.acceptanceTest})
+      continue
+    }
     validateValue(values[key], rule, key, environment)
     checks.push({id: key, keys: [key], status: "pass", acceptanceTest: rule.acceptanceTest})
   }
   for (const requirement of contract.requiredAnyOf || []) {
-    const present = requirement.keys.filter((key) => typeof values[key] === "string" && values[key].trim() !== "")
-    if (present.length === 0) throw new Error(`${requirement.id} requires one of ${requirement.keys.join(", ")}`)
+    const present = requirement.keys.filter(isPresent)
+    if (present.length === 0) {
+      if (!requirementActive(requirement, values)) {
+        checks.push({id: requirement.id, keys: [], status: "inactive", acceptanceTest: requirement.acceptanceTest})
+        continue
+      }
+      throw new Error(`${requirement.id} requires one of ${requirement.keys.join(", ")}`)
+    }
     present.forEach((key) => validateValue(values[key], requirement, key, environment))
     checks.push({
       id: requirement.id,

--- a/.github/scripts/validate-production-cloud-config.test.mjs
+++ b/.github/scripts/validate-production-cloud-config.test.mjs
@@ -199,3 +199,91 @@ test("staging may run with NODE_ENV=staging while prod must be production", () =
     /not an allowed prod value/,
   )
 })
+
+const conditionalContract = {
+  schemaVersion: 1,
+  contractVersion: "test-2",
+  required: {
+    STORAGE_PROVIDER: {kind: "enum", values: ["local", "r2"], acceptanceTest: "camera"},
+    CAMERA_WEBHOOK_SECRET: {
+      kind: "secret",
+      requiredWhen: {key: "STORAGE_PROVIDER", values: ["r2"]},
+      acceptanceTest: "camera",
+    },
+  },
+  requiredAnyOf: [
+    {
+      id: "runtime-storage-endpoint",
+      keys: ["STORAGE_S3_ENDPOINT", "R2_ENDPOINT"],
+      kind: "https-url",
+      requiredWhen: {key: "STORAGE_PROVIDER", values: ["r2"]},
+      acceptanceTest: "camera",
+    },
+  ],
+}
+
+test("conditional requirements apply only while the selecting key holds a listed value", () => {
+  const local = validateProductionCloudConfig({
+    contract: conditionalContract,
+    environment: "prod",
+    values: {STORAGE_PROVIDER: "local"},
+  })
+  assert.deepEqual(
+    local.checks.map((check) => [check.id, check.status, check.keys]),
+    [
+      ["CAMERA_WEBHOOK_SECRET", "inactive", []],
+      ["runtime-storage-endpoint", "inactive", []],
+      ["STORAGE_PROVIDER", "pass", ["STORAGE_PROVIDER"]],
+    ],
+  )
+  // Inactive keys that are nevertheless present are still validated.
+  assert.throws(
+    () =>
+      validateProductionCloudConfig({
+        contract: conditionalContract,
+        environment: "prod",
+        values: {STORAGE_PROVIDER: "local", R2_ENDPOINT: "http://localhost:9000"},
+      }),
+    /R2_ENDPOINT/,
+  )
+  assert.throws(
+    () =>
+      validateProductionCloudConfig({
+        contract: conditionalContract,
+        environment: "prod",
+        values: {STORAGE_PROVIDER: "r2", R2_ENDPOINT: "https://account.r2.cloudflarestorage.com"},
+      }),
+    /CAMERA_WEBHOOK_SECRET is missing/,
+  )
+  assert.throws(
+    () =>
+      validateProductionCloudConfig({
+        contract: conditionalContract,
+        environment: "prod",
+        values: {STORAGE_PROVIDER: "r2", CAMERA_WEBHOOK_SECRET: "s3cret"},
+      }),
+    /runtime-storage-endpoint requires one of/,
+  )
+  const remote = validateProductionCloudConfig({
+    contract: conditionalContract,
+    environment: "prod",
+    values: {
+      STORAGE_PROVIDER: "r2",
+      CAMERA_WEBHOOK_SECRET: "s3cret",
+      R2_ENDPOINT: "https://account.r2.cloudflarestorage.com",
+    },
+  })
+  assert.equal(
+    remote.checks.every((check) => check.status === "pass"),
+    true,
+  )
+})
+
+test("a condition must point at a required enum that offers the listed values", () => {
+  const unknownSelector = structuredClone(conditionalContract)
+  unknownSelector.required.CAMERA_WEBHOOK_SECRET.requiredWhen = {key: "PHOTO_MODE", values: ["cloud"]}
+  assert.throws(() => validateContractCoverage(unknownSelector, []), /conditional on PHOTO_MODE/)
+  const unknownValue = structuredClone(conditionalContract)
+  unknownValue.requiredAnyOf[0].requiredWhen = {key: "STORAGE_PROVIDER", values: ["gcs"]}
+  assert.throws(() => validateContractCoverage(unknownValue, []), /conditional on STORAGE_PROVIDER/)
+})


### PR DESCRIPTION
## Scope

The first 3.1.0 Cloud preflight failed the configuration contract on production keys that have no caller: `STORAGE_PROVIDER` must be `r2`/`s3`, `CAMERA_WEBHOOK_SECRET` must exist, and the runtime R2 credentials are required. Production deliberately runs the `local` runtime storage provider for managed photos; the cloud photo path (R2 upload + storage-event webhook) is being retired by #3619 / #3622. Nothing in the repo or in Cloudflare posts storage events, so switching prod to `r2` would leave every managed photo pending forever.

- `.github/production-release/cloud-config-contract.json` (`2026-09-11.2`): `STORAGE_PROVIDER` accepts `local`; `CAMERA_WEBHOOK_SECRET` and the four `runtime-storage-*` credential groups carry `requiredWhen: {key: "STORAGE_PROVIDER", values: ["r2", "s3"]}`.
- `.github/scripts/validate-production-cloud-config.mjs`: a requirement with `requiredWhen` is enforced only while the selecting key holds a listed value. Inactive requirements are recorded as `status: "inactive"` with no keys; keys present while inactive are still validated. `validateContractCoverage` rejects a condition that does not point at a required enum offering those values.
- Tests for both behaviours; runbook paragraph on conditional requirements.

Core storage (`CLOUD_STORAGE_PROVIDER`) is unchanged and still must be `r2`/`s3`. Streams are unchanged (`STREAM_PROVIDER=cloudflare`).

## Test evidence

```
node --test .github/scripts/validate-production-cloud-config.test.mjs   # 9 pass
node --test .github/scripts/coordinated-workflow-contract.test.mjs      # 18 pass
node .github/scripts/validate-production-cloud-config.mjs --contract ... --root .   # coverage ok
```

Run locally (key names only) against the Doppler `prod` config after tonight's value updates: passes with `CAMERA_WEBHOOK_SECRET` inactive. `staging` still fails on its own missing values (`CLOUD_ADMIN_CONSOLE_URL` without scheme, localhost `WORKOS_REDIRECT_URI`, and the keys listed in the promotion thread), which are Doppler updates rather than contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
