### PR TITLE
Wake the stopped recovery worker with include-stopped intents

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
@@ -422,8 +422,9 @@ public class RecoveryWorkerManager {
      * FLAG_EXCLUDE_STOPPED_PACKAGES to every broadcast by default and also withholds
      * BOOT_COMPLETED from stopped packages, so without FLAG_INCLUDE_STOPPED_PACKAGES a freshly
      * deployed worker is never woken: start requests and downgrade handoffs are dropped
-     * silently and the worker stays dormant across reboots. Delivering the intent runs the
-     * receiver, which clears the stopped state for good.
+     * silently and the worker stays dormant across reboots. Delivering a manifest-received
+     * intent (start request, downgrade handoff) runs the receiver, which clears the stopped
+     * state until the next force-stop or fresh install.
      */
     public static Intent newRecoveryIntent(String action) {
         Intent intent = new Intent(action);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
@@ -415,9 +415,25 @@ public class RecoveryWorkerManager {
         }
     }
 
+    /**
+     * Builds an intent addressed to the recovery worker. Every ASG-to-worker intent must be
+     * created here. The worker is installed by the OEM installer and sits in Android's
+     * "stopped" state until one of its components has run once; Android adds
+     * FLAG_EXCLUDE_STOPPED_PACKAGES to every broadcast by default and also withholds
+     * BOOT_COMPLETED from stopped packages, so without FLAG_INCLUDE_STOPPED_PACKAGES a freshly
+     * deployed worker is never woken: start requests and downgrade handoffs are dropped
+     * silently and the worker stays dormant across reboots. Delivering the intent runs the
+     * receiver, which clears the stopped state for good.
+     */
+    public static Intent newRecoveryIntent(String action) {
+        Intent intent = new Intent(action);
+        intent.setPackage(RECOVERY_PACKAGE);
+        intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+        return intent;
+    }
+
     private boolean sendStartRecoveryBroadcast() {
-        Intent startIntent = new Intent(ACTION_START_RECOVERY);
-        startIntent.setPackage(RECOVERY_PACKAGE);
+        Intent startIntent = newRecoveryIntent(ACTION_START_RECOVERY);
         List<ResolveInfo> receivers =
                 context.getPackageManager().queryBroadcastReceivers(startIntent, 0);
         if (receivers == null || receivers.isEmpty()) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -17,6 +17,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import com.mentra.asg_client.AsgConstants;
+import com.mentra.asg_client.RecoveryWorkerManager;
 import com.mentra.asg_client.events.BatteryStatusEvent;
 import com.mentra.asg_client.io.ota.events.DownloadProgressEvent;
 import com.mentra.asg_client.io.ota.events.InstallationProgressEvent;
@@ -1225,8 +1226,8 @@ public class OtaHelper {
             currentUpdateStage = "install";
             sendProgressToPhone("install", 0, 0, 0, "STARTED", null);
 
-            Intent handoff = new Intent(OtaConstants.RECOVERY_REQUEST_DOWNGRADE);
-            handoff.setPackage(OtaConstants.RECOVERY_PACKAGE);
+            Intent handoff =
+                    RecoveryWorkerManager.newRecoveryIntent(OtaConstants.RECOVERY_REQUEST_DOWNGRADE);
             handoff.putExtra(OtaConstants.EXTRA_DOWNGRADE_TARGET_VERSION, targetVersion);
             handoff.putExtra(OtaConstants.EXTRA_DOWNGRADE_APK_PATH, apkFile.getAbsolutePath());
             handoff.putExtra(OtaConstants.EXTRA_DOWNGRADE_APK_SHA256, expectedSha);
@@ -1530,15 +1531,15 @@ public class OtaHelper {
         if (!isAsgClientApk(pm, apkPath)) {
             return;
         }
-        Intent intent = new Intent(OtaConstants.RECOVERY_INSTALL_IN_PROGRESS);
-        intent.setPackage(OtaConstants.RECOVERY_PACKAGE);
+        Intent intent =
+                RecoveryWorkerManager.newRecoveryIntent(OtaConstants.RECOVERY_INSTALL_IN_PROGRESS);
         context.sendBroadcast(intent, OtaConstants.RECOVERY_CONTROL_PERMISSION);
         Log.d(TAG, "Notified recovery worker: install in progress");
     }
 
     public static void notifyRecoveryInstallCompleted(Context context) {
-        Intent intent = new Intent(OtaConstants.RECOVERY_INSTALL_COMPLETED);
-        intent.setPackage(OtaConstants.RECOVERY_PACKAGE);
+        Intent intent =
+                RecoveryWorkerManager.newRecoveryIntent(OtaConstants.RECOVERY_INSTALL_COMPLETED);
         context.sendBroadcast(intent, OtaConstants.RECOVERY_CONTROL_PERMISSION);
         Log.d(TAG, "Notified recovery worker: install completed");
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/ServiceHeartbeatReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/ServiceHeartbeatReceiver.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+import com.mentra.asg_client.RecoveryWorkerManager;
 import com.mentra.asg_client.io.ota.helpers.OtaHelper;
 import com.mentra.asg_client.io.ota.utils.OtaConstants;
 import com.mentra.asg_client.service.core.AsgClientService;
@@ -55,8 +56,7 @@ public class ServiceHeartbeatReceiver extends BroadcastReceiver {
             lastHeartbeatTime = currentTime;
 
             try {
-                Intent pongIntent = new Intent(ACTION_PONG);
-                pongIntent.setPackage("com.mentra.recovery");
+                Intent pongIntent = RecoveryWorkerManager.newRecoveryIntent(ACTION_PONG);
                 context.sendBroadcast(pongIntent, RECOVERY_HEARTBEAT_PERMISSION);
                 Log.d(TAG, "Sent heartbeat acknowledgment");
             } catch (Exception e) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/RecoveryWorkerManagerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/RecoveryWorkerManagerTest.java
@@ -1,0 +1,30 @@
+package com.mentra.asg_client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import android.content.Intent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class RecoveryWorkerManagerTest {
+
+    @Test
+    public void newRecoveryIntent_targetsWorkerPackageWithAction() {
+        Intent intent = RecoveryWorkerManager.newRecoveryIntent("com.mentra.recovery.ACTION_X");
+        assertEquals("com.mentra.recovery.ACTION_X", intent.getAction());
+        assertEquals("com.mentra.recovery", intent.getPackage());
+    }
+
+    @Test
+    public void newRecoveryIntent_reachesStoppedPackages() {
+        // A freshly OEM-installed worker is in Android's stopped state until one of its
+        // components runs; broadcasts without this flag are dropped before delivery.
+        Intent intent = RecoveryWorkerManager.newRecoveryIntent("com.mentra.recovery.ACTION_X");
+        assertNotEquals(0, intent.getFlags() & Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+    }
+}

--- a/asg_client/docs/features/recovery-worker.md
+++ b/asg_client/docs/features/recovery-worker.md
@@ -25,9 +25,11 @@ ASG deploys the worker through the OEM installer, which leaves the package in An
 "stopped" state until one of its components has run. Stopped packages receive no
 broadcasts (the system adds `FLAG_EXCLUDE_STOPPED_PACKAGES` to every broadcast) and no
 `BOOT_COMPLETED`, so a freshly deployed worker cannot wake itself. Every ASG-to-worker
-intent (start request, install notifications, downgrade handoff) must therefore be built
-with `RecoveryWorkerManager.newRecoveryIntent`, which adds `FLAG_INCLUDE_STOPPED_PACKAGES`;
-the first delivered intent runs the receiver and clears the stopped state permanently.
+intent (start request, downgrade handoff, install notifications, heartbeat pong) must
+therefore be built with `RecoveryWorkerManager.newRecoveryIntent`, which adds
+`FLAG_INCLUDE_STOPPED_PACKAGES`. Only the manifest-registered `RecoveryControlReceiver`
+actions (start request, downgrade handoff) can cold-start the worker; delivering one of
+them clears the stopped state until the next force-stop or fresh install.
 
 ## Backup contract
 

--- a/asg_client/docs/features/recovery-worker.md
+++ b/asg_client/docs/features/recovery-worker.md
@@ -19,6 +19,16 @@ The recovery worker is a headless companion APK (`com.mentra.recovery`) that kee
 - `COOLDOWN`
 - `FAILED_NEEDS_MANUAL`
 
+## Start contract
+
+ASG deploys the worker through the OEM installer, which leaves the package in Android's
+"stopped" state until one of its components has run. Stopped packages receive no
+broadcasts (the system adds `FLAG_EXCLUDE_STOPPED_PACKAGES` to every broadcast) and no
+`BOOT_COMPLETED`, so a freshly deployed worker cannot wake itself. Every ASG-to-worker
+intent (start request, install notifications, downgrade handoff) must therefore be built
+with `RecoveryWorkerManager.newRecoveryIntent`, which adds `FLAG_INCLUDE_STOPPED_PACKAGES`;
+the first delivered intent runs the receiver and clears the stopped state permanently.
+
 ## Backup contract
 
 ASG writes:


### PR DESCRIPTION
## Scope

ASG-side fix for `downgrade_handoff_failed` and, more broadly, for the recovery worker never running on units where it was deployed by ASG itself.

## Root cause

ASG deploys `com.mentra.recovery` through the OEM installer (`installerPackageName=com.android.systemui`). Android leaves such a package in the **stopped** state until one of its components has run once. Stopped packages receive no broadcasts (the system adds `FLAG_EXCLUDE_STOPPED_PACKAGES` to every broadcast) and no `BOOT_COMPLETED`. Both of ASG's ways to wake the worker are broadcasts:

- the `ACTION_START_RECOVERY` sent by `RecoveryWorkerManager` on every service start (the launcher-activity fallback only runs when the receiver lookup is empty, which it never is), and
- the `ACTION_REQUEST_DOWNGRADE` handoff sent by `OtaHelper`.

So on any unit where nobody has launched the worker by hand (every consumer unit, and any developer unit after a factory flash), the worker is dormant across reboots: crash recovery, backup reinstall, and the downgrade detour are all inactive, and a pinned downgrade waits 180 s for a verdict that cannot come. Developer units masked this because `adb install` plus a manual launch clears the stopped flag for good.

## Change

- `RecoveryWorkerManager.newRecoveryIntent(action)` builds every ASG-to-worker intent with `setPackage` and `FLAG_INCLUDE_STOPPED_PACKAGES`.
- The start request, both install notifications, and the downgrade handoff go through it. No worker-side change is needed: the first delivered intent runs `RecoveryControlReceiver`, which clears the stopped state permanently.
- Robolectric test `RecoveryWorkerManagerTest` covers the factory.
- `asg_client/docs/features/recovery-worker.md` gains a "Start contract" section.

## Evidence

Mentra Live unit 023B, MTK 20260709 production firmware, ASG 3.1.0-beta.173, worker 1.1.2 (versionCode 10, fresh install 2026-09-04 by the OEM installer):

```
User 0: ... stopped=true notLaunched=true
$ cmd package query-receivers --brief -a com.mentra.recovery.ACTION_REQUEST_DOWNGRADE -p com.mentra.recovery
1 receivers found: com.mentra.recovery/.service.RecoveryControlReceiver
$ cmd package query-receivers --brief --exclude-stopped-packages -a com.mentra.recovery.ACTION_REQUEST_DOWNGRADE -p com.mentra.recovery
No receivers found
```

Glasses log: handoff broadcast at 23:04:06, no recovery process ever started, watchdog at 23:07:06: `Downgrade watchdog (no verdict from recovery worker) after 180s`, staged `asg_client_downgrade.apk` never claimed.

## Test evidence

```
./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.RecoveryWorkerManagerTest
tests="2" skipped="0" failures="0" errors="0"
```

The same run compiles `:app:compileDebugJavaWithJavac`, which is what `scripts/check-android-compile.sh asg` checks.

Hardware-verified 2026-09-11 on unit 023B (see the verification comment below). Device workaround for already-affected units until they receive this build: `adb shell am start -n com.mentra.recovery/.ui.LauncherActivity` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)