### PR TITLE
Arm the version-change detour latch only from a live apk install

### DIFF
--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -853,7 +853,12 @@ class OtaInstallCoordinator {
       // suppress ota_start and hang the fresh downgrade until the global timeout).
       this.otaStartOwnership?.outcome === "acknowledged" &&
       otaStatus?.stepType === "apk" &&
-      otaStatus.phase === "install"
+      otaStatus.phase === "install" &&
+      // Only a live install arms the latch. A terminal failed status keeps stepType/phase
+      // apk/install and stays in the store, so without this gate every later pass (any
+      // unrelated store change) would re-arm the latch and the non-ownership block below
+      // would release it again, flooding the log with paired enter/release lines.
+      otaStatus.status === "in_progress"
     ) {
       console.log("[OTA_PROGRESS] version-change: apk install started — entering detour wait")
       this.versionChangeInstallStarted = true

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -664,6 +664,40 @@ describe("OtaInstallCoordinator version-change detour retry gate", () => {
     },
   )
 
+  it("a re-observed failed install status arms the latch at most once and releases it once", async () => {
+    setGlassesConnected()
+    useGlassesStore.getState().setOtaUpdateAvailable({
+      updateAvailable: true,
+      isDowngrade: true,
+      versionCode: 49000000,
+    } as never)
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    await flushNativeStartPromise()
+
+    const logSpy = jest.spyOn(console, "log")
+    const countLogs = (needle: string) =>
+      logSpy.mock.calls.filter((call) => typeof call[0] === "string" && call[0].includes(needle)).length
+
+    // Real handoff failure: ASG emits apk/install in_progress, then the terminal failed status.
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 100}))
+    expect(countLogs("entering detour wait")).toBe(1)
+    const failed = inProgressStatus({phase: "install", status: "failed", error: "downgrade_handoff_failed"})
+    useGlassesStore.getState().setOtaStatus(failed)
+    expect(countLogs("releasing latch")).toBe(1)
+
+    // The failed status stays in the store: the same object is re-observed on unrelated
+    // store changes, and the glasses may re-send it. Neither may re-arm the latch.
+    useGlassesStore.getState().setBatteryInfo(42, false, -1, false)
+    useGlassesStore.getState().setOtaStatus({...failed})
+    useGlassesStore.getState().setBatteryInfo(41, false, -1, false)
+
+    expect(countLogs("entering detour wait")).toBe(1)
+    expect(countLogs("releasing latch")).toBe(1)
+    expect(otaInstallCoordinator.snapshot().displayState).toBe("failed")
+    logSpy.mockRestore()
+  })
+
   it("a generic failure during a latched detour does NOT release the latch (accepted-but-slow)", async () => {
     setGlassesConnected()
     useGlassesStore.getState().setOtaUpdateAvailable({


### PR DESCRIPTION
## Scope

`OtaInstallCoordinator` latches "recovery now owns the downgrade" when it sees an acknowledged `ota_start` followed by an `apk`/`install` status. That condition never checked `otaStatus.status`. A terminal `failed` status keeps `stepType: "apk"` / `phase: "install"` and stays in the glasses store, so every later coordinator pass (any unrelated store change, or the glasses re-sending the status) re-armed the latch, and the non-ownership block right below released it again.

Observed on a Samsung phone log on 2026-09-11 after one real `downgrade_handoff_failed`: dozens of paired `entering detour wait` / `releasing latch` lines.

## Change

- Gate the latch on `otaStatus.status === "in_progress"` (the enum in `@mentra/bluetooth-sdk` is `in_progress | step_complete | complete | failed | idle`). The release logic is unchanged.
- New test in `mobile/src/__tests__/otaInstallCoordinator.test.ts`: a `downgrade_handoff_failed` install status is observed several times (same object via unrelated battery store changes, and a fresh copy from the glasses). Asserts `entering detour wait` and `releasing latch` are each logged exactly once and the display state stays `failed`.

## Test evidence

```
npx jest src/__tests__/otaInstallCoordinator.test.ts
Tests:       92 passed, 92 total
```

Without the source change the new test fails with the latch armed twice (`Expected: 1, Received: 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
