### PR TITLE
Pass the frozen source tag explicitly to porter apply

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -230,6 +230,11 @@ test("Cloud V2 deploys once per coordinated environment before mobile publicatio
   assert.match(cloud, /group: coordinated-cloud-v2-\$\{\{ inputs\.deployment_environment \}\}/)
   assert.match(cloud, /cancel-in-progress: false/)
   assert.match(cloud, /porter apply \\\n+            -w/)
+  // Porter's CLI otherwise tags from GITHUB_SHA, which on a workflow_dispatch
+  // from main is the dispatching commit, not the frozen source; the deploy
+  // verifies the observed image tag against the source, so the tag is explicit.
+  assert.match(cloud, /PORTER_TAG: \$\{\{ steps\.source\.outputs\.tag \}\}/)
+  assert.match(cloud, /--tag "\$PORTER_TAG" \\/)
   assert.match(cloud, /getent hosts "\$host"/)
   assert.match(cloud, /for probe in healthz ready/)
   assert.match(cloud, /porter kubectl -- get pods/)

--- a/.github/workflows/reusable-coordinated-cloud-v2.yml
+++ b/.github/workflows/reusable-coordinated-cloud-v2.yml
@@ -120,10 +120,14 @@ jobs:
         run: |
           set -euo pipefail
           config="${{ steps.target.outputs.porter_config }}"
+          # Porter's CLI tags the image from GITHUB_SHA when it runs inside
+          # Actions, which is the dispatching commit rather than the frozen
+          # source on a workflow_dispatch from main; the explicit flag wins.
           porter apply \
             -w \
             -f "${config#cloud-v2/}" \
             -x "${{ steps.target.outputs.porter_target }}" \
+            --tag "$PORTER_TAG" \
             --cluster "$PORTER_CLUSTER" \
             --project "$PORTER_PROJECT"
 


### PR DESCRIPTION
## Scope

The first 3.1.0 production Cloud deploy (run 34658918636) failed at "Observed core image does not use requested source tag d1ead9b7…". The job checked out the frozen source and set `PORTER_TAG` to it, but Porter's CLI tags the image from `GITHUB_SHA` when it runs inside Actions. On a `workflow_dispatch` from main that is the dispatching commit (`25000f0a`, the #4013 merge), so the image was built from the right checkout yet pushed as `cloud-prod:25000f0a…`, and the observed-deployment check correctly refused it. Coordinated staging deploys never hit this because there the dispatching commit is the source.

- `reusable-coordinated-cloud-v2.yml`: `porter apply` now passes `--tag "$PORTER_TAG"`; the flag overrides both the yaml field and the environment.
- `coordinated-workflow-contract.test.mjs`: asserts the tag comes from the verified source step and is passed explicitly.

No change for the coordinated dev/staging path other than making the tag explicit where it was already equal.

## Test evidence

```
node --test .github/scripts/coordinated-workflow-contract.test.mjs   # 18 pass
```

Prod is currently running the beta.212 build under the wrong tag and is healthy; rerunning the deploy phase after this merge rebuilds it under the source tag and records the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
