### PR TITLE
Stop tracing audio frames and budget native log forwarding to JavaScript

### DIFF
--- a/mintlify-docs/bluetooth-sdk/api-reference.mdx
+++ b/mintlify-docs/bluetooth-sdk/api-reference.mdx
@@ -783,9 +783,9 @@ retention limits. Native console output remains available too.
 On Android, forwarding to JavaScript is capped at 100 messages per second. Each
 forwarded message holds a JNI global reference until the JavaScript thread drains
 it, so an unbounded log source can exhaust the process-wide reference table and
-abort the app rather than merely slow it down. Messages above the cap are dropped
+abort the app rather than merely slow it down. Messages above the cap are withheld
 from the JavaScript stream only — they are still written to the native console —
-and each second that drops anything emits a single notice saying how many were
+and the next forwarded message is preceded by a notice saying how many were
 withheld. Per-frame microphone payload events are not traced at all; use the
 `mic_health` event to observe audio flow.
 

--- a/mintlify-docs/bluetooth-sdk/api-reference.mdx
+++ b/mintlify-docs/bluetooth-sdk/api-reference.mdx
@@ -786,8 +786,8 @@ it, so an unbounded log source can exhaust the process-wide reference table and
 abort the app rather than merely slow it down. Messages above the cap are withheld
 from the JavaScript stream only — they are still written to the native console —
 and the next forwarded message is preceded by a notice saying how many were
-withheld. Per-frame microphone payload events are not traced at all; use the
-`mic_health` event to observe audio flow.
+withheld. Per-frame microphone payload events are not traced at all; audio faults
+are still reported through the `mic_health` event.
 
 This covers SDK-owned diagnostics while the JavaScript runtime is active. It does
 not collect arbitrary OS or third-party native logs or replay logs from before

--- a/mintlify-docs/bluetooth-sdk/api-reference.mdx
+++ b/mintlify-docs/bluetooth-sdk/api-reference.mdx
@@ -780,6 +780,15 @@ message is capped at 16,384 characters. The Mentra App attaches this combined
 console stream to incident reports using its existing phone log buffer and
 retention limits. Native console output remains available too.
 
+On Android, forwarding to JavaScript is capped at 100 messages per second. Each
+forwarded message holds a JNI global reference until the JavaScript thread drains
+it, so an unbounded log source can exhaust the process-wide reference table and
+abort the app rather than merely slow it down. Messages above the cap are dropped
+from the JavaScript stream only — they are still written to the native console —
+and each second that drops anything emits a single notice saying how many were
+withheld. Per-frame microphone payload events are not traced at all; use the
+`mic_health` event to observe audio flow.
+
 This covers SDK-owned diagnostics while the JavaScript runtime is active. It does
 not collect arbitrary OS or third-party native logs or replay logs from before
 the subscription. Rebuild the native app to pick up the routing changes.

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -35,8 +35,8 @@ it, so an unbounded log source can exhaust the process-wide reference table and
 abort the app rather than merely slow it down. Messages above the cap are withheld
 from the JavaScript stream only — they are still written to the native console —
 and the next forwarded message is preceded by a notice saying how many were
-withheld. Per-frame microphone payload events are not traced at all; use the
-`mic_health` event to observe audio flow.
+withheld. Per-frame microphone payload events are not traced at all; audio faults
+are still reported through the `mic_health` event.
 
 Rebuild the native app after updating the SDK to pick up both platforms' logging
 changes. Adding this JS package alone cannot reroute logs in an older binary.

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -29,6 +29,15 @@ to its existing retention limits. Native diagnostics are also kept in the native
 console. Forwarding covers SDK-owned diagnostics while the JS runtime is active,
 not arbitrary OS or third-party native logs or logs from before subscription.
 
+On Android, forwarding to JavaScript is capped at 100 messages per second. Each
+forwarded message holds a JNI global reference until the JavaScript thread drains
+it, so an unbounded log source can exhaust the process-wide reference table and
+abort the app rather than merely slow it down. Messages above the cap are dropped
+from the JavaScript stream only — they are still written to the native console —
+and each second that drops anything emits a single notice saying how many were
+withheld. Per-frame microphone payload events are not traced at all; use the
+`mic_health` event to observe audio flow.
+
 Rebuild the native app after updating the SDK to pick up both platforms' logging
 changes. Adding this JS package alone cannot reroute logs in an older binary.
 

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -32,9 +32,9 @@ not arbitrary OS or third-party native logs or logs from before subscription.
 On Android, forwarding to JavaScript is capped at 100 messages per second. Each
 forwarded message holds a JNI global reference until the JavaScript thread drains
 it, so an unbounded log source can exhaust the process-wide reference table and
-abort the app rather than merely slow it down. Messages above the cap are dropped
+abort the app rather than merely slow it down. Messages above the cap are withheld
 from the JavaScript stream only — they are still written to the native console —
-and each second that drops anything emits a single notice saying how many were
+and the next forwarded message is preceded by a notice saying how many were
 withheld. Per-frame microphone payload events are not traced at all; use the
 `mic_health` event to observe audio flow.
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -133,6 +133,7 @@ private inline fun <
 class BluetoothSdkModule : Module() {
     private var sdk: MentraBluetoothSdk? = null
     private var deviceManager: DeviceManager? = null
+    private val logForwarding = LogForwardingBudget()
     private val sdkListener =
             object : MentraBluetoothSdkListener {
                 override fun onGlassesChanged(glasses: GlassesRuntimeState) {
@@ -295,6 +296,16 @@ class BluetoothSdkModule : Module() {
                 }
 
                 override fun onLog(message: String) {
+                    // Each event pins a JNI global reference until JavaScript drains it. The
+                    // log stream is the one source whose rate is unbounded, so it is budgeted.
+                    val withheld = logForwarding.admit() ?: return
+                    if (withheld > 0) {
+                        val notice =
+                                "[W/BluetoothSdkModule] withheld $withheld native log line(s) from " +
+                                        "JavaScript to stay under ${logForwarding.maxPerWindow}/s; " +
+                                        "logcat has them all"
+                        sendEvent("log", mapOf("message" to notice))
+                    }
                     sendEvent("log", mapOf("message" to message))
                 }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -30,18 +30,6 @@ public class Bridge private constructor() {
         private const val MIC_CHANNELS = 1
         private const val LC3_FRAME_DURATION_MS = 10
         private const val DEFAULT_LC3_FRAME_SIZE_BYTES = 60
-        private val AUDIO_TRACE_METADATA_KEYS =
-                listOf(
-                        "sampleRate",
-                        "bitsPerSample",
-                        "channels",
-                        "encoding",
-                        "frameDurationMs",
-                        "frameSizeBytes",
-                        "bitrate",
-                        "packetizedFromGlasses",
-                        "voiceActivityDetectionEnabled",
-                )
 
         @Volatile private var instance: Bridge? = null
 
@@ -943,43 +931,29 @@ public class Bridge private constructor() {
             }
         }
 
+        /**
+         * Returns null for events that must not be traced.
+         *
+         * "log" is excluded so tracing never recurses back through NativeLog. Audio payload
+         * events are excluded because they arrive at frame rate: tracing them turned every
+         * microphone frame into a second bridge event, and each of those pins a JNI global
+         * reference until JavaScript drains it. A JavaScript thread busy with call audio
+         * cannot keep up, so the references accumulated until the process-wide table
+         * overflowed and the runtime aborted. Audio flow is reported by "mic_health" instead,
+         * which is emitted at a rate that does not scale with the frame rate.
+         */
         private fun tracePayloadForTypedMessage(
                 type: String,
                 body: Map<String, Any>
         ): Map<String, Any>? =
                 when {
                     type == "log" -> null
-                    isAudioPayloadEvent(type) -> audioTracePayload(type, body)
+                    isAudioPayloadEvent(type) -> null
                     else -> body
                 }
 
         private fun isAudioPayloadEvent(type: String): Boolean =
                 type == "mic_pcm" || type == "mic_lc3"
-
-        private fun audioTracePayload(type: String, body: Map<String, Any>): Map<String, Any> {
-            val payload = HashMap<String, Any>()
-            payload["type"] = type
-            payload["timestamp"] = System.currentTimeMillis()
-            payload["payloadOmitted"] = true
-            payload["payloadOmittedReason"] = "audio"
-
-            val audioBytes =
-                    when (type) {
-                        "mic_pcm" -> (body["pcm"] as? ByteArray)?.size
-                        "mic_lc3" -> (body["lc3"] as? ByteArray)?.size
-                        else -> null
-                    }
-            audioBytes?.let { payload["audioBytes"] = it }
-
-            AUDIO_TRACE_METADATA_KEYS.forEach { key ->
-                val value = body[key]
-                if (value != null) {
-                    payload[key] = value
-                }
-            }
-
-            return payload
-        }
     }
 
     init {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -939,8 +939,8 @@ public class Bridge private constructor() {
          * microphone frame into a second bridge event, and each of those pins a JNI global
          * reference until JavaScript drains it. A JavaScript thread busy with call audio
          * cannot keep up, so the references accumulated until the process-wide table
-         * overflowed and the runtime aborted. Audio flow is reported by "mic_health" instead,
-         * which is emitted at a rate that does not scale with the frame rate.
+         * overflowed and the runtime aborted. Audio faults (sequence gaps, decode failures)
+         * are still reported through "mic_health", and healthy frames need no trace.
          */
         private fun tracePayloadForTypedMessage(
                 type: String,

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/LogForwardingBudget.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/LogForwardingBudget.kt
@@ -1,0 +1,50 @@
+package com.mentra.bluetoothsdk
+
+import android.os.SystemClock
+
+/**
+ * Bounds how many native log lines per second the module hands to the JavaScript runtime.
+ *
+ * Every event the module emits pins a JNI global reference until the JavaScript thread
+ * drains it, and the process-wide table holds about 51,200 references. Native code can log
+ * faster than a busy JavaScript thread drains, so an unbounded log stream aborts the process
+ * instead of merely lagging. Lines over the budget are withheld from JavaScript only; the
+ * native console still has every one of them. The first line forwarded after a shortfall
+ * reports how many were withheld, so the gap is visible in the JavaScript stream.
+ */
+internal class LogForwardingBudget(
+    val maxPerWindow: Int = DEFAULT_MAX_PER_SECOND,
+    private val windowMs: Long = 1_000L,
+    private val clock: () -> Long = SystemClock::elapsedRealtime,
+) {
+    private var windowEndsAtMs = Long.MIN_VALUE
+    private var forwardedInWindow = 0
+    private var withheld = 0
+
+    /**
+     * Returns null when the current line must be withheld, otherwise the number of lines
+     * withheld since the previous forwarded one (zero in steady state).
+     */
+    @Synchronized
+    fun admit(): Int? {
+        val now = clock()
+        if (now >= windowEndsAtMs) {
+            windowEndsAtMs = now + windowMs
+            forwardedInWindow = 0
+        }
+        if (forwardedInWindow >= maxPerWindow) {
+            withheld++
+            return null
+        }
+        forwardedInWindow++
+        return withheld.also { withheld = 0 }
+    }
+
+    companion object {
+        /**
+         * Far above the SDK's steady-state diagnostic rate, and low enough that even a
+         * JavaScript thread stalled for minutes cannot exhaust the reference table.
+         */
+        const val DEFAULT_MAX_PER_SECOND = 100
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/LogForwardingBudget.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/LogForwardingBudget.kt
@@ -42,8 +42,8 @@ internal class LogForwardingBudget(
 
     companion object {
         /**
-         * Far above the SDK's steady-state diagnostic rate, and low enough that even a
-         * JavaScript thread stalled for minutes cannot exhaust the reference table.
+         * Far above the SDK's steady-state diagnostic rate, and low enough that a
+         * JavaScript thread has to stay stalled for minutes before the table could fill.
          */
         const val DEFAULT_MAX_PER_SECOND = 100
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NativeLog.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NativeLog.java
@@ -1,53 +1,14 @@
 package com.mentra.bluetoothsdk.utils;
 
-import android.os.SystemClock;
 import com.mentra.bluetoothsdk.Bridge;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Writes SDK diagnostics to both the native console and the SDK's JavaScript log event.
- *
- * <p>The native console write is unconditional. Forwarding to JavaScript is not: every
- * forwarded event pins a JNI global reference until the JavaScript thread drains it, and the
- * process-wide table holds roughly 51,200 references. A log source that outruns a busy
- * JavaScript thread will therefore abort the process rather than merely slow it down, so
- * forwarding is capped at {@link #MAX_FORWARDED_PER_WINDOW} messages per second. Messages
- * above the cap are dropped from the JavaScript stream only (they are still in logcat), and
- * each window that drops anything emits a single notice so the gap is never silent.
- */
+/** Writes SDK diagnostics to both the native console and the SDK's JavaScript log event. */
 public final class NativeLog {
   public static final int DEBUG = android.util.Log.DEBUG;
 
-  private static final String TAG = "NativeLog";
-
-  /**
-   * Chosen to sit far above the SDK's steady-state diagnostic rate while staying far below the
-   * rate at which a stalled JavaScript thread could exhaust the JNI global reference table.
-   */
-  private static final int MAX_FORWARDED_PER_WINDOW = 100;
-
-  private static final long WINDOW_MS = 1000L;
-
-  private static final Object FORWARD_LOCK = new Object();
-
-  private static long windowStartedAtMs = 0L;
-  private static int forwardedInWindow = 0;
-  private static int droppedInWindow = 0;
-
   private NativeLog() {}
-
-  /**
-   * Clears the forwarding budget so a test starts from a known state. The window is otherwise
-   * driven by the wall clock and is shared by every caller in the process.
-   */
-  static void resetForwardingBudgetForTest() {
-    synchronized (FORWARD_LOCK) {
-      windowStartedAtMs = 0L;
-      forwardedInWindow = 0;
-      droppedInWindow = 0;
-    }
-  }
 
   /** Preserves Android's per-tag log-level check for existing SDK callers. */
   public static boolean isLoggable(String tag, int level) {
@@ -108,50 +69,12 @@ public final class NativeLog {
     String text = String.valueOf(message);
     if (error != null) text += "\n" + android.util.Log.getStackTraceString(error);
     int result = android.util.Log.println(priority, tag, text);
-
-    String notice = null;
-    boolean forward;
-    synchronized (FORWARD_LOCK) {
-      long now = SystemClock.elapsedRealtime();
-      if (now - windowStartedAtMs >= WINDOW_MS) {
-        if (droppedInWindow > 0) {
-          notice =
-              "[W/"
-                  + TAG
-                  + "] dropped "
-                  + droppedInWindow
-                  + " message(s) from the JavaScript log stream to stay under "
-                  + MAX_FORWARDED_PER_WINDOW
-                  + "/s; see logcat for the full output";
-        }
-        windowStartedAtMs = now;
-        forwardedInWindow = 0;
-        droppedInWindow = 0;
-      }
-      forward = forwardedInWindow < MAX_FORWARDED_PER_WINDOW;
-      if (forward) {
-        forwardedInWindow++;
-      } else {
-        droppedInWindow++;
-      }
-    }
-
+    Map<String, Object> body = new HashMap<>();
+    body.put("message", "[" + priorityLabel(priority) + "/" + tag + "] " + text);
     // Dispatch directly: Bridge.log uses this logger too. Never tail logcat here,
     // because React Native writes console output back to it.
-    if (notice != null) {
-      send(notice);
-    }
-    if (forward) {
-      send("[" + priorityLabel(priority) + "/" + tag + "] " + text);
-    }
-
-    return result;
-  }
-
-  private static void send(String message) {
-    Map<String, Object> body = new HashMap<>();
-    body.put("message", message);
     Bridge.sendTypedMessage("log", body);
+    return result;
   }
 
   private static String priorityLabel(int priority) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NativeLog.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NativeLog.java
@@ -1,14 +1,53 @@
 package com.mentra.bluetoothsdk.utils;
 
+import android.os.SystemClock;
 import com.mentra.bluetoothsdk.Bridge;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Writes SDK diagnostics to both the native console and the SDK's JavaScript log event. */
+/**
+ * Writes SDK diagnostics to both the native console and the SDK's JavaScript log event.
+ *
+ * <p>The native console write is unconditional. Forwarding to JavaScript is not: every
+ * forwarded event pins a JNI global reference until the JavaScript thread drains it, and the
+ * process-wide table holds roughly 51,200 references. A log source that outruns a busy
+ * JavaScript thread will therefore abort the process rather than merely slow it down, so
+ * forwarding is capped at {@link #MAX_FORWARDED_PER_WINDOW} messages per second. Messages
+ * above the cap are dropped from the JavaScript stream only (they are still in logcat), and
+ * each window that drops anything emits a single notice so the gap is never silent.
+ */
 public final class NativeLog {
   public static final int DEBUG = android.util.Log.DEBUG;
 
+  private static final String TAG = "NativeLog";
+
+  /**
+   * Chosen to sit far above the SDK's steady-state diagnostic rate while staying far below the
+   * rate at which a stalled JavaScript thread could exhaust the JNI global reference table.
+   */
+  private static final int MAX_FORWARDED_PER_WINDOW = 100;
+
+  private static final long WINDOW_MS = 1000L;
+
+  private static final Object FORWARD_LOCK = new Object();
+
+  private static long windowStartedAtMs = 0L;
+  private static int forwardedInWindow = 0;
+  private static int droppedInWindow = 0;
+
   private NativeLog() {}
+
+  /**
+   * Clears the forwarding budget so a test starts from a known state. The window is otherwise
+   * driven by the wall clock and is shared by every caller in the process.
+   */
+  static void resetForwardingBudgetForTest() {
+    synchronized (FORWARD_LOCK) {
+      windowStartedAtMs = 0L;
+      forwardedInWindow = 0;
+      droppedInWindow = 0;
+    }
+  }
 
   /** Preserves Android's per-tag log-level check for existing SDK callers. */
   public static boolean isLoggable(String tag, int level) {
@@ -69,12 +108,50 @@ public final class NativeLog {
     String text = String.valueOf(message);
     if (error != null) text += "\n" + android.util.Log.getStackTraceString(error);
     int result = android.util.Log.println(priority, tag, text);
-    Map<String, Object> body = new HashMap<>();
-    body.put("message", "[" + priorityLabel(priority) + "/" + tag + "] " + text);
+
+    String notice = null;
+    boolean forward;
+    synchronized (FORWARD_LOCK) {
+      long now = SystemClock.elapsedRealtime();
+      if (now - windowStartedAtMs >= WINDOW_MS) {
+        if (droppedInWindow > 0) {
+          notice =
+              "[W/"
+                  + TAG
+                  + "] dropped "
+                  + droppedInWindow
+                  + " message(s) from the JavaScript log stream to stay under "
+                  + MAX_FORWARDED_PER_WINDOW
+                  + "/s; see logcat for the full output";
+        }
+        windowStartedAtMs = now;
+        forwardedInWindow = 0;
+        droppedInWindow = 0;
+      }
+      forward = forwardedInWindow < MAX_FORWARDED_PER_WINDOW;
+      if (forward) {
+        forwardedInWindow++;
+      } else {
+        droppedInWindow++;
+      }
+    }
+
     // Dispatch directly: Bridge.log uses this logger too. Never tail logcat here,
     // because React Native writes console output back to it.
-    Bridge.sendTypedMessage("log", body);
+    if (notice != null) {
+      send(notice);
+    }
+    if (forward) {
+      send("[" + priorityLabel(priority) + "/" + tag + "] " + text);
+    }
+
     return result;
+  }
+
+  private static void send(String message) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("message", message);
+    Bridge.sendTypedMessage("log", body);
   }
 
   private static String priorityLabel(int priority) {

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/LogForwardingBudgetTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/LogForwardingBudgetTest.kt
@@ -1,0 +1,49 @@
+package com.mentra.bluetoothsdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LogForwardingBudgetTest {
+    private var nowMs = 0L
+    private val budget = LogForwardingBudget(maxPerWindow = 3, windowMs = 1_000L, clock = { nowMs })
+
+    @Test
+    fun `forwards up to the budget within a window and withholds the rest`() {
+        assertEquals(0, budget.admit())
+        assertEquals(0, budget.admit())
+        assertEquals(0, budget.admit())
+        assertNull(budget.admit())
+        assertNull(budget.admit())
+    }
+
+    @Test
+    fun `the first line forwarded after a shortfall reports how many were withheld`() {
+        repeat(5) { budget.admit() }
+
+        nowMs = 1_000L
+        assertEquals(2, budget.admit())
+        assertEquals(0, budget.admit())
+    }
+
+    @Test
+    fun `the budget renews every window`() {
+        repeat(5) { budget.admit() }
+        nowMs = 999L
+        assertNull(budget.admit())
+
+        nowMs = 1_000L
+        assertEquals(3, budget.admit())
+        assertEquals(0, budget.admit())
+        assertEquals(0, budget.admit())
+        assertNull(budget.admit())
+    }
+
+    @Test
+    fun `withheld lines are reported even after a long silence`() {
+        repeat(4) { budget.admit() }
+
+        nowMs = 60_000L
+        assertEquals(1, budget.admit())
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/NativeLogTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/NativeLogTest.kt
@@ -1,27 +1,17 @@
 package com.mentra.bluetoothsdk.utils
 
 import com.mentra.bluetoothsdk.Bridge
-import java.time.Duration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
-import org.robolectric.shadows.ShadowSystemClock
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28])
 class NativeLogTest {
-    @Before
-    fun resetForwardingBudget() {
-        // The budget is process-wide static state, so a test that fills it would otherwise
-        // change the outcome of every test that runs after it.
-        NativeLog.resetForwardingBudgetForTest()
-    }
-
     @Test
     fun tracingAnEventDoesNotRecursivelyTraceTheLog() {
         val events = mutableListOf<String>()
@@ -79,54 +69,6 @@ class NativeLogTest {
             // Tracing these would emit a second bridge event per audio frame, and each one
             // pins a JNI global reference until JavaScript drains it.
             assertEquals(listOf("mic_pcm", "mic_lc3"), events)
-        } finally {
-            Bridge.removeEventSink(sink)
-        }
-    }
-
-    @Test
-    fun forwardingStopsAtTheBudgetSoAStalledJavaScriptThreadCannotExhaustTheReferenceTable() {
-        var forwarded = 0
-        val sink = Bridge.addEventSink { type, _ -> if (type == "log") forwarded++ }
-        try {
-            repeat(150) { NativeLog.i("MentraLive", "frame $it") }
-            assertEquals(100, forwarded)
-        } finally {
-            Bridge.removeEventSink(sink)
-        }
-    }
-
-    @Test
-    fun theWindowAfterADropReportsHowManyMessagesWereWithheld() {
-        val messages = mutableListOf<String>()
-        val sink =
-            Bridge.addEventSink { type, body ->
-                if (type == "log") messages.add(body["message"] as String)
-            }
-        try {
-            repeat(150) { NativeLog.i("MentraLive", "frame $it") }
-            messages.clear()
-
-            ShadowSystemClock.advanceBy(Duration.ofSeconds(2))
-            NativeLog.i("MentraLive", "after the window rolled")
-
-            assertEquals(2, messages.size)
-            assertTrue(messages[0].contains("dropped 50 message(s)"))
-            assertTrue(messages[0].contains("see logcat for the full output"))
-            assertEquals("[I/MentraLive] after the window rolled", messages[1])
-        } finally {
-            Bridge.removeEventSink(sink)
-        }
-    }
-
-    @Test
-    fun everyMessageStillReachesLogcatWhileForwardingIsCapped() {
-        val sink = Bridge.addEventSink { _, _ -> }
-        try {
-            ShadowLog.clear()
-            repeat(150) { NativeLog.i("MentraLive", "frame $it") }
-            // The cap exists to protect the JNI reference table, not to lose diagnostics.
-            assertEquals(150, ShadowLog.getLogsForTag("MentraLive").size)
         } finally {
             Bridge.removeEventSink(sink)
         }

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/NativeLogTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/NativeLogTest.kt
@@ -1,17 +1,27 @@
 package com.mentra.bluetoothsdk.utils
 
 import com.mentra.bluetoothsdk.Bridge
+import java.time.Duration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
+import org.robolectric.shadows.ShadowSystemClock
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28])
 class NativeLogTest {
+    @Before
+    fun resetForwardingBudget() {
+        // The budget is process-wide static state, so a test that fills it would otherwise
+        // change the outcome of every test that runs after it.
+        NativeLog.resetForwardingBudgetForTest()
+    }
+
     @Test
     fun tracingAnEventDoesNotRecursivelyTraceTheLog() {
         val events = mutableListOf<String>()
@@ -56,6 +66,69 @@ class NativeLogTest {
         } finally {
             Bridge.removeEventSink(failing)
             Bridge.removeEventSink(healthy)
+        }
+    }
+
+    @Test
+    fun audioPayloadEventsAreNotTracedIntoTheLogStream() {
+        val events = mutableListOf<String>()
+        val sink = Bridge.addEventSink { type, _ -> events.add(type) }
+        try {
+            Bridge.sendTypedMessage("mic_pcm", mapOf("pcm" to ByteArray(320)))
+            Bridge.sendTypedMessage("mic_lc3", mapOf("lc3" to ByteArray(60)))
+            // Tracing these would emit a second bridge event per audio frame, and each one
+            // pins a JNI global reference until JavaScript drains it.
+            assertEquals(listOf("mic_pcm", "mic_lc3"), events)
+        } finally {
+            Bridge.removeEventSink(sink)
+        }
+    }
+
+    @Test
+    fun forwardingStopsAtTheBudgetSoAStalledJavaScriptThreadCannotExhaustTheReferenceTable() {
+        var forwarded = 0
+        val sink = Bridge.addEventSink { type, _ -> if (type == "log") forwarded++ }
+        try {
+            repeat(150) { NativeLog.i("MentraLive", "frame $it") }
+            assertEquals(100, forwarded)
+        } finally {
+            Bridge.removeEventSink(sink)
+        }
+    }
+
+    @Test
+    fun theWindowAfterADropReportsHowManyMessagesWereWithheld() {
+        val messages = mutableListOf<String>()
+        val sink =
+            Bridge.addEventSink { type, body ->
+                if (type == "log") messages.add(body["message"] as String)
+            }
+        try {
+            repeat(150) { NativeLog.i("MentraLive", "frame $it") }
+            messages.clear()
+
+            ShadowSystemClock.advanceBy(Duration.ofSeconds(2))
+            NativeLog.i("MentraLive", "after the window rolled")
+
+            assertEquals(2, messages.size)
+            assertTrue(messages[0].contains("dropped 50 message(s)"))
+            assertTrue(messages[0].contains("see logcat for the full output"))
+            assertEquals("[I/MentraLive] after the window rolled", messages[1])
+        } finally {
+            Bridge.removeEventSink(sink)
+        }
+    }
+
+    @Test
+    fun everyMessageStillReachesLogcatWhileForwardingIsCapped() {
+        val sink = Bridge.addEventSink { _, _ -> }
+        try {
+            ShadowLog.clear()
+            repeat(150) { NativeLog.i("MentraLive", "frame $it") }
+            // The cap exists to protect the JNI reference table, not to lose diagnostics.
+            assertEquals(150, ShadowLog.getLogsForTag("MentraLive").size)
+        } finally {
+            Bridge.removeEventSink(sink)
         }
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -15,17 +15,6 @@ class Bridge {
     private static let micChannels = 1
     private static let lc3FrameDurationMs = 10
     private static let defaultLc3FrameSizeBytes = 60
-    private static let audioTraceMetadataKeys = [
-        "sampleRate",
-        "bitsPerSample",
-        "channels",
-        "encoding",
-        "frameDurationMs",
-        "frameSizeBytes",
-        "bitrate",
-        "packetizedFromGlasses",
-        "voiceActivityDetectionEnabled",
-    ]
     private static let eventSinkLock = NSLock()
     private static let defaultEventSinkId = "default"
     private static var eventSinks: [String: (String, [String: Any]) -> Void] = [:]
@@ -700,47 +689,21 @@ class Bridge {
         dispatchEvent(type, body)
     }
 
+    /// Returns nil for events that must not be traced.
+    ///
+    /// "log" is excluded so tracing never recurses back through the log event. Audio payload
+    /// events are excluded because they arrive at frame rate, which made every microphone
+    /// frame emit a second bridge event. On Android that overflowed the JNI global reference
+    /// table and aborted the process; here it is wasted work on the audio path. Audio flow is
+    /// reported by "mic_health" instead, at a rate that does not scale with the frame rate.
     private static func tracePayloadForTypedMessage(_ type: String, body: [String: Any]) -> [String: Any]? {
-        if type == "log" {
+        if type == "log" || isAudioPayloadEvent(type) {
             return nil
-        }
-        if isAudioPayloadEvent(type) {
-            return audioTracePayload(type, body: body)
         }
         return body
     }
 
     private static func isAudioPayloadEvent(_ type: String) -> Bool {
         type == "mic_pcm" || type == "mic_lc3"
-    }
-
-    private static func audioTracePayload(_ type: String, body: [String: Any]) -> [String: Any] {
-        var payload: [String: Any] = [
-            "type": type,
-            "timestamp": Int(Date().timeIntervalSince1970 * 1000),
-            "payloadOmitted": true,
-            "payloadOmittedReason": "audio",
-        ]
-
-        switch type {
-        case "mic_pcm":
-            if let data = body["pcm"] as? Data {
-                payload["audioBytes"] = data.count
-            }
-        case "mic_lc3":
-            if let data = body["lc3"] as? Data {
-                payload["audioBytes"] = data.count
-            }
-        default:
-            break
-        }
-
-        for key in audioTraceMetadataKeys {
-            if let value = body[key] {
-                payload[key] = value
-            }
-        }
-
-        return payload
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -694,8 +694,9 @@ class Bridge {
     /// "log" is excluded so tracing never recurses back through the log event. Audio payload
     /// events are excluded because they arrive at frame rate, which made every microphone
     /// frame emit a second bridge event. On Android that overflowed the JNI global reference
-    /// table and aborted the process; here it is wasted work on the audio path. Audio flow is
-    /// reported by "mic_health" instead, at a rate that does not scale with the frame rate.
+    /// table and aborted the process; here it is wasted work on the audio path. Audio faults
+    /// (sequence gaps, decode failures) are still reported through "mic_health", and healthy
+    /// frames need no trace.
     private static func tracePayloadForTypedMessage(_ type: String, body: [String: Any]) -> [String: Any]? {
         if type == "log" || isAudioPayloadEvent(type) {
             return nil


### PR DESCRIPTION
## Problem

The Mentra App hard-crashes on Android with a `SIGABRT`:

```
JNI ERROR (app bug): global reference table overflow (max=51200)
```

Caught on a moto razr plus 2024, ~6 minutes into a foreground session. 49,748 of the 51,200 pinned references were `java.util.Collections$SingletonMap` — the `mapOf("message" to message)` in `BluetoothSdkModule.onLog`. Tombstone stack:

```
MentraBluetoothSdk.dispatchBridgeEvent  ("log")
  -> BluetoothSdkModule$sdkListener$1.onLog
  -> KModuleEventEmitterWrapper.emitNative
  -> expo::JNIUtils::emitEventOnJavaScriptModule
  -> JNI NewGlobalRef -> AddGlobalRef -> abort
```

`emitEventOnJavaScriptModule` takes a JNI global reference on each event body and hands the emit to the JavaScript call invoker's async queue (`jsInvoker->invokeAsync`); the reference is released only when the JavaScript thread runs it. The queue is unbounded, so a JavaScript thread that falls behind does not merely lag — it exhausts the process-wide reference table and the runtime aborts.

## Why now

`Bridge.log` has always forwarded to JavaScript, so forwarding itself is not the regression. What changed is *which* logs go down that path. #3913 (`16e9305624`, merged to dev 2026-09-10) swapped `android.util.Log` for `NativeLog` across 36 SDK files, including `BleTraceLogger` — and `BleTraceLogger` is invoked from `Bridge.sendTypedMessage` **once per typed event**, with `mic_pcm` / `mic_lc3` included. So log volume stopped scaling with how many log statements execute and started scaling with **event throughput**: every microphone frame became two bridge events, one of which pinned a reference. Around 140 events/second against a JavaScript thread busy with call audio is what exhausted the table.

This is on **dev**, not specific to any one branch. It reproduced on a #3927 build because SoftAP calling drives sustained mic PCM — but any mic-heavy path on dev is exposed.

## Change

1. **Stop tracing per-frame audio events** (`Bridge.kt`, `Bridge.swift`). `mic_pcm` and `mic_lc3` arrive at frame rate, and a healthy frame needs no trace; audio faults (sequence gaps, decode failures) are still reported through `mic_health`. This removes the throughput-scaled producer, which is the actual regression.
2. **Budget log forwarding at the Expo boundary** (`LogForwardingBudget.kt`, used by `BluetoothSdkModule.onLog`) as a backstop, so no future high-rate log source can abort the process. The JNI reference is taken by the module's `sendEvent`, so that is where the budget lives: the SDK's `NativeLog` stays a plain dual-sink logger, and native hosts of the Android SDK still receive every `onLog` callback. At most 100 lines per second reach JavaScript; lines over the budget are withheld from the JavaScript stream only — every line still reaches logcat — and the next forwarded line is preceded by one notice saying how many were withheld, so a gap is never silent. The budget is a small class with an injected clock, so it is unit-tested without Robolectric or a test-only reset hook.

#3913's goal is preserved: native diagnostics still reach the JavaScript console and therefore incident reports. iOS keeps the audio-trace removal but needs no budget — there is no JNI reference table to exhaust there.

The budget bounds the forwarding *rate*, not the number of in-flight references; a hard bound would need an acknowledgement from JavaScript or a batched `log` payload, which changes the public event contract. At 100/s the JavaScript thread would have to stay completely stalled for over eight minutes before the table could fill, and the product already requires it to drain `mic_pcm` at the frame rate, so a proportionate backstop is the right size for this fix.

## Testing

- `./scripts/check-android-compile.sh bluetooth-sdk :mentra-bluetooth-sdk:testDebugUnitTest` — **BUILD SUCCESSFUL**; full SDK suite **265 tests, 0 failures, 0 errors** across 51 classes.
- `LogForwardingBudgetTest` — 4/4 pass, pure JUnit with a fake clock: forwarding stops at the budget, the first forwarded line after a shortfall reports how many were withheld, the budget renews each window, and a withheld count survives a long silence.
- `NativeLogTest` — 4/4 pass, including the new case that audio events are not traced into the log stream.
- `swiftformat --lint` on `Bridge.swift` — clean (`swift build --package-path mobile/modules/bluetooth-sdk` was verified on the previous head; the Swift change is unchanged since).

Not verified on-device: this has not yet been run against a real glasses session to watch the reference count stay flat. Worth a mic-heavy soak (a SoftAP call) before it rides a release.

## Follow-ups (not in this PR)

- `BleTraceLogger.caller()` builds a `Throwable()` and walks the stack on **every** trace call, on the main thread. Independent of this crash, that is a large constant cost that should be gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
