### PR TITLE
Read the requested Cloud V2 image tag from the deployed pod spec

### DIFF
--- a/.github/scripts/coordinated-cloud-v2-records.mjs
+++ b/.github/scripts/coordinated-cloud-v2-records.mjs
@@ -153,7 +153,13 @@ function observeServices(pods) {
         const match = status.imageID.match(/@?(sha256:[0-9a-f]{64})$/)
         if (!match) throw new Error(`Observed ${service} imageID does not contain an immutable digest`)
         digests.add(match[1])
-        if (status.image) images.add(status.image)
+        // The requested tag is read from the pod spec, which is what Porter
+        // deployed. The kubelet's status.image names the reference under which
+        // the node first pulled that digest, so a byte-identical rebuild under
+        // a new tag keeps reporting the old tag there while imageID is exact.
+        const requested = (pod.spec?.containers || []).find((container) => container.name === status.name)?.image
+        if (!requested) throw new Error(`Observed ${service} container ${status.name} has no requested image`)
+        images.add(requested)
       }
       const revision = observedPodRevision(pod)
       if (revision) revisions.add(revision)

--- a/.github/scripts/coordinated-cloud-v2-records.test.mjs
+++ b/.github/scripts/coordinated-cloud-v2-records.test.mjs
@@ -32,7 +32,13 @@ function pods() {
         ownerReferences: [{uid: `${service}-workload-uid`}],
       },
       spec: {
-        containers: [{name: service, env: [{name: "PORTER_POD_REVISION", value: "revision-42"}]}],
+        containers: [
+          {
+            name: service,
+            image: `registry.example.com/cloud-v2:${sourceCommit}`,
+            env: [{name: "PORTER_POD_REVISION", value: "revision-42"}],
+          },
+        ],
       },
       status: {
         phase: "Running",
@@ -161,7 +167,7 @@ test("fails closed on unready pods, mutable image observations, and missing publ
   )
 
   const wrongSource = pods()
-  wrongSource.items[1].status.containerStatuses[0].image = `registry.example.com/cloud-v2:${"b".repeat(40)}`
+  wrongSource.items[1].spec.containers[0].image = `registry.example.com/cloud-v2:${"b".repeat(40)}`
   assert.throws(
     () =>
       createCloudV2DeploymentRecord({
@@ -192,6 +198,53 @@ test("fails closed on unready pods, mutable image observations, and missing publ
         provenanceUrl,
       }),
     /missing or duplicated/,
+  )
+})
+
+test("identifies the requested tag from the deployed pod spec, not the kubelet's image name", () => {
+  // A byte-identical rebuild under a new tag keeps the digest the node already
+  // pulled, and the kubelet keeps reporting that digest under the first tag it
+  // knew. The spec carries what Porter deployed; the digest stays the identity.
+  const stale = pods()
+  for (const pod of stale.items) {
+    pod.status.containerStatuses[0].image = `registry.example.com/cloud-v2:${"c".repeat(40)}`
+  }
+  const record = createCloudV2DeploymentRecord({
+    plan: plan("production", "3.1.0"),
+    environment: "prod",
+    sourceCommit,
+    requestedTag: sourceCommit,
+    status: "deployed",
+    pods: stale,
+    checks: checks("prod"),
+    completedAt: "2026-08-27T20:00:00.000Z",
+    provenanceUrl,
+  })
+  assert.deepEqual(
+    record.observedServices.map((service) => service.images),
+    [[`registry.example.com/cloud-v2:${sourceCommit}`], [`registry.example.com/cloud-v2:${sourceCommit}`]],
+  )
+  assert.equal(
+    record.observedServices.every((service) => service.digest === `sha256:${"b".repeat(64)}`),
+    true,
+  )
+
+  const missingSpec = pods()
+  delete missingSpec.items[0].spec.containers[0].image
+  assert.throws(
+    () =>
+      createCloudV2DeploymentRecord({
+        plan: plan("production", "3.1.0"),
+        environment: "prod",
+        sourceCommit,
+        requestedTag: sourceCommit,
+        status: "deployed",
+        pods: missingSpec,
+        checks: checks("prod"),
+        completedAt: "2026-08-27T20:00:00.000Z",
+        provenanceUrl,
+      }),
+    /has no requested image/,
   )
 })
 


### PR DESCRIPTION
## Scope

The second 3.1.0 production Cloud deploy (run 34659395297, after #4016) built and deployed `cloud-prod:d1ead9b7…` correctly, yet the observed-deployment check still failed with "Observed core image does not use requested source tag". The rebuilt image is byte-identical to the mis-tagged first attempt (same digest `sha256:660ad7b6…`), and the kubelet reports `status.image` as the reference under which the node first pulled that digest (`…:25000f0a…`), while `spec.image` shows the requested tag. Staging never hits this because every staging build is a new digest.

- `coordinated-cloud-v2-records.mjs`: the requested-tag identity now comes from the ready container's `spec` image (what Porter deployed); the immutable digest still comes from `status.imageID` and remains the identity the record and its load-time validation rely on. A container without a spec image fails closed.
- Tests: fixture carries spec images; the wrong-tag case mutates the spec; new test for the stale `status.image` case and the missing-spec-image case.

## Test evidence

```
node --test .github/scripts/coordinated-cloud-v2-records.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs   # 24 pass
```

Live prod pods right now: `spec.image` = `cloud-prod:d1ead9b7…`, `status.image` = `cloud-prod:25000f0a…`, `status.imageID` = `cloud-prod@sha256:660ad7b6…`, both services ready. Rerunning the deploy phase after this merge will observe and record that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
