### PR TITLE
Run the Cloud V2 deploy tooling from the workflow revision

### DIFF
--- a/.github/scripts/coordinated-workflow-contract.test.mjs
+++ b/.github/scripts/coordinated-workflow-contract.test.mjs
@@ -235,6 +235,12 @@ test("Cloud V2 deploys once per coordinated environment before mobile publicatio
   // verifies the observed image tag against the source, so the tag is explicit.
   assert.match(cloud, /PORTER_TAG: \$\{\{ steps\.source\.outputs\.tag \}\}/)
   assert.match(cloud, /--tag "\$PORTER_TAG" \\/)
+  // The frozen source may predate tooling fixes on main; scripts run from the
+  // workflow revision, which is the same revision the workflow file came from.
+  assert.match(cloud, /ref: \$\{\{ github\.sha \}\}\n\s+path: release-tooling/)
+  assert.doesNotMatch(cloud, /node \.github\/scripts\//)
+  assert.match(cloud, /node release-tooling\/\.github\/scripts\/coordinated-cloud-v2-records\.mjs resolve/)
+  assert.match(cloud, /node release-tooling\/\.github\/scripts\/coordinated-cloud-v2-records\.mjs create/)
   assert.match(cloud, /getent hosts "\$host"/)
   assert.match(cloud, /for probe in healthz ready/)
   assert.match(cloud, /porter kubectl -- get pods/)

--- a/.github/workflows/reusable-coordinated-cloud-v2.yml
+++ b/.github/workflows/reusable-coordinated-cloud-v2.yml
@@ -54,6 +54,16 @@ jobs:
         with:
           ref: ${{ inputs.source_commit }}
 
+      # The release tooling runs from the workflow's own revision, not from the
+      # frozen source: a production deploy checks out an older commit whose
+      # scripts predate fixes merged to main, while the workflow file itself
+      # already comes from main.
+      - name: Check out the release tooling at the workflow revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: release-tooling
+
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.release_plan_artifact }}
@@ -70,7 +80,7 @@ jobs:
       - name: Resolve and validate the guarded deployment target
         id: target
         run: >-
-          node .github/scripts/coordinated-cloud-v2-records.mjs resolve
+          node release-tooling/.github/scripts/coordinated-cloud-v2-records.mjs resolve
           --plan release-input/plan/release-plan.json
           --environment "${{ inputs.deployment_environment }}"
           --source-commit "${{ inputs.source_commit }}"
@@ -183,7 +193,7 @@ jobs:
       - name: Record validation-only evidence
         if: inputs.dry_run
         run: >-
-          node .github/scripts/coordinated-cloud-v2-records.mjs create
+          node release-tooling/.github/scripts/coordinated-cloud-v2-records.mjs create
           --plan release-input/plan/release-plan.json
           --environment "${{ inputs.deployment_environment }}"
           --source-commit "${{ inputs.source_commit }}"
@@ -196,7 +206,7 @@ jobs:
       - name: Record observed deployment evidence
         if: inputs.dry_run != true
         run: >-
-          node .github/scripts/coordinated-cloud-v2-records.mjs create
+          node release-tooling/.github/scripts/coordinated-cloud-v2-records.mjs create
           --plan release-input/plan/release-plan.json
           --environment "${{ inputs.deployment_environment }}"
           --source-commit "${{ inputs.source_commit }}"


### PR DESCRIPTION
## Scope

The third 3.1.0 production Cloud deploy (run 34660024390) failed on the same observed-image check that #4018 fixed. The reusable deploy checks out the frozen source commit (beta.212, `d1ead9b7`) and ran `coordinated-cloud-v2-records.mjs` from that checkout, so the script that executed was the beta's copy, not main's. The workflow file itself is loaded from main, which is why #4016 took effect and #4018 did not.

- `reusable-coordinated-cloud-v2.yml`: check out `${{ github.sha }}` into `release-tooling` and run the records script from there for `resolve` and both `create` invocations. Same pattern as `reusable-coordinated-example-google-play.yml`. The source checkout, the `git rev-parse HEAD` tag verification, and the Porter build context are unchanged.
- `coordinated-workflow-contract.test.mjs`: asserts the tooling checkout and that no script runs from the source checkout.

For coordinated dev/staging deploys `github.sha` equals the source commit, so nothing changes there.

## Test evidence

```
node --test .github/scripts/coordinated-workflow-contract.test.mjs   # 18 pass
```

Prod is running `cloud-prod:d1ead9b7` (digest `sha256:660ad7b6`) and healthy; the next deploy dispatch after this merge should observe and record it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
