### PR TITLE
Map glasses OTA failure codes to translated copy on the failed screen

### DIFF
--- a/mobile/modules/engine/src/index.ts
+++ b/mobile/modules/engine/src/index.ts
@@ -119,7 +119,13 @@ export {
 export type {OtaAutoChainAdvanceResult} from "./services/OtaAutoChain"
 export {
   BES_INSTALL_RESTART_MESSAGE,
+  OTA_ERROR_BES_RESTART_REQUIRED_COPY_KEY,
+  OTA_ERROR_ENGLISH_COPY,
+  OTA_ERROR_GENERIC_COPY_KEY,
+  OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY,
+  OTA_GLASSES_ERROR_COPY_KEYS,
   getOtaErrorMessage,
+  otaErrorCopyKey,
   shouldRequireGlassesRebootForBesFailure,
   shouldShowChangeWifiForOtaDownloadFailure,
 } from "./services/OtaErrorMapping"

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -14,10 +14,12 @@ import {useMarkdown, type MarkedStyles, type useMarkdownHookOptions} from "react
 import {SafeAreaView} from "react-native-safe-area-context"
 import Svg, {Path, Rect} from "react-native-svg"
 
+import {OTA_ERROR_ENGLISH_COPY} from "../services/OtaErrorMapping"
 import {
   MINIMUM_OTA_BATTERY_LEVEL,
   useMentraLiveOta,
   type MentraLiveOtaController,
+  type MentraLiveOtaError,
   type MentraLiveOtaFlowPage,
 } from "./useMentraLiveOta"
 
@@ -142,6 +144,8 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:versionChangeFirmwarePassComplete": "Firmware updated",
   "ota:versionChangeFirmwarePassCompleteMessage":
     "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
+  "ota:updateFailed": "Update Failed",
+  ...OTA_ERROR_ENGLISH_COPY,
 }
 
 const componentCopyKey = {
@@ -149,6 +153,15 @@ const componentCopyKey = {
   mtk: "ota:componentMtk",
   bes: "ota:componentBes",
 } as const
+
+/**
+ * Copy for the failed screen: the translated copy key when the failure maps to one,
+ * otherwise the engine's English message (phone-side watchdog and preflight text).
+ */
+function failureMessage(error: MentraLiveOtaError | null, translate: MentraLiveOtaFlowTranslate): string {
+  if (!error) return translate("ota:errorGeneric")
+  return error.copyKey ? translate(error.copyKey) : error.message
+}
 
 function defaultTranslate(key: string, options?: Record<string, string>): string {
   let value = ENGLISH_COPY[key] ?? key
@@ -559,8 +572,13 @@ function OtaFlowContent({
         }
         colors={colors}
         icon="alert"
-        title="Update Failed">
-        <BodyText colors={colors}>{state.error?.message}</BodyText>
+        title={translate("ota:updateFailed")}>
+        <BodyText colors={colors}>{failureMessage(state.error, translate)}</BodyText>
+        {state.error?.glassesCode ? (
+          <Text style={[styles.errorCode, {color: colors.textDim}]} testID="ota-error-code">
+            {translate("ota:errorCode", {code: state.error.glassesCode})}
+          </Text>
+        ) : null}
       </FlowPage>
     )
   }
@@ -810,6 +828,7 @@ const styles = StyleSheet.create({
   icon: {fontSize: 64, fontWeight: "500", lineHeight: 72, textAlign: "center"},
   title: {fontSize: 20, fontWeight: "600", textAlign: "center"},
   body: {fontSize: 14, lineHeight: 20, maxWidth: 420, textAlign: "center"},
+  errorCode: {fontSize: 12, fontVariant: ["tabular-nums"], lineHeight: 16, opacity: 0.7, textAlign: "center"},
   percent: {fontSize: 30, fontVariant: ["tabular-nums"], fontWeight: "700"},
   progressTrack: {borderRadius: 4, height: 8, maxWidth: 420, overflow: "hidden", width: "100%"},
   progressFill: {borderRadius: 4, height: 8},

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -164,7 +164,7 @@ function failureMessage(error: MentraLiveOtaError | null, translate: MentraLiveO
 }
 
 function defaultTranslate(key: string, options?: Record<string, string>): string {
-  let value = ENGLISH_COPY[key] ?? key
+  let value = Object.prototype.hasOwnProperty.call(ENGLISH_COPY, key) ? ENGLISH_COPY[key] : key
   for (const [name, replacement] of Object.entries(options ?? {})) {
     value = value.replaceAll(`{{${name}}}`, replacement)
   }

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -143,7 +143,9 @@ mock.module("../../services/OtaAutoChain", () => ({
 }))
 mock.module("../../services/OtaErrorMapping", () => ({
   BES_INSTALL_RESTART_MESSAGE: "Restart the glasses",
-  getOtaErrorMessage: (error?: string) => error || "Install failed",
+  OTA_ERROR_BES_RESTART_REQUIRED_COPY_KEY: "ota:errorBesRestartRequired",
+  getOtaErrorMessage: (error?: string | null) => (error ? `mapped:${error}` : "Install failed"),
+  otaErrorCopyKey: (error?: string | null) => (error ? `ota:key:${error}` : "ota:errorGeneric"),
   shouldRequireGlassesRebootForBesFailure: () => false,
   shouldShowChangeWifiForOtaDownloadFailure: () => false,
 }))
@@ -280,10 +282,46 @@ describe("useMentraLiveOta", () => {
     expect(latestController.state).toMatchObject({
       screen: "failed",
       canRetry: true,
-      error: {code: "install_failed", message: "Network lost"},
+      // Phone-side watchdog copy is English-only: no copy key, and no glasses code to show.
+      error: {code: "install_failed", message: "Network lost", copyKey: null, glassesCode: null},
     })
     latestController.retryInstall()
     expect(retry).toHaveBeenCalledTimes(1)
+    await act(async () => renderer.unmount())
+  })
+
+  test("maps a glasses failure code to copy and keeps the raw code for support", async () => {
+    const renderer = await renderProbe()
+    installSnapshot = {
+      ...installSnapshot,
+      displayState: "failed",
+      errorMsg: "",
+      otaStatus: {
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "apk",
+        phase: "install",
+        stepPercent: 0,
+        overallPercent: 0,
+        status: "failed",
+        error: "downgrade_handoff_failed",
+      },
+    }
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+
+    expect(latestController.state).toMatchObject({
+      screen: "failed",
+      canRetry: true,
+      error: {
+        code: "install_failed",
+        message: "mapped:downgrade_handoff_failed",
+        copyKey: "ota:key:downgrade_handoff_failed",
+        glassesCode: "downgrade_handoff_failed",
+      },
+    })
     await act(async () => renderer.unmount())
   })
 

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -14,7 +14,9 @@ import {
 } from "../services/OtaAutoChain"
 import {
   BES_INSTALL_RESTART_MESSAGE,
+  OTA_ERROR_BES_RESTART_REQUIRED_COPY_KEY,
   getOtaErrorMessage,
+  otaErrorCopyKey,
   shouldRequireGlassesRebootForBesFailure,
   shouldShowChangeWifiForOtaDownloadFailure,
 } from "../services/OtaErrorMapping"
@@ -54,7 +56,18 @@ export type MentraLiveOtaErrorCode =
 
 export type MentraLiveOtaError = {
   code: MentraLiveOtaErrorCode
+  /** English copy for hosts without localization. */
   message: string
+  /**
+   * Copy key for `message` when the failure maps to known copy, so localized hosts can
+   * translate it. Null for phone-side watchdog and preflight messages, which are English-only.
+   */
+  copyKey: string | null
+  /**
+   * Raw failure code reported by the glasses (`ota_status.error`), for support. Null when the
+   * failure originated on the phone.
+   */
+  glassesCode: string | null
 }
 
 export type MentraLiveOtaTransport = "wifi" | "hotspot"
@@ -680,9 +693,16 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
         error = {
           code: "check_failed",
           message: "Couldn't check for updates. Please check your connection and try again.",
+          copyKey: "ota:checkFailedMessage",
+          glassesCode: null,
         }
       } else if (screen === "update_info_unavailable") {
-        error = {code: "update_info_unavailable", message: "Update information for this app version is unavailable."}
+        error = {
+          code: "update_info_unavailable",
+          message: "Update information for this app version is unavailable.",
+          copyKey: "ota:updateInfoUnavailableMessage",
+          glassesCode: null,
+        }
       }
       return {
         screen,
@@ -745,16 +765,33 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
       installSnapshot.otaProgress,
       installSnapshot.errorMsg,
     )
-    const displayedError = requiresGlassesReboot
-      ? BES_INSTALL_RESTART_MESSAGE
-      : installSnapshot.errorMsg || getOtaErrorMessage(installSnapshot.otaStatus?.error)
+    // The raw code the glasses attached to their failure report, kept for support even when
+    // phone-side copy outranks it. Only a failed ota_status carries a current code.
+    const glassesCode = installSnapshot.otaStatus?.status === "failed" ? installSnapshot.otaStatus.error || null : null
+    // Precedence mirrors the legacy screen: the BES restart instruction, then a phone-side
+    // watchdog/preflight message (English-only, no copy key), then the glasses code mapped to
+    // copy (unknown codes get the generic glasses-error copy rather than the raw code).
+    let displayedError: string
+    let copyKey: string | null
+    if (requiresGlassesReboot) {
+      displayedError = BES_INSTALL_RESTART_MESSAGE
+      copyKey = OTA_ERROR_BES_RESTART_REQUIRED_COPY_KEY
+    } else if (installSnapshot.errorMsg) {
+      displayedError = installSnapshot.errorMsg
+      copyKey = null
+    } else {
+      displayedError = getOtaErrorMessage(glassesCode)
+      copyKey = otaErrorCopyKey(glassesCode)
+    }
     const progressState = progressScreen(installSnapshot)
     const screen = progressState === "complete" && autoChainActive ? "finishing" : progressState
-    const error =
+    const error: MentraLiveOtaError | null =
       screen === "failed"
         ? {
-            code: requiresGlassesReboot ? ("bes_restart_required" as const) : ("install_failed" as const),
+            code: requiresGlassesReboot ? "bes_restart_required" : "install_failed",
             message: displayedError,
+            copyKey,
+            glassesCode,
           }
         : null
     const totalSteps = installSnapshot.otaStatus?.totalSteps ?? null

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -61,13 +61,14 @@ export type MentraLiveOtaError = {
   /**
    * Copy key for `message` when the failure maps to known copy, so localized hosts can
    * translate it. Null for phone-side watchdog and preflight messages, which are English-only.
+   * Optional so host code that builds this type by hand keeps compiling; the hook always sets it.
    */
-  copyKey: string | null
+  copyKey?: string | null
   /**
    * Raw failure code reported by the glasses (`ota_status.error`), for support. Null when the
-   * failure originated on the phone.
+   * failure originated on the phone. Optional for the same source-compatibility reason.
    */
-  glassesCode: string | null
+  glassesCode?: string | null
 }
 
 export type MentraLiveOtaTransport = "wifi" | "hotspot"

--- a/mobile/modules/engine/src/services/OtaErrorMapping.ts
+++ b/mobile/modules/engine/src/services/OtaErrorMapping.ts
@@ -21,6 +21,7 @@ export const OTA_GLASSES_ERROR_COPY_KEYS: Readonly<Record<string, string>> = {
   firmware_verify_failed: "ota:errorFirmwareVerifyFailed",
   apk_verify_failed: "ota:errorApkVerifyFailed",
   install_failed: "ota:errorInstallFailed",
+  apk_restart_guard_not_persisted: "ota:errorApkRestartGuardNotPersisted",
   downgrade_handoff_refused: "ota:errorDowngradeHandoffRefused",
   downgrade_handoff_failed: "ota:errorDowngradeHandoffFailed",
   downgrade_transaction_stalled: "ota:errorDowngradeTransactionStalled",
@@ -41,6 +42,8 @@ export const OTA_ERROR_ENGLISH_COPY: Readonly<Record<string, string>> = {
   "ota:errorFirmwareVerifyFailed": "Firmware verification failed — please try again or contact support",
   "ota:errorApkVerifyFailed": "Update verification failed — please try again or contact support",
   "ota:errorInstallFailed": "Install failed — please try again",
+  "ota:errorApkRestartGuardNotPersisted":
+    "Your glasses could not save the update before restarting. Restart your glasses and try again.",
   "ota:errorDowngradeHandoffRefused":
     "Your glasses could not start the version change. Restart your glasses and try again.",
   "ota:errorDowngradeHandoffFailed":
@@ -61,7 +64,15 @@ export const BES_INSTALL_RESTART_MESSAGE = OTA_ERROR_ENGLISH_COPY[OTA_ERROR_BES_
  */
 export function otaErrorCopyKey(error?: string | null): string {
   if (!error) return OTA_ERROR_GENERIC_COPY_KEY
-  return OTA_GLASSES_ERROR_COPY_KEYS[error] ?? OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY
+  // Own-property lookup: a code that happens to name an inherited Object member
+  // ("constructor", "toString", ...) is unknown, not a mapped key.
+  return hasOwn(OTA_GLASSES_ERROR_COPY_KEYS, error)
+    ? OTA_GLASSES_ERROR_COPY_KEYS[error]
+    : OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY
+}
+
+function hasOwn(table: Readonly<Record<string, string>>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(table, key)
 }
 
 function isDownloadPhaseSnapshot(

--- a/mobile/modules/engine/src/services/OtaErrorMapping.ts
+++ b/mobile/modules/engine/src/services/OtaErrorMapping.ts
@@ -1,7 +1,68 @@
 import type {OtaProgress, OtaStatus} from "../facades/ota"
 
-export const BES_INSTALL_RESTART_MESSAGE =
-  "Restart your glasses to safely exit firmware update mode before trying again"
+/**
+ * Copy keys for OTA failures the glasses report by code (`ota_status.error`), plus the
+ * phone-side BES restart instruction. Hosts translate these keys; the engine's own
+ * English copy for each key lives in `OTA_ERROR_ENGLISH_COPY`.
+ *
+ * The glasses-side producers are `sendProgressToPhone(..., "FAILED", errorCode)` in the
+ * ASG client's OtaHelper (download classification, install failures, and the downgrade
+ * handoff to the recovery worker). Keep this table in sync with those codes; anything
+ * else falls back to `OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY` and the raw code is shown in a
+ * secondary line so support can still identify it.
+ */
+export const OTA_GLASSES_ERROR_COPY_KEYS: Readonly<Record<string, string>> = {
+  no_internet: "ota:errorNoInternet",
+  clock_skew: "ota:errorClockSkew",
+  ssl_error: "ota:errorSslError",
+  download_failed: "ota:errorDownloadFailed",
+  insufficient_storage: "ota:errorInsufficientStorage",
+  firmware_too_large: "ota:errorFirmwareTooLarge",
+  firmware_verify_failed: "ota:errorFirmwareVerifyFailed",
+  apk_verify_failed: "ota:errorApkVerifyFailed",
+  install_failed: "ota:errorInstallFailed",
+  downgrade_handoff_refused: "ota:errorDowngradeHandoffRefused",
+  downgrade_handoff_failed: "ota:errorDowngradeHandoffFailed",
+  downgrade_transaction_stalled: "ota:errorDowngradeTransactionStalled",
+}
+
+export const OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY = "ota:errorGlassesUnknown"
+export const OTA_ERROR_GENERIC_COPY_KEY = "ota:errorGeneric"
+export const OTA_ERROR_BES_RESTART_REQUIRED_COPY_KEY = "ota:errorBesRestartRequired"
+
+/** English copy for every OTA error key above. Mirrored in the Mentra App's `ota` i18n namespace. */
+export const OTA_ERROR_ENGLISH_COPY: Readonly<Record<string, string>> = {
+  "ota:errorNoInternet": "Glasses WiFi has no internet connection",
+  "ota:errorClockSkew": "Glasses clock is wrong — syncing time from your phone, then retrying update check",
+  "ota:errorSslError": "Secure connection failed — try a different WiFi network",
+  "ota:errorDownloadFailed": "Download failed — check glasses WiFi connection",
+  "ota:errorInsufficientStorage": "Not enough storage on your glasses — free up space before trying again",
+  "ota:errorFirmwareTooLarge": "Firmware file is unexpectedly large — please contact support",
+  "ota:errorFirmwareVerifyFailed": "Firmware verification failed — please try again or contact support",
+  "ota:errorApkVerifyFailed": "Update verification failed — please try again or contact support",
+  "ota:errorInstallFailed": "Install failed — please try again",
+  "ota:errorDowngradeHandoffRefused":
+    "Your glasses could not start the version change. Restart your glasses and try again.",
+  "ota:errorDowngradeHandoffFailed":
+    "The recovery service on your glasses did not respond. Restart your glasses and try again.",
+  "ota:errorDowngradeTransactionStalled":
+    "The version change on your glasses did not finish. Restart your glasses and try again.",
+  "ota:errorGlassesUnknown": "Your glasses reported an unexpected error. Restart your glasses and try again.",
+  "ota:errorGeneric": "Update failed",
+  "ota:errorBesRestartRequired": "Restart your glasses to safely exit firmware update mode before trying again",
+  "ota:errorCode": "Error code: {{code}}",
+}
+
+export const BES_INSTALL_RESTART_MESSAGE = OTA_ERROR_ENGLISH_COPY[OTA_ERROR_BES_RESTART_REQUIRED_COPY_KEY]
+
+/**
+ * Copy key for a glasses-reported failure code. Unknown codes get the generic
+ * glasses-error copy; a missing code gets the plain generic copy.
+ */
+export function otaErrorCopyKey(error?: string | null): string {
+  if (!error) return OTA_ERROR_GENERIC_COPY_KEY
+  return OTA_GLASSES_ERROR_COPY_KEYS[error] ?? OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY
+}
 
 function isDownloadPhaseSnapshot(
   otaStatus: OtaStatus | null | undefined,
@@ -43,29 +104,9 @@ export function shouldShowChangeWifiForOtaDownloadFailure(
   return false
 }
 
-export function getOtaErrorMessage(error?: string): string {
-  switch (error) {
-    case "no_internet":
-      return "Glasses WiFi has no internet connection"
-    case "clock_skew":
-      return "Glasses clock is wrong — syncing time from your phone, then retrying update check"
-    case "ssl_error":
-      return "Secure connection failed — try a different WiFi network"
-    case "download_failed":
-      return "Download failed — check glasses WiFi connection"
-    case "insufficient_storage":
-      return "Not enough storage on your glasses — free up space before trying again"
-    case "firmware_too_large":
-      return "Firmware file is unexpectedly large — please contact support"
-    case "firmware_verify_failed":
-      return "Firmware verification failed — please try again or contact support"
-    case "apk_verify_failed":
-      return "Update verification failed — please try again or contact support"
-    case "install_failed":
-      return "Install failed — please try again"
-    default:
-      return error || "Update failed"
-  }
+/** English message for a glasses-reported failure code. Never echoes the raw code. */
+export function getOtaErrorMessage(error?: string | null): string {
+  return OTA_ERROR_ENGLISH_COPY[otaErrorCopyKey(error)]
 }
 
 /**

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -456,6 +456,56 @@ describe("progress.tsx display states", () => {
     expect(queryByText("Retry")).toBeNull()
   })
 
+  it("explains a failed downgrade handoff instead of echoing the glasses code", () => {
+    setGlassesConnected()
+    const {getByText, getByTestId, queryByText} = render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "apk",
+        phase: "install",
+        stepPercent: 0,
+        overallPercent: 0,
+        status: "failed",
+        error: "downgrade_handoff_failed",
+      })
+    })
+
+    expect(getByText("Update Failed")).toBeDefined()
+    expect(
+      getByText("The recovery service on your glasses did not respond. Restart your glasses and try again."),
+    ).toBeDefined()
+    // The raw code stays visible for support, but only in the subdued secondary line.
+    expect(getByTestId("ota-error-code").props.children).toBe("Error code: downgrade_handoff_failed")
+    expect(queryByText("downgrade_handoff_failed")).toBeNull()
+    expect(getByText("Retry")).toBeDefined()
+  })
+
+  it("falls back to generic glasses-error copy for an unknown code and keeps the code visible", () => {
+    setGlassesConnected()
+    const {getByText, getByTestId} = render(<OtaProgressScreen />)
+
+    act(() => {
+      useGlassesStore.getState().setOtaStatus({
+        sessionId: "s1",
+        totalSteps: 1,
+        currentStep: 1,
+        stepType: "apk",
+        phase: "install",
+        stepPercent: 0,
+        overallPercent: 0,
+        status: "failed",
+        error: "brand_new_code",
+      })
+    })
+
+    expect(getByText("Your glasses reported an unexpected error. Restart your glasses and try again.")).toBeDefined()
+    expect(getByTestId("ota-error-code").props.children).toBe("Error code: brand_new_code")
+  })
+
   it("shows disconnected state when not connected and not terminal", () => {
     setGlassesDisconnected()
     const {getByText} = render(<OtaProgressScreen />)

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -491,6 +491,27 @@ const en = {
     whatsNew: "What's new",
     updateFailed: "Update Failed",
     updateFailedMessage: "The update could not be completed. You can try again later from Settings.",
+    // Glasses-reported OTA failure codes. Keys mirror OTA_ERROR_ENGLISH_COPY in the engine's
+    // OtaErrorMapping; the raw code is shown under the message via errorCode.
+    errorNoInternet: "Glasses WiFi has no internet connection",
+    errorClockSkew: "Glasses clock is wrong — syncing time from your phone, then retrying update check",
+    errorSslError: "Secure connection failed — try a different WiFi network",
+    errorDownloadFailed: "Download failed — check glasses WiFi connection",
+    errorInsufficientStorage: "Not enough storage on your glasses — free up space before trying again",
+    errorFirmwareTooLarge: "Firmware file is unexpectedly large — please contact support",
+    errorFirmwareVerifyFailed: "Firmware verification failed — please try again or contact support",
+    errorApkVerifyFailed: "Update verification failed — please try again or contact support",
+    errorInstallFailed: "Install failed — please try again",
+    errorDowngradeHandoffRefused:
+      "Your glasses could not start the version change. Restart your glasses and try again.",
+    errorDowngradeHandoffFailed:
+      "The recovery service on your glasses did not respond. Restart your glasses and try again.",
+    errorDowngradeTransactionStalled:
+      "The version change on your glasses did not finish. Restart your glasses and try again.",
+    errorGlassesUnknown: "Your glasses reported an unexpected error. Restart your glasses and try again.",
+    errorGeneric: "Update failed",
+    errorBesRestartRequired: "Restart your glasses to safely exit firmware update mode before trying again",
+    errorCode: "Error code: {{code}}",
     glassesDisconnected: "Glasses Disconnected",
     glassesDisconnectedMessage: "Your glasses disconnected during the update. Please reconnect and try again.",
   },

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -502,6 +502,8 @@ const en = {
     errorFirmwareVerifyFailed: "Firmware verification failed — please try again or contact support",
     errorApkVerifyFailed: "Update verification failed — please try again or contact support",
     errorInstallFailed: "Install failed — please try again",
+    errorApkRestartGuardNotPersisted:
+      "Your glasses could not save the update before restarting. Restart your glasses and try again.",
     errorDowngradeHandoffRefused:
       "Your glasses could not start the version change. Restart your glasses and try again.",
     errorDowngradeHandoffFailed:

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -2,7 +2,11 @@ import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk-internal"
 
 import {
   BES_INSTALL_RESTART_MESSAGE,
+  OTA_ERROR_ENGLISH_COPY,
+  OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY,
+  OTA_GLASSES_ERROR_COPY_KEYS,
   getOtaErrorMessage,
+  otaErrorCopyKey,
   shouldRequireGlassesRebootForBesFailure,
   shouldShowChangeWifiForOtaDownloadFailure,
 } from "@/utils/otaErrorMapping"
@@ -84,16 +88,54 @@ describe("getOtaErrorMessage", () => {
     )
   })
 
+  it("maps the downgrade handoff codes to recovery-service copy", () => {
+    expect(getOtaErrorMessage("downgrade_handoff_failed")).toBe(
+      "The recovery service on your glasses did not respond. Restart your glasses and try again.",
+    )
+    expect(getOtaErrorMessage("downgrade_handoff_refused")).toBe(
+      "Your glasses could not start the version change. Restart your glasses and try again.",
+    )
+    expect(getOtaErrorMessage("downgrade_transaction_stalled")).toBe(
+      "The version change on your glasses did not finish. Restart your glasses and try again.",
+    )
+  })
+
   it("returns generic message for undefined error", () => {
     expect(getOtaErrorMessage(undefined)).toBe("Update failed")
   })
 
-  it("passes through arbitrary error strings", () => {
-    expect(getOtaErrorMessage("some_custom_error")).toBe("some_custom_error")
+  it("never echoes an unknown glasses code as the message", () => {
+    expect(getOtaErrorMessage("some_custom_error")).toBe(
+      "Your glasses reported an unexpected error. Restart your glasses and try again.",
+    )
   })
 
   it("returns generic message for empty string", () => {
     expect(getOtaErrorMessage("")).toBe("Update failed")
+  })
+})
+
+describe("otaErrorCopyKey", () => {
+  it("resolves every known glasses code to a key with English copy", () => {
+    for (const [code, key] of Object.entries(OTA_GLASSES_ERROR_COPY_KEYS)) {
+      expect(otaErrorCopyKey(code)).toBe(key)
+      expect(OTA_ERROR_ENGLISH_COPY[key]).toEqual(expect.any(String))
+    }
+  })
+
+  it("resolves the downgrade handoff failure to its own key", () => {
+    expect(otaErrorCopyKey("downgrade_handoff_failed")).toBe("ota:errorDowngradeHandoffFailed")
+  })
+
+  it("falls back to the unknown-glasses-error key for unmapped codes", () => {
+    expect(otaErrorCopyKey("some_custom_error")).toBe(OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY)
+    expect(otaErrorCopyKey("some_custom_error")).toBe("ota:errorGlassesUnknown")
+  })
+
+  it("falls back to the plain generic key without a code", () => {
+    expect(otaErrorCopyKey(undefined)).toBe("ota:errorGeneric")
+    expect(otaErrorCopyKey(null)).toBe("ota:errorGeneric")
+    expect(otaErrorCopyKey("")).toBe("ota:errorGeneric")
   })
 })
 

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -1,3 +1,6 @@
+import {readFileSync} from "fs"
+import {resolve} from "path"
+
 import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk-internal"
 
 import {
@@ -40,7 +43,9 @@ function baseOtaProgress(overrides: Partial<OtaProgress> = {}): OtaProgress {
 describe("getOtaErrorMessage", () => {
   it("reports insufficient storage without suggesting a WiFi change", () => {
     expect(getOtaErrorMessage("insufficient_storage")).toContain("free up space")
-    expect(shouldShowChangeWifiForOtaDownloadFailure(baseOtaStatus({error: "insufficient_storage"}), null, "")).toBe(false)
+    expect(shouldShowChangeWifiForOtaDownloadFailure(baseOtaStatus({error: "insufficient_storage"}), null, "")).toBe(
+      false,
+    )
   })
   it("maps no_internet to WiFi message", () => {
     expect(getOtaErrorMessage("no_internet")).toBe("Glasses WiFi has no internet connection")
@@ -113,6 +118,14 @@ describe("getOtaErrorMessage", () => {
   it("returns generic message for empty string", () => {
     expect(getOtaErrorMessage("")).toBe("Update failed")
   })
+
+  it("treats codes that name inherited Object members as unknown", () => {
+    for (const code of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      expect(getOtaErrorMessage(code)).toBe(
+        "Your glasses reported an unexpected error. Restart your glasses and try again.",
+      )
+    }
+  })
 })
 
 describe("otaErrorCopyKey", () => {
@@ -136,6 +149,65 @@ describe("otaErrorCopyKey", () => {
     expect(otaErrorCopyKey(undefined)).toBe("ota:errorGeneric")
     expect(otaErrorCopyKey(null)).toBe("ota:errorGeneric")
     expect(otaErrorCopyKey("")).toBe("ota:errorGeneric")
+  })
+
+  it("never resolves an inherited Object member name to a mapped key", () => {
+    expect(otaErrorCopyKey("constructor")).toBe(OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY)
+    expect(otaErrorCopyKey("__proto__")).toBe(OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY)
+  })
+})
+
+describe("glasses-side producer coverage", () => {
+  // Every code the ASG client can attach to a FAILED ota_status must have its own copy, so
+  // scan the producers rather than only the codes already in the table. Producers: literal
+  // codes passed to sendProgressToPhone(..., "FAILED", code), the downgrade watchdog codes,
+  // classifyDownloadError's return values, FirmwareDownloadException's CODE_* constants, and
+  // AsgConstants' OTA_* codes.
+  const asgJavaRoot = resolve(__dirname, "../../../../asg_client/app/src/main/java/com/mentra/asg_client")
+  const otaHelper = readFileSync(resolve(asgJavaRoot, "io/ota/helpers/OtaHelper.java"), "utf8")
+  const downloadException = readFileSync(resolve(asgJavaRoot, "io/ota/utils/FirmwareDownloadException.java"), "utf8")
+  const asgConstants = readFileSync(resolve(asgJavaRoot, "AsgConstants.java"), "utf8")
+
+  function matchAll(source: string, pattern: RegExp): string[] {
+    return Array.from(source.matchAll(pattern), (match) => match[1])
+  }
+
+  const classifyDownloadErrorBody = otaHelper.slice(otaHelper.indexOf("private String classifyDownloadError("))
+  const producedCodes = new Set<string>([
+    ...matchAll(otaHelper, /"FAILED",\s*"([a-z_]+)"/g),
+    ...matchAll(otaHelper, /armHandoffWatchdog\(\s*[\w.]+,\s*"([a-z_]+)"/g),
+    ...matchAll(
+      classifyDownloadErrorBody.slice(0, classifyDownloadErrorBody.indexOf("\n    }\n")),
+      /return "([a-z_]+)";/g,
+    ),
+    ...matchAll(downloadException, /CODE_[A-Z_]+\s*=\s*"([a-z_]+)"/g),
+    ...matchAll(asgConstants, /\bOTA_[A-Z_]+\s*=\s*"([a-z_]+)"/g),
+  ])
+
+  it("finds the producers it scans for", () => {
+    for (const code of [
+      "download_failed",
+      "install_failed",
+      "no_internet",
+      "apk_verify_failed",
+      "insufficient_storage",
+      "downgrade_handoff_refused",
+      "downgrade_handoff_failed",
+      "apk_restart_guard_not_persisted",
+    ]) {
+      expect(producedCodes.has(code)).toBe(true)
+    }
+  })
+
+  it("maps every code the glasses can report", () => {
+    const unmapped = Array.from(producedCodes).filter((code) => !(code in OTA_GLASSES_ERROR_COPY_KEYS))
+    expect(unmapped).toEqual([])
+  })
+
+  it("has English copy for every mapped key", () => {
+    for (const key of Object.values(OTA_GLASSES_ERROR_COPY_KEYS)) {
+      expect(typeof OTA_ERROR_ENGLISH_COPY[key]).toBe("string")
+    }
   })
 })
 

--- a/mobile/src/utils/otaErrorMapping.ts
+++ b/mobile/src/utils/otaErrorMapping.ts
@@ -1,6 +1,10 @@
 export {
   BES_INSTALL_RESTART_MESSAGE,
+  OTA_ERROR_ENGLISH_COPY,
+  OTA_ERROR_UNKNOWN_GLASSES_COPY_KEY,
+  OTA_GLASSES_ERROR_COPY_KEYS,
   getOtaErrorMessage,
+  otaErrorCopyKey,
   shouldRequireGlassesRebootForBesFailure,
   shouldShowChangeWifiForOtaDownloadFailure,
 } from "@mentra/engine"


### PR DESCRIPTION
## Scope

The Mentra Live OTA failed screen rendered the raw error string from the glasses. `getOtaErrorMessage` in the engine passed any code outside its switch straight through, so a failed downgrade handoff showed the literal `downgrade_handoff_failed` (seen on a Galaxy Z Fold on 2026-09-11).

This PR:

- Keeps the English copy for every glasses-reported OTA failure code in one table in the engine's `OtaErrorMapping.ts`, keyed by i18n copy keys (`ota:errorDowngradeHandoffFailed` etc.). The known codes are the ones the ASG client's `OtaHelper` sends via `sendProgressToPhone(..., "FAILED", errorCode)`: the download classification codes, `install_failed`, the verify codes, and the three downgrade codes (`downgrade_handoff_refused`, `downgrade_handoff_failed`, `downgrade_transaction_stalled`).
- Exposes `copyKey` and `glassesCode` on the hook's `MentraLiveOtaError` state alongside the existing English `message`. Precedence is unchanged: BES restart instruction, then phone-side watchdog/preflight text (English-only, no key), then the glasses code mapped to copy.
- Has the flow screen translate the copy key through the host's `translate` prop and print the raw code in a subdued secondary line (`Error code: downgrade_handoff_failed`, testID `ota-error-code`) so support can still identify it. The screen title now goes through `ota:updateFailed` too.
- Falls back to generic glasses-error copy for unknown codes instead of echoing the code. `getOtaErrorMessage` keeps its signature but no longer returns the raw code for unmapped input.
- For `downgrade_handoff_failed` the message says the recovery service on the glasses did not respond and suggests restarting the glasses and retrying.
- Mirrors the new keys in the Mentra App's `ota` i18n namespace in `mobile/src/i18n/en.ts` (other locales fall back to English).

## Review rework (second commit)

- `copyKey` and `glassesCode` are optional on `MentraLiveOtaError` so host code that builds the type by hand keeps compiling; the hook always populates them.
- `apk_restart_guard_not_persisted` (OtaHelper, APK restart guard could not be persisted) is now mapped with its own copy.
- Code lookups use own properties, so a code naming an inherited Object member (`constructor`, `__proto__`) is unknown rather than a mapped key. The engine's default translator is hardened the same way.
- A producer-coverage test scans the ASG client sources (literal `FAILED` codes, downgrade watchdog codes, `classifyDownloadError` returns, `FirmwareDownloadException` constants, `AsgConstants` OTA codes) and asserts every code is mapped with English copy.

## Test evidence

Jest (`mobile`): `otaErrorMapping.test.ts`, `ota/__tests__/progress.test.tsx`, `ota/__tests__/shared-flow.test.tsx`, `otaInstallCoordinator.test.ts`: 4 suites, 163 tests passed. New cases cover the downgrade handoff copy, the raw-code secondary line, the unknown-code fallback, and that a phone-side watchdog message shows no code line.

Bun (`mobile/modules/engine`): `useMentraLiveOta.test.tsx`: 14 tests passed, including a new case asserting `copyKey` and `glassesCode` for a glasses failure code.

`tsc --noEmit` clean for `mobile` and for the engine module, and the engine's `test:public-ota-consumer` fixture still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

