### PR TITLE
Narrate the downgrade detour as a reinstall, not a verification

### DIFF
--- a/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
+++ b/mobile/modules/engine/scripts/fixtures/public-ota-consumer.tsx
@@ -41,6 +41,8 @@ function screenLabel(screen: MentraLiveOtaScreen): string {
       return "Updating"
     case "restarting":
       return "Restarting"
+    case "reinstalling":
+      return "Reinstalling"
     case "verifying":
       return "Verifying"
     case "complete":

--- a/mobile/modules/engine/src/facades/ota.ts
+++ b/mobile/modules/engine/src/facades/ota.ts
@@ -19,7 +19,11 @@ import type {
 } from "@mentra/bluetooth-sdk"
 import {isGlassesConnected, isGlassesReady, useGlassesStore} from "../stores/glasses"
 import {resolveOtaManifestUrl} from "../services/otaManifestUrl"
-import {otaInstallCoordinator, type OtaInstallSnapshot} from "../services/OtaInstallCoordinator"
+import {
+  otaInstallCoordinator,
+  type OtaInstallSnapshot,
+  type VersionChangePhase,
+} from "../services/OtaInstallCoordinator"
 import {startGlassesStatusProjection} from "../services/GlassesStatusProjection"
 import {startOtaService} from "../services/OtaService"
 import {
@@ -59,6 +63,7 @@ export type {
   OtaUpdateInfo,
   ReleaseChangelog,
   OtaInstallSnapshot,
+  VersionChangePhase,
   OtaCheckCurrentGlassesOptions,
   OtaCheckCurrentGlassesResult,
 }

--- a/mobile/modules/engine/src/index.ts
+++ b/mobile/modules/engine/src/index.ts
@@ -104,6 +104,7 @@ export type {
   ReleaseChangelog,
   OtaSnapshot,
   OtaInstallSnapshot,
+  VersionChangePhase,
 } from "./facades/ota"
 export {
   beginOtaAutoChain,

--- a/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
+++ b/mobile/modules/engine/src/react/MentraLiveOtaFlow.tsx
@@ -129,9 +129,11 @@ const ENGLISH_COPY: Record<string, string> = {
   "ota:updateInfoUnavailableMessage":
     "Update information for this version of the app is unavailable. Please check the app store for a newer version of the Mentra App.",
   "ota:downgradeDuration": "Your glasses will restart twice — this may take up to 2 minutes.",
-  "ota:versionChangeRestarting": "Installing a different version…",
+  "ota:versionChangeReinstalling": "Reinstalling glasses software…",
+  "ota:versionChangeReinstallingMessage":
+    "This can take a few minutes and your glasses will restart on their own. Keep them nearby and leave this screen open.",
   "ota:versionChangeVerifying": "Verifying your glasses…",
-  "ota:versionChangeKeepNearby": "Keep your glasses nearby and connected. They will restart on their own.",
+  "ota:versionChangeVerifyingMessage": "Checking the installed version. Keep your glasses nearby and connected.",
   "ota:restartingGlasses": "Restarting {{deviceName}}…",
   "ota:restartingGlassesMessage":
     "The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.",
@@ -399,17 +401,20 @@ function OtaFlowContent({
     )
   }
 
-  if (state.versionChangePhase === "restarting" || state.versionChangePhase === "verifying") {
+  if (state.versionChangePhase === "reinstalling" || state.versionChangePhase === "verifying") {
+    // The recovery worker reports no progress while it replaces the glasses software, so
+    // this page narrates the wait; "verifying" is only the moment after a physical
+    // reconnect, before the reported version has been checked.
+    const verifying = state.versionChangePhase === "verifying"
     return (
       <FlowPage
         colors={colors}
         icon="download"
-        title={translate(
-          state.versionChangePhase === "verifying" ? "ota:versionChangeVerifying" : "ota:versionChangeRestarting",
-        )}>
+        title={translate(verifying ? "ota:versionChangeVerifying" : "ota:versionChangeReinstalling")}>
         <ActivityIndicator size="large" color={colors.foreground} />
-        <BodyText colors={colors}>{translate("ota:versionChangeKeepNearby")}</BodyText>
-        <BodyText colors={colors}>{translate("ota:downgradeDuration")}</BodyText>
+        <BodyText colors={colors}>
+          {translate(verifying ? "ota:versionChangeVerifyingMessage" : "ota:versionChangeReinstallingMessage")}
+        </BodyText>
       </FlowPage>
     )
   }

--- a/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
+++ b/mobile/modules/engine/src/react/__tests__/useMentraLiveOta.test.tsx
@@ -308,6 +308,30 @@ describe("useMentraLiveOta", () => {
     await act(async () => renderer.unmount())
   })
 
+  test("keeps the downgrade reinstall wait on its own screen and blocks finish while connected", async () => {
+    installSnapshot = {
+      ...installSnapshot,
+      connected: true,
+      displayState: "updating",
+      isVersionChange: true,
+      versionChangePhase: "reinstalling",
+    }
+    const renderer = await renderProbe()
+
+    expect(latestController.state).toMatchObject({screen: "reinstalling", canFinish: false})
+    await act(async () => {
+      await latestController.finish()
+    })
+    expect(finish).not.toHaveBeenCalled()
+
+    installSnapshot = {...installSnapshot, versionChangePhase: "verifying"}
+    await act(async () => {
+      installListeners.forEach((listener) => listener())
+    })
+    expect(latestController.state.screen).toBe("verifying")
+    await act(async () => renderer.unmount())
+  })
+
   test("treats an active pass completion as a continuation check", async () => {
     const renderer = await renderProbe("check")
     expect(latestController.state.hotspotArtifact).toBeNull()

--- a/mobile/modules/engine/src/react/useMentraLiveOta.ts
+++ b/mobile/modules/engine/src/react/useMentraLiveOta.ts
@@ -18,7 +18,7 @@ import {
   shouldRequireGlassesRebootForBesFailure,
   shouldShowChangeWifiForOtaDownloadFailure,
 } from "../services/OtaErrorMapping"
-import type {OtaInstallSnapshot} from "../services/OtaInstallCoordinator"
+import type {OtaInstallSnapshot, VersionChangePhase} from "../services/OtaInstallCoordinator"
 import type {OtaCheckCurrentGlassesResult} from "../services/OtaUpdateCheckService"
 import type {ReleaseChangelog} from "../facades/ota"
 import {useEngineSnapshot} from "./useEngineSnapshot"
@@ -41,6 +41,7 @@ export type MentraLiveOtaScreen =
   | "preparing_hotspot"
   | "updating"
   | "restarting"
+  | "reinstalling"
   | "verifying"
   | "complete"
   | "failed"
@@ -77,7 +78,7 @@ export type MentraLiveOtaState = {
   updateRequired: boolean
   versionChange: boolean
   versionChangeConverged: boolean
-  versionChangePhase: "installing" | "restarting" | "verifying" | null
+  versionChangePhase: VersionChangePhase | null
   wifiConnected: boolean
   wifiStatusKnown: boolean
   hotspotSupported: boolean
@@ -185,7 +186,7 @@ function installProgress(snapshot: OtaInstallSnapshot): number | null {
 }
 
 function progressScreen(snapshot: OtaInstallSnapshot): MentraLiveOtaScreen {
-  if (snapshot.versionChangePhase === "restarting") return "restarting"
+  if (snapshot.versionChangePhase === "reinstalling") return "reinstalling"
   if (snapshot.versionChangePhase === "verifying") return "verifying"
   switch (snapshot.displayState) {
     case "starting":
@@ -492,8 +493,8 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
 
   const firmwareRestarting =
     page === "progress" &&
-    ((!installSnapshot.connected && installSnapshot.displayState === "restarting") ||
-      installSnapshot.versionChangePhase === "restarting")
+    !installSnapshot.connected &&
+    (installSnapshot.displayState === "restarting" || installSnapshot.versionChangePhase === "reinstalling")
 
   useEffect(() => {
     if (page !== "progress") return
@@ -597,7 +598,7 @@ export function useMentraLiveOta(options: UseMentraLiveOtaOptions = {}): MentraL
     }
     const restartStillInProgress =
       installSnapshot.displayState === "restarting" ||
-      installSnapshot.versionChangePhase === "restarting" ||
+      installSnapshot.versionChangePhase === "reinstalling" ||
       installSnapshot.versionChangePhase === "verifying"
     if (restartStillInProgress) return
     const requiresGlassesReboot = shouldRequireGlassesRebootForBesFailure(

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -146,6 +146,9 @@ function hasRecoveringOtaReply(otaStatus: OtaStatus | null, otaProgress: OtaProg
   return !!otaProgress
 }
 
+/** Downgrade-detour sub-phase; see OtaInstallSnapshot.versionChangePhase. */
+export type VersionChangePhase = "installing" | "reinstalling" | "verifying"
+
 /** Read model the host progress screen renders from. */
 export interface OtaInstallSnapshot {
   displayState: DisplayState
@@ -166,11 +169,13 @@ export interface OtaInstallSnapshot {
   versionChangeConverged: boolean
   /**
    * Sub-phase of the downgrade detour for the progress narrative, or null when not
-   * in one: "installing" before the handoff, "restarting" while the glasses are dark
-   * (uninstall / factory flicker / target install), "verifying" once reconnected and
-   * checking the version. Completion is the "complete" displayState.
+   * in one: "installing" before the handoff, "reinstalling" while the recovery worker
+   * replaces the glasses software (uninstall / factory flicker / target install — it
+   * reports no progress, and the BES keeps the BLE link up, so `connected` says nothing
+   * about it), "verifying" only between a physical reconnect and the version report
+   * the phone then checks. Completion is the "complete" displayState.
    */
-  versionChangePhase: "installing" | "restarting" | "verifying" | null
+  versionChangePhase: VersionChangePhase | null
   /** Pre-ota_start phone staging/join state for a hotspot attempt. */
   hotspotPhase: HotspotOtaPhase
   hotspotArtifactPercent: number | null
@@ -237,6 +242,13 @@ class OtaInstallCoordinator {
   private versionChangeInstallStarted = false
   // Latched when a reconnect reports buildNumber === versionChangeTarget.
   private versionChangeConverged = false
+  // A physical BLE reconnect happened inside the detour and no build number has been
+  // reported since: the phone is about to check the version. Drives the "verifying"
+  // phase. NOT set by glasses_session_changed — the bridge detects the sid change inside
+  // the same version_info message that already applied the build number, so by the time
+  // that signal arrives the check has already run (and latching here would leave
+  // "verifying" stuck on for the target install that follows a factory-build flicker).
+  private versionChangeVerifyPending = false
   // Holds a legacy apk install FINISHED out of "complete" for the settle window.
   private legacyApkSettleHold = false
   // Display-only legacy MTK install stall simulation.
@@ -515,7 +527,7 @@ class OtaInstallCoordinator {
       mtkInstallStallSimulatedPercent: this.mtkSimulatedPercent,
       isVersionChange: this.versionChangeSession,
       versionChangeConverged: this.versionChangeConverged,
-      versionChangePhase: this.deriveVersionChangePhase(connected),
+      versionChangePhase: this.deriveVersionChangePhase(),
       hotspotPhase: this.hotspotPhase,
       hotspotArtifactPercent: this.hotspotArtifactPercent,
       hotspotArtifact: this.hotspotArtifact ? {...this.hotspotArtifact} : null,
@@ -535,10 +547,10 @@ class OtaInstallCoordinator {
   }
 
   /** Downgrade-detour sub-phase for the progress narrative (see OtaInstallSnapshot). */
-  private deriveVersionChangePhase(connected: boolean): "installing" | "restarting" | "verifying" | null {
+  private deriveVersionChangePhase(): VersionChangePhase | null {
     if (!this.versionChangeSession || this.versionChangeConverged) return null
     if (!this.versionChangeInstallStarted) return "installing"
-    return connected ? "verifying" : "restarting"
+    return this.versionChangeVerifyPending ? "verifying" : "reinstalling"
   }
 
   /**
@@ -580,6 +592,7 @@ class OtaInstallCoordinator {
     this.versionChangeTarget = null
     this.versionChangeInstallStarted = false
     this.versionChangeConverged = false
+    this.versionChangeVerifyPending = false
     this.legacyApkSettleHold = false
     this.mtkSimulatedPercent = null
     this.lastRealMtkProgress = 0
@@ -857,6 +870,7 @@ class OtaInstallCoordinator {
     ) {
       console.log("[OTA_PROGRESS] version-change: apk install started — entering detour wait")
       this.versionChangeInstallStarted = true
+      this.versionChangeVerifyPending = false
       this.emitInternalChange()
     }
 
@@ -881,6 +895,14 @@ class OtaInstallCoordinator {
         `[OTA_PROGRESS] version-change: no transaction owns the detour (${otaStatus.error}) — releasing latch`,
       )
       this.versionChangeInstallStarted = false
+      this.emitInternalChange()
+    }
+
+    // The reconnected glasses reported a version: the check the "verifying" phase
+    // announced runs right below. Whether it converges (target) or not (the passive
+    // factory build, which recovery is now replacing), the phone is no longer verifying.
+    if (this.versionChangeVerifyPending && buildNumberChanged && buildNumber) {
+      this.versionChangeVerifyPending = false
       this.emitInternalChange()
     }
 
@@ -1122,10 +1144,21 @@ class OtaInstallCoordinator {
       // queries durable status and re-arms the one permitted fallback.
       this.clearQueryReplyTimeout()
       this.clearRetryTimeout()
+      // Glasses went dark again before reporting a version: nothing to verify until
+      // the next physical reconnect (the detour narrative falls back to "reinstalling").
+      if (this.versionChangeVerifyPending) {
+        this.versionChangeVerifyPending = false
+        this.emitInternalChange()
+      }
       return
     }
 
     const becameConnected = prev === false && connected === true
+    if (becameConnected && this.isInVersionChangeDetour()) {
+      console.log("[OTA_PROGRESS] connect-edge: physical reconnect during version-change detour — verifying")
+      this.versionChangeVerifyPending = true
+      this.emitInternalChange()
+    }
     if (becameConnected && this.runReconnectArbitration("connect-edge")) {
       return
     }

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -720,6 +720,75 @@ describe("OtaInstallCoordinator version-change detour retry gate", () => {
   })
 })
 
+describe("OtaInstallCoordinator version-change detour phase narrative", () => {
+  const TARGET = 49000000
+
+  /** Downgrade session latched into the detour wait (recovery owns the transaction). */
+  function enterDetour() {
+    setGlassesConnected()
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "51000000"})
+    useGlassesStore.getState().setOtaUpdateAvailable({
+      updateAvailable: true,
+      isDowngrade: true,
+      versionCode: TARGET,
+    } as never)
+    otaInstallCoordinator.attach()
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("installing")
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 100}))
+  }
+
+  it("narrates the detour wait as reinstalling while the BES keeps the link up (hardware 2026-09-11)", () => {
+    // The recovery worker uninstalls/reinstalls ASG without reporting progress and the
+    // BLE link never drops, so `connected` must not turn the wait into "verifying".
+    enterDetour()
+    expect(otaInstallCoordinator.snapshot().connected).toBe(true)
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("reinstalling")
+  })
+
+  it("a glasses_session_changed signal does not enter verifying (its version report already landed)", () => {
+    enterDetour()
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "45000000"})
+    GlobalEventEmitter.emit("glasses_session_changed", {previousSid: "old", sid: "new"})
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("reinstalling")
+  })
+
+  it("verifies only between a physical reconnect and the version report, then converges", () => {
+    enterDetour()
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("reinstalling")
+
+    // Passive factory build comes back on a fresh link: the phone is about to check it.
+    setGlassesConnected()
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("verifying")
+
+    // Not the target: recovery is now installing it — back to the reinstall narrative.
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "45000000"})
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("reinstalling")
+    expect(otaInstallCoordinator.snapshot().versionChangeConverged).toBe(false)
+
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("verifying")
+
+    useGlassesStore.getState().setGlassesInfo({buildNumber: String(TARGET)})
+    const snap = otaInstallCoordinator.snapshot()
+    expect(snap.versionChangeConverged).toBe(true)
+    expect(snap.versionChangePhase).toBeNull()
+    expect(snap.displayState).toBe("complete")
+  })
+
+  it("a reconnect that goes dark again before reporting a version drops back to reinstalling", () => {
+    enterDetour()
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    setGlassesConnected()
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("verifying")
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+    expect(otaInstallCoordinator.snapshot().versionChangePhase).toBe("reinstalling")
+  })
+})
+
 describe("OtaInstallCoordinator stuck-at-zero watchdog", () => {
   it("uses advancing bytes at 0%, but repeated or missing byte counts cannot mask a stall", async () => {
     setGlassesConnected()

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -473,9 +473,11 @@ const en = {
     installing: "Installing Update",
     doNotDisconnect: "Please keep your glasses connected and do not close the app.",
     downgradeDuration: "Your glasses will restart twice \u2014 this may take up to 2 minutes.",
-    versionChangeRestarting: "Installing a different version\u2026",
+    versionChangeReinstalling: "Reinstalling glasses software\u2026",
+    versionChangeReinstallingMessage:
+      "This can take a few minutes and your glasses will restart on their own. Keep them nearby and leave this screen open.",
     versionChangeVerifying: "Verifying your glasses\u2026",
-    versionChangeKeepNearby: "Keep your glasses nearby and connected. They will restart on their own.",
+    versionChangeVerifyingMessage: "Checking the installed version. Keep your glasses nearby and connected.",
     restartingGlasses: "Restarting {{deviceName}}…",
     restartingGlassesMessage:
       "The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.",


### PR DESCRIPTION
## Scope

Copy and phase-mapping fix for the Mentra Live version-change (downgrade) detour in the OTA flow. No protocol changes; the recovery worker still reports no progress.

**Observed on hardware (2026-09-11):** after ASG hands the downgrade to `com.mentra.recovery`, the worker uninstalls and reinstalls ASG silently while the BES keeps the BLE link up. `deriveVersionChangePhase` split the detour on `connected`, so the phone showed a spinner with **"Verifying your glasses…"** for the whole operation (30–60 s in the good case, up to the 180 s watchdog in the bad case). Nothing was being verified yet.

## Change

`OtaInstallCoordinator`:
- The detour wait (install latched, not converged) is now always the **`reinstalling`** phase, independent of link state.
- **`verifying`** is reserved for the window between a *physical* BLE reconnect inside the detour and the build number the phone then checks. It is cleared by the next reported build number (target → converged, passive factory build → back to `reinstalling`), by a further disconnect, and when the detour is re-latched after a retry.
- `glasses_session_changed` deliberately does not enter `verifying`: the SDK bridge detects the sid change inside the same `version_info` message that already applied the build number (`MentraLive.kt` `handleGlassesSessionId` is called from the version_info parsing path), so the check has already run by the time that signal arrives, and latching on it would leave "Verifying" stuck on for the target install that follows a factory-build flicker.
- `VersionChangePhase` is exported alongside `OtaInstallSnapshot`.

`useMentraLiveOta` / `MentraLiveOtaFlow`:
- Public screen union gains `reinstalling` (fixture `public-ota-consumer.tsx` updated). The host firmware-restarting overlay keeps its previous trigger (detour wait while the link is actually down).
- Copy (engine defaults and host `en.ts`; no other locale carries these keys):
  - `ota:versionChangeReinstalling`: "Reinstalling glasses software…"
  - `ota:versionChangeReinstallingMessage`: "This can take a few minutes and your glasses will restart on their own. Keep them nearby and leave this screen open."
  - `ota:versionChangeVerifying`: "Verifying your glasses…" (unchanged)
  - `ota:versionChangeVerifyingMessage`: "Checking the installed version. Keep your glasses nearby and connected."
  - Removed `ota:versionChangeRestarting` ("Installing a different version…") and `ota:versionChangeKeepNearby`; the detour page no longer repeats the "restart twice / up to 2 minutes" line, which contradicted the new duration copy and the 180 s watchdog.

## Tests

- `otaInstallCoordinator.test.ts`: new describe block covering the connected detour wait → `reinstalling` (the hardware regression), sid change not entering `verifying`, physical reconnect → `verifying` → non-target build → `reinstalling` → reconnect → target → converged/null, and a reconnect that goes dark again before reporting a version.
- `useMentraLiveOta.test.tsx`: `reinstalling` phase maps to its own screen with finish blocked; `verifying` follows on the next snapshot.
- `bun run test -- otaInstallCoordinator useMentraLiveOta shared-flow progress`: all green. `tsc --noEmit` clean for `mobile`.
- Not verified on hardware in this PR (copy/mapping only); the good-case sequence on unit 023B should now read "Reinstalling glasses software…" until the target build reports, then "Version Change Complete".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
