### PR TITLE
Allow deferring the pre-submission human gates until store review

### DIFF
--- a/.github/production-release/README.md
+++ b/.github/production-release/README.md
@@ -128,6 +128,15 @@ Mutating commands require typing the release identity, or `--yes` in an already
 reviewed non-interactive procedure. The CLI never reads production credentials
 and never calls Porter or a store directly.
 
+Two human gates may be deferred with `defer --check NAME --reason TEXT`:
+`production-mobile-n-compatibility` (Phase 5) and
+`production-mobile-candidate-acceptance` (Phase 8). Both precede store review,
+which takes days, and neither guards anything user-facing on its own. A
+deferral records who deferred and why, moves the promotion on, and leaves the
+gate open: `attest` the same check later, at any state before public release
+approval, and `release` refuses to proceed while a deferral is unresolved.
+`status` lists the deferred gates still to attest.
+
 ## Phase 1 - select and freeze
 
 `start` dispatches `production-release-prepare.yml`. It only reads completed
@@ -261,6 +270,14 @@ Use `evidence/production-mobile-n.template.json` and attest:
 If either platform fails, stop. Choose an explicit Cloud rollback or forward
 fix, then repeat all invalidated evidence.
 
+To submit for store review before this verification is done, defer the gate
+and attest it during review:
+
+```bash
+./scripts/production-release.mjs defer --release X.Y.Z \
+  --check production-mobile-n-compatibility --reason "verify during store review"
+```
+
 ## Phases 6 through 8 - build, upload, and accept candidates
 
 Run:
@@ -347,7 +364,9 @@ When Apple and Google show review complete for both exact coordinates, fill
 
 ## Phases 11 and 12 - public release and rollout
 
-Request the protected two-person release approval:
+Every deferred human gate must be attested first; `release` refuses otherwise,
+and so does the promotion chain itself. Then request the protected two-person
+release approval:
 
 ```bash
 ./scripts/production-release.mjs release --release X.Y.Z

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -55,6 +55,36 @@ export const ATTESTATION_CHECKS = Object.freeze({
   },
 })
 
+// Human gates that guard nothing user-facing on their own: production Mobile N
+// against the new Cloud and candidate acceptance both precede store review,
+// which takes days. Either may be deferred so submission is not held back; a
+// deferral is resolved by the same passing attestation later, and public
+// release refuses to proceed while any deferral is unresolved.
+export const DEFERRABLE_CHECKS = Object.freeze([
+  "production-mobile-n-compatibility",
+  "production-mobile-candidate-acceptance",
+])
+
+export function deferralKind(check) {
+  return `${check}-deferred`
+}
+
+export function deferredChecks(record) {
+  return DEFERRABLE_CHECKS.filter((check) => {
+    const deferredAt = record.evidence.findIndex((item) => item.kind === deferralKind(check))
+    return deferredAt !== -1 && !record.evidence.slice(deferredAt + 1).some((item) => item.kind === check)
+  })
+}
+
+// A deferred check is resolved in place: the promotion has already moved past
+// the check's own transition, so the passing attestation appends evidence
+// without changing state. It must land before public release is approved.
+export function canResolveDeferredCheck(record, check) {
+  if (!deferredChecks(record).includes(check)) return false
+  const index = STATE_INDEX.get(record.state)
+  return index >= STATE_INDEX.get(ATTESTATION_CHECKS[check].to) && index < STATE_INDEX.get("public-release-approved")
+}
+
 export const NEXT_ACTIONS = Object.freeze({
   "staging-compatible": {kind: "workflow", workflow: "production-release-cloud.yml", phase: "preflight"},
   "production-config-ready": {kind: "workflow", workflow: "production-release-cloud.yml", phase: "deploy"},
@@ -297,8 +327,16 @@ export function validatePromotionChain(previous, next) {
     ) {
       fail("staging-compatible requires lab build evidence followed by Mobile N acceptance")
     }
-    if (!rolloutUpdate && !compatibilityLabUpdate && nextIndex !== previousIndex + 1) {
+    const resolvedCheck = next.evidence.at(-1)?.kind
+    const deferredResolution =
+      previous.state === next.state &&
+      DEFERRABLE_CHECKS.includes(resolvedCheck) &&
+      canResolveDeferredCheck(previous, resolvedCheck)
+    if (!rolloutUpdate && !compatibilityLabUpdate && !deferredResolution && nextIndex !== previousIndex + 1) {
       fail(`transition ${previous.state} -> ${next.state} is not contiguous`)
+    }
+    if (next.state === "public-release-approved" && deferredChecks(next).length > 0) {
+      fail(`public release requires the deferred human gates to be attested first: ${deferredChecks(next).join(", ")}`)
     }
   }
   return next
@@ -430,11 +468,20 @@ export function validateAttestation(attestation, record, expectedCheck) {
   ) {
     fail("staging Mobile N acceptance requires recorded compatibility-lab build evidence")
   }
-  if (record.state !== check.from) fail(`attestation ${attestation.check} cannot apply in state ${record.state}`)
-  if (attestation.result !== "pass") fail("only passing attestations can advance a promotion")
   requireIsoUtc(attestation.performedAt, "attestation.performedAt")
   requireString(attestation.tester?.githubLogin, "attestation.tester.githubLogin", 100)
   requireSafeText(attestation.notes, "attestation.notes", 2000)
+  if (attestation.result === "deferred") {
+    if (!DEFERRABLE_CHECKS.includes(attestation.check)) fail(`${attestation.check} cannot be deferred`)
+    if (record.state !== check.from) fail(`deferral of ${attestation.check} cannot apply in state ${record.state}`)
+    requireSafeText(attestation.reason, "attestation.reason", 1000)
+    if (attestation.tests !== undefined) fail("a deferral carries no test results")
+    return attestation
+  }
+  if (attestation.result !== "pass") fail("only passing attestations can advance a promotion")
+  if (record.state !== check.from && !canResolveDeferredCheck(record, attestation.check)) {
+    fail(`attestation ${attestation.check} cannot apply in state ${record.state}`)
+  }
   if (!Array.isArray(attestation.tests)) fail("attestation.tests must be an array")
   const observed = new Set()
   for (const [index, item] of attestation.tests.entries()) {
@@ -482,14 +529,21 @@ export function transitionWithAttestation({
   sha256,
 }) {
   validateAttestation(attestation, record, expectedCheck)
-  const target = ATTESTATION_CHECKS[attestation.check].to
+  const check = ATTESTATION_CHECKS[attestation.check]
+  const deferred = attestation.result === "deferred"
+  const target = deferred || record.state === check.from ? check.to : record.state
   return transitionPromotionRecord({
     record,
     to: target,
     actor,
     createdAt,
     provenanceUrl,
-    evidence: {kind: attestation.check, url: evidenceUrl, assetName, sha256},
+    evidence: {
+      kind: deferred ? deferralKind(attestation.check) : attestation.check,
+      url: evidenceUrl,
+      assetName,
+      sha256,
+    },
   })
 }
 

--- a/.github/scripts/production-promotion-state.mjs
+++ b/.github/scripts/production-promotion-state.mjs
@@ -335,8 +335,13 @@ export function validatePromotionChain(previous, next) {
     if (!rolloutUpdate && !compatibilityLabUpdate && !deferredResolution && nextIndex !== previousIndex + 1) {
       fail(`transition ${previous.state} -> ${next.state} is not contiguous`)
     }
-    if (next.state === "public-release-approved" && deferredChecks(next).length > 0) {
-      fail(`public release requires the deferred human gates to be attested first: ${deferredChecks(next).join(", ")}`)
+    // Judged on the previous record: the approval's own evidence must not be
+    // what resolves the last deferral, or one crafted reference would collapse
+    // the required resolution into the approval.
+    if (next.state === "public-release-approved" && deferredChecks(previous).length > 0) {
+      fail(
+        `public release requires the deferred human gates to be attested first: ${deferredChecks(previous).join(", ")}`,
+      )
     }
   }
   return next
@@ -474,6 +479,7 @@ export function validateAttestation(attestation, record, expectedCheck) {
   if (attestation.result === "deferred") {
     if (!DEFERRABLE_CHECKS.includes(attestation.check)) fail(`${attestation.check} cannot be deferred`)
     if (record.state !== check.from) fail(`deferral of ${attestation.check} cannot apply in state ${record.state}`)
+    requireString(attestation.reason, "attestation.reason", 1000)
     requireSafeText(attestation.reason, "attestation.reason", 1000)
     if (attestation.tests !== undefined) fail("a deferral carries no test results")
     return attestation

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -389,6 +389,8 @@ test("pre-submission human gates can be deferred and must be attested before pub
       assetName: `${attestation.check}-${attestation.result}.json`,
       sha256: "e".repeat(64),
     })
+  const resolvedOneOf = (record) =>
+    attest(record, passing(record, "production-mobile-n-compatibility", initialRecord.coordinates.currentMentraApp))
   const advance = (record, to) =>
     transitionPromotionRecord({
       record,
@@ -412,6 +414,10 @@ test("pre-submission human gates can be deferred and must be attested before pub
   )
   const withTests = {...deferral(cloudDeployed, "production-mobile-n-compatibility"), tests: []}
   assert.throws(() => validateAttestation(withTests, cloudDeployed), /carries no test results/)
+  for (const reason of [undefined, "", "   ", "reason with key msk_abcdefghijklmnopqrstuvwxyz0123456789"]) {
+    const unreasoned = {...deferral(cloudDeployed, "production-mobile-n-compatibility"), reason}
+    assert.throws(() => validateAttestation(unreasoned, cloudDeployed), /attestation\.reason/)
+  }
 
   // Deferring moves the promotion on and records the open gate.
   const deferred = attest(cloudDeployed, deferral(cloudDeployed, "production-mobile-n-compatibility"))
@@ -433,8 +439,21 @@ test("pre-submission human gates can be deferred and must be attested before pub
     "production-mobile-candidate-acceptance",
   ])
 
-  // Public release is refused while any deferral is unresolved.
+  // Public release is refused while any deferral is unresolved, including when
+  // the approval's own evidence reference is crafted to look like the resolution.
   assert.throws(() => advance(record, "public-release-approved"), /deferred human gates to be attested first/)
+  assert.throws(
+    () =>
+      transitionPromotionRecord({
+        record: resolvedOneOf(record),
+        to: "public-release-approved",
+        actor: "release-owner",
+        createdAt: now,
+        provenanceUrl: runUrl,
+        evidence: evidence("production-mobile-candidate-acceptance"),
+      }),
+    /deferred human gates to be attested first: production-mobile-candidate-acceptance/,
+  )
 
   // Resolving in place: same state, the check's own evidence kind appended.
   const resolvedOne = attest(

--- a/.github/scripts/production-promotion-state.test.mjs
+++ b/.github/scripts/production-promotion-state.test.mjs
@@ -6,7 +6,9 @@ import {
   ATTESTATION_CHECKS,
   PROMOTION_STATES,
   abortPromotionRecord,
+  canResolveDeferredCheck,
   createInitialPromotionRecord,
+  deferredChecks,
   nextAction,
   promotionAssetName,
   requirePromotionMatchesPackages,
@@ -339,6 +341,137 @@ test("binds every human gate to its check-specific frozen coordinates", () => {
     wrong.tests[0].appBuild += 1
     assert.throws(() => validateAttestation(wrong, record), /does not match frozen/)
   }
+})
+
+test("pre-submission human gates can be deferred and must be attested before public release", () => {
+  const initialRecord = initial()
+  const passing = (record, check, coordinates) => ({
+    schemaVersion: 1,
+    promotionId: record.promotionId,
+    releaseIdentity: record.releaseIdentity,
+    check,
+    result: "pass",
+    performedAt: now,
+    tester: {githubLogin: "qa-owner"},
+    tests: ATTESTATION_CHECKS[check].coverage.map((coverage) => {
+      const [product, platform] = coverage.split(":")
+      return {
+        product,
+        platform,
+        result: "pass",
+        appVersion: coordinates[platform].marketingVersion,
+        appBuild: coordinates[platform].buildNumber,
+        deviceModel: "release device",
+        osVersion: "release OS",
+      }
+    }),
+    evidenceUrls: [runUrl],
+  })
+  const deferral = (record, check) => ({
+    schemaVersion: 1,
+    promotionId: record.promotionId,
+    releaseIdentity: record.releaseIdentity,
+    check,
+    result: "deferred",
+    performedAt: now,
+    tester: {githubLogin: "release-owner"},
+    reason: "verify during store review",
+    notes: "deferred",
+  })
+  const attest = (record, attestation) =>
+    transitionWithAttestation({
+      record,
+      attestation,
+      actor: "release-owner",
+      createdAt: now,
+      provenanceUrl: runUrl,
+      evidenceUrl: runUrl,
+      assetName: `${attestation.check}-${attestation.result}.json`,
+      sha256: "e".repeat(64),
+    })
+  const advance = (record, to) =>
+    transitionPromotionRecord({
+      record,
+      to,
+      actor: "release-owner",
+      createdAt: now,
+      provenanceUrl: runUrl,
+      evidence: evidence(to),
+    })
+
+  // Only the two pre-submission gates, and only in their own state.
+  const cloudDeployed = atState("cloud-deployed")
+  assert.throws(
+    () =>
+      validateAttestation(deferral(atState("stores-submitted"), "store-review-approved"), atState("stores-submitted")),
+    /cannot be deferred/,
+  )
+  assert.throws(
+    () => validateAttestation(deferral(cloudDeployed, "production-mobile-candidate-acceptance"), cloudDeployed),
+    /cannot apply in state cloud-deployed/,
+  )
+  const withTests = {...deferral(cloudDeployed, "production-mobile-n-compatibility"), tests: []}
+  assert.throws(() => validateAttestation(withTests, cloudDeployed), /carries no test results/)
+
+  // Deferring moves the promotion on and records the open gate.
+  const deferred = attest(cloudDeployed, deferral(cloudDeployed, "production-mobile-n-compatibility"))
+  assert.equal(deferred.state, "current-clients-accepted")
+  assert.equal(deferred.evidence.at(-1).kind, "production-mobile-n-compatibility-deferred")
+  assert.deepEqual(deferredChecks(deferred), ["production-mobile-n-compatibility"])
+  assert.equal(canResolveDeferredCheck(deferred, "production-mobile-n-compatibility"), true)
+  assert.deepEqual(nextAction(deferred), {kind: "workflow", workflow: "production-release-mobile.yml", phase: "build"})
+
+  // A second deferral at candidate acceptance, then the chain reaches stores-approved.
+  let record = advance(deferred, "mobile-candidates-uploaded")
+  record = attest(record, deferral(record, "production-mobile-candidate-acceptance"))
+  assert.equal(record.state, "mobile-candidates-accepted")
+  record = advance(record, "stores-submitted")
+  record = attest(record, passing(record, "store-review-approved", initialRecord.coordinates.candidates.mentraApp))
+  assert.equal(record.state, "stores-approved")
+  assert.deepEqual(deferredChecks(record), [
+    "production-mobile-n-compatibility",
+    "production-mobile-candidate-acceptance",
+  ])
+
+  // Public release is refused while any deferral is unresolved.
+  assert.throws(() => advance(record, "public-release-approved"), /deferred human gates to be attested first/)
+
+  // Resolving in place: same state, the check's own evidence kind appended.
+  const resolvedOne = attest(
+    record,
+    passing(record, "production-mobile-n-compatibility", initialRecord.coordinates.currentMentraApp),
+  )
+  assert.equal(resolvedOne.state, "stores-approved")
+  assert.equal(resolvedOne.evidence.at(-1).kind, "production-mobile-n-compatibility")
+  assert.deepEqual(deferredChecks(resolvedOne), ["production-mobile-candidate-acceptance"])
+  assert.throws(
+    () =>
+      attest(
+        resolvedOne,
+        passing(resolvedOne, "production-mobile-n-compatibility", initialRecord.coordinates.currentMentraApp),
+      ),
+    /cannot apply in state stores-approved/,
+  )
+  const resolvedBoth = attest(
+    resolvedOne,
+    passing(resolvedOne, "production-mobile-candidate-acceptance", initialRecord.coordinates.candidates.mentraApp),
+  )
+  assert.deepEqual(deferredChecks(resolvedBoth), [])
+  assert.equal(advance(resolvedBoth, "public-release-approved").state, "public-release-approved")
+
+  // A non-deferred check still cannot be attested out of its own state.
+  assert.throws(
+    () =>
+      attest(
+        atState("stores-approved"),
+        passing(
+          atState("stores-approved"),
+          "production-mobile-n-compatibility",
+          initialRecord.coordinates.currentMentraApp,
+        ),
+      ),
+    /cannot apply in state stores-approved/,
+  )
 })
 
 test("rejects Starter Kit fields from the Mentra-App-only production schema", () => {

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -670,6 +670,9 @@ async function main(argv = process.argv.slice(2)) {
     if (!options.evidence) throw commandError("attest requires --evidence FILE")
     requireCommandState(command, loaded.record, options)
     const attestation = JSON.parse(readFileSync(path.resolve(options.evidence), "utf8"))
+    if (attestation?.result !== "pass") {
+      throw commandError("attest records passing evidence only; use 'defer' to defer a human gate")
+    }
     validateAttestation(attestation, loaded.record, options.check)
     await confirmEffect(
       `This will append passing human evidence for ${options.check}. It does not deploy or publish anything.`,

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import {execFileSync} from "node:child_process"
 import {createHash} from "node:crypto"
-import {copyFileSync, mkdtempSync, readFileSync} from "node:fs"
+import {copyFileSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs"
 import {tmpdir} from "node:os"
 import path from "node:path"
 import {fileURLToPath} from "node:url"
@@ -13,7 +13,14 @@ import {
   stateAssets,
   validateStateRecordChain,
 } from "../.github/scripts/production-promotion-assets.mjs"
-import {ATTESTATION_CHECKS, nextAction, validateAttestation} from "../.github/scripts/production-promotion-state.mjs"
+import {
+  ATTESTATION_CHECKS,
+  DEFERRABLE_CHECKS,
+  canResolveDeferredCheck,
+  deferredChecks,
+  nextAction,
+  validateAttestation,
+} from "../.github/scripts/production-promotion-state.mjs"
 
 const REPOSITORY = "Mentra-Community/MentraOS"
 const DEFAULT_REF = "main"
@@ -59,6 +66,7 @@ Commands:
   status   --release X.Y.Z [--attempt N] [--refresh] [--json]
   next     --release X.Y.Z [--attempt N] [--yes]
   attest   --release X.Y.Z [--attempt N] --check NAME --evidence FILE [--yes]
+  defer    --release X.Y.Z [--attempt N] --check NAME --reason TEXT [--yes]
   release  --release X.Y.Z [--attempt N] [--yes]
   advance  --release X.Y.Z [--attempt N] [--android-percent N | --complete] [--yes]
   abort    --release X.Y.Z [--attempt N] --reason TEXT [--yes]
@@ -357,6 +365,7 @@ export function statusSummary(record) {
     sequence: record.sequence,
     sourceCommit: record.source.mentraosCommit,
     evidenceCount: record.evidence.length,
+    deferredChecks: deferredChecks(record),
     nextAction: action,
   }
 }
@@ -371,6 +380,9 @@ function printStatus(record, asJson) {
   console.log(`Selected beta: ${summary.selectedBeta}`)
   console.log(`MentraOS source: ${summary.sourceCommit}`)
   console.log(`Evidence records: ${summary.evidenceCount}`)
+  if (summary.deferredChecks.length > 0) {
+    console.log(`Deferred human gates still to attest before release: ${summary.deferredChecks.join(", ")}`)
+  }
   if (summary.nextAction.kind === "none") console.log("Next action: none")
   else if (summary.nextAction.kind === "attest") console.log(`Next action: attest ${summary.nextAction.check}`)
   else if (summary.nextAction.kind === "workflow") {
@@ -420,6 +432,20 @@ async function confirmBranchPromotion(betaIdentity, options) {
   if (answer !== betaIdentity) throw new Error("Confirmation did not match the beta identity")
 }
 
+export function deferralAttestation({record, check, reason, githubLogin, performedAt}) {
+  return {
+    schemaVersion: 1,
+    promotionId: record.promotionId,
+    releaseIdentity: record.releaseIdentity,
+    check,
+    result: "deferred",
+    performedAt,
+    tester: {githubLogin},
+    reason,
+    notes: `Deferred so store submission is not held back; must be attested before public release.`,
+  }
+}
+
 function uploadAttestation({release, record, check, evidenceFile}) {
   const original = path.resolve(evidenceFile)
   const contents = readFileSync(original)
@@ -455,12 +481,26 @@ export function requireCommandState(command, record, options = {}) {
     throw new Error(`Promotion state ${record.state} does not have an automated next phase`)
   }
   if (command === "attest") {
+    const expected = action.kind === "attest" && action.check === options.check
+    if (!expected && !canResolveDeferredCheck(record, options.check)) {
+      throw new Error(`Promotion state ${record.state} expects ${action.check || action.kind}, not ${options.check}`)
+    }
+  }
+  if (command === "defer") {
+    if (!DEFERRABLE_CHECKS.includes(options.check)) {
+      throw new Error(`Only ${DEFERRABLE_CHECKS.join(" and ")} can be deferred, not ${options.check}`)
+    }
     if (action.kind !== "attest" || action.check !== options.check) {
       throw new Error(`Promotion state ${record.state} expects ${action.check || action.kind}, not ${options.check}`)
     }
   }
   if (command === "release" && record.state !== "stores-approved") {
     throw new Error(`Public release requires stores-approved, not ${record.state}`)
+  }
+  if (command === "release" && deferredChecks(record).length > 0) {
+    throw new Error(
+      `Public release requires the deferred human gates to be attested first: ${deferredChecks(record).join(", ")}`,
+    )
   }
   if (command === "advance" && !new Set(["rolling-out", "finalizing"]).has(record.state)) {
     throw new Error(`Rollout advancement requires rolling-out or finalizing, not ${record.state}`)
@@ -640,6 +680,41 @@ async function main(argv = process.argv.slice(2)) {
       record: loaded.record,
       check: options.check,
       evidenceFile: options.evidence,
+    })
+    dispatch("production-release-attest.yml", {
+      release_identity: releaseIdentity,
+      attempt: loaded.record.attempt,
+      check: options.check,
+      evidence_asset: uploaded.name,
+      evidence_sha256: uploaded.sha256,
+    })
+    return
+  }
+
+  if (command === "defer") {
+    if (!options.check) throw commandError("defer requires --check NAME")
+    if (!options.reason) throw commandError("defer requires --reason TEXT")
+    requireCommandState(command, loaded.record, options)
+    const attestation = deferralAttestation({
+      record: loaded.record,
+      check: options.check,
+      reason: options.reason,
+      githubLogin: ghJson(["api", "user"]).login,
+      performedAt: new Date().toISOString(),
+    })
+    validateAttestation(attestation, loaded.record, options.check)
+    await confirmEffect(
+      `This defers the human gate ${options.check} so the promotion can continue towards store submission. Public release stays blocked until it is attested.`,
+      {...options, release: releaseIdentity},
+    )
+    const directory = mkdtempSync(path.join(tmpdir(), "mentra-production-deferral-"))
+    const evidenceFile = path.join(directory, `${options.check}-deferred.json`)
+    writeFileSync(evidenceFile, `${JSON.stringify(attestation, null, 2)}\n`)
+    const uploaded = uploadAttestation({
+      release: loaded.release,
+      record: loaded.record,
+      check: options.check,
+      evidenceFile,
     })
     dispatch("production-release-attest.yml", {
       release_identity: releaseIdentity,

--- a/scripts/production-release.test.mjs
+++ b/scripts/production-release.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test"
 import {
   advanceConfirmationMessage,
   branchPromotionState,
+  deferralAttestation,
   exampleConfirmationMessage,
   packagesConfirmationMessage,
   parseCliArgs,
@@ -159,6 +160,44 @@ test("prevents commands from skipping promotion states", () => {
   assert.throws(() => requireCommandState("release", baseRecord), /requires stores-approved/)
   assert.equal(requireCommandState("attest", labReadyRecord, {check: "staging-mobile-n-compatibility"}).kind, "attest")
   assert.equal(requireCommandState("advance", {...baseRecord, state: "finalizing"}).command, "advance")
+})
+
+test("defers only the pre-submission human gates and blocks release until they are attested", () => {
+  const cloudDeployed = {...baseRecord, state: "cloud-deployed"}
+  assert.equal(requireCommandState("defer", cloudDeployed, {check: "production-mobile-n-compatibility"}).kind, "attest")
+  assert.throws(
+    () => requireCommandState("defer", cloudDeployed, {check: "production-mobile-candidate-acceptance"}),
+    /expects production-mobile-n-compatibility/,
+  )
+  assert.throws(
+    () => requireCommandState("defer", {...baseRecord, state: "stores-submitted"}, {check: "store-review-approved"}),
+    /can be deferred, not store-review-approved/,
+  )
+  const reference = (kind) => ({kind, url: "https://example.com/evidence.json", sha256: "c".repeat(64)})
+  const deferred = {
+    ...baseRecord,
+    state: "stores-approved",
+    evidence: [reference("production-mobile-n-compatibility-deferred")],
+  }
+  assert.equal(requireCommandState("attest", deferred, {check: "production-mobile-n-compatibility"}).kind, "command")
+  assert.throws(() => requireCommandState("release", deferred), /deferred human gates to be attested first/)
+  assert.deepEqual(statusSummary(deferred).deferredChecks, ["production-mobile-n-compatibility"])
+  const resolved = {...deferred, evidence: [...deferred.evidence, reference("production-mobile-n-compatibility")]}
+  assert.deepEqual(statusSummary(resolved).deferredChecks, [])
+  assert.throws(
+    () => requireCommandState("attest", resolved, {check: "production-mobile-n-compatibility"}),
+    /expects command, not production-mobile-n-compatibility/,
+  )
+  const attestation = deferralAttestation({
+    record: baseRecord,
+    check: "production-mobile-n-compatibility",
+    reason: "verify during store review",
+    githubLogin: "owner",
+    performedAt: "2026-09-12T01:00:00.000Z",
+  })
+  assert.equal(attestation.result, "deferred")
+  assert.equal(attestation.promotionId, "mentra-3.1.0-attempt-1")
+  assert.equal(attestation.tests, undefined)
 })
 
 test("dispatches stable package phases from the promoted beta without a promotion state", () => {


### PR DESCRIPTION
## Scope

Store review takes days. The two human gates before submission, `production-mobile-n-compatibility` (Phase 5) and `production-mobile-candidate-acceptance` (Phase 8), guard nothing user-facing on their own, since submission ships nothing. This lets the operator submit first and verify during review, without weakening the gate that does matter.

- `production-promotion-state.mjs`: `DEFERRABLE_CHECKS`, `deferredChecks(record)`, `canResolveDeferredCheck(record, check)`. `validateAttestation` accepts `result: "deferred"` (with a reason, no tests) only for those two checks in their own state, and accepts a passing attestation for a deferred check later, in place, at any state before `public-release-approved`. `transitionWithAttestation` appends `<check>-deferred` for a deferral and the check's own kind for the resolution. `validatePromotionChain` allows the in-place resolution and refuses `public-release-approved` while any deferral is unresolved.
- `scripts/production-release.mjs`: `defer --release X.Y.Z --check NAME --reason TEXT`, which builds the deferral evidence (tester = `gh api user`), uploads it, and dispatches the existing attest workflow. `attest` is allowed for a deferred check out of sequence; `release` refuses while deferrals are open; `status` lists them.
- Runbook: operator commands, Phase 5, and Phases 11 and 12.
- No workflow changes: the attest workflow already runs the state script from main and passes the check name through; the state script decides the evidence kind and target state.

## Test evidence

```
node --test .github/scripts/production-promotion-state.test.mjs scripts/production-release.test.mjs \
  .github/scripts/finalize-production-promotion.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs \
  .github/scripts/production-promotion-assets.test.mjs   # 58 pass
```

The state test walks a promotion through two deferrals, store approval, refusal of public release, in-place resolution of both gates, and then release approval; it also checks that a non-deferrable check cannot be deferred and that a check cannot be resolved twice or out of its window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
