### PR TITLE
Wait for npm to serve a moved dist-tag before trusting the read-back

### DIFF
--- a/.github/scripts/promote-npm-latest.mjs
+++ b/.github/scripts/promote-npm-latest.mjs
@@ -77,6 +77,14 @@ function run(command, args) {
   execFileSync(command, args, {stdio: "inherit"})
 }
 
+// npm acknowledges a dist-tag change before every read path serves it: the
+// first read-back after `npm dist-tag add` can still return the previous
+// latest (seen on the first 3.1.0 release, where the tag had moved but the
+// read-back failed the run). Poll for a bounded time before concluding that
+// the move did not take.
+export const NPM_TAG_READBACK_POLL_SECONDS = 5
+export const NPM_TAG_READBACK_ATTEMPTS = 61 // five minutes
+
 export function promoteNpmLatest({
   plan,
   npmTag,
@@ -85,6 +93,8 @@ export function promoteNpmLatest({
   view = npmView,
   exec = run,
   log = console.log,
+  readbackAttempts = NPM_TAG_READBACK_ATTEMPTS,
+  sleep = () => execFileSync("sleep", [String(NPM_TAG_READBACK_POLL_SECONDS)]),
 }) {
   if (plan?.channel !== "production") throw new Error("Only a production plan can move npm latest")
   const version = plan.releaseIdentity
@@ -110,9 +120,19 @@ export function promoteNpmLatest({
       log(`Dry run: would move ${name} latest from ${decision.previousLatest ?? "<unset>"} to ${version}`)
     } else if (decision.action === "published") {
       exec("npm", ["dist-tag", "add", coordinate, "latest"])
-      const observed = parseViewValue(view(name, "dist-tags")) || {}
-      if (observed.latest !== version) {
-        throw new Error(`${name} latest reads back as ${JSON.stringify(observed.latest ?? null)}, expected ${version}`)
+      for (let attempt = 1; ; attempt += 1) {
+        const observed = parseViewValue(view(name, "dist-tags")) || {}
+        if (observed.latest === version) break
+        if (attempt >= readbackAttempts) {
+          const waited = (attempt - 1) * NPM_TAG_READBACK_POLL_SECONDS
+          throw new Error(
+            `${name} latest reads back as ${JSON.stringify(observed.latest ?? null)} after ${waited}s, expected ${version}`,
+          )
+        }
+        if (attempt === 1 || attempt % 12 === 0) {
+          log(`${name} latest still reads back as ${JSON.stringify(observed.latest ?? null)}; waiting for npm`)
+        }
+        sleep()
       }
     }
     if (!dryRun) {

--- a/.github/scripts/promote-npm-latest.test.mjs
+++ b/.github/scripts/promote-npm-latest.test.mjs
@@ -108,6 +108,76 @@ test("flips latest for every npm member, reads it back, and retires the candidat
   assert.equal(Object.keys(written.publications).length, members.length)
 })
 
+test("waits for npm to serve the moved latest before trusting the read-back", () => {
+  const members = npmMembersFromPlan(plan)
+  const initial = Object.fromEntries(
+    members.map((name) => [
+      name,
+      [
+        [candidateTag, version],
+        ["latest", "3.0.0"],
+      ],
+    ]),
+  )
+  // The registry acknowledges the move, but the next reads still serve the
+  // previous latest for a while, as npm does.
+  const staleReads = (count) => {
+    const fake = registry(initial)
+    const stale = new Map()
+    return {
+      fake,
+      view(spec, field) {
+        const fresh = fake.view(spec, field)
+        if (field !== "dist-tags" || !(stale.get(spec) > 0)) return fresh
+        stale.set(spec, stale.get(spec) - 1)
+        return JSON.stringify({...JSON.parse(fresh), latest: "3.0.0"})
+      },
+      exec(command, args) {
+        fake.exec(command, args)
+        if (args[1] === "add") stale.set(args[2].slice(0, args[2].lastIndexOf("@")), count)
+      },
+    }
+  }
+
+  const lagging = staleReads(2)
+  let sleeps = 0
+  const result = promoteNpmLatest({
+    plan,
+    npmTag: candidateTag,
+    outputDir: mkdtempSync(path.join(tmpdir(), "npm-latest-")),
+    view: lagging.view,
+    exec: lagging.exec,
+    log: () => {},
+    readbackAttempts: 4,
+    sleep: () => {
+      sleeps += 1
+    },
+  })
+  assert.equal(sleeps, 2 * members.length)
+  assert.ok(members.every((name) => result.publications[name].npm.status === "published"))
+  assert.ok(members.every((name) => lagging.fake.commands.includes(`npm dist-tag rm ${name} ${candidateTag}`)))
+
+  const stuck = staleReads(100)
+  let stuckSleeps = 0
+  assert.throws(
+    () =>
+      promoteNpmLatest({
+        plan,
+        npmTag: candidateTag,
+        outputDir: mkdtempSync(path.join(tmpdir(), "npm-latest-")),
+        view: stuck.view,
+        exec: stuck.exec,
+        log: () => {},
+        readbackAttempts: 3,
+        sleep: () => {
+          stuckSleeps += 1
+        },
+      }),
+    /latest reads back as "3\.0\.0" after 10s, expected/,
+  )
+  assert.equal(stuckSleeps, 2)
+})
+
 test("refuses unpublished versions and does nothing in a dry run", () => {
   const members = npmMembersFromPlan(plan)
   const fake = registry(Object.fromEntries(members.map((name) => [name, [[candidateTag, version]]])))

--- a/.github/workflows/production-release-packages.yml
+++ b/.github/workflows/production-release-packages.yml
@@ -330,7 +330,7 @@ jobs:
     if: inputs.phase == 'release'
     needs: load
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     environment:
       name: production-packages-release
     steps:


### PR DESCRIPTION
## Scope

The first 3.1.0 packages release phase (run 34664507004) failed at "Move npm latest to the staged plain versions" with `@mentra/jspolyfill latest reads back as "0.1.0-dev.0", expected 3.1.0`, while npm itself now reports `jspolyfill` at 3.1.0. npm acknowledged the `dist-tag add` but the immediate read-back still served the previous latest, the same read-after-write lag the publish step already tolerates (#3983).

- `promote-npm-latest.mjs`: after each move, poll the dist-tags read-back every 5 s for up to 5 minutes (`readbackAttempts`, `sleep` injectable), log progress about once a minute, and fail only when the wait is exhausted, naming how long the read stayed stale. The whole-family decision before touching any tag, the candidate-tag retirement, and the reuse of members already at the release are unchanged.
- Tests: a registry that serves the stale latest for two reads after the move (all members flip, candidate tags retired, two waits per member) and one that never catches up (fails after the bounded attempts).

## Test evidence

```
node --test .github/scripts/promote-npm-latest.test.mjs .github/scripts/coordinated-workflow-contract.test.mjs   # 25 pass
```

Rerunning `packages --beta 3.1.0-beta.212 --phase release` after this merges reuses `jspolyfill` (already latest), moves the other six, then publishes Maven Central and pushes the SwiftPM tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
